### PR TITLE
linux-patch

### DIFF
--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -66,7 +66,7 @@ extension Google_Protobuf_EnumDescriptorProto {
             let fieldPrefix = fieldChars[0..<enumChars.count]
             let fieldPrefixString = String(fieldPrefix)
             if fieldPrefixString != enumName {
-                return o
+                return 0
             }
 #else
             if enumName.commonPrefix(with: fieldName) != enumName {

--- a/Sources/protoc-gen-swift/FileIo.swift
+++ b/Sources/protoc-gen-swift/FileIo.swift
@@ -112,7 +112,7 @@ func readFileData(filename: String) throws -> [UInt8] {
     }
 
     // from NSData to [UInt8]
-    return Array(UnsafeBufferPointer(start: UnsafePointer<UInt8>(data.bytes), count: data.length))
+    return data.bytes.advanced(by: data.length).load(as: [UInt8].self)
 #else
     return try [UInt8](Data(contentsOf:URL(fileURLWithPath: filename)))
 #endif

--- a/Sources/protoc-gen-swift/FileIo.swift
+++ b/Sources/protoc-gen-swift/FileIo.swift
@@ -99,7 +99,7 @@ class Stdin {
 
 func writeFileData(filename: String, data: [UInt8]) throws {
 #if os(Linux)
-    _ = try NSData(bytes: data, length: data.count).write(to: NSURL(fileURLWithPath: filename))
+    _ = try NSData(bytes: data, length: data.count).write(to: URL(fileURLWithPath: filename))
 #else
     _ = try Data(bytes: data).write(to: URL(fileURLWithPath: filename))
 #endif


### PR DESCRIPTION
- a typo in `EnumGenerator.swift`
```console
/swift-protobuf/Sources/protoc-gen-swift/EnumGenerator.swift:69:24: error: use of unresolved identifier 'o'
                return o
/swift-protobuf/Sources/protoc-gen-swift/EnumGenerator.swift:58:13: note: did you mean 'f'?
        for f in value {
```
- a typo in `FileIo.swift`
```console
/swift-protobuf/Sources/protoc-gen-swift/FileIo.swift:102:53: error: cannot invoke 'write' with an argument list of type '(to: NSURL)'
    _ = try NSData(bytes: data, length: data.count).write(to: NSURL(fileURLWithPath: filename))
```

I changed the way to convert `NSData` to `[UInt8]`.
Can you tell me if you are agree with this ?
