### PR TITLE
Use the custom option for prefix until the option is adopted.

### DIFF
--- a/Protos/google/protobuf/unittest_import_proto3.proto
+++ b/Protos/google/protobuf/unittest_import_proto3.proto
@@ -48,7 +48,8 @@ option cc_enable_arenas = true;
 // Exercise the java_package option.
 option java_package = "com.google.protobuf.test";
 option csharp_namespace = "Google.Protobuf.TestProtos";
-option swift_prefix = "Proto3";
+import "swift-options.proto";
+option (apple_swift_prefix) = "Proto3";
 
 // Do not set a java_outer_classname here to verify that Proto2 works without
 // one.

--- a/Protos/google/protobuf/unittest_import_public_proto3.proto
+++ b/Protos/google/protobuf/unittest_import_public_proto3.proto
@@ -36,7 +36,8 @@ package protobuf_unittest_import;
 
 option java_package = "com.google.protobuf.test";
 option csharp_namespace = "Google.Protobuf.TestProtos";
-option swift_prefix = "Proto3";
+import "swift-options.proto";
+option (apple_swift_prefix) = "Proto3";
 
 message PublicImportMessage {
  int32 e = 1;

--- a/Protos/google/protobuf/unittest_proto3.proto
+++ b/Protos/google/protobuf/unittest_proto3.proto
@@ -59,7 +59,8 @@ option optimize_for = SPEED;
 option java_outer_classname = "UnittestProto";
 
 // Disambiguate generated code from unittest.proto
-option swift_prefix = "Proto3";
+import "swift-options.proto";
+option (apple_swift_prefix) = "Proto3";
 
 // This proto includes every type of field in both singular and repeated
 // forms.


### PR DESCRIPTION
The checked in sources were a mix of using both forms, this should standardize
things better.