### PR TITLE
Fix linker errors in release builds.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Wrappers+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Wrappers+Extensions.swift
@@ -53,6 +53,12 @@ protocol ProtobufWrapper {
 }
 
 extension ProtobufWrapper {
+  // NOTE: The `init(_ value: WrappedType.BaseType)` initializer repeated below
+  // should theoretically be able to go here and be declared public, but this
+  // causes linker errors in release builds (see issue #70). If this is indeed a
+  // bug and should be allowed, we should move the initializer back into this
+  // extension once it's fixed, to reduce a small amount of code duplication/
+  // bloat.
 
   func serializeWrapperJSON() throws -> String {
     if !isZeroOrEmpty {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Wrappers+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Wrappers+Extensions.swift
@@ -54,11 +54,6 @@ protocol ProtobufWrapper {
 
 extension ProtobufWrapper {
 
-  public init(_ value: WrappedType.BaseType) {
-    self.init()
-    self.value = value
-  }
-
   func serializeWrapperJSON() throws -> String {
     if !isZeroOrEmpty {
       var encoder = ProtobufJSONEncoder()
@@ -78,6 +73,11 @@ extension Google_Protobuf_DoubleValue:
 
   var isZeroOrEmpty: Bool {
     return value == 0
+  }
+
+  public init(_ value: WrappedType.BaseType) {
+    self.init()
+    self.value = value
   }
 
   public init(floatLiteral: FloatLiteralType) {
@@ -107,6 +107,11 @@ extension Google_Protobuf_FloatValue:
     return value.isZero
   }
 
+  public init(_ value: WrappedType.BaseType) {
+    self.init()
+    self.value = value
+  }
+
   public init(floatLiteral: FloatLiteralType) {
     self.init(floatLiteral)
   }
@@ -132,6 +137,11 @@ extension Google_Protobuf_Int64Value:
 
   var isZeroOrEmpty: Bool {
     return value == 0
+  }
+
+  public init(_ value: WrappedType.BaseType) {
+    self.init()
+    self.value = value
   }
 
   public init(integerLiteral: IntegerLiteralType) {
@@ -161,6 +171,11 @@ extension Google_Protobuf_UInt64Value:
     return value == 0
   }
 
+  public init(_ value: WrappedType.BaseType) {
+    self.init()
+    self.value = value
+  }
+
   public init(integerLiteral: IntegerLiteralType) {
     self.init(integerLiteral)
   }
@@ -186,6 +201,11 @@ extension Google_Protobuf_Int32Value:
 
   var isZeroOrEmpty: Bool {
     return value == 0
+  }
+
+  public init(_ value: WrappedType.BaseType) {
+    self.init()
+    self.value = value
   }
 
   public init(integerLiteral: IntegerLiteralType) {
@@ -215,6 +235,11 @@ extension Google_Protobuf_UInt32Value:
     return value == 0
   }
 
+  public init(_ value: WrappedType.BaseType) {
+    self.init()
+    self.value = value
+  }
+
   public init(integerLiteral: IntegerLiteralType) {
     self.init(integerLiteral)
   }
@@ -240,6 +265,11 @@ extension Google_Protobuf_BoolValue:
 
   var isZeroOrEmpty: Bool {
     return !value
+  }
+
+  public init(_ value: WrappedType.BaseType) {
+    self.init()
+    self.value = value
   }
 
   public init(booleanLiteral: Bool) {
@@ -269,6 +299,11 @@ extension Google_Protobuf_StringValue:
 
   var isZeroOrEmpty: Bool {
     return value.isEmpty
+  }
+
+  public init(_ value: WrappedType.BaseType) {
+    self.init()
+    self.value = value
   }
 
   public init(stringLiteral: String) {
@@ -302,6 +337,11 @@ extension Google_Protobuf_BytesValue: ProtobufWrapper {
 
   var isZeroOrEmpty: Bool {
     return value.isEmpty
+  }
+
+  public init(_ value: WrappedType.BaseType) {
+    self.init()
+    self.value = value
   }
 
   public func serializeJSON() throws -> String {


### PR DESCRIPTION
When using the `ProtobufWrapper.init(_ value: WrappedType.BaseType`)
initializer from externally linked code, the linker dies in release
builds with errors that it cannot find the protocol witness table for
the initializers on the concrete types. This *may* be a Swift bug;
either the compiler should not allow the mismatched visibility on the
conformances, or the linker should allow the call.

For now we duplicate the implementation throughout the concrete types
instead, despite the small amount of bloat this adds.

Fixes #70.