### PR TITLE
Set the tag version compiling the generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To use Swift with Protocol buffers, you'll need:
 Building the plugin should be simple on any supported Swift platform:
 ```
 $ git clone https://github.com/apple/swift-protobuf
+$ git checkout tags/0.9.23
 $ cd swift-protobuf
 $ swift build
 ```


### PR DESCRIPTION
The generator from master is incompatible with the 0.9.23 runtime: the generated classes don't have anymore the `_protoc_generated_isEmpty` property, and the compiler is complaining the lack of `ProtobufGeneratedMessage` conformance:
```
/Users/giordano.scalzo/work/EC/TestProtobuf/Sources/DataModel.pb.swift:83:15: error: type 'MyLibrary' does not conform to protocol 'ProtobufGeneratedMessage'
public struct MyLibrary: ProtobufGeneratedMessage {
              ^
SwiftProtobuf.ProtobufGeneratedMessage:11:16: note: protocol requires property '_protoc_generated_isEmpty' with type 'Bool'; do you want to add a stub?
    public var _protoc_generated_isEmpty: Bool { get }
```
I'm aware that changing the readme isn't the best solution, but at least can save time to the newbies like me when first trying the plugin.