### PR TITLE
Fix podspec issue

### DIFF
--- a/SwiftProtobuf.podspec
+++ b/SwiftProtobuf.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
-  s.source_files = 'Sources/**/*.swift'
+  s.source_files = 'Sources/SwiftProtobuf/**/*.swift'
 end


### PR DESCRIPTION
Excluded of `protoc-gen-swift` and `PluginLibrary`. Resolved https://github.com/apple/swift-protobuf/issues/30 issue.
Thanks.