### PR TITLE
Add wire format and tag helper types.

### DIFF
--- a/Sources/SwiftProtobuf/FieldTag.swift
+++ b/Sources/SwiftProtobuf/FieldTag.swift
@@ -17,6 +17,11 @@
 
 /// Encapsulates the number and wire format of a field, which together form the
 /// "tag".
+///
+/// This type also validates tags in that it will never allow a tag with an
+/// improper field number (such as zero) or wire format (such as 6 or 7) to
+/// exist. In other words, a `FieldTag`'s properties never need to be tested
+/// for validity because they are guaranteed correct at initialization time.
 internal struct FieldTag: RawRepresentable {
 
   typealias RawValue = UInt32
@@ -50,8 +55,10 @@ internal struct FieldTag: RawRepresentable {
   /// Note that if the raw value given here is not a valid tag (for example, it
   /// has an invalid wire format), this initializer will fail.
   init?(rawValue: UInt32) {
-    // Verify that the wire format is valid and fail if it is not.
-    guard let _ = WireFormat(rawValue: UInt8(rawValue % 8)) else {
+    // Verify that the field number and wire format are valid and fail if they
+    // are not.
+    guard rawValue & ~0x07 != 0,
+      let _ = WireFormat(rawValue: UInt8(rawValue % 8)) else {
       return nil
     }
     self.rawValue = rawValue

--- a/Sources/SwiftProtobuf/FieldTag.swift
+++ b/Sources/SwiftProtobuf/FieldTag.swift
@@ -1,0 +1,65 @@
+// SwiftProtobuf/Sources/SwiftProtobuf/FieldTag.swift - Describes a binary field tag
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Types related to binary encoded tags (field numbers and wire formats).
+///
+// -----------------------------------------------------------------------------
+
+
+/// Encapsulates the number and wire format of a field, which together form the
+/// "tag".
+internal struct FieldTag: RawRepresentable {
+
+  typealias RawValue = UInt32
+
+  /// The raw numeric value of the tag, which contains both the field number and
+  /// wire format.
+  let rawValue: UInt32
+
+  /// The field number component of the tag.
+  var fieldNumber: Int {
+    return Int(rawValue >> 3)
+  }
+
+  /// The wire format component of the tag.
+  var wireFormat: WireFormat {
+    // This force-unwrap is safe because there are only two initialization
+    // paths: one that takes a WireFormat directly (and is guaranteed valid at
+    // compile-time), or one that takes a raw value but which only lets valid
+    // wire formats through.
+    return WireFormat(rawValue: UInt8(rawValue & 7))!
+  }
+
+  /// A helper property that returns the number of bytes required to
+  /// varint-encode this tag.
+  var encodedSize: Int {
+    return Varint.encodedSize(of: rawValue)
+  }
+
+  /// Creates a new tag from its raw numeric representation.
+  ///
+  /// Note that if the raw value given here is not a valid tag (for example, it
+  /// has an invalid wire format), this initializer will fail.
+  init?(rawValue: UInt32) {
+    // Verify that the wire format is valid and fail if it is not.
+    guard let _ = WireFormat(rawValue: UInt8(rawValue % 8)) else {
+      return nil
+    }
+    self.rawValue = rawValue
+  }
+
+  /// Creates a new tag by composing the given field number and wire format.
+  init(fieldNumber: Int, wireFormat: WireFormat) {
+    self.rawValue = UInt32(truncatingBitPattern: fieldNumber) << 3 |
+      UInt32(wireFormat.rawValue)
+  }
+}

--- a/Sources/SwiftProtobuf/ProtobufBinaryDecoding.swift
+++ b/Sources/SwiftProtobuf/ProtobufBinaryDecoding.swift
@@ -659,7 +659,7 @@ private class ProtobufScanner {
         fieldStartP = p
         fieldStartAvailable = available
         if let t = try getRawVarint() {
-            if t > 7 && t < UInt64(UInt32.max) {
+            if t < UInt64(UInt32.max) {
                 guard let tag = FieldTag(rawValue: UInt32(truncatingBitPattern: t)) else {
                     throw ProtobufDecodingError.malformedProtobuf
                 }

--- a/Sources/SwiftProtobuf/ProtobufBinaryTypes.swift
+++ b/Sources/SwiftProtobuf/ProtobufBinaryTypes.swift
@@ -19,7 +19,7 @@ import Swift
 import Foundation
 
 public protocol ProtobufBinaryCodableType: ProtobufTypePropertiesBase {
-    static func protobufWireType() -> Int
+    static var protobufWireFormat: WireFormat { get }
     /// Write out the protobuf value only.
     static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: BaseType) throws
 
@@ -96,7 +96,7 @@ public extension ProtobufTypeProperties {
 
 public protocol ProtobufBinaryCodableMapKeyType: ProtobufTypePropertiesBase {
     /// Basic protobuf encoding hooks.
-    static func protobufWireType() -> Int
+    static var protobufWireFormat: WireFormat { get }
     /// Write out the protobuf value only.
     static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: BaseType)
     static func encodedSizeWithoutTag(of: BaseType) throws -> Int
@@ -107,7 +107,7 @@ public protocol ProtobufBinaryCodableMapKeyType: ProtobufTypePropertiesBase {
 /// Float traits
 ///
 public extension ProtobufFloat {
-    public static func protobufWireType() -> Int { return 5 }
+    public static var protobufWireFormat: WireFormat { return .fixed32 }
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Float) {
         encoder.putFloatValue(value: value)
     }
@@ -156,7 +156,7 @@ public extension ProtobufFloat {
 /// Double traits
 ///
 public extension ProtobufDouble {
-    public static func protobufWireType() -> Int { return 1 }
+    public static var protobufWireFormat: WireFormat { return .fixed64 }
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Double) {
         encoder.putDoubleValue(value: value)
     }
@@ -204,7 +204,7 @@ public extension ProtobufDouble {
 /// Int32 traits
 ///
 public extension ProtobufInt32 {
-    public static func protobufWireType() -> Int { return 0 }
+    public static var protobufWireFormat: WireFormat { return .varint }
 
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Int32) {
         encoder.putVarInt(value: Int64(value))
@@ -237,7 +237,7 @@ public extension ProtobufInt32 {
 /// Int64 traits
 ///
 public extension ProtobufInt64 {
-    public static func protobufWireType() -> Int { return 0 }
+    public static var protobufWireFormat: WireFormat { return .varint }
 
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Int64) {
         encoder.putVarInt(value: value)
@@ -270,7 +270,7 @@ public extension ProtobufInt64 {
 /// UInt32 traits
 ///
 public extension ProtobufUInt32 {
-    public static func protobufWireType() -> Int { return 0 }
+    public static var protobufWireFormat: WireFormat { return .varint }
 
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: UInt32) {
         encoder.putVarInt(value: UInt64(value))
@@ -303,7 +303,7 @@ public extension ProtobufUInt32 {
 /// UInt64 traits
 ///
 public extension ProtobufUInt64 {
-    public static func protobufWireType() -> Int { return 0 }
+    public static var protobufWireFormat: WireFormat { return .varint }
 
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: UInt64) {
         encoder.putVarInt(value: value)
@@ -336,7 +336,7 @@ public extension ProtobufUInt64 {
 /// SInt32 traits
 ///
 public extension ProtobufSInt32 {
-    public static func protobufWireType() -> Int { return 0 }
+    public static var protobufWireFormat: WireFormat { return .varint }
 
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Int32) {
         encoder.putZigZagVarInt(value: Int64(value))
@@ -371,7 +371,7 @@ public extension ProtobufSInt32 {
 /// SInt64 traits
 ///
 public extension ProtobufSInt64 {
-    public static func protobufWireType() -> Int { return 0 }
+    public static var protobufWireFormat: WireFormat { return .varint }
 
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Int64) {
         encoder.putZigZagVarInt(value: value)
@@ -404,7 +404,7 @@ public extension ProtobufSInt64 {
 /// Fixed32 traits
 ///
 public extension ProtobufFixed32 {
-    public static func protobufWireType() -> Int { return 5 }
+    public static var protobufWireFormat: WireFormat { return .fixed32 }
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: UInt32) {
         encoder.putFixedUInt32(value: value)
     }
@@ -452,7 +452,7 @@ public extension ProtobufFixed32 {
 /// Fixed64 traits
 ///
 public extension ProtobufFixed64 {
-    public static func protobufWireType() -> Int { return 1 }
+    public static var protobufWireFormat: WireFormat { return .fixed64 }
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: UInt64) {
         encoder.putFixedUInt64(value: value.littleEndian)
     }
@@ -500,7 +500,7 @@ public extension ProtobufFixed64 {
 /// SFixed32 traits
 ///
 public extension ProtobufSFixed32 {
-    public static func protobufWireType() -> Int { return 5 }
+    public static var protobufWireFormat: WireFormat { return .fixed32 }
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Int32) {
         encoder.putFixedUInt32(value: UInt32(bitPattern: value))
     }
@@ -548,7 +548,7 @@ public extension ProtobufSFixed32 {
 /// SFixed64 traits
 ///
 public extension ProtobufSFixed64 {
-    public static func protobufWireType() -> Int { return 1 }
+    public static var protobufWireFormat: WireFormat { return .fixed64 }
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Int64) {
         encoder.putFixedUInt64(value: UInt64(bitPattern: value.littleEndian))
     }
@@ -596,7 +596,7 @@ public extension ProtobufSFixed64 {
 /// Bool traits
 ///
 public extension ProtobufBool {
-    public static func protobufWireType() -> Int { return 0 }
+    public static var protobufWireFormat: WireFormat { return .varint }
 
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Bool) {
         encoder.putBoolValue(value: value)
@@ -642,7 +642,7 @@ private func bufferToString(buffer: UnsafeBufferPointer<UInt8>) -> String? {
 }
 
 public extension ProtobufString {
-    public static func protobufWireType() -> Int { return 2 }
+    public static var protobufWireFormat: WireFormat { return .lengthDelimited }
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: String) {
         encoder.putStringValue(value: value)
     }
@@ -674,7 +674,7 @@ public extension ProtobufString {
 /// Bytes traits
 ///
 public extension ProtobufBytes {
-    public static func protobufWireType() -> Int { return 2 }
+    public static var protobufWireFormat: WireFormat { return .lengthDelimited }
 
     public static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Data) {
         encoder.putBytesValue(value: [UInt8](value))
@@ -700,7 +700,7 @@ public extension ProtobufBytes {
 // Enum traits
 //
 extension ProtobufEnum where RawValue == Int {
-    public static func protobufWireType() -> Int { return 0 }
+    public static var protobufWireFormat: WireFormat { return .varint }
     public static func decodeOptionalField(decoder: inout ProtobufFieldDecoder, value: inout BaseType?) throws -> Bool {
         return try decoder.decodeOptionalField(fieldType: Self.self, value: &value)
     }
@@ -774,7 +774,7 @@ public extension ProtobufBinaryMessageBase {
         return try ProtobufBinarySizeVisitor(message: self).serializedSize
     }
 
-    static func protobufWireType() -> Int {return 2}
+    static var protobufWireFormat: WireFormat { return .lengthDelimited }
 
     static func serializeProtobufValue(encoder: inout ProtobufBinaryEncoder, value: Self) throws {
         let t = try value.serializeProtobuf()

--- a/Sources/SwiftProtobuf/WireFormat.swift
+++ b/Sources/SwiftProtobuf/WireFormat.swift
@@ -1,0 +1,31 @@
+// SwiftProtobuf/Sources/SwiftProtobuf/WireFormat.swift - Describes proto wire formats
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Types related to binary wire formats of encoded values.
+///
+// -----------------------------------------------------------------------------
+
+
+// TODO(#51): This type is currently public because there are protocols that use
+// it that cannot currently be easily made internal. Revisit the visibility of
+// this type once we've figured out if we can lock those other protocols down.
+
+/// Denotes the wire format by which a value is encoded in binary form.
+public enum WireFormat: UInt8 {
+
+  case varint = 0
+  case fixed64 = 1
+  case lengthDelimited = 2
+  case startGroup = 3
+  case endGroup = 4
+  case fixed32 = 5
+}

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -118,6 +118,14 @@
 		9C8CDA681D7A28F600E207CA /* unittest_swift_runtime_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift */; };
 		9C8CDA691D7A28F600E207CA /* unittest_swift_startup.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift */; };
 		9C8CDA6A1D7A28F600E207CA /* unittest_well_known_types.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift */; };
+		AA05BF4A1DAEB7E400619042 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF491DAEB7E400619042 /* WireFormat.swift */; };
+		AA05BF4B1DAEB7E400619042 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF491DAEB7E400619042 /* WireFormat.swift */; };
+		AA05BF4C1DAEB7E400619042 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF491DAEB7E400619042 /* WireFormat.swift */; };
+		AA05BF4D1DAEB7E400619042 /* WireFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF491DAEB7E400619042 /* WireFormat.swift */; };
+		AA05BF4F1DAEB7E800619042 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF4E1DAEB7E800619042 /* FieldTag.swift */; };
+		AA05BF501DAEB7E800619042 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF4E1DAEB7E800619042 /* FieldTag.swift */; };
+		AA05BF511DAEB7E800619042 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF4E1DAEB7E800619042 /* FieldTag.swift */; };
+		AA05BF521DAEB7E800619042 /* FieldTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA05BF4E1DAEB7E800619042 /* FieldTag.swift */; };
 		AA28A4A61DA30E5900C866D9 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A51DA30E5900C866D9 /* ZigZag.swift */; };
 		AA28A4A71DA30E5900C866D9 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A51DA30E5900C866D9 /* ZigZag.swift */; };
 		AA28A4A91DA40B0900C866D9 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A81DA40B0900C866D9 /* Varint.swift */; };
@@ -419,6 +427,8 @@
 
 /* Begin PBXFileReference section */
 		9C2F23781D778003008524F2 /* descriptor.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = descriptor.pb.swift; sourceTree = "<group>"; };
+		AA05BF491DAEB7E400619042 /* WireFormat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WireFormat.swift; sourceTree = "<group>"; };
+		AA05BF4E1DAEB7E800619042 /* FieldTag.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FieldTag.swift; sourceTree = "<group>"; };
 		AA28A4A51DA30E5900C866D9 /* ZigZag.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ZigZag.swift; sourceTree = "<group>"; tabWidth = 4; };
 		AA28A4A81DA40B0900C866D9 /* Varint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Varint.swift; sourceTree = "<group>"; };
 		AA28A4AB1DA454DA00C866D9 /* ProtobufBinarySizeVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = ProtobufBinarySizeVisitor.swift; sourceTree = "<group>"; tabWidth = 4; };
@@ -622,6 +632,7 @@
 				__PBXFileRef_Sources/Protobuf/duration.pb.swift /* duration.pb.swift */,
 				__PBXFileRef_Sources/Protobuf/empty.pb.swift /* empty.pb.swift */,
 				__PBXFileRef_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift */,
+				AA05BF4E1DAEB7E800619042 /* FieldTag.swift */,
 				__PBXFileRef_Sources/Protobuf/Google_Protobuf_Any.swift /* Google_Protobuf_Any.swift */,
 				__PBXFileRef_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration_Extensions.swift */,
 				__PBXFileRef_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask_Extensions.swift */,
@@ -652,6 +663,7 @@
 				__PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */,
 				__PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */,
 				AA28A4A81DA40B0900C866D9 /* Varint.swift */,
+				AA05BF491DAEB7E400619042 /* WireFormat.swift */,
 				AAEA52731DA80DEA003F318F /* wrappers.pb.swift */,
 				AA28A4A51DA30E5900C866D9 /* ZigZag.swift */,
 			);
@@ -1034,6 +1046,7 @@
 				9C2F238D1D7780D1008524F2 /* ProtobufFieldDecoder.swift in Sources */,
 				9C2F238F1D7780D1008524F2 /* ProtobufHash.swift in Sources */,
 				9C2F23901D7780D1008524F2 /* ProtobufJSONDecoding.swift in Sources */,
+				AA05BF501DAEB7E800619042 /* FieldTag.swift in Sources */,
 				AA28A4AA1DA40B0900C866D9 /* Varint.swift in Sources */,
 				9C2F23911D7780D1008524F2 /* ProtobufJSONEncoding.swift in Sources */,
 				9C2F23921D7780D1008524F2 /* ProtobufJSONTypes.swift in Sources */,
@@ -1048,6 +1061,7 @@
 				9C2F239C1D7780D1008524F2 /* timestamp.pb.swift in Sources */,
 				AA28A4A71DA30E5900C866D9 /* ZigZag.swift in Sources */,
 				9C2F239D1D7780D1008524F2 /* type.pb.swift in Sources */,
+				AA05BF4B1DAEB7E400619042 /* WireFormat.swift in Sources */,
 				F44F93691DAD7FA500BC5B85 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1077,6 +1091,7 @@
 				__src_cc_ref_Sources/Protobuf/ProtobufExtensions.swift /* ProtobufExtensions.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufFieldDecoder.swift /* ProtobufFieldDecoder.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufHash.swift /* ProtobufHash.swift in Sources */,
+				AA05BF4F1DAEB7E800619042 /* FieldTag.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufJSONDecoding.swift /* ProtobufJSONDecoding.swift in Sources */,
 				AAEA52721DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
 				AA28A4A91DA40B0900C866D9 /* Varint.swift in Sources */,
@@ -1091,6 +1106,7 @@
 				__src_cc_ref_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift in Sources */,
 				AA28A4A61DA30E5900C866D9 /* ZigZag.swift in Sources */,
+				AA05BF4A1DAEB7E400619042 /* WireFormat.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/type.pb.swift /* type.pb.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1206,6 +1222,7 @@
 				F44F937E1DAEA76700BC5B85 /* Google_Protobuf_Struct.swift in Sources */,
 				F44F93941DAEA76700BC5B85 /* ProtobufUnknown.swift in Sources */,
 				F44F93781DAEA76700BC5B85 /* duration.pb.swift in Sources */,
+				AA05BF511DAEB7E800619042 /* FieldTag.swift in Sources */,
 				F44F937A1DAEA76700BC5B85 /* field_mask.pb.swift in Sources */,
 				F44F93831DAEA76700BC5B85 /* ProtobufBinarySizeVisitor.swift in Sources */,
 				F44F93841DAEA76700BC5B85 /* ProtobufBinaryTypes.swift in Sources */,
@@ -1220,6 +1237,7 @@
 				F44F93771DAEA76700BC5B85 /* api.pb.swift in Sources */,
 				F44F93791DAEA76700BC5B85 /* empty.pb.swift in Sources */,
 				F44F93891DAEA76700BC5B85 /* ProtobufExtensions.swift in Sources */,
+				AA05BF4C1DAEB7E400619042 /* WireFormat.swift in Sources */,
 				F44F93881DAEA76700BC5B85 /* ProtobufExtensionFields.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1335,6 +1353,7 @@
 				F44F940D1DAEB23500BC5B85 /* Google_Protobuf_Struct.swift in Sources */,
 				F44F94231DAEB23500BC5B85 /* ProtobufUnknown.swift in Sources */,
 				F44F94071DAEB23500BC5B85 /* duration.pb.swift in Sources */,
+				AA05BF521DAEB7E800619042 /* FieldTag.swift in Sources */,
 				F44F94091DAEB23500BC5B85 /* field_mask.pb.swift in Sources */,
 				F44F94121DAEB23500BC5B85 /* ProtobufBinarySizeVisitor.swift in Sources */,
 				F44F94131DAEB23500BC5B85 /* ProtobufBinaryTypes.swift in Sources */,
@@ -1349,6 +1368,7 @@
 				F44F94061DAEB23500BC5B85 /* api.pb.swift in Sources */,
 				F44F94081DAEB23500BC5B85 /* empty.pb.swift in Sources */,
 				F44F94181DAEB23500BC5B85 /* ProtobufExtensions.swift in Sources */,
+				AA05BF4D1DAEB7E400619042 /* WireFormat.swift in Sources */,
 				F44F94171DAEB23500BC5B85 /* ProtobufExtensionFields.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1708,6 +1728,7 @@
 				F44F94041DAEB13F00BC5B85 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
 		};
 		"___RootConfs_" /* Build configuration list for PBXProject "SwiftProtobuf" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
The `WireFormat` and `FieldTag` types encapsulate behaviors around those protobuf concepts, to un-scatter all the bit-twiddling currently in the code.
