### PR TITLE
Tweaks the plugin about the WKTs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -277,7 +277,6 @@ regenerate: regenerate-library-protos regenerate-plugin-protos regenerate-test-p
 regenerate-library-protos: ${PROTOC_GEN_SWIFTX}
 	for t in ${LIBRARY_PROTOS}; do \
 		${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=Sources/SwiftProtobuf -I Protos Protos/google/protobuf/$$t.proto; \
-		sed -i~ -e 's/^import SwiftProtobuf$$//' Sources/SwiftProtobuf/$$t.pb.swift; \
 	done
 
 # Rebuild just the protos used by the plugin

--- a/Reference/google/protobuf/any.pb.swift
+++ b/Reference/google/protobuf/any.pb.swift
@@ -37,7 +37,6 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-import SwiftProtobuf
 
 
 ///   `Any` contains an arbitrary serialized protocol buffer message along with a

--- a/Reference/google/protobuf/api.pb.swift
+++ b/Reference/google/protobuf/api.pb.swift
@@ -37,7 +37,6 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-import SwiftProtobuf
 
 
 ///   Api is a light-weight descriptor for a protocol buffer service.

--- a/Reference/google/protobuf/duration.pb.swift
+++ b/Reference/google/protobuf/duration.pb.swift
@@ -37,7 +37,6 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-import SwiftProtobuf
 
 
 ///   A Duration represents a signed, fixed-length span of time represented

--- a/Reference/google/protobuf/empty.pb.swift
+++ b/Reference/google/protobuf/empty.pb.swift
@@ -37,7 +37,6 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-import SwiftProtobuf
 
 
 ///   A generic empty message that you can re-use to avoid defining duplicated

--- a/Reference/google/protobuf/field_mask.pb.swift
+++ b/Reference/google/protobuf/field_mask.pb.swift
@@ -37,7 +37,6 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-import SwiftProtobuf
 
 
 ///   `FieldMask` represents a set of symbolic field paths, for example:

--- a/Reference/google/protobuf/source_context.pb.swift
+++ b/Reference/google/protobuf/source_context.pb.swift
@@ -37,7 +37,6 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-import SwiftProtobuf
 
 
 ///   `SourceContext` represents information about the source of a

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -37,7 +37,6 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-import SwiftProtobuf
 
 
 ///   `NullValue` is a singleton enumeration to represent the null value for the

--- a/Reference/google/protobuf/timestamp.pb.swift
+++ b/Reference/google/protobuf/timestamp.pb.swift
@@ -37,7 +37,6 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-import SwiftProtobuf
 
 
 ///   A Timestamp represents a point in time independent of any time zone

--- a/Reference/google/protobuf/type.pb.swift
+++ b/Reference/google/protobuf/type.pb.swift
@@ -37,7 +37,6 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-import SwiftProtobuf
 
 
 ///   The syntax in which a protocol buffer element is defined.

--- a/Reference/google/protobuf/unittest_enormous_descriptor.pb.swift
+++ b/Reference/google/protobuf/unittest_enormous_descriptor.pb.swift
@@ -44,7 +44,6 @@
 //  such as the string literal length limit in Java.
 
 import Foundation
-import SwiftProtobuf
 
 
 public struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage {

--- a/Reference/google/protobuf/wrappers.pb.swift
+++ b/Reference/google/protobuf/wrappers.pb.swift
@@ -41,7 +41,6 @@
 //  typed field and its default value.
 
 import Foundation
-import SwiftProtobuf
 
 
 ///   Wrapper message for `double`.

--- a/Sources/SwiftProtobuf/api.pb.swift
+++ b/Sources/SwiftProtobuf/api.pb.swift
@@ -39,7 +39,6 @@
 import Foundation
 
 
-
 ///   Api is a light-weight descriptor for a protocol buffer service.
 public struct Google_Protobuf_Api: ProtobufGeneratedMessage {
   public var swiftClassName: String {return "Google_Protobuf_Api"}

--- a/Sources/SwiftProtobuf/duration.pb.swift
+++ b/Sources/SwiftProtobuf/duration.pb.swift
@@ -39,7 +39,6 @@
 import Foundation
 
 
-
 ///   A Duration represents a signed, fixed-length span of time represented
 ///   as a count of seconds and fractions of seconds at nanosecond
 ///   resolution. It is independent of any calendar and concepts like "day"

--- a/Sources/SwiftProtobuf/empty.pb.swift
+++ b/Sources/SwiftProtobuf/empty.pb.swift
@@ -39,7 +39,6 @@
 import Foundation
 
 
-
 ///   A generic empty message that you can re-use to avoid defining duplicated
 ///   empty messages in your APIs. A typical example is to use it as the request
 ///   or the response type of an API method. For instance:

--- a/Sources/SwiftProtobuf/field_mask.pb.swift
+++ b/Sources/SwiftProtobuf/field_mask.pb.swift
@@ -39,7 +39,6 @@
 import Foundation
 
 
-
 ///   `FieldMask` represents a set of symbolic field paths, for example:
 ///  
 ///       paths: "f.a"

--- a/Sources/SwiftProtobuf/source_context.pb.swift
+++ b/Sources/SwiftProtobuf/source_context.pb.swift
@@ -39,7 +39,6 @@
 import Foundation
 
 
-
 ///   `SourceContext` represents information about the source of a
 ///   protobuf element, like the file in which it is defined.
 public struct Google_Protobuf_SourceContext: ProtobufGeneratedMessage {

--- a/Sources/SwiftProtobuf/timestamp.pb.swift
+++ b/Sources/SwiftProtobuf/timestamp.pb.swift
@@ -39,7 +39,6 @@
 import Foundation
 
 
-
 ///   A Timestamp represents a point in time independent of any time zone
 ///   or calendar, represented as seconds and fractions of seconds at
 ///   nanosecond resolution in UTC Epoch time. It is encoded using the

--- a/Sources/SwiftProtobuf/type.pb.swift
+++ b/Sources/SwiftProtobuf/type.pb.swift
@@ -39,7 +39,6 @@
 import Foundation
 
 
-
 ///   The syntax in which a protocol buffer element is defined.
 public enum Google_Protobuf_Syntax: ProtobufEnum {
   public typealias RawValue = Int

--- a/Sources/SwiftProtobuf/wrappers.pb.swift
+++ b/Sources/SwiftProtobuf/wrappers.pb.swift
@@ -43,7 +43,6 @@
 import Foundation
 
 
-
 ///   Wrapper message for `double`.
 ///  
 ///   The JSON representation for `DoubleValue` is JSON number.

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -267,19 +267,13 @@ class FileGenerator {
             p.print("\n")
         }
 
-        // The well known types don't need to import SwiftProtobuf, so catch
-        // them via their package (just make sure it isn't descriptor since that
-        // isn't needed/shipped, it would be outside the library.
-        if isWellKnownType {
-          p.print(
-              "import Foundation\n",
-              "\n")
-        } else {
-          p.print(
-              "import Foundation\n",
-              "import SwiftProtobuf\n",
-              "\n")
+        p.print("import Foundation\n")
+        if !isWellKnownType {
+          // The well known types ship with the runtime, everything else needs
+          // to import the runtime.
+          p.print("import SwiftProtobuf\n")
         }
+        p.print("\n")
 
         var enums = [EnumGenerator]()
         let path = [Int32]()


### PR DESCRIPTION
The WKTs can be picked off by their proto package. So use this (like the other
language generators do) to pick them off and remove the SwiftProtobuf import as
they WKTs will be bundled with the runtime.