### PR TITLE
Allow iOS 9 for the iOS unittest.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,17 +271,21 @@ test-xcode-release: test-xcode-iOS-release test-xcode-macOS-release
 
 # The individual ones
 test-xcode-iOS-debug:
+    # 4s - 32bit, 6s - 64bit
 	xcodebuild -project SwiftProtobufRuntime.xcodeproj \
 	  -scheme SwiftProtobufRuntime_iOS \
 	  -configuration Debug \
 	  -destination "platform=iOS Simulator,name=iPhone 6s,OS=latest" \
+	  -destination "platform=iOS Simulator,name=iPhone 4s,OS=9.0" \
 	  test
 
 test-xcode-iOS-release:
+    # 4s - 32bit, 6s - 64bit
 	xcodebuild -project SwiftProtobufRuntime.xcodeproj \
 	  -scheme SwiftProtobufRuntime_iOS \
 	  -configuration Release \
 	  -destination "platform=iOS Simulator,name=iPhone 6s,OS=latest" \
+	  -destination "platform=iOS Simulator,name=iPhone 4s,OS=9.0" \
 	  test
 
 test-xcode-macOS-debug:

--- a/SwiftProtobufRuntime.xcodeproj/project.pbxproj
+++ b/SwiftProtobufRuntime.xcodeproj/project.pbxproj
@@ -965,7 +965,6 @@
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = SwiftProtobufRuntime.xcodeproj/ProtobufTestSuite_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.apple.protobuf.SwiftProtobufRuntimeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -979,7 +978,6 @@
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = SwiftProtobufRuntime.xcodeproj/ProtobufTestSuite_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "@loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.apple.protobuf.SwiftProtobufRuntimeTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
- Drop the project settings
- Add coverage to the makefile to get 64bit & 32bit coverage.