### PR TITLE
Binary serialization/decoding performance improvements

### DIFF
--- a/Sources/SwiftProtobuf/ProtobufBinaryDecoding.swift
+++ b/Sources/SwiftProtobuf/ProtobufBinaryDecoding.swift
@@ -541,15 +541,13 @@ public struct ProtobufBinaryDecoder {
 
     // Convert a 64-bit value from zigzag coding.
     fileprivate func unZigZag64(zigZag: UIntMax) -> Int64 {
-        let n = Int64(bitPattern: (zigZag >> 1))
-        return n ^ -Int64(bitPattern: zigZag & 1)
+        return ZigZag.decoded(zigZag)
     }
 
     // Convert a 32-bit value from zigzag coding.
     fileprivate func unZigZag32(zigZag: UIntMax) -> Int32 {
         let t = UInt32(truncatingBitPattern: zigZag)
-        let n = Int32(bitPattern: (t >> 1))
-        return n ^ -Int32(bitPattern: t & 1)
+        return ZigZag.decoded(t)
     }
 }
 

--- a/Sources/SwiftProtobuf/ProtobufBinaryEncoding.swift
+++ b/Sources/SwiftProtobuf/ProtobufBinaryEncoding.swift
@@ -54,7 +54,7 @@ public struct ProtobufBinaryEncodingVisitor: ProtobufVisitor {
         encoder.startField(tagType: protoFieldNumber * 8 + 2)
         var packedSize = 0
         for v in value {
-            packedSize += try S.encodedSize(of: v)
+            packedSize += try S.encodedSizeWithoutTag(of: v)
         }
         encoder.putVarInt(value: packedSize)
         for v in value {
@@ -99,7 +99,7 @@ public struct ProtobufBinaryEncodingVisitor: ProtobufVisitor {
             encoder.startField(tagType: protoFieldNumber * 8 + 2)
             let keyTagSize = Varint.encodedSize(of: UInt32(truncatingBitPattern: 1 << 3))
             let valueTagSize = Varint.encodedSize(of: UInt32(truncatingBitPattern: 2 << 3))
-            let entrySize = try keyTagSize + KeyType.encodedSize(of: k) + valueTagSize + ValueType.encodedSize(of: v)
+            let entrySize = try keyTagSize + KeyType.encodedSizeWithoutTag(of: k) + valueTagSize + ValueType.encodedSizeWithoutTag(of: v)
             encoder.putVarInt(value: entrySize)
             encoder.startField(tagType: 8 + KeyType.protobufWireType())
             KeyType.serializeProtobufValue(encoder: &encoder, value: k)

--- a/Sources/SwiftProtobuf/ProtobufBinaryEncoding.swift
+++ b/Sources/SwiftProtobuf/ProtobufBinaryEncoding.swift
@@ -19,11 +19,10 @@ import Foundation
 import Swift
 
 public struct ProtobufBinaryEncodingVisitor: ProtobufVisitor {
-    private var encoder = ProtobufBinaryEncoder()
+    private var encoder: ProtobufBinaryEncoder
 
-    public var buffer: [UInt8] {return encoder.buffer}
-
-    public init(message: ProtobufMessageBase) throws {
+    public init(message: ProtobufMessageBase, pointer: UnsafeMutablePointer<UInt8>) throws {
+        encoder = ProtobufBinaryEncoder(pointer: pointer)
         try withAbstractVisitor {(visitor: inout ProtobufVisitor) in
             try message.traverse(visitor: &visitor)
         }
@@ -32,7 +31,7 @@ public struct ProtobufBinaryEncodingVisitor: ProtobufVisitor {
     public mutating func withAbstractVisitor(clause: (inout ProtobufVisitor) throws ->()) throws {
         var visitor: ProtobufVisitor = self
         try clause(&visitor)
-        encoder.buffer = (visitor as! ProtobufBinaryEncodingVisitor).encoder.buffer
+        encoder = (visitor as! ProtobufBinaryEncodingVisitor).encoder
     }
 
     mutating public func visitUnknown(bytes: [UInt8]) {
@@ -53,11 +52,14 @@ public struct ProtobufBinaryEncodingVisitor: ProtobufVisitor {
 
     mutating public func visitPackedField<S: ProtobufTypeProperties>(fieldType: S.Type, value: [S.BaseType], protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws {
         encoder.startField(tagType: protoFieldNumber * 8 + 2)
-        var subencoder = ProtobufBinaryEncoder()
+        var packedSize = 0
         for v in value {
-            try S.serializeProtobufValue(encoder: &subencoder, value: v)
+            packedSize += try S.encodedSize(of: v)
         }
-        encoder.putBytesValue(value: subencoder.buffer)
+        encoder.putVarInt(value: packedSize)
+        for v in value {
+            try S.serializeProtobufValue(encoder: &encoder, value: v)
+        }
     }
 
     mutating public func visitSingularMessageField<M: ProtobufMessage>(value: M, protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws {
@@ -95,16 +97,18 @@ public struct ProtobufBinaryEncodingVisitor: ProtobufVisitor {
     mutating public func visitMapField<KeyType: ProtobufMapKeyType, ValueType: ProtobufMapValueType>(fieldType: ProtobufMap<KeyType, ValueType>.Type, value: ProtobufMap<KeyType, ValueType>.BaseType, protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws where KeyType.BaseType: Hashable {
         for (k,v) in value {
             encoder.startField(tagType: protoFieldNumber * 8 + 2)
-            var subencoder = ProtobufBinaryEncoder()
-            subencoder.startField(tagType: 8 + KeyType.protobufWireType())
-            KeyType.serializeProtobufValue(encoder: &subencoder, value: k)
-            subencoder.startField(tagType: 16 + ValueType.protobufWireType())
+            let keyTagSize = Varint.encodedSize(of: UInt32(truncatingBitPattern: 1 << 3))
+            let valueTagSize = Varint.encodedSize(of: UInt32(truncatingBitPattern: 2 << 3))
+            let entrySize = try keyTagSize + KeyType.encodedSize(of: k) + valueTagSize + ValueType.encodedSize(of: v)
+            encoder.putVarInt(value: entrySize)
+            encoder.startField(tagType: 8 + KeyType.protobufWireType())
+            KeyType.serializeProtobufValue(encoder: &encoder, value: k)
+            encoder.startField(tagType: 16 + ValueType.protobufWireType())
             // Note: ValueType could be a message, so messages need
             // static func serializeProtobufValue(...)
             // TODO: Could we traverse the valuetype instead?
             // TODO: Propagate failure out of here...
-            try ValueType.serializeProtobufValue(encoder: &subencoder, value: v)
-            encoder.putBytesValue(value: subencoder.buffer)
+            try ValueType.serializeProtobufValue(encoder: &encoder, value: v)
         }
     }
 }
@@ -115,12 +119,33 @@ public struct ProtobufBinaryEncodingVisitor: ProtobufVisitor {
  * TODO: Should this be a class?
  */
 public struct ProtobufBinaryEncoder {
-    public fileprivate(set) var buffer: [UInt8] = []
+    private var pointer: UnsafeMutablePointer<UInt8>
 
-    public init() {}
+    public init(pointer: UnsafeMutablePointer<UInt8>) {
+        self.pointer = pointer
+    }
+
+    private mutating func append(_ byte: UInt8) {
+        pointer.pointee = byte
+        pointer = pointer.successor()
+    }
+
+    private mutating func append(contentsOf bytes: [UInt8]) {
+        let count = bytes.count
+        bytes.withUnsafeBufferPointer { source in
+            self.pointer.assign(from: source.baseAddress!, count: count)
+        }
+        pointer = pointer.advanced(by: count)
+    }
+
+    private mutating func append(contentsOf bufferPointer: UnsafeBufferPointer<UInt8>) {
+        let count = bufferPointer.count
+        pointer.assign(from: bufferPointer.baseAddress!, count: count)
+        pointer = pointer.advanced(by: count)
+    }
 
     public mutating func appendUnknown(bytes: [UInt8]) {
-        buffer.append(contentsOf: bytes)
+        append(contentsOf: bytes)
     }
 
     mutating func startField(tagType: Int) {
@@ -130,10 +155,10 @@ public struct ProtobufBinaryEncoder {
     mutating func putVarInt(value: UInt64) {
         var v = value
         while v > 127 {
-            buffer.append(UInt8(v & 0x7f | 0x80))
+            append(UInt8(v & 0x7f | 0x80))
             v >>= 7
         }
-        buffer.append(UInt8(v))
+        append(UInt8(v))
     }
 
     mutating func putVarInt(value: Int64) {
@@ -151,7 +176,7 @@ public struct ProtobufBinaryEncoder {
     }
 
     mutating func putBoolValue(value: Bool) {
-        buffer.append(value ? 1 : 0)
+        append(value ? 1 : 0)
     }
 
     mutating func putFixedUInt64(value : UInt64) {
@@ -160,7 +185,7 @@ public struct ProtobufBinaryEncoder {
         withUnsafePointer(to: &v) { v -> () in
             v.withMemoryRebound(to: UInt8.self, capacity: n) { p -> () in
                 let buff = UnsafeBufferPointer<UInt8>(start: p, count: n)
-                buffer.append(contentsOf: buff)
+                append(contentsOf: buff)
             }
         }
     }
@@ -171,7 +196,7 @@ public struct ProtobufBinaryEncoder {
         withUnsafePointer(to: &v) { v -> () in
             v.withMemoryRebound(to: UInt8.self, capacity: n) { p -> () in
                 let buff = UnsafeBufferPointer<UInt8>(start: p, count: n)
-                buffer.append(contentsOf: buff)
+                append(contentsOf: buff)
             }
         }
     }
@@ -182,7 +207,7 @@ public struct ProtobufBinaryEncoder {
         withUnsafePointer(to: &v) { v -> () in
             v.withMemoryRebound(to: UInt8.self, capacity: n) { p -> () in
                 let buff = UnsafeBufferPointer<UInt8>(start: p, count: n)
-                buffer.append(contentsOf: buff)
+                append(contentsOf: buff)
             }
         }
     }
@@ -193,7 +218,7 @@ public struct ProtobufBinaryEncoder {
         withUnsafePointer(to: &v) { v -> () in
             v.withMemoryRebound(to: UInt8.self, capacity: n) { p -> () in
                 let buff = UnsafeBufferPointer<UInt8>(start: p, count: n)
-                buffer.append(contentsOf: buff)
+                append(contentsOf: buff)
             }
         }
     }
@@ -208,7 +233,7 @@ public struct ProtobufBinaryEncoder {
             stringWithNul.withUnsafeBufferPointer { bp -> () in
                 bp.baseAddress?.withMemoryRebound(to: UInt8.self, capacity: stringLength) { p -> () in
                     let stringWithoutNul = UnsafeBufferPointer<UInt8>(start: p, count: stringLength)
-                    buffer.append(contentsOf: stringWithoutNul)
+                    append(contentsOf: stringWithoutNul)
                 }
             }
         }
@@ -216,12 +241,12 @@ public struct ProtobufBinaryEncoder {
 
     mutating func putBytesValue(value: [UInt8]) {
         putVarInt(value: value.count)
-        buffer.append(contentsOf: value)
+        append(contentsOf: value)
     }
 
     mutating func putBytesValue(value: Data) {
         let bytes = [UInt8](value)
         putVarInt(value: bytes.count)
-        buffer.append(contentsOf: bytes)
+        append(contentsOf: bytes)
     }
 }

--- a/Sources/SwiftProtobuf/ProtobufBinaryEncoding.swift
+++ b/Sources/SwiftProtobuf/ProtobufBinaryEncoding.swift
@@ -170,8 +170,7 @@ public struct ProtobufBinaryEncoder {
     }
 
     mutating func putZigZagVarInt(value: Int64) {
-        let coded = UInt64(bitPattern: (value << 1))
-            ^ UInt64(bitPattern: (value >> 63))
+        let coded = ZigZag.encoded(value)
         putVarInt(value: coded)
     }
 

--- a/Sources/SwiftProtobuf/ProtobufBinarySizeVisitor.swift
+++ b/Sources/SwiftProtobuf/ProtobufBinarySizeVisitor.swift
@@ -1,0 +1,119 @@
+// SwiftProtobufRuntime/Sources/SwiftProtobuf/ProtobufBinarySizeVisitor.swift - Binary size calculation support
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Visitor used during binary encoding that precalcuates the size of a
+/// serialized message.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+
+/// Visitor that calculates the binary-encoded size of a message so that a properly sized `Data` or
+/// `UInt8` array can be pre-allocated before serialization.
+struct ProtobufBinarySizeVisitor: ProtobufVisitor {
+
+    /// Accumulates the required size of the message during traversal.
+    var serializedSize: Int = 0
+
+    init(message: ProtobufMessageBase) throws {
+        try withAbstractVisitor {(visitor: inout ProtobufVisitor) in
+            try message.traverse(visitor: &visitor)
+        }
+    }
+
+    mutating func withAbstractVisitor(clause: (inout ProtobufVisitor) throws ->()) throws {
+        var visitor: ProtobufVisitor = self
+        try clause(&visitor)
+        serializedSize = (visitor as! ProtobufBinarySizeVisitor).serializedSize
+    }
+
+    mutating func visitUnknown(bytes: [UInt8]) {
+        serializedSize += bytes.count
+    }
+
+    mutating func visitSingularField<S: ProtobufTypeProperties>(fieldType: S.Type, value: S.BaseType, protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws {
+        let tagSize = Varint.encodedSize(of: UInt32(
+            truncatingBitPattern: protoFieldNumber << 3 | S.protobufWireType()))
+        serializedSize += try tagSize + S.encodedSize(of: value)
+    }
+
+    mutating func visitRepeatedField<S: ProtobufTypeProperties>(fieldType: S.Type, value: [S.BaseType], protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws {
+        let tagSize = Varint.encodedSize(of: UInt32(
+            truncatingBitPattern: protoFieldNumber << 3 | S.protobufWireType()))
+        serializedSize += value.count * tagSize
+        for v in value {
+            serializedSize += try S.encodedSize(of: v)
+        }
+    }
+
+    mutating func visitPackedField<S: ProtobufTypeProperties>(fieldType: S.Type, value: [S.BaseType], protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws {
+        guard !value.isEmpty else {
+            return
+        }
+
+        let tagSize = Varint.encodedSize(of: UInt32(
+            truncatingBitPattern: protoFieldNumber << 3 | S.protobufWireType()))
+        var dataSize = 0
+        for v in value {
+            dataSize += try S.encodedSize(of: v)
+        }
+        serializedSize += tagSize + Varint.encodedSize(of: Int64(dataSize)) + dataSize
+    }
+
+    mutating func visitSingularMessageField<M: ProtobufMessage>(value: M, protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws {
+        let tagSize = Varint.encodedSize(of: UInt32(
+            truncatingBitPattern: protoFieldNumber << 3 | M.protobufWireType()))
+        let messageSize = try value.serializedSize()
+        serializedSize += tagSize + Varint.encodedSize(of: UInt64(messageSize)) + messageSize
+    }
+
+    mutating func visitRepeatedMessageField<M: ProtobufMessage>(value: [M], protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws {
+        let tagSize = Varint.encodedSize(of: UInt32(
+            truncatingBitPattern: protoFieldNumber << 3 | M.protobufWireType()))
+        serializedSize += value.count * tagSize
+        for v in value {
+            let messageSize = try v.serializedSize()
+            serializedSize += Varint.encodedSize(of: UInt64(messageSize)) + messageSize
+        }
+    }
+
+    mutating func visitSingularGroupField<G: ProtobufGroup>(value: G, protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws {
+        // The wire format doesn't matter here because the encoded size of the integer won't change
+        // based on the low three bits.
+        let tagSize = Varint.encodedSize(of: UInt32(truncatingBitPattern: protoFieldNumber << 3))
+        serializedSize += 2 * tagSize
+        try withAbstractVisitor {(visitor: inout ProtobufVisitor) in
+            try value.traverse(visitor: &visitor)
+        }
+    }
+
+    mutating func visitRepeatedGroupField<G: ProtobufGroup>(value: [G], protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws {
+        let tagSize = Varint.encodedSize(of: UInt32(truncatingBitPattern: protoFieldNumber << 3))
+        serializedSize += 2 * value.count * tagSize
+        for v in value {
+            try withAbstractVisitor {(visitor: inout ProtobufVisitor) in
+                try v.traverse(visitor: &visitor)
+            }
+        }
+    }
+
+    mutating func visitMapField<KeyType: ProtobufMapKeyType, ValueType: ProtobufMapValueType>(fieldType: ProtobufMap<KeyType, ValueType>.Type, value: ProtobufMap<KeyType, ValueType>.BaseType, protoFieldNumber: Int, protoFieldName: String, jsonFieldName: String, swiftFieldName: String) throws where KeyType.BaseType: Hashable {
+        let tagSize = Varint.encodedSize(of: UInt32(truncatingBitPattern: protoFieldNumber << 3))
+        let keyTagSize = Varint.encodedSize(of: UInt32(truncatingBitPattern: 1 << 3))
+        let valueTagSize = Varint.encodedSize(of: UInt32(truncatingBitPattern: 2 << 3))
+        for (k,v) in value {
+            let entrySize = try keyTagSize + KeyType.encodedSize(of: k) + valueTagSize + ValueType.encodedSize(of: v)
+            serializedSize += entrySize + Varint.encodedSize(of: Int64(entrySize))
+        }
+        serializedSize += value.count * tagSize
+    }
+}

--- a/Sources/SwiftProtobuf/ProtobufBinaryTypes.swift
+++ b/Sources/SwiftProtobuf/ProtobufBinaryTypes.swift
@@ -344,15 +344,13 @@ public extension ProtobufSInt32 {
 
     public static func setFromProtobufVarint(varint: UInt64, value: inout BaseType?) throws -> Bool {
         let t = UInt32(truncatingBitPattern: varint)
-        let n = Int32(bitPattern: (t >> 1))
-        value = n ^ -Int32(bitPattern: t & 1)
+        value = ZigZag.decoded(t)
         return true
     }
 
     public static func setFromProtobufVarint(varint: UInt64, value: inout [BaseType]) throws -> Bool {
         let t = UInt32(truncatingBitPattern: varint)
-        let n = Int32(bitPattern: (t >> 1))
-        value.append(n ^ -Int32(bitPattern: t & 1))
+        value.append(ZigZag.decoded(t))
         return true
     }
 
@@ -380,14 +378,12 @@ public extension ProtobufSInt64 {
     }
 
     public static func setFromProtobufVarint(varint: UInt64, value: inout BaseType?) throws -> Bool {
-        let n = Int64(bitPattern: (varint >> 1))
-        value = n ^ -Int64(bitPattern: varint & 1)
+        value = ZigZag.decoded(varint)
         return true
     }
 
     public static func setFromProtobufVarint(varint: UInt64, value: inout [BaseType]) throws -> Bool {
-        let n = Int64(bitPattern: (varint >> 1))
-        value.append(n ^ -Int64(bitPattern: varint & 1))
+        value.append(ZigZag.decoded(varint))
         return true
     }
 

--- a/Sources/SwiftProtobuf/ProtobufBinaryTypes.swift
+++ b/Sources/SwiftProtobuf/ProtobufBinaryTypes.swift
@@ -37,12 +37,12 @@ public protocol ProtobufBinaryCodableType: ProtobufTypePropertiesBase {
     // Special interface for decoding a value of this type as a map value.
     static func decodeProtobufMapValue(decoder: inout ProtobufFieldDecoder, value: inout BaseType?) throws
 
-    /// Returns the number of byte required to encode `value` on the wire.
+    /// Returns the number of bytes required to encode `value` on the wire.
     ///
     /// Note that for length-delimited data (such as strings, bytes, and messages), the returned
     /// size includes the space required for the length prefix. For messages, this is a subtle
     /// distinction from the `serializedSize()` method, which does *not* include the length prefix.
-    static func encodedSize(of value: BaseType) throws -> Int
+    static func encodedSizeWithoutTag(of value: BaseType) throws -> Int
 }
 
 /// Extension defines default handling for mismatched wire types.
@@ -99,7 +99,7 @@ public protocol ProtobufBinaryCodableMapKeyType: ProtobufTypePropertiesBase {
     static func protobufWireType() -> Int
     /// Write out the protobuf value only.
     static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: BaseType)
-    static func encodedSize(of: BaseType) throws -> Int
+    static func encodedSizeWithoutTag(of: BaseType) throws -> Int
 }
 
 
@@ -146,7 +146,7 @@ public extension ProtobufFloat {
         return true
     }
 
-    public static func encodedSize(of value: Float) -> Int {
+    public static func encodedSizeWithoutTag(of value: Float) -> Int {
         return MemoryLayout<Float>.size
     }
 }
@@ -195,7 +195,7 @@ public extension ProtobufDouble {
         return true
     }
 
-    public static func encodedSize(of value: Double) -> Int {
+    public static func encodedSizeWithoutTag(of value: Double) -> Int {
         return MemoryLayout<Double>.size
     }
 }
@@ -228,7 +228,7 @@ public extension ProtobufInt32 {
         return true
     }
 
-    public static func encodedSize(of value: Int32) -> Int {
+    public static func encodedSizeWithoutTag(of value: Int32) -> Int {
         return Varint.encodedSize(of: value)
     }
 }
@@ -261,7 +261,7 @@ public extension ProtobufInt64 {
         return true
     }
 
-    public static func encodedSize(of value: Int64) -> Int {
+    public static func encodedSizeWithoutTag(of value: Int64) -> Int {
         return Varint.encodedSize(of: value)
     }
 }
@@ -294,7 +294,7 @@ public extension ProtobufUInt32 {
         return true
     }
 
-    public static func encodedSize(of value: UInt32) -> Int {
+    public static func encodedSizeWithoutTag(of value: UInt32) -> Int {
         return Varint.encodedSize(of: value)
     }
 }
@@ -327,7 +327,7 @@ public extension ProtobufUInt64 {
         return true
     }
 
-    public static func encodedSize(of value: UInt64) -> Int {
+    public static func encodedSizeWithoutTag(of value: UInt64) -> Int {
         return Varint.encodedSize(of: value)
     }
 }
@@ -362,7 +362,7 @@ public extension ProtobufSInt32 {
         return true
     }
 
-    public static func encodedSize(of value: Int32) -> Int {
+    public static func encodedSizeWithoutTag(of value: Int32) -> Int {
         return Varint.encodedSize(of: ZigZag.encoded(value))
     }
 }
@@ -395,7 +395,7 @@ public extension ProtobufSInt64 {
         return true
     }
 
-    public static func encodedSize(of value: Int64) -> Int {
+    public static func encodedSizeWithoutTag(of value: Int64) -> Int {
         return Varint.encodedSize(of: ZigZag.encoded(value))
     }
 }
@@ -443,7 +443,7 @@ public extension ProtobufFixed32 {
         return true
     }
 
-    public static func encodedSize(of value: UInt32) -> Int {
+    public static func encodedSizeWithoutTag(of value: UInt32) -> Int {
         return MemoryLayout<UInt32>.size
     }
 }
@@ -491,7 +491,7 @@ public extension ProtobufFixed64 {
         return true
     }
 
-    public static func encodedSize(of value: UInt64) -> Int {
+    public static func encodedSizeWithoutTag(of value: UInt64) -> Int {
         return MemoryLayout<UInt64>.size
     }
 }
@@ -539,7 +539,7 @@ public extension ProtobufSFixed32 {
         return true
     }
 
-    public static func encodedSize(of value: Int32) -> Int {
+    public static func encodedSizeWithoutTag(of value: Int32) -> Int {
         return MemoryLayout<Int32>.size
     }
 }
@@ -587,7 +587,7 @@ public extension ProtobufSFixed64 {
         return true
     }
 
-    public static func encodedSize(of value: Int64) -> Int {
+    public static func encodedSizeWithoutTag(of value: Int64) -> Int {
         return MemoryLayout<Int64>.size
     }
 }
@@ -620,7 +620,7 @@ public extension ProtobufBool {
         return true
     }
 
-    public static func encodedSize(of value: Bool) -> Int {
+    public static func encodedSizeWithoutTag(of value: Bool) -> Int {
         return 1
     }
 }
@@ -663,7 +663,7 @@ public extension ProtobufString {
         throw ProtobufDecodingError.invalidUTF8
     }
 
-    public static func encodedSize(of value: String) -> Int {
+    public static func encodedSizeWithoutTag(of value: String) -> Int {
         let stringWithNul = value.utf8CString
         let stringLength = stringWithNul.count - 1
         return Varint.encodedSize(of: Int64(stringLength)) + stringLength
@@ -690,7 +690,7 @@ public extension ProtobufBytes {
         return true
     }
 
-    public static func encodedSize(of value: Data) -> Int {
+    public static func encodedSizeWithoutTag(of value: Data) -> Int {
         let count = value.count
         return Varint.encodedSize(of: Int64(count)) + count
     }
@@ -737,7 +737,7 @@ extension ProtobufEnum where RawValue == Int {
         return true
     }
 
-    public static func encodedSize(of value: Self) -> Int {
+    public static func encodedSizeWithoutTag(of value: Self) -> Int {
         return Varint.encodedSize(of: Int32(truncatingBitPattern: value.rawValue))
     }
 }
@@ -750,7 +750,7 @@ public protocol ProtobufBinaryMessageBase: ProtobufMessageBase {
     // Serialize to protobuf
     func serializeProtobuf() throws -> Data
     func serializeProtobufBytes() throws -> [UInt8]
-    func serializedSize() throws -> Int
+    func serializedProtobufSize() throws -> Int
     // Decode from protobuf
     init(protobuf: Data) throws
     init(protobuf: Data, extensions: ProtobufExtensionSet?) throws
@@ -762,7 +762,7 @@ public protocol ProtobufBinaryMessageBase: ProtobufMessageBase {
 
 public extension ProtobufBinaryMessageBase {
     func serializeProtobuf() throws -> Data {
-        let requiredSize = try serializedSize()
+        let requiredSize = try serializedProtobufSize()
         var data = Data(count: requiredSize)
         try data.withUnsafeMutableBytes { (pointer: UnsafeMutablePointer<UInt8>) in
             try serializeProtobuf(into: pointer)
@@ -770,7 +770,7 @@ public extension ProtobufBinaryMessageBase {
         return data
     }
     func serializeProtobufBytes() throws -> [UInt8] {
-        let requiredSize = try serializedSize()
+        let requiredSize = try serializedProtobufSize()
         var bytes = [UInt8](repeating: 0, count: requiredSize)
         try bytes.withUnsafeMutableBufferPointer { (pointer: inout UnsafeMutableBufferPointer<UInt8>) in
             try serializeProtobuf(into: pointer.baseAddress!)
@@ -781,7 +781,7 @@ public extension ProtobufBinaryMessageBase {
         _ = try ProtobufBinaryEncodingVisitor(message: self, pointer: pointer)
     }
 
-    func serializedSize() throws -> Int {
+    func serializedProtobufSize() throws -> Int {
         return try ProtobufBinarySizeVisitor(message: self).serializedSize
     }
 
@@ -792,8 +792,8 @@ public extension ProtobufBinaryMessageBase {
         encoder.putBytesValue(value: t)
     }
 
-    static func encodedSize(of value: Self) throws -> Int {
-        let messageSize = try value.serializedSize()
+    static func encodedSizeWithoutTag(of value: Self) throws -> Int {
+        let messageSize = try value.serializedProtobufSize()
         return Varint.encodedSize(of: Int64(messageSize)) + messageSize
     }
 }

--- a/Sources/SwiftProtobuf/Varint.swift
+++ b/Sources/SwiftProtobuf/Varint.swift
@@ -1,0 +1,94 @@
+// SwiftProtobufRuntime/Sources/SwiftProtobuf/Varint.swift - Varint encoding/decoding helpers
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Helper functions to varint-encode and decode integers.
+///
+// -----------------------------------------------------------------------------
+
+
+/// Contains helper methods to varint-encode and decode integers.
+internal enum Varint {
+
+  /// Computes the number of bytes that would be needed to store a 32-bit varint.
+  ///
+  /// - Parameter value: The number whose varint size should be calculated.
+  /// - Returns: The size, in bytes, of the 32-bit varint.
+  static func encodedSize(of value: UInt32) -> Int {
+    if (value & (~0 << 7)) == 0 {
+      return 1
+    }
+    if (value & (~0 << 14)) == 0 {
+      return 2
+    }
+    if (value & (~0 << 21)) == 0 {
+      return 3
+    }
+    if (value & (~0 << 28)) == 0 {
+      return 4
+    }
+    return 5
+  }
+
+  /// Computes the number of bytes that would be needed to store a signed 32-bit varint, if it were
+  /// treated as an unsigned integer with the same bit pattern.
+  ///
+  /// - Parameter value: The number whose varint size should be calculated.
+  /// - Returns: The size, in bytes, of the 32-bit varint.
+  static func encodedSize(of value: Int32) -> Int {
+    if value >= 0 {
+      return encodedSize(of: UInt32(bitPattern: value))
+    } else {
+      // Must sign-extend.
+      return encodedSize(of: Int64(value))
+    }
+  }
+
+  /// Computes the number of bytes that would be needed to store a 64-bit varint.
+  ///
+  /// - Parameter value: The number whose varint size should be calculated.
+  /// - Returns: The size, in bytes, of the 64-bit varint.
+  static func encodedSize(of value: Int64) -> Int {
+    // Handle two common special cases up front.
+    if (value & (~0 << 7)) == 0 {
+      return 1
+    }
+    if value < 0 {
+      return 10
+    }
+
+    // Divide and conquer the remaining eight cases.
+    var value = value
+    var n = 2
+
+    if (value & (~0 << 35)) != 0 {
+      n += 4
+      value >>= 28
+    }
+    if (value & (~0 << 21)) != 0 {
+      n += 2
+      value >>= 14
+    }
+    if (value & (~0 << 14)) != 0 {
+      n += 1
+    }
+    return n
+  }
+
+  /// Computes the number of bytes that would be needed to store an unsigned 64-bit varint, if it
+  /// were treated as a signed integer witht he same bit pattern.
+  ///
+  /// - Parameter value: The number whose varint size should be calculated.
+  /// - Returns: The size, in bytes, of the 64-bit varint.
+  static func encodedSize(of value: UInt64) -> Int {
+    return encodedSize(of: Int64(bitPattern: value))
+  }
+}

--- a/Sources/SwiftProtobuf/ZigZag.swift
+++ b/Sources/SwiftProtobuf/ZigZag.swift
@@ -1,0 +1,68 @@
+// SwiftProtobufRuntime/Sources/SwiftProtobuf/ZigZagEncoding.swift - ZigZag encoding/decoding helpers
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Helper functions to ZigZag encode and decode signed integers.
+///
+// -----------------------------------------------------------------------------
+
+
+/// Contains helper methods to ZigZag encode and decode signed integers.
+internal enum ZigZag {
+
+    /// Return a 32-bit ZigZag-encoded value.
+    ///
+    /// ZigZag encodes signed integers into values that can be efficiently encoded with varint.
+    /// (Otherwise, negative values must be sign-extended to 64 bits to be varint encoded, always
+    /// taking 10 bytes on the wire.)
+    ///
+    /// - Parameter value: A signed 32-bit integer.
+    /// - Returns: An unsigned 32-bit integer representing the ZigZag-encoded value.
+    static func encoded(_ value: Int32) -> UInt32 {
+        return UInt32(bitPattern: (value << 1) ^ (value >> 31))
+    }
+
+    /// Return a 64-bit ZigZag-encoded value.
+    ///
+    /// ZigZag encodes signed integers into values that can be efficiently encoded with varint.
+    /// (Otherwise, negative values must be sign-extended to 64 bits to be varint encoded, always
+    /// taking 10 bytes on the wire.)
+    ///
+    /// - Parameter value: A signed 64-bit integer.
+    /// - Returns: An unsigned 64-bit integer representing the ZigZag-encoded value.
+    static func encoded(_ value: Int64) -> UInt64 {
+        return UInt64(bitPattern: (value << 1) ^ (value >> 63))
+    }
+
+    /// Return a 32-bit ZigZag-decoded value.
+    ///
+    /// ZigZag enocdes signed integers into values that can be efficiently encoded with varint.
+    /// (Otherwise, negative values must be sign-extended to 64 bits to be varint encoded, always
+    /// taking 10 bytes on the wire.)
+    ///
+    /// - Parameter value: An unsigned 32-bit ZagZag-encoded integer.
+    /// - Returns: The signed 32-bit decoded value.
+    static func decoded(_ value: UInt32) -> Int32 {
+        return Int32(value >> 1) ^ -Int32(value & 1)
+    }
+
+    /// Return a 64-bit ZigZag-decoded value.
+    ///
+    /// ZigZag enocdes signed integers into values that can be efficiently encoded with varint.
+    /// (Otherwise, negative values must be sign-extended to 64 bits to be varint encoded, always
+    /// taking 10 bytes on the wire.)
+    ///
+    /// - Parameter value: An unsigned 64-bit ZigZag-encoded integer.
+    /// - Returns: The signed 64-bit decoded value.
+    static func decoded(_ value: UInt64) -> Int64 {
+        return Int64(value >> 1) ^ -Int64(value & 1)
+    }
+}

--- a/SwiftProtobufRuntime.xcodeproj/project.pbxproj
+++ b/SwiftProtobufRuntime.xcodeproj/project.pbxproj
@@ -122,6 +122,12 @@
 		9C8CDA681D7A28F600E207CA /* unittest_swift_runtime_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift */; };
 		9C8CDA691D7A28F600E207CA /* unittest_swift_startup.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift */; };
 		9C8CDA6A1D7A28F600E207CA /* unittest_well_known_types.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift */; };
+		AA28A4A61DA30E5900C866D9 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A51DA30E5900C866D9 /* ZigZag.swift */; };
+		AA28A4A71DA30E5900C866D9 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A51DA30E5900C866D9 /* ZigZag.swift */; };
+		AA28A4A91DA40B0900C866D9 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A81DA40B0900C866D9 /* Varint.swift */; };
+		AA28A4AA1DA40B0900C866D9 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A81DA40B0900C866D9 /* Varint.swift */; };
+		AA28A4AC1DA454DA00C866D9 /* ProtobufBinarySizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4AB1DA454DA00C866D9 /* ProtobufBinarySizeVisitor.swift */; };
+		AA28A4AD1DA454DA00C866D9 /* ProtobufBinarySizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4AB1DA454DA00C866D9 /* ProtobufBinarySizeVisitor.swift */; };
 		_LinkFileRef_Protobuf_via_ProtobufTestSuite /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Protobuf_macOS" /* SwiftProtobuf.framework */; };
 		__src_cc_ref_Sources/Protobuf/Google_Protobuf_Any.swift /* Google_Protobuf_Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Any.swift /* Google_Protobuf_Any.swift */; };
 		__src_cc_ref_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration_Extensions.swift */; };
@@ -256,6 +262,9 @@
 
 /* Begin PBXFileReference section */
 		9C2F23781D778003008524F2 /* descriptor.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = descriptor.pb.swift; sourceTree = "<group>"; };
+		AA28A4A51DA30E5900C866D9 /* ZigZag.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ZigZag.swift; sourceTree = "<group>"; tabWidth = 4; };
+		AA28A4A81DA40B0900C866D9 /* Varint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Varint.swift; sourceTree = "<group>"; };
+		AA28A4AB1DA454DA00C866D9 /* ProtobufBinarySizeVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ProtobufBinarySizeVisitor.swift; sourceTree = "<group>"; tabWidth = 4; };
 		__PBXFileRef_Package.swift /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		__PBXFileRef_ProtobufTestSuite_Info.plist /* ProtobufTestSuite_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = ProtobufTestSuite_Info.plist; path = SwiftProtobufRuntime.xcodeproj/ProtobufTestSuite_Info.plist; sourceTree = SOURCE_ROOT; };
 		__PBXFileRef_Protobuf_Info.plist /* Protobuf_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Protobuf_Info.plist; path = SwiftProtobufRuntime.xcodeproj/Protobuf_Info.plist; sourceTree = SOURCE_ROOT; };
@@ -266,8 +275,8 @@
 		__PBXFileRef_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp_Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Google_Protobuf_Timestamp_Extensions.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/Google_Protobuf_Wrappers.swift /* Google_Protobuf_Wrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Google_Protobuf_Wrappers.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* ProtobufBinaryDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufBinaryDecoding.swift; sourceTree = "<group>"; };
-		__PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* ProtobufBinaryEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufBinaryEncoding.swift; sourceTree = "<group>"; };
-		__PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* ProtobufBinaryTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufBinaryTypes.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* ProtobufBinaryEncoding.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ProtobufBinaryEncoding.swift; sourceTree = "<group>"; tabWidth = 4; };
+		__PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* ProtobufBinaryTypes.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ProtobufBinaryTypes.swift; sourceTree = "<group>"; tabWidth = 4; };
 		__PBXFileRef_Sources/Protobuf/ProtobufDebugDescription.swift /* ProtobufDebugDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufDebugDescription.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* ProtobufEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufEnum.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufError.swift /* ProtobufError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufError.swift; sourceTree = "<group>"; };
@@ -283,7 +292,7 @@
 		__PBXFileRef_Sources/Protobuf/ProtobufMirror.swift /* ProtobufMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufMirror.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufOneof.swift /* ProtobufOneof.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufOneof.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufRawMessage.swift /* ProtobufRawMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufRawMessage.swift; sourceTree = "<group>"; };
-		__PBXFileRef_Sources/Protobuf/ProtobufTraversal.swift /* ProtobufTraversal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufTraversal.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufTraversal.swift /* ProtobufTraversal.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ProtobufTraversal.swift; sourceTree = "<group>"; tabWidth = 4; };
 		__PBXFileRef_Sources/Protobuf/ProtobufTypes.swift /* ProtobufTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufTypes.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufUnknown.swift /* ProtobufUnknown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufUnknown.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufUtility.swift /* ProtobufUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufUtility.swift; sourceTree = "<group>"; };
@@ -295,7 +304,7 @@
 		__PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = timestamp.pb.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = type.pb.swift; sourceTree = "<group>"; };
 		__PBXFileRef_SwiftProtobufRuntime.xcodeproj/Configs/Project.xcconfig /* Project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Project.xcconfig; path = SwiftProtobufRuntime.xcodeproj/Configs/Project.xcconfig; sourceTree = "<group>"; };
-		__PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; tabWidth = 4; };
 		__PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_AllTypes.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_AllTypes_Proto3.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Any.swift; sourceTree = "<group>"; };
@@ -453,6 +462,7 @@
 				__PBXFileRef_Sources/Protobuf/Google_Protobuf_Wrappers.swift /* Google_Protobuf_Wrappers.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* ProtobufBinaryDecoding.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* ProtobufBinaryEncoding.swift */,
+				AA28A4AB1DA454DA00C866D9 /* ProtobufBinarySizeVisitor.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* ProtobufBinaryTypes.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufDebugDescription.swift /* ProtobufDebugDescription.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* ProtobufEnum.swift */,
@@ -476,6 +486,8 @@
 				__PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */,
 				__PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */,
 				__PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */,
+				AA28A4A81DA40B0900C866D9 /* Varint.swift */,
+				AA28A4A51DA30E5900C866D9 /* ZigZag.swift */,
 			);
 			name = SwiftProtobuf;
 			path = Sources/SwiftProtobuf;
@@ -778,6 +790,7 @@
 				9C2F237F1D7780D1008524F2 /* Google_Protobuf_Any.swift in Sources */,
 				9C2F23801D7780D1008524F2 /* Google_Protobuf_Duration_Extensions.swift in Sources */,
 				9C2F23811D7780D1008524F2 /* Google_Protobuf_FieldMask_Extensions.swift in Sources */,
+				AA28A4AD1DA454DA00C866D9 /* ProtobufBinarySizeVisitor.swift in Sources */,
 				9C2F23821D7780D1008524F2 /* Google_Protobuf_Struct.swift in Sources */,
 				9C2F23831D7780D1008524F2 /* Google_Protobuf_Timestamp_Extensions.swift in Sources */,
 				9C2F23841D7780D1008524F2 /* Google_Protobuf_Wrappers.swift in Sources */,
@@ -793,6 +806,7 @@
 				9C2F238E1D7780D1008524F2 /* ProtobufGroup.swift in Sources */,
 				9C2F238F1D7780D1008524F2 /* ProtobufHash.swift in Sources */,
 				9C2F23901D7780D1008524F2 /* ProtobufJSONDecoding.swift in Sources */,
+				AA28A4AA1DA40B0900C866D9 /* Varint.swift in Sources */,
 				9C2F23911D7780D1008524F2 /* ProtobufJSONEncoding.swift in Sources */,
 				9C2F23921D7780D1008524F2 /* ProtobufJSONTypes.swift in Sources */,
 				9C2F23931D7780D1008524F2 /* ProtobufMessage.swift in Sources */,
@@ -805,6 +819,7 @@
 				9C2F239A1D7780D1008524F2 /* ProtobufUtility.swift in Sources */,
 				9C2F239B1D7780D1008524F2 /* source_context.pb.swift in Sources */,
 				9C2F239C1D7780D1008524F2 /* timestamp.pb.swift in Sources */,
+				AA28A4A71DA30E5900C866D9 /* ZigZag.swift in Sources */,
 				9C2F239D1D7780D1008524F2 /* type.pb.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -820,6 +835,7 @@
 				__src_cc_ref_Sources/Protobuf/Google_Protobuf_Any.swift /* Google_Protobuf_Any.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration_Extensions.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask_Extensions.swift in Sources */,
+				AA28A4AC1DA454DA00C866D9 /* ProtobufBinarySizeVisitor.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp_Extensions.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/Google_Protobuf_Wrappers.swift /* Google_Protobuf_Wrappers.swift in Sources */,
@@ -835,6 +851,7 @@
 				__src_cc_ref_Sources/Protobuf/ProtobufGroup.swift /* ProtobufGroup.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufHash.swift /* ProtobufHash.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufJSONDecoding.swift /* ProtobufJSONDecoding.swift in Sources */,
+				AA28A4A91DA40B0900C866D9 /* Varint.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufJSONEncoding.swift /* ProtobufJSONEncoding.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufJSONTypes.swift /* ProtobufJSONTypes.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufMessage.swift /* ProtobufMessage.swift in Sources */,
@@ -847,6 +864,7 @@
 				__src_cc_ref_Sources/Protobuf/ProtobufUtility.swift /* ProtobufUtility.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift in Sources */,
+				AA28A4A61DA30E5900C866D9 /* ZigZag.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/type.pb.swift /* type.pb.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/SwiftProtobufTests/Helpers.swift
+++ b/Tests/SwiftProtobufTests/Helpers.swift
@@ -26,6 +26,10 @@ protocol PBTestHelpers {
 
 extension PBTestHelpers where MessageTestType: ProtobufMessage & Equatable {
 
+    private func string(from data: Data) -> String {
+        return "[" + data.map { String($0) }.joined(separator: ", ") + "]"
+    }
+
     func assertEncode(_ expected: [UInt8], file: XCTestFileArgType = #file, line: UInt = #line, configure: (inout MessageTestType) -> Void) {
         let empty = MessageTestType()
         var configured = empty
@@ -33,12 +37,12 @@ extension PBTestHelpers where MessageTestType: ProtobufMessage & Equatable {
         XCTAssert(configured != empty, "Object should not be equal to empty object", file: file, line: line)
         do {
             let encoded = try configured.serializeProtobuf()
-            XCTAssert(Data(bytes: expected) == encoded, "Did not encode correctly: got \(encoded)", file: file, line: line)
+            XCTAssert(Data(bytes: expected) == encoded, "Did not encode correctly: got \(string(from: encoded))", file: file, line: line)
             do {
                 let decoded = try MessageTestType(protobuf: encoded)
                 XCTAssert(decoded == configured, "Encode/decode cycle should generate equal object: \(decoded) != \(configured)", file: file, line: line)
             } catch {
-                XCTFail("Failed to decode protobuf: \(encoded)", file: file, line: line)
+                XCTFail("Failed to decode protobuf: \(string(from: encoded))", file: file, line: line)
             }
         } catch let e {
             XCTFail("Failed to encode: \(e)\n    \(configured)", file: file, line: line)


### PR DESCRIPTION
This PR contains the following changes:

* Precalculate the space required to serialize a message in a separate pass before writing it, so the entire buffer can be allocated once up front.
* Avoid very costly `[UInt8]`-to-`Data` conversions and vice versa by rewriting the encoder/decoder to manipulate underlying memory directly.
* Add helpers to concentrate zig-zag encoding and varint size calculation into one place.

In a basic test of 100 `fixed32` fields, these changes were able to speed up serialization by 3500% (!) and decoding by about 16%.