### PR TITLE
Enforce minimum version of CocoaPods

### DIFF
--- a/SwiftProtobuf.podspec
+++ b/SwiftProtobuf.podspec
@@ -13,5 +13,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
+  s.cocoapods_version = '>= 1.1.0'
+
   s.source_files = 'Sources/SwiftProtobuf/**/*.swift'
 end


### PR DESCRIPTION
From the README:

> (Swift 3 frameworks require CocoaPods 1.1 or newer)

This can be enforced at the podspec level to prevent consumers of older versions to use this podspec.