### PR TITLE
Building out unittesting

### DIFF
--- a/Protos/unittest_swift_runtime_proto2.proto
+++ b/Protos/unittest_swift_runtime_proto2.proto
@@ -98,7 +98,7 @@ message Message2 {
       string oneof_string   = 64 [default = "string"];
        bytes oneof_bytes    = 65 [default = "data"];
        group OneofGroup     = 66 {
-         optional int32 a = 67;
+         optional int32 a = 67 [default = 116];
          optional int32 b = 167;
        }
      Message2 oneof_message = 68;

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -1067,7 +1067,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
 
     private var _a: Int32? = nil
     public var a: Int32 {
-      get {return _a ?? 0}
+      get {return _a ?? 116}
       set {_a = newValue}
     }
     public var hasA: Bool {
@@ -1117,7 +1117,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
     }
 
     public func _protoc_generated_isEqualTo(other: ProtobufUnittest_Message2.OneofGroup) -> Bool {
-      if (a != other.a) {return false}
+      if (((_a != nil && _a! != 116) || (other._a != nil && other._a! != 116)) && (_a == nil || other._a == nil || _a! != other._a!)) {return false}
       if (b != other.b) {return false}
       if unknown != other.unknown {return false}
       return true

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -403,7 +403,11 @@ class MessageGenerator {
         self.path = path
         self.comments = file.commentsFor(path: path)
 
-        let useHeapStorage = hasMessageField(descriptor: descriptor, context: context) || fields.count > 16
+        // NOTE: This check for fields.count likely isn't completely correct
+        // when the message has one or more oneof{}s. As that will efficively
+        // reduce the real number of fields and the message might not need heap
+        // storage yet.
+        let useHeapStorage = fields.count > 16 || hasMessageField(descriptor: descriptor, context: context)
         if useHeapStorage {
             self.storage = StorageClassGenerator(descriptor: descriptor, fields: fields, file: file, messageSwiftName: self.swiftFullName, isExtensible: isExtensible)
         } else {

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 		9C8CDA1D1D7A28F600E207CA /* any_test.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */; };
 		9C8CDA1E1D7A28F600E207CA /* conformance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */; };
 		9C8CDA1F1D7A28F600E207CA /* descriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C2F23781D778003008524F2 /* descriptor.pb.swift */; };
-		9C8CDA201D7A28F600E207CA /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */; };
+		9C8CDA201D7A28F600E207CA /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */; };
 		9C8CDA211D7A28F600E207CA /* map_unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */; };
 		9C8CDA221D7A28F600E207CA /* map_unittest_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest_proto3.pb.swift /* map_unittest_proto3.pb.swift */; };
 		9C8CDA231D7A28F600E207CA /* Test_AllTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */; };
@@ -181,7 +181,7 @@
 		F44F93AA1DAEA8C900BC5B85 /* any_test.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */; };
 		F44F93AB1DAEA8C900BC5B85 /* conformance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */; };
 		F44F93AC1DAEA8C900BC5B85 /* descriptor.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C2F23781D778003008524F2 /* descriptor.pb.swift */; };
-		F44F93AD1DAEA8C900BC5B85 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */; };
+		F44F93AD1DAEA8C900BC5B85 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */; };
 		F44F93AE1DAEA8C900BC5B85 /* map_unittest_proto3.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest_proto3.pb.swift /* map_unittest_proto3.pb.swift */; };
 		F44F93AF1DAEA8C900BC5B85 /* map_unittest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */; };
 		F44F93B01DAEA8C900BC5B85 /* ProtobufBinaryMessageBase+UInt8ArrayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA521F1DA5BB81003F318F /* ProtobufBinaryMessageBase+UInt8ArrayHelpers.swift */; };
@@ -325,7 +325,7 @@
 		__src_cc_ref_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */; };
 		__src_cc_ref_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */; };
 		__src_cc_ref_Sources/Protobuf/type.pb.swift /* type.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */; };
-		__src_cc_ref_Tests/ProtobufTests/Helpers.swift /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */; };
+		__src_cc_ref_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */; };
 		__src_cc_ref_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */; };
 		__src_cc_ref_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */; };
 		__src_cc_ref_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */; };
@@ -476,7 +476,7 @@
 		__PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = source_context.pb.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = timestamp.pb.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = type.pb.swift; sourceTree = "<group>"; };
-		__PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; tabWidth = 4; };
+		__PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; tabWidth = 4; };
 		__PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_AllTypes.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_AllTypes_Proto3.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test_Any.swift; sourceTree = "<group>"; };
@@ -681,10 +681,10 @@
 				__PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */,
 				9C2F23781D778003008524F2 /* descriptor.pb.swift */,
-				__PBXFileRef_Tests/ProtobufTests/Helpers.swift /* Helpers.swift */,
 				__PBXFileRef_Tests/ProtobufTests/map_unittest_proto3.pb.swift /* map_unittest_proto3.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */,
 				AAEA521F1DA5BB81003F318F /* ProtobufBinaryMessageBase+UInt8ArrayHelpers.swift */,
+				__PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */,
@@ -948,7 +948,7 @@
 				9C8CDA1D1D7A28F600E207CA /* any_test.pb.swift in Sources */,
 				9C8CDA1E1D7A28F600E207CA /* conformance.pb.swift in Sources */,
 				9C8CDA1F1D7A28F600E207CA /* descriptor.pb.swift in Sources */,
-				9C8CDA201D7A28F600E207CA /* Helpers.swift in Sources */,
+				9C8CDA201D7A28F600E207CA /* TestHelpers.swift in Sources */,
 				9C8CDA211D7A28F600E207CA /* map_unittest.pb.swift in Sources */,
 				9C8CDA221D7A28F600E207CA /* map_unittest_proto3.pb.swift in Sources */,
 				9C8CDA231D7A28F600E207CA /* Test_AllTypes.swift in Sources */,
@@ -1125,7 +1125,7 @@
 				__src_cc_ref_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift in Sources */,
 				9C2F237A1D77807E008524F2 /* descriptor.pb.swift in Sources */,
-				__src_cc_ref_Tests/ProtobufTests/Helpers.swift /* Helpers.swift in Sources */,
+				__src_cc_ref_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/map_unittest_proto3.pb.swift /* map_unittest_proto3.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift in Sources */,
@@ -1319,7 +1319,7 @@
 				F44F93B01DAEA8C900BC5B85 /* ProtobufBinaryMessageBase+UInt8ArrayHelpers.swift in Sources */,
 				F44F93F41DAEA8C900BC5B85 /* unittest_swift_runtime_proto2.pb.swift in Sources */,
 				F44F93CE1DAEA8C900BC5B85 /* Test_Unknown_proto2.swift in Sources */,
-				F44F93AD1DAEA8C900BC5B85 /* Helpers.swift in Sources */,
+				F44F93AD1DAEA8C900BC5B85 /* TestHelpers.swift in Sources */,
 				F44F93F61DAEA8C900BC5B85 /* unittest_swift_startup.pb.swift in Sources */,
 				F44F93C51DAEA8C900BC5B85 /* Test_ParsingMerge.swift in Sources */,
 				F44F93E91DAEA8C900BC5B85 /* unittest_proto3.pb.swift in Sources */,

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -293,6 +293,24 @@
 		F44F94271DAEB23500BC5B85 /* Varint.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A81DA40B0900C866D9 /* Varint.swift */; };
 		F44F94281DAEB23500BC5B85 /* wrappers.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52731DA80DEA003F318F /* wrappers.pb.swift */; };
 		F44F94291DAEB23500BC5B85 /* ZigZag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4A51DA30E5900C866D9 /* ZigZag.swift */; };
+		F44F94351DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */; };
+		F44F94361DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */; };
+		F44F94371DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */; };
+		F44F943A1DBFBB7400BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */; };
+		F44F943B1DBFBB7500BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */; };
+		F44F943C1DBFBB7700BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */; };
+		F44F943E1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */; };
+		F44F943F1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */; };
+		F44F94401DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */; };
+		F44F94431DBFE0BE00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */; };
+		F44F94441DBFE0BF00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */; };
+		F44F94451DBFE0C000BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */; };
+		F44F94481DBFF17F00BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */; };
+		F44F94491DBFF18000BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */; };
+		F44F944A1DBFF18100BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */; };
+		F44F944D1DBFF8DB00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */; };
+		F44F944E1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */; };
+		F44F944F1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */; };
 		_LinkFileRef_Protobuf_via_ProtobufTestSuite /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Protobuf_macOS" /* SwiftProtobuf.framework */; };
 		__src_cc_ref_Sources/Protobuf/Google_Protobuf_Any.swift /* Google_Protobuf_Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Any.swift /* Google_Protobuf_Any.swift */; };
 		__src_cc_ref_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Duration_Extensions.swift /* Google_Protobuf_Duration_Extensions.swift */; };
@@ -442,6 +460,12 @@
 		F44F936F1DAEA53900BC5B85 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F44F939F1DAEA7C500BC5B85 /* SwiftProtobufTestSuite_tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftProtobufTestSuite_tvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F44F93FE1DAEB13F00BC5B85 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftProtobuf.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_BasicFields_Access_Proto2.swift; sourceTree = "<group>"; };
+		F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_BasicFields_Access_Proto3.swift; sourceTree = "<group>"; };
+		F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_OneofFields_Access_Proto2.swift; sourceTree = "<group>"; };
+		F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_OneofFields_Access_Proto3.swift; sourceTree = "<group>"; };
+		F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_MapFields_Access_Proto2.swift; sourceTree = "<group>"; };
+		F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_MapFields_Access_Proto3.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Package.swift /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		__PBXFileRef_ProtobufTestSuite_Info.plist /* ProtobufTestSuite_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = ProtobufTestSuite_Info.plist; path = SwiftProtobuf.xcodeproj/ProtobufTestSuite_Info.plist; sourceTree = SOURCE_ROOT; };
 		__PBXFileRef_Protobuf_Info.plist /* Protobuf_Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Protobuf_Info.plist; path = SwiftProtobuf.xcodeproj/Protobuf_Info.plist; sourceTree = SOURCE_ROOT; };
@@ -684,11 +708,12 @@
 				__PBXFileRef_Tests/ProtobufTests/map_unittest_proto3.pb.swift /* map_unittest_proto3.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift */,
 				AAEA521F1DA5BB81003F318F /* ProtobufBinaryMessageBase+UInt8ArrayHelpers.swift */,
-				__PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Any.swift /* Test_Any.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Api.swift /* Test_Api.swift */,
+				F44F94341DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift */,
+				F44F94381DBFBB6800BC5B85 /* Test_BasicFields_Access_Proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Conformance.swift /* Test_Conformance.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Descriptor.swift /* Test_Descriptor.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift */,
@@ -705,6 +730,10 @@
 				__PBXFileRef_Tests/ProtobufTests/Test_JSON.swift /* Test_JSON.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Map_JSON.swift /* Test_Map_JSON.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Map.swift /* Test_Map.swift */,
+				F44F94461DBFF17B00BC5B85 /* Test_MapFields_Access_Proto2.swift */,
+				F44F944B1DBFF8D000BC5B85 /* Test_MapFields_Access_Proto3.swift */,
+				F44F943D1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift */,
+				F44F94411DBFE0BA00BC5B85 /* Test_OneofFields_Access_Proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Packed.swift /* Test_Packed.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_ParsingMerge.swift /* Test_ParsingMerge.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Performance.swift /* Test_Performance.swift */,
@@ -718,6 +747,7 @@
 				__PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift */,
+				__PBXFileRef_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift */,
 				__PBXFileRef_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift */,
 				__PBXFileRef_Tests/ProtobufTests/unittest_drop_unknown_fields.pb.swift /* unittest_drop_unknown_fields.pb.swift */,
@@ -959,6 +989,7 @@
 				9C8CDA281D7A28F600E207CA /* Test_Descriptor.swift in Sources */,
 				9C8CDA291D7A28F600E207CA /* Test_Duration.swift in Sources */,
 				9C8CDA2A1D7A28F600E207CA /* Test_Empty.swift in Sources */,
+				F44F94441DBFE0BF00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */,
 				9C8CDA2B1D7A28F600E207CA /* Test_Enum.swift in Sources */,
 				9C8CDA2C1D7A28F600E207CA /* Test_Extensions.swift in Sources */,
 				9C8CDA2D1D7A28F600E207CA /* Test_ExtremeDefaultValues.swift in Sources */,
@@ -984,6 +1015,7 @@
 				9C8CDA401D7A28F600E207CA /* Test_Unknown_proto2.swift in Sources */,
 				9C8CDA411D7A28F600E207CA /* Test_Unknown_proto3.swift in Sources */,
 				9C8CDA421D7A28F600E207CA /* Test_Wrappers.swift in Sources */,
+				F44F94491DBFF18000BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */,
 				9C8CDA431D7A28F600E207CA /* unittest.pb.swift in Sources */,
 				9C8CDA441D7A28F600E207CA /* unittest_arena.pb.swift in Sources */,
 				9C8CDA451D7A28F600E207CA /* unittest_custom_options.pb.swift in Sources */,
@@ -994,6 +1026,7 @@
 				9C8CDA4A1D7A28F600E207CA /* unittest_import_lite.pb.swift in Sources */,
 				9C8CDA4B1D7A28F600E207CA /* unittest_import_proto3.pb.swift in Sources */,
 				9C8CDA4C1D7A28F600E207CA /* unittest_import_public.pb.swift in Sources */,
+				F44F943B1DBFBB7500BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */,
 				9C8CDA4D1D7A28F600E207CA /* unittest_import_public_lite.pb.swift in Sources */,
 				9C8CDA4E1D7A28F600E207CA /* unittest_import_public_proto3.pb.swift in Sources */,
 				9C8CDA4F1D7A28F600E207CA /* unittest_lite.pb.swift in Sources */,
@@ -1003,6 +1036,7 @@
 				9C8CDA531D7A28F600E207CA /* unittest_no_arena.pb.swift in Sources */,
 				9C8CDA541D7A28F600E207CA /* unittest_no_arena_import.pb.swift in Sources */,
 				AA6CF6F61DB6D228007DF26B /* Test_Enum_Proto2.swift in Sources */,
+				F44F94361DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */,
 				9C8CDA551D7A28F600E207CA /* unittest_no_arena_lite.pb.swift in Sources */,
 				9C8CDA561D7A28F600E207CA /* unittest_no_field_presence.pb.swift in Sources */,
 				9C8CDA571D7A28F600E207CA /* unittest_no_generic_services.pb.swift in Sources */,
@@ -1018,9 +1052,11 @@
 				9C8CDA611D7A28F600E207CA /* unittest_swift_extension.pb.swift in Sources */,
 				9C8CDA621D7A28F600E207CA /* unittest_swift_fieldorder.pb.swift in Sources */,
 				9C8CDA631D7A28F600E207CA /* unittest_swift_groups.pb.swift in Sources */,
+				F44F944E1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */,
 				9C8CDA651D7A28F600E207CA /* unittest_swift_performance.pb.swift in Sources */,
 				9C8CDA661D7A28F600E207CA /* unittest_swift_reserved.pb.swift in Sources */,
 				9C8CDA671D7A28F600E207CA /* unittest_swift_runtime_proto2.pb.swift in Sources */,
+				F44F943F1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */,
 				9C8CDA681D7A28F600E207CA /* unittest_swift_runtime_proto3.pb.swift in Sources */,
 				9C8CDA691D7A28F600E207CA /* unittest_swift_startup.pb.swift in Sources */,
 				9C8CDA6A1D7A28F600E207CA /* unittest_well_known_types.pb.swift in Sources */,
@@ -1136,6 +1172,7 @@
 				__src_cc_ref_Tests/ProtobufTests/Test_Descriptor.swift /* Test_Descriptor.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Duration.swift /* Test_Duration.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Empty.swift /* Test_Empty.swift in Sources */,
+				F44F94431DBFE0BE00BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Enum.swift /* Test_Enum.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Extensions.swift /* Test_Extensions.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_ExtremeDefaultValues.swift /* Test_ExtremeDefaultValues.swift in Sources */,
@@ -1161,6 +1198,7 @@
 				__src_cc_ref_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Wrappers.swift /* Test_Wrappers.swift in Sources */,
+				F44F94481DBFF17F00BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest.pb.swift /* unittest.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_arena.pb.swift /* unittest_arena.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_custom_options.pb.swift /* unittest_custom_options.pb.swift in Sources */,
@@ -1171,6 +1209,7 @@
 				__src_cc_ref_Tests/ProtobufTests/unittest_import_lite.pb.swift /* unittest_import_lite.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_import_proto3.pb.swift /* unittest_import_proto3.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_import_public.pb.swift /* unittest_import_public.pb.swift in Sources */,
+				F44F943A1DBFBB7400BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_import_public_lite.pb.swift /* unittest_import_public_lite.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_import_public_proto3.pb.swift /* unittest_import_public_proto3.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_lite.pb.swift /* unittest_lite.pb.swift in Sources */,
@@ -1180,6 +1219,7 @@
 				__src_cc_ref_Tests/ProtobufTests/unittest_no_arena.pb.swift /* unittest_no_arena.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_no_arena_import.pb.swift /* unittest_no_arena_import.pb.swift in Sources */,
 				AA6CF6F51DB6D227007DF26B /* Test_Enum_Proto2.swift in Sources */,
+				F44F94351DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_no_arena_lite.pb.swift /* unittest_no_arena_lite.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_no_field_presence.pb.swift /* unittest_no_field_presence.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_no_generic_services.pb.swift /* unittest_no_generic_services.pb.swift in Sources */,
@@ -1195,9 +1235,11 @@
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_extension.pb.swift /* unittest_swift_extension.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_fieldorder.pb.swift /* unittest_swift_fieldorder.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_groups.pb.swift /* unittest_swift_groups.pb.swift in Sources */,
+				F44F944D1DBFF8DB00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_performance.pb.swift /* unittest_swift_performance.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_reserved.pb.swift /* unittest_swift_reserved.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_runtime_proto2.pb.swift /* unittest_swift_runtime_proto2.pb.swift in Sources */,
+				F44F943E1DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_runtime_proto3.pb.swift /* unittest_swift_runtime_proto3.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_startup.pb.swift /* unittest_swift_startup.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_well_known_types.pb.swift /* unittest_well_known_types.pb.swift in Sources */,
@@ -1268,6 +1310,7 @@
 				F44F93E01DAEA8C900BC5B85 /* unittest_no_arena_import.pb.swift in Sources */,
 				F44F93B81DAEA8C900BC5B85 /* Test_Empty.swift in Sources */,
 				F44F93B11DAEA8C900BC5B85 /* Test_AllTypes_Proto3.swift in Sources */,
+				F44F94451DBFE0C000BC5B85 /* Test_OneofFields_Access_Proto3.swift in Sources */,
 				F44F93DC1DAEA8C900BC5B85 /* unittest_lite_imports_nonlite.pb.swift in Sources */,
 				F44F93F01DAEA8C900BC5B85 /* unittest_swift_groups.pb.swift in Sources */,
 				F44F93AE1DAEA8C900BC5B85 /* map_unittest_proto3.pb.swift in Sources */,
@@ -1293,6 +1336,7 @@
 				F44F93F21DAEA8C900BC5B85 /* unittest_swift_performance.pb.swift in Sources */,
 				F44F93B41DAEA8C900BC5B85 /* Test_Api.swift in Sources */,
 				F44F93E41DAEA8C900BC5B85 /* unittest_no_generic_services.pb.swift in Sources */,
+				F44F944A1DBFF18100BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */,
 				F44F93CF1DAEA8C900BC5B85 /* Test_Unknown_proto3.swift in Sources */,
 				F44F93AC1DAEA8C900BC5B85 /* descriptor.pb.swift in Sources */,
 				F44F93C61DAEA8C900BC5B85 /* Test_Performance.swift in Sources */,
@@ -1303,6 +1347,7 @@
 				F44F93BF1DAEA8C900BC5B85 /* Test_JSON_Group.swift in Sources */,
 				F44F93E61DAEA8C900BC5B85 /* unittest_preserve_unknown_enum.pb.swift in Sources */,
 				F44F93E51DAEA8C900BC5B85 /* unittest_optimize_for.pb.swift in Sources */,
+				F44F943C1DBFBB7700BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */,
 				F44F93DB1DAEA8C900BC5B85 /* unittest_import.pb.swift in Sources */,
 				F44F93D91DAEA8C900BC5B85 /* unittest_import_public_proto3.pb.swift in Sources */,
 				F44F93BC1DAEA8C900BC5B85 /* Test_FieldMask.swift in Sources */,
@@ -1312,6 +1357,7 @@
 				F44F93D01DAEA8C900BC5B85 /* Test_Wrappers.swift in Sources */,
 				F44F93DA1DAEA8C900BC5B85 /* unittest_import_public.pb.swift in Sources */,
 				AA6CF6F71DB6D229007DF26B /* Test_Enum_Proto2.swift in Sources */,
+				F44F94371DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */,
 				F44F93C71DAEA8C900BC5B85 /* Test_ReallyLargeTagNumber.swift in Sources */,
 				F44F93C41DAEA8C900BC5B85 /* Test_Packed.swift in Sources */,
 				F44F93B21DAEA8C900BC5B85 /* Test_AllTypes.swift in Sources */,
@@ -1327,9 +1373,11 @@
 				F44F93B91DAEA8C900BC5B85 /* Test_Enum.swift in Sources */,
 				F44F93DE1DAEA8C900BC5B85 /* unittest_mset_wire_format.pb.swift in Sources */,
 				F44F93CB1DAEA8C900BC5B85 /* Test_Struct.swift in Sources */,
+				F44F944F1DBFF8DC00BC5B85 /* Test_MapFields_Access_Proto3.swift in Sources */,
 				F44F93CC1DAEA8C900BC5B85 /* Test_Timestamp.swift in Sources */,
 				F44F93F31DAEA8C900BC5B85 /* unittest_swift_reserved.pb.swift in Sources */,
 				F44F93B61DAEA8C900BC5B85 /* Test_Descriptor.swift in Sources */,
+				F44F94401DBFC2CF00BC5B85 /* Test_OneofFields_Access_Proto2.swift in Sources */,
 				F44F93F11DAEA8C900BC5B85 /* unittest_swift_naming.pb.swift in Sources */,
 				F44F93F51DAEA8C900BC5B85 /* unittest_swift_runtime_proto3.pb.swift in Sources */,
 				F44F93ED1DAEA8C900BC5B85 /* unittest_swift_enum.pb.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -203,6 +203,132 @@ extension Test_Api {
     }
 }
 
+extension Test_BasicFields_Access_Proto2 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testOptionalInt32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalInt32)}),
+            ("testOptionalInt64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalInt64)}),
+            ("testOptionalUint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalUint32)}),
+            ("testOptionalUint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalUint64)}),
+            ("testOptionalSint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalSint32)}),
+            ("testOptionalSint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalSint64)}),
+            ("testOptionalFixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalFixed32)}),
+            ("testOptionalFixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalFixed64)}),
+            ("testOptionalSfixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalSfixed32)}),
+            ("testOptionalSfixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalSfixed64)}),
+            ("testOptionalFloat", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalFloat)}),
+            ("testOptionalDouble", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalDouble)}),
+            ("testOptionalBool", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalBool)}),
+            ("testOptionalString", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalString)}),
+            ("testOptionalBytes", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalBytes)}),
+            ("testOptionalGroup", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalGroup)}),
+            ("testOptionalNestedMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalNestedMessage)}),
+            ("testOptionalForeignMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalForeignMessage)}),
+            ("testOptionalImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalImportMessage)}),
+            ("testOptionalNestedEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalNestedEnum)}),
+            ("testOptionalForeignEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalForeignEnum)}),
+            ("testOptionalImportEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalImportEnum)}),
+            ("testOptionalStringPiece", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalStringPiece)}),
+            ("testOptionalCord", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalCord)}),
+            ("testOptionalPublicImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalPublicImportMessage)}),
+            ("testOptionalLazyMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testOptionalLazyMessage)}),
+            ("testDefaultInt32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultInt32)}),
+            ("testDefaultInt64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultInt64)}),
+            ("testDefaultUint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultUint32)}),
+            ("testDefaultUint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultUint64)}),
+            ("testDefaultSint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultSint32)}),
+            ("testDefaultSint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultSint64)}),
+            ("testDefaultFixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultFixed32)}),
+            ("testDefaultFixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultFixed64)}),
+            ("testDefaultSfixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultSfixed32)}),
+            ("testDefaultSfixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultSfixed64)}),
+            ("testDefaultFloat", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultFloat)}),
+            ("testDefaultDouble", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultDouble)}),
+            ("testDefaultBool", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultBool)}),
+            ("testDefaultString", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultString)}),
+            ("testDefaultBytes", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultBytes)}),
+            ("testDefaultNestedEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultNestedEnum)}),
+            ("testDefaultForeignEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultForeignEnum)}),
+            ("testDefaultImportEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultImportEnum)}),
+            ("testDefaultStringPiece", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultStringPiece)}),
+            ("testDefaultCord", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testDefaultCord)}),
+            ("testRepeatedInt32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedInt32)}),
+            ("testRepeatedInt64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedInt64)}),
+            ("testRepeatedUint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedUint32)}),
+            ("testRepeatedUint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedUint64)}),
+            ("testRepeatedSint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedSint32)}),
+            ("testRepeatedSint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedSint64)}),
+            ("testRepeatedFixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedFixed32)}),
+            ("testRepeatedFixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedFixed64)}),
+            ("testRepeatedSfixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedSfixed32)}),
+            ("testRepeatedSfixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedSfixed64)}),
+            ("testRepeatedFloat", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedFloat)}),
+            ("testRepeatedDouble", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedDouble)}),
+            ("testRepeatedBool", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedBool)}),
+            ("testRepeatedString", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedString)}),
+            ("testRepeatedBytes", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedBytes)}),
+            ("testRepeatedGroup", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedGroup)}),
+            ("testRepeatedNestedMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedNestedMessage)}),
+            ("testRepeatedForeignMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedForeignMessage)}),
+            ("testRepeatedImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedImportMessage)}),
+            ("testRepeatedNestedEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedNestedEnum)}),
+            ("testRepeatedForeignEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedForeignEnum)}),
+            ("testRepeatedImportEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedImportEnum)}),
+            ("testRepeatedStringPiece", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedStringPiece)}),
+            ("testRepeatedCord", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedCord)}),
+            ("testRepeatedLazyMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto2).testRepeatedLazyMessage)})        ]
+    }
+}
+
+extension Test_BasicFields_Access_Proto3 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testOptionalInt32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalInt32)}),
+            ("testOptionalInt64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalInt64)}),
+            ("testOptionalUint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalUint32)}),
+            ("testOptionalUint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalUint64)}),
+            ("testOptionalSint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalSint32)}),
+            ("testOptionalSint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalSint64)}),
+            ("testOptionalFixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalFixed32)}),
+            ("testOptionalFixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalFixed64)}),
+            ("testOptionalSfixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalSfixed32)}),
+            ("testOptionalSfixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalSfixed64)}),
+            ("testOptionalFloat", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalFloat)}),
+            ("testOptionalDouble", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalDouble)}),
+            ("testOptionalBool", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalBool)}),
+            ("testOptionalString", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalString)}),
+            ("testOptionalBytes", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalBytes)}),
+            ("testOptionalNestedMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalNestedMessage)}),
+            ("testOptionalForeignMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalForeignMessage)}),
+            ("testOptionalImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalImportMessage)}),
+            ("testOptionalNestedEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalNestedEnum)}),
+            ("testOptionalForeignEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalForeignEnum)}),
+            ("testOptionalImportEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalImportEnum)}),
+            ("testOptionalPublicImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testOptionalPublicImportMessage)}),
+            ("testRepeatedInt32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedInt32)}),
+            ("testRepeatedInt64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedInt64)}),
+            ("testRepeatedUint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedUint32)}),
+            ("testRepeatedUint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedUint64)}),
+            ("testRepeatedSint32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedSint32)}),
+            ("testRepeatedSint64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedSint64)}),
+            ("testRepeatedFixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedFixed32)}),
+            ("testRepeatedFixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedFixed64)}),
+            ("testRepeatedSfixed32", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedSfixed32)}),
+            ("testRepeatedSfixed64", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedSfixed64)}),
+            ("testRepeatedFloat", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedFloat)}),
+            ("testRepeatedDouble", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedDouble)}),
+            ("testRepeatedBool", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedBool)}),
+            ("testRepeatedString", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedString)}),
+            ("testRepeatedBytes", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedBytes)}),
+            ("testRepeatedNestedMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedNestedMessage)}),
+            ("testRepeatedForeignMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedForeignMessage)}),
+            ("testRepeatedImportMessage", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedImportMessage)}),
+            ("testRepeatedNestedEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedNestedEnum)}),
+            ("testRepeatedForeignEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedForeignEnum)}),
+            ("testRepeatedImportEnum", {try run_test(test:($0 as! Test_BasicFields_Access_Proto3).testRepeatedImportEnum)})        ]
+    }
+}
+
 extension Test_Conformance {
     static var allTests: [(String, (XCTestCase) throws -> ())] {
         return [
@@ -428,6 +554,56 @@ extension Test_Map {
     }
 }
 
+extension Test_MapFields_Access_Proto2 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testMapInt32Int32", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Int32)}),
+            ("testMapInt64Int64", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt64Int64)}),
+            ("testMapUint32Uint32", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapUint32Uint32)}),
+            ("testMapUint64Uint64", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapUint64Uint64)}),
+            ("testMapSint32Sint32", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapSint32Sint32)}),
+            ("testMapSint64Sint64", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapSint64Sint64)}),
+            ("testMapFixed32Fixed32", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapFixed32Fixed32)}),
+            ("testMapFixed64Fixed64", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapFixed64Fixed64)}),
+            ("testMapSfixed32Sfixed32", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapSfixed32Sfixed32)}),
+            ("testMapSfixed64Sfixed64", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapSfixed64Sfixed64)}),
+            ("testMapInt32Float", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Float)}),
+            ("testMapInt32Double", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Double)}),
+            ("testMapBoolBool", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapBoolBool)}),
+            ("testMapStringString", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapStringString)}),
+            ("testMapStringBytes", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapStringBytes)}),
+            ("testMapStringMessage", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapStringMessage)}),
+            ("testMapInt32Bytes", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Bytes)}),
+            ("testMapInt32Enum", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Enum)}),
+            ("testMapInt32Message", {try run_test(test:($0 as! Test_MapFields_Access_Proto2).testMapInt32Message)})        ]
+    }
+}
+
+extension Test_MapFields_Access_Proto3 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testMapInt32Int32", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Int32)}),
+            ("testMapInt64Int64", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt64Int64)}),
+            ("testMapUint32Uint32", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapUint32Uint32)}),
+            ("testMapUint64Uint64", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapUint64Uint64)}),
+            ("testMapSint32Sint32", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapSint32Sint32)}),
+            ("testMapSint64Sint64", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapSint64Sint64)}),
+            ("testMapFixed32Fixed32", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapFixed32Fixed32)}),
+            ("testMapFixed64Fixed64", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapFixed64Fixed64)}),
+            ("testMapSfixed32Sfixed32", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapSfixed32Sfixed32)}),
+            ("testMapSfixed64Sfixed64", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapSfixed64Sfixed64)}),
+            ("testMapInt32Float", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Float)}),
+            ("testMapInt32Double", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Double)}),
+            ("testMapBoolBool", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapBoolBool)}),
+            ("testMapStringString", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapStringString)}),
+            ("testMapStringBytes", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapStringBytes)}),
+            ("testMapStringMessage", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapStringMessage)}),
+            ("testMapInt32Bytes", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Bytes)}),
+            ("testMapInt32Enum", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Enum)}),
+            ("testMapInt32Message", {try run_test(test:($0 as! Test_MapFields_Access_Proto3).testMapInt32Message)})        ]
+    }
+}
+
 extension Test_Map_JSON {
     static var allTests: [(String, (XCTestCase) throws -> ())] {
         return [
@@ -436,6 +612,55 @@ extension Test_Map_JSON {
             ("testMapInt32Bytes", {try run_test(test:($0 as! Test_Map_JSON).testMapInt32Bytes)}),
             ("testMapInt32Message", {try run_test(test:($0 as! Test_Map_JSON).testMapInt32Message)}),
             ("test_mapBoolBool", {try run_test(test:($0 as! Test_Map_JSON).test_mapBoolBool)})        ]
+    }
+}
+
+extension Test_OneofFields_Access_Proto2 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testOneofInt32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofInt32)}),
+            ("testOneofInt64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofInt64)}),
+            ("testOneofUint32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofUint32)}),
+            ("testOneofUint64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofUint64)}),
+            ("testOneofSint32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofSint32)}),
+            ("testOneofSint64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofSint64)}),
+            ("testOneofFixed32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofFixed32)}),
+            ("testOneofFixed64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofFixed64)}),
+            ("testOneofSfixed32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofSfixed32)}),
+            ("testOneofSfixed64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofSfixed64)}),
+            ("testOneofFloat", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofFloat)}),
+            ("testOneofDouble", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofDouble)}),
+            ("testOneofBool", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofBool)}),
+            ("testOneofString", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofString)}),
+            ("testOneofBytes", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofBytes)}),
+            ("testOneofGroup", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofGroup)}),
+            ("testOneofMessage", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofMessage)}),
+            ("testOneofEnum", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofEnum)}),
+            ("testOneofOnlyOneSet", {try run_test(test:($0 as! Test_OneofFields_Access_Proto2).testOneofOnlyOneSet)})        ]
+    }
+}
+
+extension Test_OneofFields_Access_Proto3 {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testOneofInt32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofInt32)}),
+            ("testOneofInt64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofInt64)}),
+            ("testOneofUint32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofUint32)}),
+            ("testOneofUint64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofUint64)}),
+            ("testOneofSint32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofSint32)}),
+            ("testOneofSint64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofSint64)}),
+            ("testOneofFixed32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofFixed32)}),
+            ("testOneofFixed64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofFixed64)}),
+            ("testOneofSfixed32", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofSfixed32)}),
+            ("testOneofSfixed64", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofSfixed64)}),
+            ("testOneofFloat", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofFloat)}),
+            ("testOneofDouble", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofDouble)}),
+            ("testOneofBool", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofBool)}),
+            ("testOneofString", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofString)}),
+            ("testOneofBytes", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofBytes)}),
+            ("testOneofMessage", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofMessage)}),
+            ("testOneofEnum", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofEnum)}),
+            ("testOneofOnlyOneSet", {try run_test(test:($0 as! Test_OneofFields_Access_Proto3).testOneofOnlyOneSet)})        ]
     }
 }
 
@@ -607,6 +832,8 @@ XCTMain(
         (testCaseClass: Test_AllTypes_Proto3.self, allTests: Test_AllTypes_Proto3.allTests),
         (testCaseClass: Test_Any.self, allTests: Test_Any.allTests),
         (testCaseClass: Test_Api.self, allTests: Test_Api.allTests),
+        (testCaseClass: Test_BasicFields_Access_Proto2.self, allTests: Test_BasicFields_Access_Proto2.allTests),
+        (testCaseClass: Test_BasicFields_Access_Proto3.self, allTests: Test_BasicFields_Access_Proto3.allTests),
         (testCaseClass: Test_Conformance.self, allTests: Test_Conformance.allTests),
         (testCaseClass: Test_Descriptor.self, allTests: Test_Descriptor.allTests),
         (testCaseClass: Test_Duration.self, allTests: Test_Duration.allTests),
@@ -624,7 +851,11 @@ XCTMain(
         (testCaseClass: Test_JSON_Group.self, allTests: Test_JSON_Group.allTests),
         (testCaseClass: Test_Scanner.self, allTests: Test_Scanner.allTests),
         (testCaseClass: Test_Map.self, allTests: Test_Map.allTests),
+        (testCaseClass: Test_MapFields_Access_Proto2.self, allTests: Test_MapFields_Access_Proto2.allTests),
+        (testCaseClass: Test_MapFields_Access_Proto3.self, allTests: Test_MapFields_Access_Proto3.allTests),
         (testCaseClass: Test_Map_JSON.self, allTests: Test_Map_JSON.allTests),
+        (testCaseClass: Test_OneofFields_Access_Proto2.self, allTests: Test_OneofFields_Access_Proto2.allTests),
+        (testCaseClass: Test_OneofFields_Access_Proto3.self, allTests: Test_OneofFields_Access_Proto3.allTests),
         (testCaseClass: Test_Packed.self, allTests: Test_Packed.allTests),
         (testCaseClass: Test_ParsingMerge.self, allTests: Test_ParsingMerge.allTests),
         (testCaseClass: Test_Performance.self, allTests: Test_Performance.allTests),

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -1,4 +1,4 @@
-// Test/Sources/TestSuite/Helpers.swift - Test helpers
+// Test/Sources/TestSuite/TestHelpers.swift - Test helpers
 //
 // This source file is part of the Swift.org open source project
 //

--- a/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto2.swift
@@ -1,0 +1,871 @@
+// Test/Sources/TestSuite/Test_BasicFields_Access_Proto2.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis for optional/optional+default/repeated fields.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_BasicFields_Access_Proto2: XCTestCase {
+
+  // Optional
+
+  func testOptionalInt32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalInt32, 0)
+    XCTAssertFalse(msg.hasOptionalInt32)
+    msg.optionalInt32 = 1
+    XCTAssertTrue(msg.hasOptionalInt32)
+    XCTAssertEqual(msg.optionalInt32, 1)
+    msg.clearOptionalInt32()
+    XCTAssertEqual(msg.optionalInt32, 0)
+    XCTAssertFalse(msg.hasOptionalInt32)
+  }
+
+  func testOptionalInt64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalInt64, 0)
+    XCTAssertFalse(msg.hasOptionalInt64)
+    msg.optionalInt64 = 2
+    XCTAssertTrue(msg.hasOptionalInt64)
+    XCTAssertEqual(msg.optionalInt64, 2)
+    msg.clearOptionalInt64()
+    XCTAssertEqual(msg.optionalInt64, 0)
+    XCTAssertFalse(msg.hasOptionalInt64)
+  }
+
+  func testOptionalUint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalUint32, 0)
+    XCTAssertFalse(msg.hasOptionalUint32)
+    msg.optionalUint32 = 3
+    XCTAssertTrue(msg.hasOptionalUint32)
+    XCTAssertEqual(msg.optionalUint32, 3)
+    msg.clearOptionalUint32()
+    XCTAssertEqual(msg.optionalUint32, 0)
+    XCTAssertFalse(msg.hasOptionalUint32)
+  }
+
+  func testOptionalUint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalUint64, 0)
+    XCTAssertFalse(msg.hasOptionalUint64)
+    msg.optionalUint64 = 4
+    XCTAssertTrue(msg.hasOptionalUint64)
+    XCTAssertEqual(msg.optionalUint64, 4)
+    msg.clearOptionalUint64()
+    XCTAssertEqual(msg.optionalUint64, 0)
+    XCTAssertFalse(msg.hasOptionalUint64)
+  }
+
+  func testOptionalSint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalSint32, 0)
+    XCTAssertFalse(msg.hasOptionalSint32)
+    msg.optionalSint32 = 5
+    XCTAssertTrue(msg.hasOptionalSint32)
+    XCTAssertEqual(msg.optionalSint32, 5)
+    msg.clearOptionalSint32()
+    XCTAssertEqual(msg.optionalSint32, 0)
+    XCTAssertFalse(msg.hasOptionalSint32)
+  }
+
+  func testOptionalSint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalSint64, 0)
+    XCTAssertFalse(msg.hasOptionalSint64)
+    msg.optionalSint64 = 6
+    XCTAssertTrue(msg.hasOptionalSint64)
+    XCTAssertEqual(msg.optionalSint64, 6)
+    msg.clearOptionalSint64()
+    XCTAssertEqual(msg.optionalSint64, 0)
+    XCTAssertFalse(msg.hasOptionalSint64)
+  }
+
+  func testOptionalFixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalFixed32, 0)
+    XCTAssertFalse(msg.hasOptionalFixed32)
+    msg.optionalFixed32 = 7
+    XCTAssertTrue(msg.hasOptionalFixed32)
+    XCTAssertEqual(msg.optionalFixed32, 7)
+    msg.clearOptionalFixed32()
+    XCTAssertEqual(msg.optionalFixed32, 0)
+    XCTAssertFalse(msg.hasOptionalFixed32)
+  }
+
+  func testOptionalFixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalFixed64, 0)
+    XCTAssertFalse(msg.hasOptionalFixed64)
+    msg.optionalFixed64 = 8
+    XCTAssertTrue(msg.hasOptionalFixed64)
+    XCTAssertEqual(msg.optionalFixed64, 8)
+    msg.clearOptionalFixed64()
+    XCTAssertEqual(msg.optionalFixed64, 0)
+    XCTAssertFalse(msg.hasOptionalFixed64)
+  }
+
+  func testOptionalSfixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalSfixed32, 0)
+    XCTAssertFalse(msg.hasOptionalSfixed32)
+    msg.optionalSfixed32 = 9
+    XCTAssertTrue(msg.hasOptionalSfixed32)
+    XCTAssertEqual(msg.optionalSfixed32, 9)
+    msg.clearOptionalSfixed32()
+    XCTAssertEqual(msg.optionalSfixed32, 0)
+    XCTAssertFalse(msg.hasOptionalSfixed32)
+  }
+
+  func testOptionalSfixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalSfixed64, 0)
+    XCTAssertFalse(msg.hasOptionalSfixed64)
+    msg.optionalSfixed64 = 10
+    XCTAssertTrue(msg.hasOptionalSfixed64)
+    XCTAssertEqual(msg.optionalSfixed64, 10)
+    msg.clearOptionalSfixed64()
+    XCTAssertEqual(msg.optionalSfixed64, 0)
+    XCTAssertFalse(msg.hasOptionalSfixed64)
+  }
+
+  func testOptionalFloat() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalFloat, 0.0)
+    XCTAssertFalse(msg.hasOptionalFloat)
+    msg.optionalFloat = 11.0
+    XCTAssertTrue(msg.hasOptionalFloat)
+    XCTAssertEqual(msg.optionalFloat, 11.0)
+    msg.clearOptionalFloat()
+    XCTAssertEqual(msg.optionalFloat, 0.0)
+    XCTAssertFalse(msg.hasOptionalFloat)
+  }
+
+  func testOptionalDouble() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalDouble, 0.0)
+    XCTAssertFalse(msg.hasOptionalDouble)
+    msg.optionalDouble = 12.0
+    XCTAssertTrue(msg.hasOptionalDouble)
+    XCTAssertEqual(msg.optionalDouble, 12.0)
+    msg.clearOptionalDouble()
+    XCTAssertEqual(msg.optionalDouble, 0.0)
+    XCTAssertFalse(msg.hasOptionalDouble)
+  }
+
+  func testOptionalBool() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalBool, false)
+    XCTAssertFalse(msg.hasOptionalBool)
+    msg.optionalBool = true
+    XCTAssertTrue(msg.hasOptionalBool)
+    XCTAssertEqual(msg.optionalBool, true)
+    msg.clearOptionalBool()
+    XCTAssertEqual(msg.optionalBool, false)
+    XCTAssertFalse(msg.hasOptionalBool)
+  }
+
+  func testOptionalString() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalString, "")
+    XCTAssertFalse(msg.hasOptionalString)
+    msg.optionalString = "14"
+    XCTAssertTrue(msg.hasOptionalString)
+    XCTAssertEqual(msg.optionalString, "14")
+    msg.clearOptionalString()
+    XCTAssertEqual(msg.optionalString, "")
+    XCTAssertFalse(msg.hasOptionalString)
+  }
+
+  func testOptionalBytes() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalBytes, Data())
+    XCTAssertFalse(msg.hasOptionalBytes)
+    msg.optionalBytes = Data([15])
+    XCTAssertTrue(msg.hasOptionalBytes)
+    XCTAssertEqual(msg.optionalBytes, Data([15]))
+    msg.clearOptionalBytes()
+    XCTAssertEqual(msg.optionalBytes, Data())
+    XCTAssertFalse(msg.hasOptionalBytes)
+  }
+
+  func testOptionalGroup() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalGroup.a, 0)
+    XCTAssertFalse(msg.hasOptionalGroup)
+    var grp = ProtobufUnittest_TestAllTypes.OptionalGroup()
+    grp.a = 16
+    msg.optionalGroup = grp
+    XCTAssertTrue(msg.hasOptionalGroup)
+    XCTAssertEqual(msg.optionalGroup.a, 16)
+    msg.clearOptionalGroup()
+    XCTAssertEqual(msg.optionalGroup.a, 0)
+    XCTAssertFalse(msg.hasOptionalGroup)
+  }
+
+  func testOptionalNestedMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalNestedMessage.bb, 0)
+    XCTAssertFalse(msg.hasOptionalNestedMessage)
+    var nestedMsg = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg.bb = 18
+    msg.optionalNestedMessage = nestedMsg
+    XCTAssertTrue(msg.hasOptionalNestedMessage)
+    XCTAssertEqual(msg.optionalNestedMessage.bb, 18)
+    XCTAssertEqual(msg.optionalNestedMessage, nestedMsg)
+    msg.clearOptionalNestedMessage()
+    XCTAssertEqual(msg.optionalNestedMessage.bb, 0)
+    XCTAssertFalse(msg.hasOptionalNestedMessage)
+  }
+
+  func testOptionalForeignMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalForeignMessage.c, 0)
+    XCTAssertFalse(msg.hasOptionalForeignMessage)
+    var foreignMsg = ProtobufUnittest_ForeignMessage()
+    foreignMsg.c = 19
+    msg.optionalForeignMessage = foreignMsg
+    XCTAssertTrue(msg.hasOptionalForeignMessage)
+    XCTAssertEqual(msg.optionalForeignMessage.c, 19)
+    XCTAssertEqual(msg.optionalForeignMessage, foreignMsg)
+    msg.clearOptionalForeignMessage()
+    XCTAssertEqual(msg.optionalForeignMessage.c, 0)
+    XCTAssertFalse(msg.hasOptionalForeignMessage)
+  }
+
+  func testOptionalImportMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalImportMessage.d, 0)
+    XCTAssertFalse(msg.hasOptionalImportMessage)
+    var importedMsg = ProtobufUnittestImport_ImportMessage()
+    importedMsg.d = 20
+    msg.optionalImportMessage = importedMsg
+    XCTAssertTrue(msg.hasOptionalImportMessage)
+    XCTAssertEqual(msg.optionalImportMessage.d, 20)
+    XCTAssertEqual(msg.optionalImportMessage, importedMsg)
+    msg.clearOptionalImportMessage()
+    XCTAssertEqual(msg.optionalImportMessage.d, 0)
+    XCTAssertFalse(msg.hasOptionalImportMessage)
+  }
+
+  func testOptionalNestedEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalNestedEnum, .foo)
+    XCTAssertFalse(msg.hasOptionalNestedEnum)
+    msg.optionalNestedEnum = .bar
+    XCTAssertTrue(msg.hasOptionalNestedEnum)
+    XCTAssertEqual(msg.optionalNestedEnum, .bar)
+    msg.clearOptionalNestedEnum()
+    XCTAssertEqual(msg.optionalNestedEnum, .foo)
+    XCTAssertFalse(msg.hasOptionalNestedEnum)
+  }
+
+  func testOptionalForeignEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalForeignEnum, .foreignFoo)
+    XCTAssertFalse(msg.hasOptionalForeignEnum)
+    msg.optionalForeignEnum = .foreignBar
+    XCTAssertTrue(msg.hasOptionalForeignEnum)
+    XCTAssertEqual(msg.optionalForeignEnum, .foreignBar)
+    msg.clearOptionalForeignEnum()
+    XCTAssertEqual(msg.optionalForeignEnum, .foreignFoo)
+    XCTAssertFalse(msg.hasOptionalForeignEnum)
+  }
+
+  func testOptionalImportEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalImportEnum, .importFoo)
+    XCTAssertFalse(msg.hasOptionalImportEnum)
+    msg.optionalImportEnum = .importBar
+    XCTAssertTrue(msg.hasOptionalImportEnum)
+    XCTAssertEqual(msg.optionalImportEnum, .importBar)
+    msg.clearOptionalImportEnum()
+    XCTAssertEqual(msg.optionalImportEnum, .importFoo)
+    XCTAssertFalse(msg.hasOptionalImportEnum)
+  }
+
+  func testOptionalStringPiece() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalStringPiece, "")
+    XCTAssertFalse(msg.hasOptionalStringPiece)
+    msg.optionalStringPiece = "24"
+    XCTAssertTrue(msg.hasOptionalStringPiece)
+    XCTAssertEqual(msg.optionalStringPiece, "24")
+    msg.clearOptionalStringPiece()
+    XCTAssertEqual(msg.optionalStringPiece, "")
+    XCTAssertFalse(msg.hasOptionalStringPiece)
+  }
+
+  func testOptionalCord() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalCord, "")
+    XCTAssertFalse(msg.hasOptionalCord)
+    msg.optionalCord = "25"
+    XCTAssertTrue(msg.hasOptionalCord)
+    XCTAssertEqual(msg.optionalCord, "25")
+    msg.clearOptionalCord()
+    XCTAssertEqual(msg.optionalCord, "")
+    XCTAssertFalse(msg.hasOptionalCord)
+  }
+
+  func testOptionalPublicImportMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalPublicImportMessage.e, 0)
+    XCTAssertFalse(msg.hasOptionalPublicImportMessage)
+    var pubImportedMsg = ProtobufUnittestImport_PublicImportMessage()
+    pubImportedMsg.e = 26
+    msg.optionalPublicImportMessage = pubImportedMsg
+    XCTAssertTrue(msg.hasOptionalPublicImportMessage)
+    XCTAssertEqual(msg.optionalPublicImportMessage.e, 26)
+    XCTAssertEqual(msg.optionalPublicImportMessage, pubImportedMsg)
+    msg.clearOptionalPublicImportMessage()
+    XCTAssertEqual(msg.optionalPublicImportMessage.e, 0)
+    XCTAssertFalse(msg.hasOptionalPublicImportMessage)
+  }
+
+  func testOptionalLazyMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.optionalLazyMessage.bb, 0)
+    XCTAssertFalse(msg.hasOptionalLazyMessage)
+    var nestedMsg = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg.bb = 27
+    msg.optionalLazyMessage = nestedMsg
+    XCTAssertTrue(msg.hasOptionalLazyMessage)
+    XCTAssertEqual(msg.optionalLazyMessage.bb, 27)
+    XCTAssertEqual(msg.optionalLazyMessage, nestedMsg)
+    msg.clearOptionalLazyMessage()
+    XCTAssertEqual(msg.optionalLazyMessage.bb, 0)
+    XCTAssertFalse(msg.hasOptionalLazyMessage)
+  }
+
+  // Optional with explicit default values (non zero)
+
+  func testDefaultInt32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultInt32, 41)
+    XCTAssertFalse(msg.hasDefaultInt32)
+    msg.defaultInt32 = 61
+    XCTAssertTrue(msg.hasDefaultInt32)
+    XCTAssertEqual(msg.defaultInt32, 61)
+    msg.clearDefaultInt32()
+    XCTAssertEqual(msg.defaultInt32, 41)
+    XCTAssertFalse(msg.hasDefaultInt32)
+  }
+
+  func testDefaultInt64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultInt64, 42)
+    XCTAssertFalse(msg.hasDefaultInt64)
+    msg.defaultInt64 = 62
+    XCTAssertTrue(msg.hasDefaultInt64)
+    XCTAssertEqual(msg.defaultInt64, 62)
+    msg.clearDefaultInt64()
+    XCTAssertEqual(msg.defaultInt64, 42)
+    XCTAssertFalse(msg.hasDefaultInt64)
+  }
+
+  func testDefaultUint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultUint32, 43)
+    XCTAssertFalse(msg.hasDefaultUint32)
+    msg.defaultUint32 = 63
+    XCTAssertTrue(msg.hasDefaultUint32)
+    XCTAssertEqual(msg.defaultUint32, 63)
+    msg.clearDefaultUint32()
+    XCTAssertEqual(msg.defaultUint32, 43)
+    XCTAssertFalse(msg.hasDefaultUint32)
+  }
+
+  func testDefaultUint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultUint64, 44)
+    XCTAssertFalse(msg.hasDefaultUint64)
+    msg.defaultUint64 = 64
+    XCTAssertTrue(msg.hasDefaultUint64)
+    XCTAssertEqual(msg.defaultUint64, 64)
+    msg.clearDefaultUint64()
+    XCTAssertEqual(msg.defaultUint64, 44)
+    XCTAssertFalse(msg.hasDefaultUint64)
+  }
+
+  func testDefaultSint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultSint32, -45)
+    XCTAssertFalse(msg.hasDefaultSint32)
+    msg.defaultSint32 = 65
+    XCTAssertTrue(msg.hasDefaultSint32)
+    XCTAssertEqual(msg.defaultSint32, 65)
+    msg.clearDefaultSint32()
+    XCTAssertEqual(msg.defaultSint32, -45)
+    XCTAssertFalse(msg.hasDefaultSint32)
+  }
+
+  func testDefaultSint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultSint64, 46)
+    XCTAssertFalse(msg.hasDefaultSint64)
+    msg.defaultSint64 = 66
+    XCTAssertTrue(msg.hasDefaultSint64)
+    XCTAssertEqual(msg.defaultSint64, 66)
+    msg.clearDefaultSint64()
+    XCTAssertEqual(msg.defaultSint64, 46)
+    XCTAssertFalse(msg.hasDefaultSint64)
+  }
+
+  func testDefaultFixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultFixed32, 47)
+    XCTAssertFalse(msg.hasDefaultFixed32)
+    msg.defaultFixed32 = 67
+    XCTAssertTrue(msg.hasDefaultFixed32)
+    XCTAssertEqual(msg.defaultFixed32, 67)
+    msg.clearDefaultFixed32()
+    XCTAssertEqual(msg.defaultFixed32, 47)
+    XCTAssertFalse(msg.hasDefaultFixed32)
+  }
+
+  func testDefaultFixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultFixed64, 48)
+    XCTAssertFalse(msg.hasDefaultFixed64)
+    msg.defaultFixed64 = 68
+    XCTAssertTrue(msg.hasDefaultFixed64)
+    XCTAssertEqual(msg.defaultFixed64, 68)
+    msg.clearDefaultFixed64()
+    XCTAssertEqual(msg.defaultFixed64, 48)
+    XCTAssertFalse(msg.hasDefaultFixed64)
+  }
+
+  func testDefaultSfixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultSfixed32, 49)
+    XCTAssertFalse(msg.hasDefaultSfixed32)
+    msg.defaultSfixed32 = 69
+    XCTAssertTrue(msg.hasDefaultSfixed32)
+    XCTAssertEqual(msg.defaultSfixed32, 69)
+    msg.clearDefaultSfixed32()
+    XCTAssertEqual(msg.defaultSfixed32, 49)
+    XCTAssertFalse(msg.hasDefaultSfixed32)
+  }
+
+  func testDefaultSfixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultSfixed64, -50)
+    XCTAssertFalse(msg.hasDefaultSfixed64)
+    msg.defaultSfixed64 = 70
+    XCTAssertTrue(msg.hasDefaultSfixed64)
+    XCTAssertEqual(msg.defaultSfixed64, 70)
+    msg.clearDefaultSfixed64()
+    XCTAssertEqual(msg.defaultSfixed64, -50)
+    XCTAssertFalse(msg.hasDefaultSfixed64)
+  }
+
+  func testDefaultFloat() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultFloat, 51.5)
+    XCTAssertFalse(msg.hasDefaultFloat)
+    msg.defaultFloat = 71
+    XCTAssertTrue(msg.hasDefaultFloat)
+    XCTAssertEqual(msg.defaultFloat, 71)
+    msg.clearDefaultFloat()
+    XCTAssertEqual(msg.defaultFloat, 51.5)
+    XCTAssertFalse(msg.hasDefaultFloat)
+  }
+
+  func testDefaultDouble() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultDouble, 52e3)
+    XCTAssertFalse(msg.hasDefaultDouble)
+    msg.defaultDouble = 72
+    XCTAssertTrue(msg.hasDefaultDouble)
+    XCTAssertEqual(msg.defaultDouble, 72)
+    msg.clearDefaultDouble()
+    XCTAssertEqual(msg.defaultDouble, 52e3)
+    XCTAssertFalse(msg.hasDefaultDouble)
+  }
+
+  func testDefaultBool() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultBool, true)
+    XCTAssertFalse(msg.hasDefaultBool)
+    msg.defaultBool = false
+    XCTAssertTrue(msg.hasDefaultBool)
+    XCTAssertEqual(msg.defaultBool, false)
+    msg.clearDefaultBool()
+    XCTAssertEqual(msg.defaultBool, true)
+    XCTAssertFalse(msg.hasDefaultBool)
+  }
+
+  func testDefaultString() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultString, "hello")
+    XCTAssertFalse(msg.hasDefaultString)
+    msg.defaultString = "74"
+    XCTAssertTrue(msg.hasDefaultString)
+    XCTAssertEqual(msg.defaultString, "74")
+    msg.clearDefaultString()
+    XCTAssertEqual(msg.defaultString, "hello")
+    XCTAssertFalse(msg.hasDefaultString)
+  }
+
+  func testDefaultBytes() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultBytes, "world".data(using: .utf8))
+    XCTAssertFalse(msg.hasDefaultBytes)
+    msg.defaultBytes = Data([75])
+    XCTAssertTrue(msg.hasDefaultBytes)
+    XCTAssertEqual(msg.defaultBytes, Data([75]))
+    msg.clearDefaultBytes()
+    XCTAssertEqual(msg.defaultBytes, "world".data(using: .utf8))
+    XCTAssertFalse(msg.hasDefaultBytes)
+  }
+
+  func testDefaultNestedEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultNestedEnum, .bar)
+    XCTAssertFalse(msg.hasDefaultNestedEnum)
+    msg.defaultNestedEnum = .baz
+    XCTAssertTrue(msg.hasDefaultNestedEnum)
+    XCTAssertEqual(msg.defaultNestedEnum, .baz)
+    msg.clearDefaultNestedEnum()
+    XCTAssertEqual(msg.defaultNestedEnum, .bar)
+    XCTAssertFalse(msg.hasDefaultNestedEnum)
+  }
+
+  func testDefaultForeignEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultForeignEnum, .foreignBar)
+    XCTAssertFalse(msg.hasDefaultForeignEnum)
+    msg.defaultForeignEnum = .foreignBaz
+    XCTAssertTrue(msg.hasDefaultForeignEnum)
+    XCTAssertEqual(msg.defaultForeignEnum, .foreignBaz)
+    msg.clearDefaultForeignEnum()
+    XCTAssertEqual(msg.defaultForeignEnum, .foreignBar)
+    XCTAssertFalse(msg.hasDefaultForeignEnum)
+  }
+
+  func testDefaultImportEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultImportEnum, .importBar)
+    XCTAssertFalse(msg.hasDefaultImportEnum)
+    msg.defaultImportEnum = .importBaz
+    XCTAssertTrue(msg.hasDefaultImportEnum)
+    XCTAssertEqual(msg.defaultImportEnum, .importBaz)
+    msg.clearDefaultImportEnum()
+    XCTAssertEqual(msg.defaultImportEnum, .importBar)
+    XCTAssertFalse(msg.hasDefaultImportEnum)
+  }
+
+  func testDefaultStringPiece() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultStringPiece, "abc")
+    XCTAssertFalse(msg.hasDefaultStringPiece)
+    msg.defaultStringPiece = "84"
+    XCTAssertTrue(msg.hasDefaultStringPiece)
+    XCTAssertEqual(msg.defaultStringPiece, "84")
+    msg.clearDefaultStringPiece()
+    XCTAssertEqual(msg.defaultStringPiece, "abc")
+    XCTAssertFalse(msg.hasDefaultStringPiece)
+  }
+
+  func testDefaultCord() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.defaultCord, "123")
+    XCTAssertFalse(msg.hasDefaultCord)
+    msg.defaultCord = "85"
+    XCTAssertTrue(msg.hasDefaultCord)
+    XCTAssertEqual(msg.defaultCord, "85")
+    msg.clearDefaultCord()
+    XCTAssertEqual(msg.defaultCord, "123")
+    XCTAssertFalse(msg.hasDefaultCord)
+  }
+
+  // Repeated
+
+  func testRepeatedInt32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedInt32, [])
+    msg.repeatedInt32 = [31]
+    XCTAssertEqual(msg.repeatedInt32, [31])
+    msg.repeatedInt32.append(131)
+    XCTAssertEqual(msg.repeatedInt32, [31, 131])
+  }
+
+  func testRepeatedInt64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedInt64, [])
+    msg.repeatedInt64 = [32]
+    XCTAssertEqual(msg.repeatedInt64, [32])
+    msg.repeatedInt64.append(132)
+    XCTAssertEqual(msg.repeatedInt64, [32, 132])
+  }
+
+  func testRepeatedUint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedUint32, [])
+    msg.repeatedUint32 = [33]
+    XCTAssertEqual(msg.repeatedUint32, [33])
+    msg.repeatedUint32.append(133)
+    XCTAssertEqual(msg.repeatedUint32, [33, 133])
+  }
+
+  func testRepeatedUint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedUint64, [])
+    msg.repeatedUint64 = [34]
+    XCTAssertEqual(msg.repeatedUint64, [34])
+    msg.repeatedUint64.append(134)
+    XCTAssertEqual(msg.repeatedUint64, [34, 134])
+  }
+
+  func testRepeatedSint32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedSint32, [])
+    msg.repeatedSint32 = [35]
+    XCTAssertEqual(msg.repeatedSint32, [35])
+    msg.repeatedSint32.append(135)
+    XCTAssertEqual(msg.repeatedSint32, [35, 135])
+  }
+
+  func testRepeatedSint64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedSint64, [])
+    msg.repeatedSint64 = [36]
+    XCTAssertEqual(msg.repeatedSint64, [36])
+    msg.repeatedSint64.append(136)
+    XCTAssertEqual(msg.repeatedSint64, [36, 136])
+  }
+
+  func testRepeatedFixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedFixed32, [])
+    msg.repeatedFixed32 = [37]
+    XCTAssertEqual(msg.repeatedFixed32, [37])
+    msg.repeatedFixed32.append(137)
+    XCTAssertEqual(msg.repeatedFixed32, [37, 137])
+  }
+
+  func testRepeatedFixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedFixed64, [])
+    msg.repeatedFixed64 = [38]
+    XCTAssertEqual(msg.repeatedFixed64, [38])
+    msg.repeatedFixed64.append(138)
+    XCTAssertEqual(msg.repeatedFixed64, [38, 138])
+  }
+
+  func testRepeatedSfixed32() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedSfixed32, [])
+    msg.repeatedSfixed32 = [39]
+    XCTAssertEqual(msg.repeatedSfixed32, [39])
+    msg.repeatedSfixed32.append(139)
+    XCTAssertEqual(msg.repeatedSfixed32, [39, 139])
+  }
+
+  func testRepeatedSfixed64() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedSfixed64, [])
+    msg.repeatedSfixed64 = [40]
+    XCTAssertEqual(msg.repeatedSfixed64, [40])
+    msg.repeatedSfixed64.append(140)
+    XCTAssertEqual(msg.repeatedSfixed64, [40, 140])
+  }
+
+  func testRepeatedFloat() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedFloat, [])
+    msg.repeatedFloat = [41.0]
+    XCTAssertEqual(msg.repeatedFloat, [41.0])
+    msg.repeatedFloat.append(141.0)
+    XCTAssertEqual(msg.repeatedFloat, [41.0, 141.0])
+  }
+
+  func testRepeatedDouble() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedDouble, [])
+    msg.repeatedDouble = [42.0]
+    XCTAssertEqual(msg.repeatedDouble, [42.0])
+    msg.repeatedDouble.append(142.0)
+    XCTAssertEqual(msg.repeatedDouble, [42.0, 142.0])
+  }
+
+  func testRepeatedBool() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedBool, [])
+    msg.repeatedBool = [true]
+    XCTAssertEqual(msg.repeatedBool, [true])
+    msg.repeatedBool.append(false)
+    XCTAssertEqual(msg.repeatedBool, [true, false])
+  }
+
+  func testRepeatedString() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedString, [])
+    msg.repeatedString = ["44"]
+    XCTAssertEqual(msg.repeatedString, ["44"])
+    msg.repeatedString.append("144")
+    XCTAssertEqual(msg.repeatedString, ["44", "144"])
+  }
+
+  func testRepeatedBytes() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedBytes, [])
+    msg.repeatedBytes = [Data([45])]
+    XCTAssertEqual(msg.repeatedBytes, [Data([45])])
+    msg.repeatedBytes.append(Data([145]))
+    XCTAssertEqual(msg.repeatedBytes, [Data([45]), Data([145])])
+  }
+
+  func testRepeatedGroup() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedGroup, [])
+    var grp = ProtobufUnittest_TestAllTypes.RepeatedGroup()
+    grp.a = 46
+    msg.repeatedGroup = [grp]
+    XCTAssertEqual(msg.repeatedGroup.count, 1)
+    XCTAssertEqual(msg.repeatedGroup[0].a, 46)
+    XCTAssertEqual(msg.repeatedGroup, [grp])
+    var grp2 = ProtobufUnittest_TestAllTypes.RepeatedGroup()
+    grp2.a = 146
+    msg.repeatedGroup.append(grp2)
+    XCTAssertEqual(msg.repeatedGroup.count, 2)
+    XCTAssertEqual(msg.repeatedGroup[0].a, 46)
+    XCTAssertEqual(msg.repeatedGroup[1].a, 146)
+    XCTAssertEqual(msg.repeatedGroup, [grp, grp2])
+  }
+
+  func testRepeatedNestedMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedNestedMessage, [])
+    var nestedMsg = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg.bb = 48
+    msg.repeatedNestedMessage = [nestedMsg]
+    XCTAssertEqual(msg.repeatedNestedMessage.count, 1)
+    XCTAssertEqual(msg.repeatedNestedMessage[0].bb, 48)
+    XCTAssertEqual(msg.repeatedNestedMessage, [nestedMsg])
+    var nestedMsg2 = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg2.bb = 148
+    msg.repeatedNestedMessage.append(nestedMsg2)
+    XCTAssertEqual(msg.repeatedNestedMessage.count, 2)
+    XCTAssertEqual(msg.repeatedNestedMessage[0].bb, 48)
+    XCTAssertEqual(msg.repeatedNestedMessage[1].bb, 148)
+    XCTAssertEqual(msg.repeatedNestedMessage, [nestedMsg, nestedMsg2])
+  }
+
+  func testRepeatedForeignMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedForeignMessage, [])
+    var foreignMsg = ProtobufUnittest_ForeignMessage()
+    foreignMsg.c = 49
+    msg.repeatedForeignMessage = [foreignMsg]
+    XCTAssertEqual(msg.repeatedForeignMessage.count, 1)
+    XCTAssertEqual(msg.repeatedForeignMessage[0].c, 49)
+    XCTAssertEqual(msg.repeatedForeignMessage, [foreignMsg])
+    var foreignMsg2 = ProtobufUnittest_ForeignMessage()
+    foreignMsg2.c = 149
+    msg.repeatedForeignMessage.append(foreignMsg2)
+    XCTAssertEqual(msg.repeatedForeignMessage.count, 2)
+    XCTAssertEqual(msg.repeatedForeignMessage[0].c, 49)
+    XCTAssertEqual(msg.repeatedForeignMessage[1].c, 149)
+    XCTAssertEqual(msg.repeatedForeignMessage, [foreignMsg, foreignMsg2])
+  }
+
+  func testRepeatedImportMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedImportMessage, [])
+    var importedMsg = ProtobufUnittestImport_ImportMessage()
+    importedMsg.d = 50
+    msg.repeatedImportMessage = [importedMsg]
+    XCTAssertEqual(msg.repeatedImportMessage.count, 1)
+    XCTAssertEqual(msg.repeatedImportMessage[0].d, 50)
+    XCTAssertEqual(msg.repeatedImportMessage, [importedMsg])
+    var importedMsg2 = ProtobufUnittestImport_ImportMessage()
+    importedMsg2.d = 150
+    msg.repeatedImportMessage.append(importedMsg2)
+    XCTAssertEqual(msg.repeatedImportMessage.count, 2)
+    XCTAssertEqual(msg.repeatedImportMessage[0].d, 50)
+    XCTAssertEqual(msg.repeatedImportMessage[1].d, 150)
+    XCTAssertEqual(msg.repeatedImportMessage, [importedMsg, importedMsg2])
+  }
+
+  func testRepeatedNestedEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedNestedEnum, [])
+    msg.repeatedNestedEnum = [.bar]
+    XCTAssertEqual(msg.repeatedNestedEnum, [.bar])
+    msg.repeatedNestedEnum.append(.baz)
+    XCTAssertEqual(msg.repeatedNestedEnum, [.bar, .baz])
+  }
+
+  func testRepeatedForeignEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedForeignEnum, [])
+    msg.repeatedForeignEnum = [.foreignBar]
+    XCTAssertEqual(msg.repeatedForeignEnum, [.foreignBar])
+    msg.repeatedForeignEnum.append(.foreignBaz)
+    XCTAssertEqual(msg.repeatedForeignEnum, [.foreignBar, .foreignBaz])
+  }
+
+  func testRepeatedImportEnum() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedImportEnum, [])
+    msg.repeatedImportEnum = [.importBar]
+    XCTAssertEqual(msg.repeatedImportEnum, [.importBar])
+    msg.repeatedImportEnum.append(.importBaz)
+    XCTAssertEqual(msg.repeatedImportEnum, [.importBar, .importBaz])
+  }
+
+  func testRepeatedStringPiece() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedStringPiece, [])
+    msg.repeatedStringPiece = ["54"]
+    XCTAssertEqual(msg.repeatedStringPiece, ["54"])
+    msg.repeatedStringPiece.append("154")
+    XCTAssertEqual(msg.repeatedStringPiece, ["54", "154"])
+  }
+
+  func testRepeatedCord() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedCord, [])
+    msg.repeatedCord = ["55"]
+    XCTAssertEqual(msg.repeatedCord, ["55"])
+    msg.repeatedCord.append("155")
+    XCTAssertEqual(msg.repeatedCord, ["55", "155"])
+  }
+
+  func testRepeatedLazyMessage() {
+    var msg = ProtobufUnittest_TestAllTypes()
+    XCTAssertEqual(msg.repeatedLazyMessage, [])
+    var nestedMsg = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg.bb = 57
+    msg.repeatedLazyMessage = [nestedMsg]
+    XCTAssertEqual(msg.repeatedLazyMessage.count, 1)
+    XCTAssertEqual(msg.repeatedLazyMessage[0].bb, 57)
+    XCTAssertEqual(msg.repeatedLazyMessage, [nestedMsg])
+    var nestedMsg2 = ProtobufUnittest_TestAllTypes.NestedMessage()
+    nestedMsg2.bb = 157
+    msg.repeatedLazyMessage.append(nestedMsg2)
+    XCTAssertEqual(msg.repeatedLazyMessage.count, 2)
+    XCTAssertEqual(msg.repeatedLazyMessage[0].bb, 57)
+    XCTAssertEqual(msg.repeatedLazyMessage[1].bb, 157)
+    XCTAssertEqual(msg.repeatedLazyMessage, [nestedMsg, nestedMsg2])
+  }
+
+}

--- a/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto3.swift
@@ -1,0 +1,412 @@
+// Test/Sources/TestSuite/Test_BasicFields_Access_Proto3.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis for optional & repeated fields.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_BasicFields_Access_Proto3: XCTestCase {
+
+  // Optional
+
+  func testOptionalInt32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleInt32, 0)
+    msg.singleInt32 = 1
+    XCTAssertEqual(msg.singleInt32, 1)
+  }
+
+  func testOptionalInt64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleInt64, 0)
+    msg.singleInt64 = 2
+    XCTAssertEqual(msg.singleInt64, 2)
+  }
+
+  func testOptionalUint32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleUint32, 0)
+    msg.singleUint32 = 3
+    XCTAssertEqual(msg.singleUint32, 3)
+  }
+
+  func testOptionalUint64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleUint64, 0)
+    msg.singleUint64 = 4
+    XCTAssertEqual(msg.singleUint64, 4)
+  }
+
+  func testOptionalSint32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleSint32, 0)
+    msg.singleSint32 = 5
+    XCTAssertEqual(msg.singleSint32, 5)
+  }
+
+  func testOptionalSint64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleSint64, 0)
+    msg.singleSint64 = 6
+    XCTAssertEqual(msg.singleSint64, 6)
+  }
+
+  func testOptionalFixed32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleFixed32, 0)
+    msg.singleFixed32 = 7
+    XCTAssertEqual(msg.singleFixed32, 7)
+  }
+
+  func testOptionalFixed64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleFixed64, 0)
+    msg.singleFixed64 = 8
+    XCTAssertEqual(msg.singleFixed64, 8)
+  }
+
+  func testOptionalSfixed32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleSfixed32, 0)
+    msg.singleSfixed32 = 9
+    XCTAssertEqual(msg.singleSfixed32, 9)
+  }
+
+  func testOptionalSfixed64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleSfixed64, 0)
+    msg.singleSfixed64 = 10
+    XCTAssertEqual(msg.singleSfixed64, 10)
+  }
+
+  func testOptionalFloat() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleFloat, 0.0)
+    msg.singleFloat = 11.0
+    XCTAssertEqual(msg.singleFloat, 11.0)
+  }
+
+  func testOptionalDouble() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleDouble, 0.0)
+    msg.singleDouble = 12.0
+    XCTAssertEqual(msg.singleDouble, 12.0)
+  }
+
+  func testOptionalBool() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleBool, false)
+    msg.singleBool = true
+    XCTAssertEqual(msg.singleBool, true)
+  }
+
+  func testOptionalString() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleString, "")
+    msg.singleString = "14"
+    XCTAssertEqual(msg.singleString, "14")
+  }
+
+  func testOptionalBytes() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleBytes, Data())
+    msg.singleBytes = Data([15])
+    XCTAssertEqual(msg.singleBytes, Data([15]))
+  }
+
+  func testOptionalNestedMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleNestedMessage.bb, 0)
+    var nestedMsg = Proto3TestAllTypes.NestedMessage()
+    nestedMsg.bb = 18
+    msg.singleNestedMessage = nestedMsg
+    XCTAssertEqual(msg.singleNestedMessage.bb, 18)
+    XCTAssertEqual(msg.singleNestedMessage, nestedMsg)
+  }
+
+  func testOptionalForeignMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleForeignMessage.c, 0)
+    var foreignMsg = Proto3ForeignMessage()
+    foreignMsg.c = 19
+    msg.singleForeignMessage = foreignMsg
+    XCTAssertEqual(msg.singleForeignMessage.c, 19)
+    XCTAssertEqual(msg.singleForeignMessage, foreignMsg)
+  }
+
+  func testOptionalImportMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleImportMessage.d, 0)
+    var importedMsg = Proto3ImportMessage()
+    importedMsg.d = 20
+    msg.singleImportMessage = importedMsg
+    XCTAssertEqual(msg.singleImportMessage.d, 20)
+    XCTAssertEqual(msg.singleImportMessage, importedMsg)
+  }
+
+  func testOptionalNestedEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleNestedEnum, .nestedEnumUnspecified)
+    msg.singleNestedEnum = .bar
+    XCTAssertEqual(msg.singleNestedEnum, .bar)
+  }
+
+  func testOptionalForeignEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleForeignEnum, .foreignUnspecified)
+    msg.singleForeignEnum = .foreignBar
+    XCTAssertEqual(msg.singleForeignEnum, .foreignBar)
+  }
+
+  func testOptionalImportEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singleImportEnum, .importEnumUnspecified)
+    msg.singleImportEnum = .importBar
+    XCTAssertEqual(msg.singleImportEnum, .importBar)
+  }
+
+  func testOptionalPublicImportMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.singlePublicImportMessage.e, 0)
+    var pubImportedMsg = Proto3PublicImportMessage()
+    pubImportedMsg.e = 26
+    msg.singlePublicImportMessage = pubImportedMsg
+    XCTAssertEqual(msg.singlePublicImportMessage.e, 26)
+    XCTAssertEqual(msg.singlePublicImportMessage, pubImportedMsg)
+  }
+
+  // Repeated
+
+  func testRepeatedInt32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedInt32, [])
+    msg.repeatedInt32 = [31]
+    XCTAssertEqual(msg.repeatedInt32, [31])
+    msg.repeatedInt32.append(131)
+    XCTAssertEqual(msg.repeatedInt32, [31, 131])
+  }
+
+  func testRepeatedInt64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedInt64, [])
+    msg.repeatedInt64 = [32]
+    XCTAssertEqual(msg.repeatedInt64, [32])
+    msg.repeatedInt64.append(132)
+    XCTAssertEqual(msg.repeatedInt64, [32, 132])
+  }
+
+  func testRepeatedUint32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedUint32, [])
+    msg.repeatedUint32 = [33]
+    XCTAssertEqual(msg.repeatedUint32, [33])
+    msg.repeatedUint32.append(133)
+    XCTAssertEqual(msg.repeatedUint32, [33, 133])
+  }
+
+  func testRepeatedUint64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedUint64, [])
+    msg.repeatedUint64 = [34]
+    XCTAssertEqual(msg.repeatedUint64, [34])
+    msg.repeatedUint64.append(134)
+    XCTAssertEqual(msg.repeatedUint64, [34, 134])
+  }
+
+  func testRepeatedSint32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedSint32, [])
+    msg.repeatedSint32 = [35]
+    XCTAssertEqual(msg.repeatedSint32, [35])
+    msg.repeatedSint32.append(135)
+    XCTAssertEqual(msg.repeatedSint32, [35, 135])
+  }
+
+  func testRepeatedSint64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedSint64, [])
+    msg.repeatedSint64 = [36]
+    XCTAssertEqual(msg.repeatedSint64, [36])
+    msg.repeatedSint64.append(136)
+    XCTAssertEqual(msg.repeatedSint64, [36, 136])
+  }
+
+  func testRepeatedFixed32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedFixed32, [])
+    msg.repeatedFixed32 = [37]
+    XCTAssertEqual(msg.repeatedFixed32, [37])
+    msg.repeatedFixed32.append(137)
+    XCTAssertEqual(msg.repeatedFixed32, [37, 137])
+  }
+
+  func testRepeatedFixed64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedFixed64, [])
+    msg.repeatedFixed64 = [38]
+    XCTAssertEqual(msg.repeatedFixed64, [38])
+    msg.repeatedFixed64.append(138)
+    XCTAssertEqual(msg.repeatedFixed64, [38, 138])
+  }
+
+  func testRepeatedSfixed32() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedSfixed32, [])
+    msg.repeatedSfixed32 = [39]
+    XCTAssertEqual(msg.repeatedSfixed32, [39])
+    msg.repeatedSfixed32.append(139)
+    XCTAssertEqual(msg.repeatedSfixed32, [39, 139])
+  }
+
+  func testRepeatedSfixed64() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedSfixed64, [])
+    msg.repeatedSfixed64 = [40]
+    XCTAssertEqual(msg.repeatedSfixed64, [40])
+    msg.repeatedSfixed64.append(140)
+    XCTAssertEqual(msg.repeatedSfixed64, [40, 140])
+  }
+
+  func testRepeatedFloat() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedFloat, [])
+    msg.repeatedFloat = [41.0]
+    XCTAssertEqual(msg.repeatedFloat, [41.0])
+    msg.repeatedFloat.append(141.0)
+    XCTAssertEqual(msg.repeatedFloat, [41.0, 141.0])
+  }
+
+  func testRepeatedDouble() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedDouble, [])
+    msg.repeatedDouble = [42.0]
+    XCTAssertEqual(msg.repeatedDouble, [42.0])
+    msg.repeatedDouble.append(142.0)
+    XCTAssertEqual(msg.repeatedDouble, [42.0, 142.0])
+  }
+
+  func testRepeatedBool() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedBool, [])
+    msg.repeatedBool = [true]
+    XCTAssertEqual(msg.repeatedBool, [true])
+    msg.repeatedBool.append(false)
+    XCTAssertEqual(msg.repeatedBool, [true, false])
+  }
+
+  func testRepeatedString() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedString, [])
+    msg.repeatedString = ["44"]
+    XCTAssertEqual(msg.repeatedString, ["44"])
+    msg.repeatedString.append("144")
+    XCTAssertEqual(msg.repeatedString, ["44", "144"])
+  }
+
+  func testRepeatedBytes() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedBytes, [])
+    msg.repeatedBytes = [Data([45])]
+    XCTAssertEqual(msg.repeatedBytes, [Data([45])])
+    msg.repeatedBytes.append(Data([145]))
+    XCTAssertEqual(msg.repeatedBytes, [Data([45]), Data([145])])
+  }
+
+  func testRepeatedNestedMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedNestedMessage, [])
+    var nestedMsg = Proto3TestAllTypes.NestedMessage()
+    nestedMsg.bb = 48
+    msg.repeatedNestedMessage = [nestedMsg]
+    XCTAssertEqual(msg.repeatedNestedMessage.count, 1)
+    XCTAssertEqual(msg.repeatedNestedMessage[0].bb, 48)
+    XCTAssertEqual(msg.repeatedNestedMessage, [nestedMsg])
+    var nestedMsg2 = Proto3TestAllTypes.NestedMessage()
+    nestedMsg2.bb = 148
+    msg.repeatedNestedMessage.append(nestedMsg2)
+    XCTAssertEqual(msg.repeatedNestedMessage.count, 2)
+    XCTAssertEqual(msg.repeatedNestedMessage[0].bb, 48)
+    XCTAssertEqual(msg.repeatedNestedMessage[1].bb, 148)
+    XCTAssertEqual(msg.repeatedNestedMessage, [nestedMsg, nestedMsg2])
+  }
+
+  func testRepeatedForeignMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedForeignMessage, [])
+    var foreignMsg = Proto3ForeignMessage()
+    foreignMsg.c = 49
+    msg.repeatedForeignMessage = [foreignMsg]
+    XCTAssertEqual(msg.repeatedForeignMessage.count, 1)
+    XCTAssertEqual(msg.repeatedForeignMessage[0].c, 49)
+    XCTAssertEqual(msg.repeatedForeignMessage, [foreignMsg])
+    var foreignMsg2 = Proto3ForeignMessage()
+    foreignMsg2.c = 149
+    msg.repeatedForeignMessage.append(foreignMsg2)
+    XCTAssertEqual(msg.repeatedForeignMessage.count, 2)
+    XCTAssertEqual(msg.repeatedForeignMessage[0].c, 49)
+    XCTAssertEqual(msg.repeatedForeignMessage[1].c, 149)
+    XCTAssertEqual(msg.repeatedForeignMessage, [foreignMsg, foreignMsg2])
+  }
+
+  func testRepeatedImportMessage() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedImportMessage, [])
+    var importedMsg = Proto3ImportMessage()
+    importedMsg.d = 50
+    msg.repeatedImportMessage = [importedMsg]
+    XCTAssertEqual(msg.repeatedImportMessage.count, 1)
+    XCTAssertEqual(msg.repeatedImportMessage[0].d, 50)
+    XCTAssertEqual(msg.repeatedImportMessage, [importedMsg])
+    var importedMsg2 = Proto3ImportMessage()
+    importedMsg2.d = 150
+    msg.repeatedImportMessage.append(importedMsg2)
+    XCTAssertEqual(msg.repeatedImportMessage.count, 2)
+    XCTAssertEqual(msg.repeatedImportMessage[0].d, 50)
+    XCTAssertEqual(msg.repeatedImportMessage[1].d, 150)
+    XCTAssertEqual(msg.repeatedImportMessage, [importedMsg, importedMsg2])
+  }
+
+  func testRepeatedNestedEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedNestedEnum, [])
+    msg.repeatedNestedEnum = [.bar]
+    XCTAssertEqual(msg.repeatedNestedEnum, [.bar])
+    msg.repeatedNestedEnum.append(.baz)
+    XCTAssertEqual(msg.repeatedNestedEnum, [.bar, .baz])
+  }
+
+  func testRepeatedForeignEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedForeignEnum, [])
+    msg.repeatedForeignEnum = [.foreignBar]
+    XCTAssertEqual(msg.repeatedForeignEnum, [.foreignBar])
+    msg.repeatedForeignEnum.append(.foreignBaz)
+    XCTAssertEqual(msg.repeatedForeignEnum, [.foreignBar, .foreignBaz])
+  }
+
+  func testRepeatedImportEnum() {
+    var msg = Proto3TestAllTypes()
+    XCTAssertEqual(msg.repeatedImportEnum, [])
+    msg.repeatedImportEnum = [.importBar]
+    XCTAssertEqual(msg.repeatedImportEnum, [.importBar])
+    msg.repeatedImportEnum.append(.importBaz)
+    XCTAssertEqual(msg.repeatedImportEnum, [.importBar, .importBaz])
+  }
+
+}

--- a/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto2.swift
@@ -1,0 +1,239 @@
+// Test/Sources/TestSuite/Test_MapFields_Access_Proto2.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis map fields.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_MapFields_Access_Proto2: XCTestCase {
+
+  func testMapInt32Int32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Int32, [:])
+    msg.mapInt32Int32 = [70: 1070]
+    XCTAssertEqual(msg.mapInt32Int32, [70: 1070])
+    msg.mapInt32Int32[170] = 1170
+    XCTAssertEqual(msg.mapInt32Int32, [70: 1070, 170: 1170])
+  }
+
+  func testMapInt64Int64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt64Int64, [:])
+    msg.mapInt64Int64 = [71: 1071]
+    XCTAssertEqual(msg.mapInt64Int64, [71: 1071])
+    msg.mapInt64Int64[171] = 1171
+    XCTAssertEqual(msg.mapInt64Int64, [71: 1071, 171: 1171])
+  }
+
+  func testMapUint32Uint32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapUint32Uint32, [:])
+    msg.mapUint32Uint32 = [72: 1072]
+    XCTAssertEqual(msg.mapUint32Uint32, [72: 1072])
+    msg.mapUint32Uint32[172] = 1172
+    XCTAssertEqual(msg.mapUint32Uint32, [72: 1072, 172: 1172])
+  }
+
+  func testMapUint64Uint64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapUint64Uint64, [:])
+    msg.mapUint64Uint64 = [73: 1073]
+    XCTAssertEqual(msg.mapUint64Uint64, [73: 1073])
+    msg.mapUint64Uint64[173] = 1173
+    XCTAssertEqual(msg.mapUint64Uint64, [73: 1073, 173: 1173])
+  }
+
+  func testMapSint32Sint32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapSint32Sint32, [:])
+    msg.mapSint32Sint32 = [74: 1074]
+    XCTAssertEqual(msg.mapSint32Sint32, [74: 1074])
+    msg.mapSint32Sint32[174] = 1174
+    XCTAssertEqual(msg.mapSint32Sint32, [74: 1074, 174: 1174])
+  }
+
+  func testMapSint64Sint64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapSint64Sint64, [:])
+    msg.mapSint64Sint64 = [75: 1075]
+    XCTAssertEqual(msg.mapSint64Sint64, [75: 1075])
+    msg.mapSint64Sint64[175] = 1175
+    XCTAssertEqual(msg.mapSint64Sint64, [75: 1075, 175: 1175])
+  }
+
+  func testMapFixed32Fixed32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapFixed32Fixed32, [:])
+    msg.mapFixed32Fixed32 = [76: 1076]
+    XCTAssertEqual(msg.mapFixed32Fixed32, [76: 1076])
+    msg.mapFixed32Fixed32[176] = 1176
+    XCTAssertEqual(msg.mapFixed32Fixed32, [76: 1076, 176: 1176])
+  }
+
+  func testMapFixed64Fixed64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapFixed64Fixed64, [:])
+    msg.mapFixed64Fixed64 = [77: 1077]
+    XCTAssertEqual(msg.mapFixed64Fixed64, [77: 1077])
+    msg.mapFixed64Fixed64[177] = 1177
+    XCTAssertEqual(msg.mapFixed64Fixed64, [77: 1077, 177: 1177])
+  }
+
+  func testMapSfixed32Sfixed32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [:])
+    msg.mapSfixed32Sfixed32 = [78: 1078]
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [78: 1078])
+    msg.mapSfixed32Sfixed32[178] = 1178
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [78: 1078, 178: 1178])
+  }
+
+  func testMapSfixed64Sfixed64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [:])
+    msg.mapSfixed64Sfixed64 = [79: 1079]
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [79: 1079])
+    msg.mapSfixed64Sfixed64[179] = 1179
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [79: 1079, 179: 1179])
+  }
+
+  func testMapInt32Float() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Float, [:])
+    msg.mapInt32Float = [80: 1080.0]
+    XCTAssertEqual(msg.mapInt32Float, [80: 1080.0])
+    msg.mapInt32Float[180] = 1180.0
+    XCTAssertEqual(msg.mapInt32Float, [80: 1080.0, 180: 1180.0])
+  }
+
+  func testMapInt32Double() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Double, [:])
+    msg.mapInt32Double = [81: 1081.0]
+    XCTAssertEqual(msg.mapInt32Double, [81: 1081.0])
+    msg.mapInt32Double[181] = 1181.0
+    XCTAssertEqual(msg.mapInt32Double, [81: 1081, 181: 1181.0])
+  }
+
+  func testMapBoolBool() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapBoolBool, [:])
+    msg.mapBoolBool = [true: false]
+    XCTAssertEqual(msg.mapBoolBool, [true: false])
+    msg.mapBoolBool[false] = true
+    XCTAssertEqual(msg.mapBoolBool, [true: false, false: true])
+  }
+
+  func testMapStringString() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapStringString, [:])
+    msg.mapStringString = ["83": "1083"]
+    XCTAssertEqual(msg.mapStringString, ["83": "1083"])
+    msg.mapStringString["183"] = "1183"
+    XCTAssertEqual(msg.mapStringString, ["83": "1083", "183": "1183"])
+  }
+
+  func testMapStringBytes() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapStringBytes, [:])
+    msg.mapStringBytes = ["84": Data([84])]
+    XCTAssertEqual(msg.mapStringBytes, ["84": Data([84])])
+    msg.mapStringBytes["184"] = Data([184])
+    XCTAssertEqual(msg.mapStringBytes, ["84": Data([84]), "184": Data([184])])
+  }
+
+  func testMapStringMessage() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapStringMessage, [:])
+    var valueMsg1 = ProtobufUnittest_Message2()
+    valueMsg1.optionalInt32 = 1085
+    msg.mapStringMessage = ["85": valueMsg1]
+    XCTAssertEqual(msg.mapStringMessage.count, 1)
+    if let v = msg.mapStringMessage["85"] {
+      XCTAssertEqual(v.optionalInt32, 1085)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapStringMessage, ["85": valueMsg1])
+    var valueMsg2 = ProtobufUnittest_Message2()
+    valueMsg2.optionalInt32 = 1185
+    msg.mapStringMessage["185"] = valueMsg2
+    XCTAssertEqual(msg.mapStringMessage.count, 2)
+    if let v = msg.mapStringMessage["85"] {
+      XCTAssertEqual(v.optionalInt32, 1085)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    if let v = msg.mapStringMessage["185"] {
+      XCTAssertEqual(v.optionalInt32, 1185)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapStringMessage, ["85": valueMsg1, "185": valueMsg2])
+  }
+
+  func testMapInt32Bytes() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Bytes, [:])
+    msg.mapInt32Bytes = [86: Data([86])]
+    XCTAssertEqual(msg.mapInt32Bytes, [86: Data([86])])
+    msg.mapInt32Bytes[186] = Data([186])
+    XCTAssertEqual(msg.mapInt32Bytes, [86: Data([86]), 186: Data([186])])
+  }
+
+  func testMapInt32Enum() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Enum, [:])
+    msg.mapInt32Enum = [87: .bar]
+    XCTAssertEqual(msg.mapInt32Enum, [87: .bar])
+    msg.mapInt32Enum[187] = .baz
+    XCTAssertEqual(msg.mapInt32Enum, [87: .bar, 187: .baz])
+  }
+
+  func testMapInt32Message() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.mapInt32Message, [:])
+    var valueMsg1 = ProtobufUnittest_Message2()
+    valueMsg1.optionalInt32 = 1088
+    msg.mapInt32Message = [88: valueMsg1]
+    XCTAssertEqual(msg.mapInt32Message.count, 1)
+    if let v = msg.mapInt32Message[88] {
+      XCTAssertEqual(v.optionalInt32, 1088)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapInt32Message, [88: valueMsg1])
+    var valueMsg2 = ProtobufUnittest_Message2()
+    valueMsg2.optionalInt32 = 1188
+    msg.mapInt32Message[188] = valueMsg2
+    XCTAssertEqual(msg.mapInt32Message.count, 2)
+    if let v = msg.mapInt32Message[88] {
+      XCTAssertEqual(v.optionalInt32, 1088)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    if let v = msg.mapInt32Message[188] {
+      XCTAssertEqual(v.optionalInt32, 1188)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapInt32Message, [88: valueMsg1, 188: valueMsg2])
+  }
+
+}

--- a/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto3.swift
@@ -1,0 +1,239 @@
+// Test/Sources/TestSuite/Test_MapFields_Access_Proto3.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis map fields.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_MapFields_Access_Proto3: XCTestCase {
+
+  func testMapInt32Int32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Int32, [:])
+    msg.mapInt32Int32 = [70: 1070]
+    XCTAssertEqual(msg.mapInt32Int32, [70: 1070])
+    msg.mapInt32Int32[170] = 1170
+    XCTAssertEqual(msg.mapInt32Int32, [70: 1070, 170: 1170])
+  }
+
+  func testMapInt64Int64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt64Int64, [:])
+    msg.mapInt64Int64 = [71: 1071]
+    XCTAssertEqual(msg.mapInt64Int64, [71: 1071])
+    msg.mapInt64Int64[171] = 1171
+    XCTAssertEqual(msg.mapInt64Int64, [71: 1071, 171: 1171])
+  }
+
+  func testMapUint32Uint32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapUint32Uint32, [:])
+    msg.mapUint32Uint32 = [72: 1072]
+    XCTAssertEqual(msg.mapUint32Uint32, [72: 1072])
+    msg.mapUint32Uint32[172] = 1172
+    XCTAssertEqual(msg.mapUint32Uint32, [72: 1072, 172: 1172])
+  }
+
+  func testMapUint64Uint64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapUint64Uint64, [:])
+    msg.mapUint64Uint64 = [73: 1073]
+    XCTAssertEqual(msg.mapUint64Uint64, [73: 1073])
+    msg.mapUint64Uint64[173] = 1173
+    XCTAssertEqual(msg.mapUint64Uint64, [73: 1073, 173: 1173])
+  }
+
+  func testMapSint32Sint32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapSint32Sint32, [:])
+    msg.mapSint32Sint32 = [74: 1074]
+    XCTAssertEqual(msg.mapSint32Sint32, [74: 1074])
+    msg.mapSint32Sint32[174] = 1174
+    XCTAssertEqual(msg.mapSint32Sint32, [74: 1074, 174: 1174])
+  }
+
+  func testMapSint64Sint64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapSint64Sint64, [:])
+    msg.mapSint64Sint64 = [75: 1075]
+    XCTAssertEqual(msg.mapSint64Sint64, [75: 1075])
+    msg.mapSint64Sint64[175] = 1175
+    XCTAssertEqual(msg.mapSint64Sint64, [75: 1075, 175: 1175])
+  }
+
+  func testMapFixed32Fixed32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapFixed32Fixed32, [:])
+    msg.mapFixed32Fixed32 = [76: 1076]
+    XCTAssertEqual(msg.mapFixed32Fixed32, [76: 1076])
+    msg.mapFixed32Fixed32[176] = 1176
+    XCTAssertEqual(msg.mapFixed32Fixed32, [76: 1076, 176: 1176])
+  }
+
+  func testMapFixed64Fixed64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapFixed64Fixed64, [:])
+    msg.mapFixed64Fixed64 = [77: 1077]
+    XCTAssertEqual(msg.mapFixed64Fixed64, [77: 1077])
+    msg.mapFixed64Fixed64[177] = 1177
+    XCTAssertEqual(msg.mapFixed64Fixed64, [77: 1077, 177: 1177])
+  }
+
+  func testMapSfixed32Sfixed32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [:])
+    msg.mapSfixed32Sfixed32 = [78: 1078]
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [78: 1078])
+    msg.mapSfixed32Sfixed32[178] = 1178
+    XCTAssertEqual(msg.mapSfixed32Sfixed32, [78: 1078, 178: 1178])
+  }
+
+  func testMapSfixed64Sfixed64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [:])
+    msg.mapSfixed64Sfixed64 = [79: 1079]
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [79: 1079])
+    msg.mapSfixed64Sfixed64[179] = 1179
+    XCTAssertEqual(msg.mapSfixed64Sfixed64, [79: 1079, 179: 1179])
+  }
+
+  func testMapInt32Float() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Float, [:])
+    msg.mapInt32Float = [80: 1080.0]
+    XCTAssertEqual(msg.mapInt32Float, [80: 1080.0])
+    msg.mapInt32Float[180] = 1180.0
+    XCTAssertEqual(msg.mapInt32Float, [80: 1080.0, 180: 1180.0])
+  }
+
+  func testMapInt32Double() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Double, [:])
+    msg.mapInt32Double = [81: 1081.0]
+    XCTAssertEqual(msg.mapInt32Double, [81: 1081.0])
+    msg.mapInt32Double[181] = 1181.0
+    XCTAssertEqual(msg.mapInt32Double, [81: 1081, 181: 1181.0])
+  }
+
+  func testMapBoolBool() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapBoolBool, [:])
+    msg.mapBoolBool = [true: false]
+    XCTAssertEqual(msg.mapBoolBool, [true: false])
+    msg.mapBoolBool[false] = true
+    XCTAssertEqual(msg.mapBoolBool, [true: false, false: true])
+  }
+
+  func testMapStringString() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapStringString, [:])
+    msg.mapStringString = ["83": "1083"]
+    XCTAssertEqual(msg.mapStringString, ["83": "1083"])
+    msg.mapStringString["183"] = "1183"
+    XCTAssertEqual(msg.mapStringString, ["83": "1083", "183": "1183"])
+  }
+
+  func testMapStringBytes() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapStringBytes, [:])
+    msg.mapStringBytes = ["84": Data([84])]
+    XCTAssertEqual(msg.mapStringBytes, ["84": Data([84])])
+    msg.mapStringBytes["184"] = Data([184])
+    XCTAssertEqual(msg.mapStringBytes, ["84": Data([84]), "184": Data([184])])
+  }
+
+  func testMapStringMessage() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapStringMessage, [:])
+    var valueMsg1 = ProtobufUnittest_Message3()
+    valueMsg1.optionalInt32 = 1085
+    msg.mapStringMessage = ["85": valueMsg1]
+    XCTAssertEqual(msg.mapStringMessage.count, 1)
+    if let v = msg.mapStringMessage["85"] {
+      XCTAssertEqual(v.optionalInt32, 1085)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapStringMessage, ["85": valueMsg1])
+    var valueMsg2 = ProtobufUnittest_Message3()
+    valueMsg2.optionalInt32 = 1185
+    msg.mapStringMessage["185"] = valueMsg2
+    XCTAssertEqual(msg.mapStringMessage.count, 2)
+    if let v = msg.mapStringMessage["85"] {
+      XCTAssertEqual(v.optionalInt32, 1085)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    if let v = msg.mapStringMessage["185"] {
+      XCTAssertEqual(v.optionalInt32, 1185)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapStringMessage, ["85": valueMsg1, "185": valueMsg2])
+  }
+
+  func testMapInt32Bytes() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Bytes, [:])
+    msg.mapInt32Bytes = [86: Data([86])]
+    XCTAssertEqual(msg.mapInt32Bytes, [86: Data([86])])
+    msg.mapInt32Bytes[186] = Data([186])
+    XCTAssertEqual(msg.mapInt32Bytes, [86: Data([86]), 186: Data([186])])
+  }
+
+  func testMapInt32Enum() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Enum, [:])
+    msg.mapInt32Enum = [87: .bar]
+    XCTAssertEqual(msg.mapInt32Enum, [87: .bar])
+    msg.mapInt32Enum[187] = .baz
+    XCTAssertEqual(msg.mapInt32Enum, [87: .bar, 187: .baz])
+  }
+
+  func testMapInt32Message() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.mapInt32Message, [:])
+    var valueMsg1 = ProtobufUnittest_Message3()
+    valueMsg1.optionalInt32 = 1088
+    msg.mapInt32Message = [88: valueMsg1]
+    XCTAssertEqual(msg.mapInt32Message.count, 1)
+    if let v = msg.mapInt32Message[88] {
+      XCTAssertEqual(v.optionalInt32, 1088)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapInt32Message, [88: valueMsg1])
+    var valueMsg2 = ProtobufUnittest_Message3()
+    valueMsg2.optionalInt32 = 1188
+    msg.mapInt32Message[188] = valueMsg2
+    XCTAssertEqual(msg.mapInt32Message.count, 2)
+    if let v = msg.mapInt32Message[88] {
+      XCTAssertEqual(v.optionalInt32, 1088)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    if let v = msg.mapInt32Message[188] {
+      XCTAssertEqual(v.optionalInt32, 1188)
+    } else {
+      XCTFail("Lookup failed")
+    }
+    XCTAssertEqual(msg.mapInt32Message, [88: valueMsg1, 188: valueMsg2])
+  }
+
+}

--- a/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto2.swift
@@ -1,0 +1,576 @@
+// Test/Sources/TestSuite/Test_OneofFields_Access_Proto2.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis for fields within a oneof.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_OneofFields_Access_Proto2: XCTestCase {
+
+  // Accessing one field.
+  // - Returns default
+  // - Accepts/Captures value
+  // - Resets
+  // - Accepts/Captures default value
+
+  func testOneofInt32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofInt32, 100)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt32 = 51
+    XCTAssertEqual(msg.oneofInt32, 51)
+    XCTAssertEqual(msg.o, .oneofInt32(51))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofInt32, 100)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt32 = 100
+    XCTAssertEqual(msg.oneofInt32, 100)
+    XCTAssertEqual(msg.o, .oneofInt32(100))
+  }
+
+  func testOneofInt64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofInt64, 101)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt64 = 52
+    XCTAssertEqual(msg.oneofInt64, 52)
+    XCTAssertEqual(msg.o, .oneofInt64(52))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofInt64, 101)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt64 = 101
+    XCTAssertEqual(msg.oneofInt64, 101)
+    XCTAssertEqual(msg.o, .oneofInt64(101))
+  }
+
+  func testOneofUint32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofUint32, 102)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint32 = 53
+    XCTAssertEqual(msg.oneofUint32, 53)
+    XCTAssertEqual(msg.o, .oneofUint32(53))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofUint32, 102)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint32 = 102
+    XCTAssertEqual(msg.oneofUint32, 102)
+    XCTAssertEqual(msg.o, .oneofUint32(102))
+  }
+
+  func testOneofUint64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofUint64, 103)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint64 = 54
+    XCTAssertEqual(msg.oneofUint64, 54)
+    XCTAssertEqual(msg.o, .oneofUint64(54))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofUint64, 103)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint64 = 103
+    XCTAssertEqual(msg.oneofUint64, 103)
+    XCTAssertEqual(msg.o, .oneofUint64(103))
+  }
+
+  func testOneofSint32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofSint32, 104)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint32 = 55
+    XCTAssertEqual(msg.oneofSint32, 55)
+    XCTAssertEqual(msg.o, .oneofSint32(55))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSint32, 104)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint32 = 104
+    XCTAssertEqual(msg.oneofSint32, 104)
+    XCTAssertEqual(msg.o, .oneofSint32(104))
+  }
+
+  func testOneofSint64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofSint64, 105)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint64 = 56
+    XCTAssertEqual(msg.oneofSint64, 56)
+    XCTAssertEqual(msg.o, .oneofSint64(56))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSint64, 105)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint64 = 105
+    XCTAssertEqual(msg.oneofSint64, 105)
+    XCTAssertEqual(msg.o, .oneofSint64(105))
+  }
+
+  func testOneofFixed32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofFixed32, 106)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed32 = 57
+    XCTAssertEqual(msg.oneofFixed32, 57)
+    XCTAssertEqual(msg.o, .oneofFixed32(57))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFixed32, 106)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed32 = 106
+    XCTAssertEqual(msg.oneofFixed32, 106)
+    XCTAssertEqual(msg.o, .oneofFixed32(106))
+  }
+
+  func testOneofFixed64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofFixed64, 107)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed64 = 58
+    XCTAssertEqual(msg.oneofFixed64, 58)
+    XCTAssertEqual(msg.o, .oneofFixed64(58))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFixed64, 107)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed64 = 107
+    XCTAssertEqual(msg.oneofFixed64, 107)
+    XCTAssertEqual(msg.o, .oneofFixed64(107))
+  }
+
+  func testOneofSfixed32() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofSfixed32, 108)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed32 = 59
+    XCTAssertEqual(msg.oneofSfixed32, 59)
+    XCTAssertEqual(msg.o, .oneofSfixed32(59))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSfixed32, 108)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed32 = 108
+    XCTAssertEqual(msg.oneofSfixed32, 108)
+    XCTAssertEqual(msg.o, .oneofSfixed32(108))
+  }
+
+  func testOneofSfixed64() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofSfixed64, 109)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed64 = 60
+    XCTAssertEqual(msg.oneofSfixed64, 60)
+    XCTAssertEqual(msg.o, .oneofSfixed64(60))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSfixed64, 109)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed64 = 109
+    XCTAssertEqual(msg.oneofSfixed64, 109)
+    XCTAssertEqual(msg.o, .oneofSfixed64(109))
+  }
+
+  func testOneofFloat() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofFloat, 110.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFloat = 61.0
+    XCTAssertEqual(msg.oneofFloat, 61.0)
+    XCTAssertEqual(msg.o, .oneofFloat(61.0))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFloat, 110.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFloat = 110.0
+    XCTAssertEqual(msg.oneofFloat, 110.0)
+    XCTAssertEqual(msg.o, .oneofFloat(110.0))
+  }
+
+  func testOneofDouble() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofDouble, 111.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofDouble = 62.0
+    XCTAssertEqual(msg.oneofDouble, 62.0)
+    XCTAssertEqual(msg.o, .oneofDouble(62.0))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofDouble, 111.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofDouble = 111.0
+    XCTAssertEqual(msg.oneofDouble, 111.0)
+    XCTAssertEqual(msg.o, .oneofDouble(111.0))
+  }
+
+  func testOneofBool() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofBool, true)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBool = false
+    XCTAssertEqual(msg.oneofBool, false)
+    XCTAssertEqual(msg.o, .oneofBool(false))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofBool, true)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBool = true
+    XCTAssertEqual(msg.oneofBool, true)
+    XCTAssertEqual(msg.o, .oneofBool(true))
+  }
+
+  func testOneofString() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofString, "string")
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofString = "64"
+    XCTAssertEqual(msg.oneofString, "64")
+    XCTAssertEqual(msg.o, .oneofString("64"))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofString, "string")
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofString = "string"
+    XCTAssertEqual(msg.oneofString, "string")
+    XCTAssertEqual(msg.o, .oneofString("string"))
+  }
+
+  func testOneofBytes() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8))
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBytes = Data([65])
+    XCTAssertEqual(msg.oneofBytes, Data([65]))
+    XCTAssertEqual(msg.o, .oneofBytes(Data([65])))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8))
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBytes = "data".data(using: .utf8)!
+    XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8))
+    XCTAssertEqual(msg.o, .oneofBytes("data".data(using: .utf8)!))
+  }
+
+  func testOneofGroup() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofGroup.a, 116)
+    XCTAssertFalse(msg.oneofGroup.hasA)
+    XCTAssertEqual(msg.o, .None)
+    var grp = ProtobufUnittest_Message2.OneofGroup()
+    grp.a = 66
+    msg.oneofGroup = grp
+    XCTAssertEqual(msg.oneofGroup.a, 66)
+    XCTAssertTrue(msg.oneofGroup.hasA)
+    XCTAssertEqual(msg.oneofGroup, grp)
+    if case .oneofGroup(let v) = msg.o {
+      XCTAssertTrue(v.hasA)
+      XCTAssertEqual(v.a, 66)
+      XCTAssertEqual(v, grp)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    XCTAssertEqual(msg.oneofGroup.a, 116)
+    XCTAssertFalse(msg.oneofGroup.hasA)
+    XCTAssertEqual(msg.o, .None)
+    // Default within the group
+    var grp2 = ProtobufUnittest_Message2.OneofGroup()
+    grp2.a = 116
+    msg.oneofGroup = grp2
+    XCTAssertEqual(msg.oneofGroup.a, 116)
+    XCTAssertTrue(msg.oneofGroup.hasA)
+    XCTAssertEqual(msg.oneofGroup, grp2)
+    if case .oneofGroup(let v) = msg.o {
+      XCTAssertTrue(v.hasA)
+      XCTAssertEqual(v.a, 116)
+      XCTAssertEqual(v, grp2)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    // Group with nothing set.
+    let grp3 = ProtobufUnittest_Message2.OneofGroup()
+    msg.oneofGroup = grp3
+    XCTAssertEqual(msg.oneofGroup.a, 116)
+    XCTAssertFalse(msg.oneofGroup.hasA)
+    XCTAssertEqual(msg.oneofGroup, grp3)
+    if case .oneofGroup(let v) = msg.o {
+      XCTAssertFalse(v.hasA)
+      XCTAssertEqual(v.a, 116)
+      XCTAssertEqual(v, grp3)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+  }
+
+  func testOneofMessage() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    var subMsg = ProtobufUnittest_Message2()
+    subMsg.optionalInt32 = 66
+    msg.oneofMessage = subMsg
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 66)
+    XCTAssertEqual(msg.oneofMessage, subMsg)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertEqual(v.optionalInt32, 66)
+      XCTAssertEqual(v, subMsg)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    // Default within the message
+    var subMsg2 = ProtobufUnittest_Message2()
+    subMsg2.optionalInt32 = 0
+    msg.oneofMessage = subMsg2
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertTrue(msg.oneofMessage.hasOptionalInt32)
+    XCTAssertEqual(msg.oneofMessage, subMsg2)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertTrue(v.hasOptionalInt32)
+      XCTAssertEqual(v.optionalInt32, 0)
+      XCTAssertEqual(v, subMsg2)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    // Message with nothing set.
+    let subMsg3 = ProtobufUnittest_Message2()
+    msg.oneofMessage = subMsg3
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertFalse(msg.oneofMessage.hasOptionalInt32)
+    XCTAssertEqual(msg.oneofMessage, subMsg3)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertFalse(v.hasOptionalInt32)
+      XCTAssertEqual(v.optionalInt32, 0)
+      XCTAssertEqual(v, subMsg3)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+  }
+
+  func testOneofEnum() {
+    var msg = ProtobufUnittest_Message2()
+    XCTAssertEqual(msg.oneofEnum, .baz)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofEnum = .bar
+    XCTAssertEqual(msg.oneofEnum, .bar)
+    XCTAssertEqual(msg.o, .oneofEnum(.bar))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofEnum, .baz)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofEnum = .baz
+    XCTAssertEqual(msg.oneofEnum, .baz)
+    XCTAssertEqual(msg.o, .oneofEnum(.baz))
+  }
+
+  // Chaining. Set each item in the oneof clear the previous one.
+
+  func testOneofOnlyOneSet() {
+    var msg = ProtobufUnittest_Message2()
+
+    func assertRightFiledSet(_ i: Int) {
+      // Make sure the case is correct for the enum based access.
+      switch msg.o {
+      case .None:
+        XCTAssertEqual(i, 0)
+      case .oneofInt32(let v):
+        XCTAssertEqual(i, 1)
+        XCTAssertEqual(v, 51)
+      case .oneofInt64(let v):
+        XCTAssertEqual(i, 2)
+        XCTAssertEqual(v, 52)
+      case .oneofUint32(let v):
+        XCTAssertEqual(i, 3)
+        XCTAssertEqual(v, 53)
+      case .oneofUint64(let v):
+        XCTAssertEqual(i, 4)
+        XCTAssertEqual(v, 54)
+      case .oneofSint32(let v):
+        XCTAssertEqual(i, 5)
+        XCTAssertEqual(v, 55)
+      case .oneofSint64(let v):
+        XCTAssertEqual(i, 6)
+        XCTAssertEqual(v, 56)
+      case .oneofFixed32(let v):
+        XCTAssertEqual(i, 7)
+        XCTAssertEqual(v, 57)
+      case .oneofFixed64(let v):
+        XCTAssertEqual(i, 8)
+        XCTAssertEqual(v, 58)
+      case .oneofSfixed32(let v):
+        XCTAssertEqual(i, 9)
+        XCTAssertEqual(v, 59)
+      case .oneofSfixed64(let v):
+        XCTAssertEqual(i, 10)
+        XCTAssertEqual(v, 60)
+      case .oneofFloat(let v):
+        XCTAssertEqual(i, 11)
+        XCTAssertEqual(v, 61.0)
+      case .oneofDouble(let v):
+        XCTAssertEqual(i, 12)
+        XCTAssertEqual(v, 62.0)
+      case .oneofBool(let v):
+        XCTAssertEqual(i, 13)
+        XCTAssertEqual(v, false)
+      case .oneofString(let v):
+        XCTAssertEqual(i, 14)
+        XCTAssertEqual(v, "64")
+      case .oneofBytes(let v):
+        XCTAssertEqual(i, 15)
+        XCTAssertEqual(v, Data([65]))
+      case .oneofGroup(let v):
+        XCTAssertEqual(i, 16)
+        XCTAssertTrue(v.hasA)
+        XCTAssertEqual(v.a, 66)
+      case .oneofMessage(let v):
+        XCTAssertEqual(i, 17)
+        XCTAssertTrue(v.hasOptionalInt32)
+        XCTAssertEqual(v.optionalInt32, 68)
+      case .oneofEnum(let v):
+        XCTAssertEqual(i, 18)
+        XCTAssertEqual(v, .bar)
+      }
+
+      // Check direct field access (gets the right value or the default)
+      if i == 1 {
+        XCTAssertEqual(msg.oneofInt32, 51)
+      } else {
+        XCTAssertEqual(msg.oneofInt32, 100, "i = \(i)")
+      }
+      if i == 2 {
+        XCTAssertEqual(msg.oneofInt64, 52)
+      } else {
+        XCTAssertEqual(msg.oneofInt64, 101, "i = \(i)")
+      }
+      if i == 3 {
+        XCTAssertEqual(msg.oneofUint32, 53)
+      } else {
+        XCTAssertEqual(msg.oneofUint32, 102, "i = \(i)")
+      }
+      if i == 4 {
+        XCTAssertEqual(msg.oneofUint64, 54)
+      } else {
+        XCTAssertEqual(msg.oneofUint64, 103, "i = \(i)")
+      }
+      if i == 5 {
+        XCTAssertEqual(msg.oneofSint32, 55)
+      } else {
+        XCTAssertEqual(msg.oneofSint32, 104, "i = \(i)")
+      }
+      if i == 6 {
+        XCTAssertEqual(msg.oneofSint64, 56)
+      } else {
+        XCTAssertEqual(msg.oneofSint64, 105, "i = \(i)")
+      }
+      if i == 7 {
+        XCTAssertEqual(msg.oneofFixed32, 57)
+      } else {
+        XCTAssertEqual(msg.oneofFixed32, 106, "i = \(i)")
+      }
+      if i == 8 {
+        XCTAssertEqual(msg.oneofFixed64, 58)
+      } else {
+        XCTAssertEqual(msg.oneofFixed64, 107, "i = \(i)")
+      }
+      if i == 9 {
+        XCTAssertEqual(msg.oneofSfixed32, 59)
+      } else {
+        XCTAssertEqual(msg.oneofSfixed32, 108, "i = \(i)")
+      }
+      if i == 10 {
+        XCTAssertEqual(msg.oneofSfixed64, 60)
+      } else {
+        XCTAssertEqual(msg.oneofSfixed64, 109, "i = \(i)")
+      }
+      if i == 11 {
+        XCTAssertEqual(msg.oneofFloat, 61.0)
+      } else {
+        XCTAssertEqual(msg.oneofFloat, 110.0, "i = \(i)")
+      }
+      if i == 12 {
+        XCTAssertEqual(msg.oneofDouble, 62.0)
+      } else {
+        XCTAssertEqual(msg.oneofDouble, 111.0, "i = \(i)")
+      }
+      if i == 13 {
+        XCTAssertEqual(msg.oneofBool, false)
+      } else {
+        XCTAssertEqual(msg.oneofBool, true, "i = \(i)")
+      }
+      if i == 14 {
+        XCTAssertEqual(msg.oneofString, "64")
+      } else {
+        XCTAssertEqual(msg.oneofString, "string", "i = \(i)")
+      }
+      if i == 15 {
+        XCTAssertEqual(msg.oneofBytes, Data([65]))
+      } else {
+        XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8), "i = \(i)")
+      }
+      if i == 16 {
+        XCTAssertTrue(msg.oneofGroup.hasA)
+        XCTAssertEqual(msg.oneofGroup.a, 66)
+      } else {
+        XCTAssertFalse(msg.oneofGroup.hasA, "i = \(i)")
+        XCTAssertEqual(msg.oneofGroup.a, 116, "i = \(i)")
+      }
+      if i == 17 {
+        XCTAssertTrue(msg.oneofMessage.hasOptionalInt32)
+        XCTAssertEqual(msg.oneofMessage.optionalInt32, 68)
+      } else {
+        XCTAssertFalse(msg.oneofMessage.hasOptionalInt32, "i = \(i)")
+        XCTAssertEqual(msg.oneofMessage.optionalInt32, 0, "i = \(i)")
+      }
+      if i == 18 {
+        XCTAssertEqual(msg.oneofEnum, .bar)
+      } else {
+        XCTAssertEqual(msg.oneofEnum, .baz, "i = \(i)")
+      }
+    }
+
+    // Now cycle through the cases.
+    assertRightFiledSet(0)
+    msg.oneofInt32 = 51
+    assertRightFiledSet(1)
+    msg.oneofInt64 = 52
+    assertRightFiledSet(2)
+    msg.oneofUint32 = 53
+    assertRightFiledSet(3)
+    msg.oneofUint64 = 54
+    assertRightFiledSet(4)
+    msg.oneofSint32 = 55
+    assertRightFiledSet(5)
+    msg.oneofSint64 = 56
+    assertRightFiledSet(6)
+    msg.oneofFixed32 = 57
+    assertRightFiledSet(7)
+    msg.oneofFixed64 = 58
+    assertRightFiledSet(8)
+    msg.oneofSfixed32 = 59
+    assertRightFiledSet(9)
+    msg.oneofSfixed64 = 60
+    assertRightFiledSet(10)
+    msg.oneofFloat = 61.0
+    assertRightFiledSet(11)
+    msg.oneofDouble = 62.0
+    assertRightFiledSet(12)
+    msg.oneofBool = false
+    assertRightFiledSet(13)
+    msg.oneofString = "64"
+    assertRightFiledSet(14)
+    msg.oneofBytes = Data([65])
+    assertRightFiledSet(15)
+    msg.oneofGroup.a = 66
+    assertRightFiledSet(16)
+    msg.oneofMessage.optionalInt32 = 68
+    assertRightFiledSet(17)
+    msg.oneofEnum = .bar
+    assertRightFiledSet(18)
+  }
+}

--- a/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto3.swift
@@ -1,0 +1,509 @@
+// Test/Sources/TestSuite/Test_OneofFields_Access_Proto3.swift
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Exercises the apis for fields within a oneof.
+///
+// -----------------------------------------------------------------------------
+
+import XCTest
+
+// NOTE: The generator changes what is generated based on the number/types
+// of fields (using a nested storage class or not), to be completel, all
+// these tests should be done once with a message that gets that storage
+// class and a second time with messages that avoid that.
+
+class Test_OneofFields_Access_Proto3: XCTestCase {
+
+  // Accessing one field.
+  // - Returns default
+  // - Accepts/Captures value
+  // - Resets
+  // - Accepts/Captures default value
+
+  func testOneofInt32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt32 = 51
+    XCTAssertEqual(msg.oneofInt32, 51)
+    XCTAssertEqual(msg.o, .oneofInt32(51))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt32 = 0
+    XCTAssertEqual(msg.oneofInt32, 0)
+    XCTAssertEqual(msg.o, .oneofInt32(0))
+  }
+
+  func testOneofInt64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofInt64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt64 = 52
+    XCTAssertEqual(msg.oneofInt64, 52)
+    XCTAssertEqual(msg.o, .oneofInt64(52))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofInt64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofInt64 = 0
+    XCTAssertEqual(msg.oneofInt64, 0)
+    XCTAssertEqual(msg.o, .oneofInt64(0))
+  }
+
+  func testOneofUint32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofUint32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint32 = 53
+    XCTAssertEqual(msg.oneofUint32, 53)
+    XCTAssertEqual(msg.o, .oneofUint32(53))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofUint32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint32 = 0
+    XCTAssertEqual(msg.oneofUint32, 0)
+    XCTAssertEqual(msg.o, .oneofUint32(0))
+  }
+
+  func testOneofUint64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofUint64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint64 = 54
+    XCTAssertEqual(msg.oneofUint64, 54)
+    XCTAssertEqual(msg.o, .oneofUint64(54))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofUint64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofUint64 = 0
+    XCTAssertEqual(msg.oneofUint64, 0)
+    XCTAssertEqual(msg.o, .oneofUint64(0))
+  }
+
+  func testOneofSint32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofSint32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint32 = 55
+    XCTAssertEqual(msg.oneofSint32, 55)
+    XCTAssertEqual(msg.o, .oneofSint32(55))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSint32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint32 = 0
+    XCTAssertEqual(msg.oneofSint32, 0)
+    XCTAssertEqual(msg.o, .oneofSint32(0))
+  }
+
+  func testOneofSint64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofSint64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint64 = 56
+    XCTAssertEqual(msg.oneofSint64, 56)
+    XCTAssertEqual(msg.o, .oneofSint64(56))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSint64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSint64 = 0
+    XCTAssertEqual(msg.oneofSint64, 0)
+    XCTAssertEqual(msg.o, .oneofSint64(0))
+  }
+
+  func testOneofFixed32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofFixed32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed32 = 57
+    XCTAssertEqual(msg.oneofFixed32, 57)
+    XCTAssertEqual(msg.o, .oneofFixed32(57))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFixed32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed32 = 0
+    XCTAssertEqual(msg.oneofFixed32, 0)
+    XCTAssertEqual(msg.o, .oneofFixed32(0))
+  }
+
+  func testOneofFixed64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofFixed64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed64 = 58
+    XCTAssertEqual(msg.oneofFixed64, 58)
+    XCTAssertEqual(msg.o, .oneofFixed64(58))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFixed64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFixed64 = 0
+    XCTAssertEqual(msg.oneofFixed64, 0)
+    XCTAssertEqual(msg.o, .oneofFixed64(0))
+  }
+
+  func testOneofSfixed32() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofSfixed32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed32 = 59
+    XCTAssertEqual(msg.oneofSfixed32, 59)
+    XCTAssertEqual(msg.o, .oneofSfixed32(59))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSfixed32, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed32 = 0
+    XCTAssertEqual(msg.oneofSfixed32, 0)
+    XCTAssertEqual(msg.o, .oneofSfixed32(0))
+  }
+
+  func testOneofSfixed64() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofSfixed64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed64 = 60
+    XCTAssertEqual(msg.oneofSfixed64, 60)
+    XCTAssertEqual(msg.o, .oneofSfixed64(60))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofSfixed64, 0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofSfixed64 = 0
+    XCTAssertEqual(msg.oneofSfixed64, 0)
+    XCTAssertEqual(msg.o, .oneofSfixed64(0))
+  }
+
+  func testOneofFloat() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofFloat, 0.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFloat = 61.0
+    XCTAssertEqual(msg.oneofFloat, 61.0)
+    XCTAssertEqual(msg.o, .oneofFloat(61.0))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofFloat, 0.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofFloat = 0.0
+    XCTAssertEqual(msg.oneofFloat, 0.0)
+    XCTAssertEqual(msg.o, .oneofFloat(0.0))
+  }
+
+  func testOneofDouble() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofDouble, 0.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofDouble = 62.0
+    XCTAssertEqual(msg.oneofDouble, 62.0)
+    XCTAssertEqual(msg.o, .oneofDouble(62.0))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofDouble, 0.0)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofDouble = 0.0
+    XCTAssertEqual(msg.oneofDouble, 0.0)
+    XCTAssertEqual(msg.o, .oneofDouble(0.0))
+  }
+
+  func testOneofBool() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofBool, false)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBool = true
+    XCTAssertEqual(msg.oneofBool, true)
+    XCTAssertEqual(msg.o, .oneofBool(true))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofBool, false)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBool = false
+    XCTAssertEqual(msg.oneofBool, false)
+    XCTAssertEqual(msg.o, .oneofBool(false))
+  }
+
+  func testOneofString() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofString, "")
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofString = "64"
+    XCTAssertEqual(msg.oneofString, "64")
+    XCTAssertEqual(msg.o, .oneofString("64"))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofString, "")
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofString = ""
+    XCTAssertEqual(msg.oneofString, "")
+    XCTAssertEqual(msg.o, .oneofString(""))
+  }
+
+  func testOneofBytes() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofBytes, Data())
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBytes = Data([65])
+    XCTAssertEqual(msg.oneofBytes, Data([65]))
+    XCTAssertEqual(msg.o, .oneofBytes(Data([65])))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofBytes, Data())
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofBytes = Data()
+    XCTAssertEqual(msg.oneofBytes, Data())
+    XCTAssertEqual(msg.o, .oneofBytes(Data()))
+  }
+
+  // No group.
+
+  func testOneofMessage() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    var subMsg = ProtobufUnittest_Message3()
+    subMsg.optionalInt32 = 66
+    msg.oneofMessage = subMsg
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 66)
+    XCTAssertEqual(msg.oneofMessage, subMsg)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertEqual(v.optionalInt32, 66)
+      XCTAssertEqual(v, subMsg)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.o, .None)
+    // Default within the message
+    var subMsg2 = ProtobufUnittest_Message3()
+    subMsg2.optionalInt32 = 0
+    msg.oneofMessage = subMsg2
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.oneofMessage, subMsg2)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertEqual(v.optionalInt32, 0)
+      XCTAssertEqual(v, subMsg2)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+    msg.o = .None
+    // Message with nothing set.
+    let subMsg3 = ProtobufUnittest_Message3()
+    msg.oneofMessage = subMsg3
+    XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
+    XCTAssertEqual(msg.oneofMessage, subMsg3)
+    if case .oneofMessage(let v) = msg.o {
+      XCTAssertEqual(v.optionalInt32, 0)
+      XCTAssertEqual(v, subMsg3)
+    } else {
+      XCTFail("Wasn't the right case")
+    }
+  }
+
+  func testOneofEnum() {
+    var msg = ProtobufUnittest_Message3()
+    XCTAssertEqual(msg.oneofEnum, .foo)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofEnum = .bar
+    XCTAssertEqual(msg.oneofEnum, .bar)
+    XCTAssertEqual(msg.o, .oneofEnum(.bar))
+    msg.o = .None
+    XCTAssertEqual(msg.oneofEnum, .foo)
+    XCTAssertEqual(msg.o, .None)
+    msg.oneofEnum = .foo
+    XCTAssertEqual(msg.oneofEnum, .foo)
+    XCTAssertEqual(msg.o, .oneofEnum(.foo))
+  }
+
+  // Chaining. Set each item in the oneof clear the previous one.
+
+  func testOneofOnlyOneSet() {
+    var msg = ProtobufUnittest_Message3()
+
+    func assertRightFiledSet(_ i: Int) {
+      // Make sure the case is correct for the enum based access.
+      switch msg.o {
+      case .None:
+        XCTAssertEqual(i, 0)
+      case .oneofInt32(let v):
+        XCTAssertEqual(i, 1)
+        XCTAssertEqual(v, 51)
+      case .oneofInt64(let v):
+        XCTAssertEqual(i, 2)
+        XCTAssertEqual(v, 52)
+      case .oneofUint32(let v):
+        XCTAssertEqual(i, 3)
+        XCTAssertEqual(v, 53)
+      case .oneofUint64(let v):
+        XCTAssertEqual(i, 4)
+        XCTAssertEqual(v, 54)
+      case .oneofSint32(let v):
+        XCTAssertEqual(i, 5)
+        XCTAssertEqual(v, 55)
+      case .oneofSint64(let v):
+        XCTAssertEqual(i, 6)
+        XCTAssertEqual(v, 56)
+      case .oneofFixed32(let v):
+        XCTAssertEqual(i, 7)
+        XCTAssertEqual(v, 57)
+      case .oneofFixed64(let v):
+        XCTAssertEqual(i, 8)
+        XCTAssertEqual(v, 58)
+      case .oneofSfixed32(let v):
+        XCTAssertEqual(i, 9)
+        XCTAssertEqual(v, 59)
+      case .oneofSfixed64(let v):
+        XCTAssertEqual(i, 10)
+        XCTAssertEqual(v, 60)
+      case .oneofFloat(let v):
+        XCTAssertEqual(i, 11)
+        XCTAssertEqual(v, 61.0)
+      case .oneofDouble(let v):
+        XCTAssertEqual(i, 12)
+        XCTAssertEqual(v, 62.0)
+      case .oneofBool(let v):
+        XCTAssertEqual(i, 13)
+        XCTAssertEqual(v, true)
+      case .oneofString(let v):
+        XCTAssertEqual(i, 14)
+        XCTAssertEqual(v, "64")
+      case .oneofBytes(let v):
+        XCTAssertEqual(i, 15)
+        XCTAssertEqual(v, Data([65]))
+      // No group.
+      case .oneofMessage(let v):
+        XCTAssertEqual(i, 17)
+        XCTAssertEqual(v.optionalInt32, 68)
+      case .oneofEnum(let v):
+        XCTAssertEqual(i, 18)
+        XCTAssertEqual(v, .bar)
+      }
+
+      // Check direct field access (gets the right value or the default)
+      if i == 1 {
+        XCTAssertEqual(msg.oneofInt32, 51)
+      } else {
+        XCTAssertEqual(msg.oneofInt32, 0, "i = \(i)")
+      }
+      if i == 2 {
+        XCTAssertEqual(msg.oneofInt64, 52)
+      } else {
+        XCTAssertEqual(msg.oneofInt64, 0, "i = \(i)")
+      }
+      if i == 3 {
+        XCTAssertEqual(msg.oneofUint32, 53)
+      } else {
+        XCTAssertEqual(msg.oneofUint32, 0, "i = \(i)")
+      }
+      if i == 4 {
+        XCTAssertEqual(msg.oneofUint64, 54)
+      } else {
+        XCTAssertEqual(msg.oneofUint64, 0, "i = \(i)")
+      }
+      if i == 5 {
+        XCTAssertEqual(msg.oneofSint32, 55)
+      } else {
+        XCTAssertEqual(msg.oneofSint32, 0, "i = \(i)")
+      }
+      if i == 6 {
+        XCTAssertEqual(msg.oneofSint64, 56)
+      } else {
+        XCTAssertEqual(msg.oneofSint64, 0, "i = \(i)")
+      }
+      if i == 7 {
+        XCTAssertEqual(msg.oneofFixed32, 57)
+      } else {
+        XCTAssertEqual(msg.oneofFixed32, 0, "i = \(i)")
+      }
+      if i == 8 {
+        XCTAssertEqual(msg.oneofFixed64, 58)
+      } else {
+        XCTAssertEqual(msg.oneofFixed64, 0, "i = \(i)")
+      }
+      if i == 9 {
+        XCTAssertEqual(msg.oneofSfixed32, 59)
+      } else {
+        XCTAssertEqual(msg.oneofSfixed32, 0, "i = \(i)")
+      }
+      if i == 10 {
+        XCTAssertEqual(msg.oneofSfixed64, 60)
+      } else {
+        XCTAssertEqual(msg.oneofSfixed64, 0, "i = \(i)")
+      }
+      if i == 11 {
+        XCTAssertEqual(msg.oneofFloat, 61.0)
+      } else {
+        XCTAssertEqual(msg.oneofFloat, 0.0, "i = \(i)")
+      }
+      if i == 12 {
+        XCTAssertEqual(msg.oneofDouble, 62.0)
+      } else {
+        XCTAssertEqual(msg.oneofDouble, 0.0, "i = \(i)")
+      }
+      if i == 13 {
+        XCTAssertEqual(msg.oneofBool, true)
+      } else {
+        XCTAssertEqual(msg.oneofBool, false, "i = \(i)")
+      }
+      if i == 14 {
+        XCTAssertEqual(msg.oneofString, "64")
+      } else {
+        XCTAssertEqual(msg.oneofString, "", "i = \(i)")
+      }
+      if i == 15 {
+        XCTAssertEqual(msg.oneofBytes, Data([65]))
+      } else {
+        XCTAssertEqual(msg.oneofBytes, Data(), "i = \(i)")
+      }
+      // No group
+      if i == 17 {
+        XCTAssertEqual(msg.oneofMessage.optionalInt32, 68)
+      } else {
+        XCTAssertEqual(msg.oneofMessage.optionalInt32, 0, "i = \(i)")
+      }
+      if i == 18 {
+        XCTAssertEqual(msg.oneofEnum, .bar)
+      } else {
+        XCTAssertEqual(msg.oneofEnum, .foo, "i = \(i)")
+      }
+    }
+
+    // Now cycle through the cases.
+    assertRightFiledSet(0)
+    msg.oneofInt32 = 51
+    assertRightFiledSet(1)
+    msg.oneofInt64 = 52
+    assertRightFiledSet(2)
+    msg.oneofUint32 = 53
+    assertRightFiledSet(3)
+    msg.oneofUint64 = 54
+    assertRightFiledSet(4)
+    msg.oneofSint32 = 55
+    assertRightFiledSet(5)
+    msg.oneofSint64 = 56
+    assertRightFiledSet(6)
+    msg.oneofFixed32 = 57
+    assertRightFiledSet(7)
+    msg.oneofFixed64 = 58
+    assertRightFiledSet(8)
+    msg.oneofSfixed32 = 59
+    assertRightFiledSet(9)
+    msg.oneofSfixed64 = 60
+    assertRightFiledSet(10)
+    msg.oneofFloat = 61
+    assertRightFiledSet(11)
+    msg.oneofDouble = 62
+    assertRightFiledSet(12)
+    msg.oneofBool = true
+    assertRightFiledSet(13)
+    msg.oneofString = "64"
+    assertRightFiledSet(14)
+    msg.oneofBytes = Data([65])
+    assertRightFiledSet(15)
+    // No group
+    msg.oneofMessage.optionalInt32 = 68
+    assertRightFiledSet(17)
+    msg.oneofEnum = .bar
+    assertRightFiledSet(18)
+  }
+}

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -1067,7 +1067,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
 
     private var _a: Int32? = nil
     public var a: Int32 {
-      get {return _a ?? 0}
+      get {return _a ?? 116}
       set {_a = newValue}
     }
     public var hasA: Bool {
@@ -1117,7 +1117,7 @@ public struct ProtobufUnittest_Message2: ProtobufGeneratedMessage {
     }
 
     public func _protoc_generated_isEqualTo(other: ProtobufUnittest_Message2.OneofGroup) -> Bool {
-      if (a != other.a) {return false}
+      if (((_a != nil && _a! != 116) || (other._a != nil && other._a! != 116)) && (_a == nil || other._a == nil || _a! != other._a!)) {return false}
       if (b != other.b) {return false}
       if unknown != other.unknown {return false}
       return true


### PR DESCRIPTION
Following up on #102, add tests that cover all those apis point, start building out general tests that access all the different field types, explicit default values, etc.
