### PR TITLE
Bump the version number.

### DIFF
--- a/Sources/protoc-gen-swift/Version.swift
+++ b/Sources/protoc-gen-swift/Version.swift
@@ -17,7 +17,7 @@
 struct Version {
     static let major = 0
     static let minor = 9
-    static let revision = 24
+    static let revision = 25
     static let versionString = "\(major).\(minor).\(revision)"
     static let name = "protoc-gen-swift"
     static let versionedName = "protoc-gen-swift \(versionString)"


### PR DESCRIPTION
Inspired by https://github.com/apple/swift-protobuf/issues/120.

The version number on master probably should get a bump right after ever tag is
cut. That way master reports something different and helps identify when folks
are trying to use master with a tagged release.