### PR TITLE
Support an generator parameter for output FileNaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,52 +48,52 @@ PROTOC_GEN_SWIFTX=.build/debug/protoc-gen-swiftX
 
 # Protos used for the unit and functional tests
 TEST_PROTOS= \
-	conformance/conformance.proto \
-	google/protobuf/any_test.proto \
-	google/protobuf/descriptor.proto \
-	google/protobuf/map_unittest.proto \
-	google/protobuf/map_unittest_proto3.proto \
-	google/protobuf/unittest.proto \
-	google/protobuf/unittest_arena.proto \
-	google/protobuf/unittest_custom_options.proto \
-	google/protobuf/unittest_drop_unknown_fields.proto \
-	google/protobuf/unittest_embed_optimize_for.proto \
-	google/protobuf/unittest_empty.proto \
-	google/protobuf/unittest_import.proto \
-	google/protobuf/unittest_import_lite.proto \
-	google/protobuf/unittest_import_proto3.proto \
-	google/protobuf/unittest_import_public.proto \
-	google/protobuf/unittest_import_public_lite.proto \
-	google/protobuf/unittest_import_public_proto3.proto \
-	google/protobuf/unittest_lite.proto \
-	google/protobuf/unittest_lite_imports_nonlite.proto \
-	google/protobuf/unittest_mset.proto \
-	google/protobuf/unittest_mset_wire_format.proto \
-	google/protobuf/unittest_no_arena.proto \
-	google/protobuf/unittest_no_arena_import.proto \
-	google/protobuf/unittest_no_arena_lite.proto \
-	google/protobuf/unittest_no_field_presence.proto \
-	google/protobuf/unittest_no_generic_services.proto \
-	google/protobuf/unittest_optimize_for.proto \
-	google/protobuf/unittest_preserve_unknown_enum.proto \
-	google/protobuf/unittest_preserve_unknown_enum2.proto \
-	google/protobuf/unittest_proto3.proto \
-	google/protobuf/unittest_proto3_arena.proto \
-	google/protobuf/unittest_well_known_types.proto \
-	swift-options.proto \
-	unittest_swift_all_required_types.proto \
-	unittest_swift_cycle.proto \
-	unittest_swift_enum.proto \
-	unittest_swift_enum_optional_default.proto \
-	unittest_swift_extension.proto \
-	unittest_swift_fieldorder.proto \
-	unittest_swift_groups.proto \
-	unittest_swift_naming.proto \
-	unittest_swift_performance.proto \
-	unittest_swift_reserved.proto \
-	unittest_swift_runtime_proto2.proto \
-	unittest_swift_runtime_proto3.proto \
-	unittest_swift_startup.proto
+	Protos/conformance/conformance.proto \
+	Protos/google/protobuf/any_test.proto \
+	Protos/google/protobuf/descriptor.proto \
+	Protos/google/protobuf/map_unittest.proto \
+	Protos/google/protobuf/map_unittest_proto3.proto \
+	Protos/google/protobuf/unittest.proto \
+	Protos/google/protobuf/unittest_arena.proto \
+	Protos/google/protobuf/unittest_custom_options.proto \
+	Protos/google/protobuf/unittest_drop_unknown_fields.proto \
+	Protos/google/protobuf/unittest_embed_optimize_for.proto \
+	Protos/google/protobuf/unittest_empty.proto \
+	Protos/google/protobuf/unittest_import.proto \
+	Protos/google/protobuf/unittest_import_lite.proto \
+	Protos/google/protobuf/unittest_import_proto3.proto \
+	Protos/google/protobuf/unittest_import_public.proto \
+	Protos/google/protobuf/unittest_import_public_lite.proto \
+	Protos/google/protobuf/unittest_import_public_proto3.proto \
+	Protos/google/protobuf/unittest_lite.proto \
+	Protos/google/protobuf/unittest_lite_imports_nonlite.proto \
+	Protos/google/protobuf/unittest_mset.proto \
+	Protos/google/protobuf/unittest_mset_wire_format.proto \
+	Protos/google/protobuf/unittest_no_arena.proto \
+	Protos/google/protobuf/unittest_no_arena_import.proto \
+	Protos/google/protobuf/unittest_no_arena_lite.proto \
+	Protos/google/protobuf/unittest_no_field_presence.proto \
+	Protos/google/protobuf/unittest_no_generic_services.proto \
+	Protos/google/protobuf/unittest_optimize_for.proto \
+	Protos/google/protobuf/unittest_preserve_unknown_enum.proto \
+	Protos/google/protobuf/unittest_preserve_unknown_enum2.proto \
+	Protos/google/protobuf/unittest_proto3.proto \
+	Protos/google/protobuf/unittest_proto3_arena.proto \
+	Protos/google/protobuf/unittest_well_known_types.proto \
+	Protos/swift-options.proto \
+	Protos/unittest_swift_all_required_types.proto \
+	Protos/unittest_swift_cycle.proto \
+	Protos/unittest_swift_enum.proto \
+	Protos/unittest_swift_enum_optional_default.proto \
+	Protos/unittest_swift_extension.proto \
+	Protos/unittest_swift_fieldorder.proto \
+	Protos/unittest_swift_groups.proto \
+	Protos/unittest_swift_naming.proto \
+	Protos/unittest_swift_performance.proto \
+	Protos/unittest_swift_reserved.proto \
+	Protos/unittest_swift_runtime_proto2.proto \
+	Protos/unittest_swift_runtime_proto3.proto \
+	Protos/unittest_swift_startup.proto
 
 # TODO: The library and plugin Protos come directly from google sources.
 # There should be an easy way to copy the Google versions from a protobuf
@@ -101,20 +101,20 @@ TEST_PROTOS= \
 
 # Protos that are embedded into the SwiftProtobuf runtime library module
 LIBRARY_PROTOS= \
-    api \
-    duration \
-    empty \
-    field_mask \
-    source_context \
-    timestamp \
-    type \
-    wrappers
+    Protos/google/protobuf/api.proto \
+    Protos/google/protobuf/duration.proto \
+    Protos/google/protobuf/empty.proto \
+    Protos/google/protobuf/field_mask.proto \
+    Protos/google/protobuf/source_context.proto \
+    Protos/google/protobuf/timestamp.proto \
+    Protos/google/protobuf/type.proto \
+    Protos/google/protobuf/wrappers.proto
 
 # Protos that are used internally by the plugin
 PLUGIN_PROTOS= \
-	google/protobuf/compiler/plugin.proto \
-	google/protobuf/descriptor.proto \
-	swift-options.proto
+	Protos/google/protobuf/compiler/plugin.proto \
+	Protos/google/protobuf/descriptor.proto \
+	Protos/swift-options.proto
 
 XCODEBUILD_EXTRAS =
 # Invoke make with XCODE_SKIP_OPTIMIZER=1 to suppress the optimizer when
@@ -235,31 +235,30 @@ ${PROTOC_GEN_SWIFTX}: ${PROTOC_GEN_SWIFT}
 #   * MANUALLY go through `git diff Reference` to verify that the generated Swift changed in the way you expect
 #   * `make clean build test` to do a final check
 #
+# Note: Some of these protos define the same package.(message|enum)s, so they
+# can't be done in a single protoc/proto-gen-swift invoke and have to be done
+# one at a time instead.
 test-plugin: ${PROTOC_GEN_SWIFTX}
-	rm -rf _test
-	for p in `cd Protos; find . -type f -name '*.proto'`; do \
-		echo "==> Testing plugin for $$p"; \
-		d=`dirname $$p`; b=`basename $$p .proto`; \
-		mkdir -p _test/$$d; \
-		${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=_test/$$d -I Protos Protos/$$p || exit 1; \
-		diff -u _test/$$d/$$b.pb.swift Reference/$$d/$$b.pb.swift || exit 1; \
+	rm -rf _test && mkdir _test
+	for p in `find Protos -type f -name '*.proto'`; do \
+		${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=_test -I Protos $$p; \
 	done
+	diff -ru _test Reference
 
 #
-# Rebuild the reference files by running the local
-# version of protoc-gen-swift against our menagerie
-# of sample protos.
+# Rebuild the reference files by running the local version of protoc-gen-swift
+# against our menagerie of sample protos.
 #
-# If you do this, you MUST MANUALLY verify these files
-# before checking them in, since the new checkin will
-# become the new master reference.
+# If you do this, you MUST MANUALLY verify these files before checking them in,
+# since the new checkin will become the new master reference.
 #
+# Note: Some of these protos define the same package.(message|enum)s, so they
+# can't be done in a single protoc/proto-gen-swift invoke and have to be done
+# one at a time instead.
 reference: ${PROTOC_GEN_SWIFTX}
-	rm -rf Reference; \
-	for p in `cd Protos; find . -type f -name '*.proto'`; do \
-		d=`dirname $$p`; \
-		mkdir -p Reference/$$d; \
-		${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=Reference/$$d -I Protos Protos/$$p; \
+	rm -rf Reference && mkdir Reference
+	for p in `find Protos -type f -name '*.proto'`; do \
+		${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=Reference -I Protos $$p; \
 	done
 
 #
@@ -275,20 +274,19 @@ regenerate: regenerate-library-protos regenerate-plugin-protos regenerate-test-p
 
 # Rebuild just the protos included in the runtime library
 regenerate-library-protos: ${PROTOC_GEN_SWIFTX}
-	for t in ${LIBRARY_PROTOS}; do \
-		${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=Sources/SwiftProtobuf -I Protos Protos/google/protobuf/$$t.proto; \
-	done
+	${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=FileNaming=DropPath:Sources/SwiftProtobuf -I Protos ${LIBRARY_PROTOS}
 
 # Rebuild just the protos used by the plugin
 regenerate-plugin-protos: ${PROTOC_GEN_SWIFTX}
-	for t in ${PLUGIN_PROTOS}; do \
-		${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=Sources/PluginLibrary -I Protos Protos/$$t; \
-	done
+	${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=FileNaming=DropPath:Sources/PluginLibrary -I Protos ${PLUGIN_PROTOS}
 
 # Rebuild just the protos used by the runtime test suite
+# Note: Some of these protos define the same package.(message|enum)s, so they
+# can't be done in a single protoc/proto-gen-swift invoke and have to be done
+# one at a time instead.
 regenerate-test-protos: ${PROTOC_GEN_SWIFTX}
 	for t in ${TEST_PROTOS}; do \
-		${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=Tests/SwiftProtobufTests -I Protos Protos/$$t; \
+		${PROTOC} --plugin=${PROTOC_GEN_SWIFTX} --swiftX_out=FileNaming=DropPath:Tests/SwiftProtobufTests -I Protos $$t; \
 	done;
 
 

--- a/Sources/protoc-gen-swift/Context.swift
+++ b/Sources/protoc-gen-swift/Context.swift
@@ -88,11 +88,24 @@ extension CodeGeneratorResponse.File {
 }
 
 class GeneratorOptions {
+  enum OutputNaming : String {
+    case FullPath
+    case PathToUnderscores
+    case DropPath
+  }
+
+  private(set) var outputNaming: OutputNaming = .FullPath
 
   init(parameter: String?) throws {
     for pair in parseParameter(string:parameter) {
       switch pair.key {
-      // TODO: Add cases for things really supported
+      case "FileNaming":
+        if let naming = OutputNaming(rawValue: pair.value) {
+          outputNaming = naming
+        } else {
+          throw GenerationError.invalidParameterValue(name: pair.key,
+                                                      value: pair.value)
+        }
       default:
         throw GenerationError.unknownParameter(name: pair.key)
       }
@@ -216,7 +229,7 @@ class Context {
 
     for fileProto in request.protoFile where explicit.contains(fileProto.name!) {
       var printer = CodePrinter()
-      let file = FileGenerator(descriptor: fileProto)
+      let file = FileGenerator(descriptor: fileProto, generatorOptions: options)
       file.generateOutputFile(printer: &printer, context: self)
       let fileResponse = CodeGeneratorResponse.File(name: file.outputFilename, content: printer.content)
       response.file.append(fileResponse)

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -173,9 +173,12 @@ extension Google_Protobuf_FileDescriptorProto {
 
 class FileGenerator {
     let descriptor: Google_Protobuf_FileDescriptorProto
+    let generatorOptions: GeneratorOptions
 
-    init(descriptor: Google_Protobuf_FileDescriptorProto) {
+    init(descriptor: Google_Protobuf_FileDescriptorProto,
+         generatorOptions: GeneratorOptions) {
         self.descriptor = descriptor
+        self.generatorOptions = generatorOptions
     }
 
     func messageNameForPath(path: String) -> String? {
@@ -204,7 +207,18 @@ class FileGenerator {
     var baseFilename: String {return descriptor.baseFilename}
 
     var outputFilename: String {
-        return baseFilename + ".pb.swift"
+        let ext = ".pb.swift"
+        let pathParts = splitPath(pathname: descriptor.name ?? "")
+        switch generatorOptions.outputNaming {
+        case .FullPath:
+            return pathParts.dir + pathParts.base + ext
+        case .PathToUnderscores:
+            let dirWithUnderscores =
+                pathParts.dir.replacingOccurrences(of: "/", with: "_")
+            return dirWithUnderscores + pathParts.base + ext
+        case .DropPath:
+            return pathParts.base + ext
+        }
     }
 
     func commentsFor(path: [Int32]) -> String {

--- a/Sources/protoc-gen-swift/main.swift
+++ b/Sources/protoc-gen-swift/main.swift
@@ -27,8 +27,10 @@ import PluginLibrary
 enum GenerationError: Error {
   /// Raised for any errors reading the input
   case readFailure
-  /// Raise when parsing the parameter string and found an unknown key
+  /// Raised when parsing the parameter string and found an unknown key
   case unknownParameter(name: String)
+  /// Raised when a parameter was giving an invalid value
+  case invalidParameterValue(name: String, value: String)
 }
 
 func help(progname: String) {
@@ -91,6 +93,9 @@ if justVersion {
     response = CodeGeneratorResponse(error: "Failed to read the input")
   } catch GenerationError.unknownParameter(let name) {
     response = CodeGeneratorResponse(error: "Unknown generation parameter '\(name)'")
+  } catch GenerationError.invalidParameterValue(let name, let value) {
+    response = CodeGeneratorResponse(
+      error: "Unknown value for generation parameter '\(name)': '\(value)'")
   } catch let e {
     response = CodeGeneratorResponse(error: "Internal Error: \(e)")
   }


### PR DESCRIPTION
The available values for "FileNaming" are:

* "FullPath" - (default) - Like all other language, "foo/bar/baz.proto" makes
  "foo/bar/baz.pb.swift.
* "PathToUnderscores" - To help with things like the Swift package manager where
  someone might want all the files in one directory; "foo/bar/baz.proto" makes
  "foo_bar_baz.pb.swift".
* "DropPath" - Drop the path from the input and just write all files into the
  output directory; "foo/bar/baz.proto" makes "baz.pb.swift".

Fixes https://github.com/apple/swift-protobuf/issues/83