### PR TITLE
Fix typo in tag checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Once you pick the version you will use, set your local state to match, and
 build the protoc plugin:
 
 ```
-$ git checkout tag/[tag_name]
+$ git checkout tags/[tag_name]
 $ swift build
 ```
 


### PR DESCRIPTION
`git checkout tag/[tag_name]` should be `git checkout tags/[tag_name]`