### PR TITLE
Issue #82: Use protoc-provided name for JSON fields

### DIFF
--- a/Protos/unittest_swift_naming.proto
+++ b/Protos/unittest_swift_naming.proto
@@ -228,6 +228,7 @@ message FieldNames {
     int32 TimeScale = 241;
     int32 TimeBase = 242;
     int32 TimeRecord = 243;
+    int32 json_should_be_overriden = 244 [json_name = "json_was_overridden"];
 }
 
 message MessageNames {

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -1972,6 +1972,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
     "timeScale": 241,
     "timeBase": 242,
     "timeRecord": 243,
+    "json_was_overridden": 244,
   ]}
   public var protoFieldNames: [String: Int] {return [
     "String": 1,
@@ -2181,6 +2182,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
     "TimeScale": 241,
     "TimeBase": 242,
     "TimeRecord": 243,
+    "json_should_be_overriden": 244,
   ]}
 
   private class _StorageClass {
@@ -2392,6 +2394,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
     var _timeScale: Int32 = 0
     var _timeBase: Int32 = 0
     var _timeRecord: Int32 = 0
+    var _jsonShouldBeOverriden: Int32 = 0
 
     init() {}
 
@@ -2605,6 +2608,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
       case 241: handled = try setter.decodeSingularField(fieldType: ProtobufInt32.self, value: &_timeScale)
       case 242: handled = try setter.decodeSingularField(fieldType: ProtobufInt32.self, value: &_timeBase)
       case 243: handled = try setter.decodeSingularField(fieldType: ProtobufInt32.self, value: &_timeRecord)
+      case 244: handled = try setter.decodeSingularField(fieldType: ProtobufInt32.self, value: &_jsonShouldBeOverriden)
       default:
         handled = false
       }
@@ -3233,6 +3237,9 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
       if _timeRecord != 0 {
         try visitor.visitSingularField(fieldType: ProtobufInt32.self, value: _timeRecord, protoFieldNumber: 243, protoFieldName: "TimeRecord", jsonFieldName: "timeRecord", swiftFieldName: "timeRecord")
       }
+      if _jsonShouldBeOverriden != 0 {
+        try visitor.visitSingularField(fieldType: ProtobufInt32.self, value: _jsonShouldBeOverriden, protoFieldNumber: 244, protoFieldName: "json_should_be_overriden", jsonFieldName: "json_was_overridden", swiftFieldName: "jsonShouldBeOverriden")
+      }
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -3443,6 +3450,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
       if _timeScale != other._timeScale {return false}
       if _timeBase != other._timeBase {return false}
       if _timeRecord != other._timeRecord {return false}
+      if _jsonShouldBeOverriden != other._jsonShouldBeOverriden {return false}
       return true
     }
 
@@ -3655,6 +3663,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
       clone._timeScale = _timeScale
       clone._timeBase = _timeBase
       clone._timeRecord = _timeRecord
+      clone._jsonShouldBeOverriden = _jsonShouldBeOverriden
       return clone
     }
   }
@@ -4694,6 +4703,11 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
   public var timeRecord: Int32 {
     get {return _storage._timeRecord}
     set {_uniqueStorage()._timeRecord = newValue}
+  }
+
+  public var jsonShouldBeOverriden: Int32 {
+    get {return _storage._jsonShouldBeOverriden}
+    set {_uniqueStorage()._jsonShouldBeOverriden = newValue}
   }
 
   public init() {}

--- a/Sources/protoc-gen-swift/ExtensionGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionGenerator.swift
@@ -105,7 +105,8 @@ struct ExtensionGenerator {
         }
         let scope = declaringMessageName == nil ? "" : "static "
         let traitsType = descriptor.getTraitsType(context: context)
-        p.print("\(scope)let \(swiftRelativeExtensionName) = ProtobufGenericMessageExtension<\(extensionFieldType)<\(traitsType)>, \(swiftExtendedMessageName)>(protoFieldNumber: \(descriptor.number!), protoFieldName: \"\(descriptor.name!)\", jsonFieldName: \"\(descriptor.jsonName!)\", swiftFieldName: \"\(swiftFieldName)\", defaultValue: \(defaultValue))\n")
+        let jsonName = descriptor.jsonName ?? ""
+        p.print("\(scope)let \(swiftRelativeExtensionName) = ProtobufGenericMessageExtension<\(extensionFieldType)<\(traitsType)>, \(swiftExtendedMessageName)>(protoFieldNumber: \(descriptor.number!), protoFieldName: \"\(descriptor.name!)\", jsonFieldName: \"\(jsonName)\", swiftFieldName: \"\(swiftFieldName)\", defaultValue: \(defaultValue))\n")
     }
 
     func generateTopLevel(printer p: inout CodePrinter) {

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -210,7 +210,7 @@ struct MessageFieldGenerator {
     let descriptor: Google_Protobuf_FieldDescriptorProto
     let oneof: Google_Protobuf_OneofDescriptorProto?
     let messageDescriptor: Google_Protobuf_DescriptorProto
-    let jsonName: String
+    let jsonName: String?
     let swiftName: String
     let swiftStorageName: String
     var protoName: String {return descriptor.name!}
@@ -227,12 +227,7 @@ struct MessageFieldGenerator {
         context: Context)
     {
         self.descriptor = descriptor
-        // Note: We would just use descriptor.jsonName provided by protoc, but:
-        // 1. That only exists with protoc 3.0 and later
-        // 2. It's broken in 3.0 beta 3
-        // So we calculate the jsonName ourselves instead.
-        // (Which sucks for conformance.)
-        self.jsonName = toJsonFieldName(descriptor.name!)
+        self.jsonName = descriptor.jsonName
         if descriptor.type! == .group {
             let g = context.getMessageForPath(path: descriptor.typeName!)!
             self.swiftName = sanitizeFieldName(toLowerCamelCase(g.name!))
@@ -484,7 +479,8 @@ struct MessageFieldGenerator {
         if conditional {
             p.indent()
         }
-        p.print("try visitor.\(visitMethod)(\(fieldTypeArg)value: \(varName), protoFieldNumber: \(number), protoFieldName: \"\(protoName)\", jsonFieldName: \"\(jsonName)\", swiftFieldName: \"\(swiftName)\")\n")
+        let json = jsonName ?? ""
+        p.print("try visitor.\(visitMethod)(\(fieldTypeArg)value: \(varName), protoFieldNumber: \(number), protoFieldName: \"\(protoName)\", jsonFieldName: \"\(json)\", swiftFieldName: \"\(swiftName)\")\n")
         if conditional {
             p.outdent()
             p.print("}\n")

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -426,7 +426,9 @@ class MessageGenerator {
             p.print("public var jsonFieldNames: [String: Int] {return [\n")
             p.indent()
             for f in fields {
-                p.print("\"\(f.jsonName)\": \(f.number),\n")
+                if let jsonName = f.jsonName {
+                    p.print("\"\(jsonName)\": \(f.number),\n")
+                }
             }
             p.outdent()
             p.print("]}\n")

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -120,7 +120,8 @@ class OneofGenerator {
             let special = f.isGroup ? "Group" : f.isMessage ? "Message" : "";
             let visitorMethod = "visitSingular\(special)Field"
             let fieldClause = (f.isGroup || f.isMessage) ? "" : "fieldType: \(f.traitsType).self, "
-            p.print("try visitor.\(visitorMethod)(\(fieldClause)value: v, protoFieldNumber: \(f.number), protoFieldName: \"\(f.name)\", jsonFieldName: \"\(f.jsonName)\", swiftFieldName: \"\(f.swiftName)\")\n")
+            let jsonName = f.jsonName ?? ""
+            p.print("try visitor.\(visitorMethod)(\(fieldClause)value: v, protoFieldNumber: \(f.number), protoFieldName: \"\(f.name)\", jsonFieldName: \"\(jsonName)\", swiftFieldName: \"\(f.swiftName)\")\n")
             p.outdent()
             p.print("}\n")
             p.outdent()

--- a/Sources/protoc-gen-swift/StringUtils.swift
+++ b/Sources/protoc-gen-swift/StringUtils.swift
@@ -188,40 +188,6 @@ func toLowerCamelCase(_ s: String) -> String {
   return out
 }
 
-///
-/// This attempts to implement Google's (undocumented) translation
-/// algorithm for converting proto field names to JSON field names:
-///
-/// 1. Drop all underscores
-/// 2. Character preceded by underscore is uppercased
-/// 3. First character is lowercased (unless preceded by underscore)
-///
-/// The rules above were derived by inspecting Google's conformance
-/// test suite as of July 2016.  The C++ unit tests actually
-/// contradict this, and some later conformance test additions
-/// also contradict this.  (See github.com/google/protobuf PR #1963)
-///
-func toJsonFieldName(_ s: String) -> String {
-  var result = ""
-  var capitalizeNext = false
-  var lowercaseNext = true
-
-  for c in s.characters {
-    if c == "_" {
-      capitalizeNext = true
-    } else if capitalizeNext {
-      result.append(String(c).uppercased())
-      capitalizeNext = false
-    } else if lowercaseNext {
-      result.append(String(c).lowercased())
-    } else {
-      result.append(String(c))
-    }
-    lowercaseNext = false
-  }
-  return result;
-}
-
 private let whitespace: Set<Character> = [" ", "\t", "\n"]
 
 func trimWhitespace(_ s: String) -> String {

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -1972,6 +1972,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
     "timeScale": 241,
     "timeBase": 242,
     "timeRecord": 243,
+    "json_was_overridden": 244,
   ]}
   public var protoFieldNames: [String: Int] {return [
     "String": 1,
@@ -2181,6 +2182,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
     "TimeScale": 241,
     "TimeBase": 242,
     "TimeRecord": 243,
+    "json_should_be_overriden": 244,
   ]}
 
   private class _StorageClass {
@@ -2392,6 +2394,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
     var _timeScale: Int32 = 0
     var _timeBase: Int32 = 0
     var _timeRecord: Int32 = 0
+    var _jsonShouldBeOverriden: Int32 = 0
 
     init() {}
 
@@ -2605,6 +2608,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
       case 241: handled = try setter.decodeSingularField(fieldType: ProtobufInt32.self, value: &_timeScale)
       case 242: handled = try setter.decodeSingularField(fieldType: ProtobufInt32.self, value: &_timeBase)
       case 243: handled = try setter.decodeSingularField(fieldType: ProtobufInt32.self, value: &_timeRecord)
+      case 244: handled = try setter.decodeSingularField(fieldType: ProtobufInt32.self, value: &_jsonShouldBeOverriden)
       default:
         handled = false
       }
@@ -3233,6 +3237,9 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
       if _timeRecord != 0 {
         try visitor.visitSingularField(fieldType: ProtobufInt32.self, value: _timeRecord, protoFieldNumber: 243, protoFieldName: "TimeRecord", jsonFieldName: "timeRecord", swiftFieldName: "timeRecord")
       }
+      if _jsonShouldBeOverriden != 0 {
+        try visitor.visitSingularField(fieldType: ProtobufInt32.self, value: _jsonShouldBeOverriden, protoFieldNumber: 244, protoFieldName: "json_should_be_overriden", jsonFieldName: "json_was_overridden", swiftFieldName: "jsonShouldBeOverriden")
+      }
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -3443,6 +3450,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
       if _timeScale != other._timeScale {return false}
       if _timeBase != other._timeBase {return false}
       if _timeRecord != other._timeRecord {return false}
+      if _jsonShouldBeOverriden != other._jsonShouldBeOverriden {return false}
       return true
     }
 
@@ -3655,6 +3663,7 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
       clone._timeScale = _timeScale
       clone._timeBase = _timeBase
       clone._timeRecord = _timeRecord
+      clone._jsonShouldBeOverriden = _jsonShouldBeOverriden
       return clone
     }
   }
@@ -4694,6 +4703,11 @@ public struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage {
   public var timeRecord: Int32 {
     get {return _storage._timeRecord}
     set {_uniqueStorage()._timeRecord = newValue}
+  }
+
+  public var jsonShouldBeOverriden: Int32 {
+    get {return _storage._jsonShouldBeOverriden}
+    set {_uniqueStorage()._jsonShouldBeOverriden = newValue}
   }
 
   public init() {}


### PR DESCRIPTION
In particular, this ensures that the json_name option in the
proto file actually works.