### PR TITLE
Assign access control by visibility option

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -60,17 +60,17 @@ import SwiftProtobuf
 //      iOS apps, where fork/stdin/stdout are not available.
 
 enum Conformance_WireFormat: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case unspecified // = 0
   case protobuf // = 1
   case json_ // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .unspecified
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .unspecified
     case 1: self = .protobuf
@@ -79,7 +79,7 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "unspecified": self = .unspecified
     case "protobuf": self = .protobuf
@@ -88,7 +88,7 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "UNSPECIFIED": self = .unspecified
     case "PROTOBUF": self = .protobuf
@@ -97,7 +97,7 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "UNSPECIFIED": self = .unspecified
     case "PROTOBUF": self = .protobuf
@@ -106,7 +106,7 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .unspecified: return 0
@@ -117,7 +117,7 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .unspecified: return "\"UNSPECIFIED\""
@@ -128,9 +128,9 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .unspecified: return ".unspecified"
@@ -144,17 +144,17 @@ enum Conformance_WireFormat: ProtobufEnum {
 }
 
 enum Conformance_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
   case foreignBaz // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foreignFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foreignFoo
     case 1: self = .foreignBar
@@ -163,7 +163,7 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignFoo": self = .foreignFoo
     case "foreignBar": self = .foreignBar
@@ -172,7 +172,7 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -181,7 +181,7 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -190,7 +190,7 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignFoo: return 0
@@ -201,7 +201,7 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignFoo: return "\"FOREIGN_FOO\""
@@ -212,9 +212,9 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignFoo: return ".foreignFoo"
@@ -295,7 +295,7 @@ struct Conformance_ConformanceRequest: ProtobufGeneratedMessage, ProtobufProto3M
     }
   }
 
-  public var protobufPayload: Data {
+  var protobufPayload: Data {
     get {
       if case .protobufPayload(let v) = payload {
         return v
@@ -309,7 +309,7 @@ struct Conformance_ConformanceRequest: ProtobufGeneratedMessage, ProtobufProto3M
 
   public var payload: Conformance_ConformanceRequest.OneOf_Payload = .None
 
-  public var jsonPayload: String {
+  var jsonPayload: String {
     get {
       if case .jsonPayload(let v) = payload {
         return v
@@ -322,9 +322,9 @@ struct Conformance_ConformanceRequest: ProtobufGeneratedMessage, ProtobufProto3M
   }
 
   ///   Which format should the testee serialize its message to?
-  public var requestedOutputFormat: Conformance_WireFormat = Conformance_WireFormat.unspecified
+  var requestedOutputFormat: Conformance_WireFormat = Conformance_WireFormat.unspecified
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -459,7 +459,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
   ///  
   ///   Setting this string does not necessarily mean the testee failed the
   ///   test.  Some of the test cases are intentionally invalid input.
-  public var parseError: String {
+  var parseError: String {
     get {
       if case .parseError(let v) = result {
         return v
@@ -476,7 +476,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
   ///   If the input was successfully parsed but errors occurred when
   ///   serializing it to the requested output format, set the error message in
   ///   this field.
-  public var serializeError: String {
+  var serializeError: String {
     get {
       if case .serializeError(let v) = result {
         return v
@@ -491,7 +491,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
   ///   This should be set if some other error occurred.  This will always
   ///   indicate that the test failed.  The string can provide more information
   ///   about the failure.
-  public var runtimeError: String {
+  var runtimeError: String {
     get {
       if case .runtimeError(let v) = result {
         return v
@@ -505,7 +505,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
 
   ///   If the input was successfully parsed and the requested output was
   ///   protobuf, serialize it to protobuf and set it in this field.
-  public var protobufPayload: Data {
+  var protobufPayload: Data {
     get {
       if case .protobufPayload(let v) = result {
         return v
@@ -519,7 +519,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
 
   ///   If the input was successfully parsed and the requested output was JSON,
   ///   serialize to JSON and set it in this field.
-  public var jsonPayload: String {
+  var jsonPayload: String {
     get {
       if case .jsonPayload(let v) = result {
         return v
@@ -533,7 +533,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
 
   ///   For when the testee skipped the test, likely because a certain feature
   ///   wasn't supported, like JSON input/output.
-  public var skipped: String {
+  var skipped: String {
     get {
       if case .skipped(let v) = result {
         return v
@@ -545,7 +545,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1619,7 +1619,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
@@ -1628,11 +1628,11 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     case neg // = -1
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -1642,7 +1642,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -1652,7 +1652,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1662,7 +1662,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1672,7 +1672,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -1684,7 +1684,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -1696,9 +1696,9 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1766,12 +1766,12 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     private var _storage = _StorageClass()
 
 
-    public var a: Int32 {
+    var a: Int32 {
       get {return _storage._a}
       set {_uniqueStorage()._a = newValue}
     }
 
-    public var corecursive: Conformance_TestAllTypes {
+    var corecursive: Conformance_TestAllTypes {
       get {return _storage._corecursive ?? Conformance_TestAllTypes()}
       set {_uniqueStorage()._corecursive = newValue}
     }
@@ -1782,7 +1782,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       return _storage._corecursive = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1805,82 +1805,82 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  public var optionalNestedMessage: Conformance_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: Conformance_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Conformance_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -1891,7 +1891,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: Conformance_ForeignMessage {
+  var optionalForeignMessage: Conformance_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? Conformance_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -1902,27 +1902,27 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalNestedEnum: Conformance_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: Conformance_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
 
-  public var optionalForeignEnum: Conformance_ForeignEnum {
+  var optionalForeignEnum: Conformance_ForeignEnum {
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord}
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
-  public var recursiveMessage: Conformance_TestAllTypes {
+  var recursiveMessage: Conformance_TestAllTypes {
     get {return _storage._recursiveMessage ?? Conformance_TestAllTypes()}
     set {_uniqueStorage()._recursiveMessage = newValue}
   }
@@ -1934,208 +1934,208 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedNestedMessage: [Conformance_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [Conformance_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [Conformance_ForeignMessage] {
+  var repeatedForeignMessage: [Conformance_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [Conformance_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [Conformance_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [Conformance_ForeignEnum] {
+  var repeatedForeignEnum: [Conformance_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
   ///   Map
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapStringBytes: Dictionary<String,Data> {
+  var mapStringBytes: Dictionary<String,Data> {
     get {return _storage._mapStringBytes}
     set {_uniqueStorage()._mapStringBytes = newValue}
   }
 
-  public var mapStringNestedMessage: Dictionary<String,Conformance_TestAllTypes.NestedMessage> {
+  var mapStringNestedMessage: Dictionary<String,Conformance_TestAllTypes.NestedMessage> {
     get {return _storage._mapStringNestedMessage}
     set {_uniqueStorage()._mapStringNestedMessage = newValue}
   }
 
-  public var mapStringForeignMessage: Dictionary<String,Conformance_ForeignMessage> {
+  var mapStringForeignMessage: Dictionary<String,Conformance_ForeignMessage> {
     get {return _storage._mapStringForeignMessage}
     set {_uniqueStorage()._mapStringForeignMessage = newValue}
   }
 
-  public var mapStringNestedEnum: Dictionary<String,Conformance_TestAllTypes.NestedEnum> {
+  var mapStringNestedEnum: Dictionary<String,Conformance_TestAllTypes.NestedEnum> {
     get {return _storage._mapStringNestedEnum}
     set {_uniqueStorage()._mapStringNestedEnum = newValue}
   }
 
-  public var mapStringForeignEnum: Dictionary<String,Conformance_ForeignEnum> {
+  var mapStringForeignEnum: Dictionary<String,Conformance_ForeignEnum> {
     get {return _storage._mapStringForeignEnum}
     set {_uniqueStorage()._mapStringForeignEnum = newValue}
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -2147,7 +2147,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     }
   }
 
-  public var oneofNestedMessage: Conformance_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: Conformance_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -2159,7 +2159,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -2171,7 +2171,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -2184,7 +2184,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
   }
 
   ///   Well-known types
-  public var optionalBoolWrapper: Google_Protobuf_BoolValue {
+  var optionalBoolWrapper: Google_Protobuf_BoolValue {
     get {return _storage._optionalBoolWrapper ?? Google_Protobuf_BoolValue()}
     set {_uniqueStorage()._optionalBoolWrapper = newValue}
   }
@@ -2195,7 +2195,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalBoolWrapper = nil
   }
 
-  public var optionalInt32Wrapper: Google_Protobuf_Int32Value {
+  var optionalInt32Wrapper: Google_Protobuf_Int32Value {
     get {return _storage._optionalInt32Wrapper ?? Google_Protobuf_Int32Value()}
     set {_uniqueStorage()._optionalInt32Wrapper = newValue}
   }
@@ -2206,7 +2206,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalInt32Wrapper = nil
   }
 
-  public var optionalInt64Wrapper: Google_Protobuf_Int64Value {
+  var optionalInt64Wrapper: Google_Protobuf_Int64Value {
     get {return _storage._optionalInt64Wrapper ?? Google_Protobuf_Int64Value()}
     set {_uniqueStorage()._optionalInt64Wrapper = newValue}
   }
@@ -2217,7 +2217,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalInt64Wrapper = nil
   }
 
-  public var optionalUint32Wrapper: Google_Protobuf_UInt32Value {
+  var optionalUint32Wrapper: Google_Protobuf_UInt32Value {
     get {return _storage._optionalUint32Wrapper ?? Google_Protobuf_UInt32Value()}
     set {_uniqueStorage()._optionalUint32Wrapper = newValue}
   }
@@ -2228,7 +2228,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalUint32Wrapper = nil
   }
 
-  public var optionalUint64Wrapper: Google_Protobuf_UInt64Value {
+  var optionalUint64Wrapper: Google_Protobuf_UInt64Value {
     get {return _storage._optionalUint64Wrapper ?? Google_Protobuf_UInt64Value()}
     set {_uniqueStorage()._optionalUint64Wrapper = newValue}
   }
@@ -2239,7 +2239,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalUint64Wrapper = nil
   }
 
-  public var optionalFloatWrapper: Google_Protobuf_FloatValue {
+  var optionalFloatWrapper: Google_Protobuf_FloatValue {
     get {return _storage._optionalFloatWrapper ?? Google_Protobuf_FloatValue()}
     set {_uniqueStorage()._optionalFloatWrapper = newValue}
   }
@@ -2250,7 +2250,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalFloatWrapper = nil
   }
 
-  public var optionalDoubleWrapper: Google_Protobuf_DoubleValue {
+  var optionalDoubleWrapper: Google_Protobuf_DoubleValue {
     get {return _storage._optionalDoubleWrapper ?? Google_Protobuf_DoubleValue()}
     set {_uniqueStorage()._optionalDoubleWrapper = newValue}
   }
@@ -2261,7 +2261,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalDoubleWrapper = nil
   }
 
-  public var optionalStringWrapper: Google_Protobuf_StringValue {
+  var optionalStringWrapper: Google_Protobuf_StringValue {
     get {return _storage._optionalStringWrapper ?? Google_Protobuf_StringValue()}
     set {_uniqueStorage()._optionalStringWrapper = newValue}
   }
@@ -2272,7 +2272,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalStringWrapper = nil
   }
 
-  public var optionalBytesWrapper: Google_Protobuf_BytesValue {
+  var optionalBytesWrapper: Google_Protobuf_BytesValue {
     get {return _storage._optionalBytesWrapper ?? Google_Protobuf_BytesValue()}
     set {_uniqueStorage()._optionalBytesWrapper = newValue}
   }
@@ -2283,52 +2283,52 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalBytesWrapper = nil
   }
 
-  public var repeatedBoolWrapper: [Google_Protobuf_BoolValue] {
+  var repeatedBoolWrapper: [Google_Protobuf_BoolValue] {
     get {return _storage._repeatedBoolWrapper}
     set {_uniqueStorage()._repeatedBoolWrapper = newValue}
   }
 
-  public var repeatedInt32Wrapper: [Google_Protobuf_Int32Value] {
+  var repeatedInt32Wrapper: [Google_Protobuf_Int32Value] {
     get {return _storage._repeatedInt32Wrapper}
     set {_uniqueStorage()._repeatedInt32Wrapper = newValue}
   }
 
-  public var repeatedInt64Wrapper: [Google_Protobuf_Int64Value] {
+  var repeatedInt64Wrapper: [Google_Protobuf_Int64Value] {
     get {return _storage._repeatedInt64Wrapper}
     set {_uniqueStorage()._repeatedInt64Wrapper = newValue}
   }
 
-  public var repeatedUint32Wrapper: [Google_Protobuf_UInt32Value] {
+  var repeatedUint32Wrapper: [Google_Protobuf_UInt32Value] {
     get {return _storage._repeatedUint32Wrapper}
     set {_uniqueStorage()._repeatedUint32Wrapper = newValue}
   }
 
-  public var repeatedUint64Wrapper: [Google_Protobuf_UInt64Value] {
+  var repeatedUint64Wrapper: [Google_Protobuf_UInt64Value] {
     get {return _storage._repeatedUint64Wrapper}
     set {_uniqueStorage()._repeatedUint64Wrapper = newValue}
   }
 
-  public var repeatedFloatWrapper: [Google_Protobuf_FloatValue] {
+  var repeatedFloatWrapper: [Google_Protobuf_FloatValue] {
     get {return _storage._repeatedFloatWrapper}
     set {_uniqueStorage()._repeatedFloatWrapper = newValue}
   }
 
-  public var repeatedDoubleWrapper: [Google_Protobuf_DoubleValue] {
+  var repeatedDoubleWrapper: [Google_Protobuf_DoubleValue] {
     get {return _storage._repeatedDoubleWrapper}
     set {_uniqueStorage()._repeatedDoubleWrapper = newValue}
   }
 
-  public var repeatedStringWrapper: [Google_Protobuf_StringValue] {
+  var repeatedStringWrapper: [Google_Protobuf_StringValue] {
     get {return _storage._repeatedStringWrapper}
     set {_uniqueStorage()._repeatedStringWrapper = newValue}
   }
 
-  public var repeatedBytesWrapper: [Google_Protobuf_BytesValue] {
+  var repeatedBytesWrapper: [Google_Protobuf_BytesValue] {
     get {return _storage._repeatedBytesWrapper}
     set {_uniqueStorage()._repeatedBytesWrapper = newValue}
   }
 
-  public var optionalDuration: Google_Protobuf_Duration {
+  var optionalDuration: Google_Protobuf_Duration {
     get {return _storage._optionalDuration ?? Google_Protobuf_Duration()}
     set {_uniqueStorage()._optionalDuration = newValue}
   }
@@ -2339,7 +2339,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalDuration = nil
   }
 
-  public var optionalTimestamp: Google_Protobuf_Timestamp {
+  var optionalTimestamp: Google_Protobuf_Timestamp {
     get {return _storage._optionalTimestamp ?? Google_Protobuf_Timestamp()}
     set {_uniqueStorage()._optionalTimestamp = newValue}
   }
@@ -2350,7 +2350,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalTimestamp = nil
   }
 
-  public var optionalFieldMask: Google_Protobuf_FieldMask {
+  var optionalFieldMask: Google_Protobuf_FieldMask {
     get {return _storage._optionalFieldMask ?? Google_Protobuf_FieldMask()}
     set {_uniqueStorage()._optionalFieldMask = newValue}
   }
@@ -2361,7 +2361,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalFieldMask = nil
   }
 
-  public var optionalStruct: Google_Protobuf_Struct {
+  var optionalStruct: Google_Protobuf_Struct {
     get {return _storage._optionalStruct ?? Google_Protobuf_Struct()}
     set {_uniqueStorage()._optionalStruct = newValue}
   }
@@ -2372,7 +2372,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalStruct = nil
   }
 
-  public var optionalAny: Google_Protobuf_Any {
+  var optionalAny: Google_Protobuf_Any {
     get {return _storage._optionalAny ?? Google_Protobuf_Any()}
     set {_uniqueStorage()._optionalAny = newValue}
   }
@@ -2383,7 +2383,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalAny = nil
   }
 
-  public var optionalValue: Google_Protobuf_Value {
+  var optionalValue: Google_Protobuf_Value {
     get {return _storage._optionalValue ?? Google_Protobuf_Value()}
     set {_uniqueStorage()._optionalValue = newValue}
   }
@@ -2394,93 +2394,93 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalValue = nil
   }
 
-  public var repeatedDuration: [Google_Protobuf_Duration] {
+  var repeatedDuration: [Google_Protobuf_Duration] {
     get {return _storage._repeatedDuration}
     set {_uniqueStorage()._repeatedDuration = newValue}
   }
 
-  public var repeatedTimestamp: [Google_Protobuf_Timestamp] {
+  var repeatedTimestamp: [Google_Protobuf_Timestamp] {
     get {return _storage._repeatedTimestamp}
     set {_uniqueStorage()._repeatedTimestamp = newValue}
   }
 
-  public var repeatedFieldmask: [Google_Protobuf_FieldMask] {
+  var repeatedFieldmask: [Google_Protobuf_FieldMask] {
     get {return _storage._repeatedFieldmask}
     set {_uniqueStorage()._repeatedFieldmask = newValue}
   }
 
-  public var repeatedStruct: [Google_Protobuf_Struct] {
+  var repeatedStruct: [Google_Protobuf_Struct] {
     get {return _storage._repeatedStruct}
     set {_uniqueStorage()._repeatedStruct = newValue}
   }
 
-  public var repeatedAny: [Google_Protobuf_Any] {
+  var repeatedAny: [Google_Protobuf_Any] {
     get {return _storage._repeatedAny}
     set {_uniqueStorage()._repeatedAny = newValue}
   }
 
-  public var repeatedValue: [Google_Protobuf_Value] {
+  var repeatedValue: [Google_Protobuf_Value] {
     get {return _storage._repeatedValue}
     set {_uniqueStorage()._repeatedValue = newValue}
   }
 
   ///   Test field-name-to-JSON-name convention.
-  public var fieldname1: Int32 {
+  var fieldname1: Int32 {
     get {return _storage._fieldname1}
     set {_uniqueStorage()._fieldname1 = newValue}
   }
 
-  public var fieldName2: Int32 {
+  var fieldName2: Int32 {
     get {return _storage._fieldName2}
     set {_uniqueStorage()._fieldName2 = newValue}
   }
 
-  public var fieldName3: Int32 {
+  var fieldName3: Int32 {
     get {return _storage._fieldName3}
     set {_uniqueStorage()._fieldName3 = newValue}
   }
 
-  public var field_Name4_: Int32 {
+  var field_Name4_: Int32 {
     get {return _storage._field_Name4_}
     set {_uniqueStorage()._field_Name4_ = newValue}
   }
 
-  public var field0Name5: Int32 {
+  var field0Name5: Int32 {
     get {return _storage._field0Name5}
     set {_uniqueStorage()._field0Name5 = newValue}
   }
 
-  public var field0Name6: Int32 {
+  var field0Name6: Int32 {
     get {return _storage._field0Name6}
     set {_uniqueStorage()._field0Name6 = newValue}
   }
 
-  public var fieldName7: Int32 {
+  var fieldName7: Int32 {
     get {return _storage._fieldName7}
     set {_uniqueStorage()._fieldName7 = newValue}
   }
 
-  public var fieldName8: Int32 {
+  var fieldName8: Int32 {
     get {return _storage._fieldName8}
     set {_uniqueStorage()._fieldName8 = newValue}
   }
 
-  public var fieldName9: Int32 {
+  var fieldName9: Int32 {
     get {return _storage._fieldName9}
     set {_uniqueStorage()._fieldName9 = newValue}
   }
 
-  public var fieldName10: Int32 {
+  var fieldName10: Int32 {
     get {return _storage._fieldName10}
     set {_uniqueStorage()._fieldName10 = newValue}
   }
 
-  public var fieldName11: Int32 {
+  var fieldName11: Int32 {
     get {return _storage._fieldName11}
     set {_uniqueStorage()._fieldName11 = newValue}
   }
 
-  public var fieldName12: Int32 {
+  var fieldName12: Int32 {
     get {return _storage._fieldName12}
     set {_uniqueStorage()._fieldName12 = newValue}
   }
@@ -2492,7 +2492,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2526,9 +2526,9 @@ struct Conformance_ForeignMessage: ProtobufGeneratedMessage, ProtobufProto3Messa
   ]}
 
 
-  public var c: Int32 = 0
+  var c: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/any.pb.swift
+++ b/Reference/google/protobuf/any.pb.swift
@@ -143,12 +143,12 @@ struct Google_Protobuf_Any: ProtobufGeneratedMessage, ProtobufProto3Message {
   ///  
   ///   Schemes other than `http`, `https` (or the empty scheme) might be
   ///   used with implementation specific semantics.
-  public var typeURL: String = ""
+  var typeURL: String = ""
 
   ///   Must be a valid serialized protocol buffer of the above specified type.
-  public var value: Data = Data()
+  var value: Data = Data()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/any_test.pb.swift
+++ b/Reference/google/protobuf/any_test.pb.swift
@@ -103,12 +103,12 @@ struct ProtobufUnittest_TestAny: ProtobufGeneratedMessage, ProtobufProto3Message
   private var _storage = _StorageClass()
 
 
-  public var int32Value: Int32 {
+  var int32Value: Int32 {
     get {return _storage._int32Value}
     set {_uniqueStorage()._int32Value = newValue}
   }
 
-  public var anyValue: Google_Protobuf_Any {
+  var anyValue: Google_Protobuf_Any {
     get {return _storage._anyValue ?? Google_Protobuf_Any()}
     set {_uniqueStorage()._anyValue = newValue}
   }
@@ -119,12 +119,12 @@ struct ProtobufUnittest_TestAny: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._anyValue = nil
   }
 
-  public var repeatedAnyValue: [Google_Protobuf_Any] {
+  var repeatedAnyValue: [Google_Protobuf_Any] {
     get {return _storage._repeatedAnyValue}
     set {_uniqueStorage()._repeatedAnyValue = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/google/protobuf/api.pb.swift
+++ b/Reference/google/protobuf/api.pb.swift
@@ -141,19 +141,19 @@ struct Google_Protobuf_Api: ProtobufGeneratedMessage, ProtobufProto3Message {
 
   ///   The fully qualified name of this api, including package name
   ///   followed by the api's simple name.
-  public var name: String {
+  var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
   ///   The methods of this api, in unspecified order.
-  public var methods: [Google_Protobuf_Method] {
+  var methods: [Google_Protobuf_Method] {
     get {return _storage._methods}
     set {_uniqueStorage()._methods = newValue}
   }
 
   ///   Any metadata attached to the API.
-  public var options: [Google_Protobuf_Option] {
+  var options: [Google_Protobuf_Option] {
     get {return _storage._options}
     set {_uniqueStorage()._options = newValue}
   }
@@ -178,14 +178,14 @@ struct Google_Protobuf_Api: ProtobufGeneratedMessage, ProtobufProto3Message {
   ///   `google.feature.v1`. For major versions 0 and 1, the suffix can
   ///   be omitted. Zero major versions must only be used for
   ///   experimental, none-GA apis.
-  public var version: String {
+  var version: String {
     get {return _storage._version}
     set {_uniqueStorage()._version = newValue}
   }
 
   ///   Source context for the protocol buffer service represented by this
   ///   message.
-  public var sourceContext: Google_Protobuf_SourceContext {
+  var sourceContext: Google_Protobuf_SourceContext {
     get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContext = newValue}
   }
@@ -197,18 +197,18 @@ struct Google_Protobuf_Api: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Included APIs. See [Mixin][].
-  public var mixins: [Google_Protobuf_Mixin] {
+  var mixins: [Google_Protobuf_Mixin] {
     get {return _storage._mixins}
     set {_uniqueStorage()._mixins = newValue}
   }
 
   ///   The source syntax of the service.
-  public var syntax: Google_Protobuf_Syntax {
+  var syntax: Google_Protobuf_Syntax {
     get {return _storage._syntax}
     set {_uniqueStorage()._syntax = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -256,27 +256,27 @@ struct Google_Protobuf_Method: ProtobufGeneratedMessage, ProtobufProto3Message {
 
 
   ///   The simple name of this method.
-  public var name: String = ""
+  var name: String = ""
 
   ///   A URL of the input message type.
-  public var requestTypeURL: String = ""
+  var requestTypeURL: String = ""
 
   ///   If true, the request is streamed.
-  public var requestStreaming: Bool = false
+  var requestStreaming: Bool = false
 
   ///   The URL of the output message type.
-  public var responseTypeURL: String = ""
+  var responseTypeURL: String = ""
 
   ///   If true, the response is streamed.
-  public var responseStreaming: Bool = false
+  var responseStreaming: Bool = false
 
   ///   Any metadata attached to the method.
-  public var options: [Google_Protobuf_Option] = []
+  var options: [Google_Protobuf_Option] = []
 
   ///   The source syntax of this method.
-  public var syntax: Google_Protobuf_Syntax = Google_Protobuf_Syntax.proto2
+  var syntax: Google_Protobuf_Syntax = Google_Protobuf_Syntax.proto2
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -419,13 +419,13 @@ struct Google_Protobuf_Mixin: ProtobufGeneratedMessage, ProtobufProto3Message {
 
 
   ///   The fully qualified name of the API which is included.
-  public var name: String = ""
+  var name: String = ""
 
   ///   If non-empty specifies a path under which inherited HTTP paths
   ///   are rooted.
-  public var root: String = ""
+  var root: String = ""
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/compiler/plugin.pb.swift
+++ b/Reference/google/protobuf/compiler/plugin.pb.swift
@@ -77,11 +77,11 @@ struct Google_Protobuf_Compiler_CodeGeneratorRequest: ProtobufGeneratedMessage, 
   ///   The .proto files that were explicitly listed on the command-line.  The
   ///   code generator should generate code only for these files.  Each file's
   ///   descriptor will be included in proto_file, below.
-  public var fileToGenerate: [String] = []
+  var fileToGenerate: [String] = []
 
   ///   The generator parameter passed on the command-line.
   private var _parameter: String? = nil
-  public var parameter: String {
+  var parameter: String {
     get {return _parameter ?? ""}
     set {_parameter = newValue}
   }
@@ -103,9 +103,9 @@ struct Google_Protobuf_Compiler_CodeGeneratorRequest: ProtobufGeneratedMessage, 
   ///   the entire set into memory at once.  However, as of this writing, this
   ///   is not similarly optimized on protoc's end -- it will store all fields in
   ///   memory at once before sending them to the plugin.
-  public var protoFile: [Google_Protobuf_FileDescriptorProto] = []
+  var protoFile: [Google_Protobuf_FileDescriptorProto] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -184,7 +184,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: ProtobufGeneratedMessage,
     ///   this writing protoc does not optimize for this -- it will read the entire
     ///   CodeGeneratorResponse before writing files to disk.
     private var _name: String? = nil
-    public var name: String {
+    var name: String {
       get {return _name ?? ""}
       set {_name = newValue}
     }
@@ -233,7 +233,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: ProtobufGeneratedMessage,
     ///  
     ///   If |insertion_point| is present, |name| must also be present.
     private var _insertionPoint: String? = nil
-    public var insertionPoint: String {
+    var insertionPoint: String {
       get {return _insertionPoint ?? ""}
       set {_insertionPoint = newValue}
     }
@@ -246,7 +246,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: ProtobufGeneratedMessage,
 
     ///   The file contents.
     private var _content: String? = nil
-    public var content: String {
+    var content: String {
       get {return _content ?? ""}
       set {_content = newValue}
     }
@@ -257,7 +257,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: ProtobufGeneratedMessage,
       return _content = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -299,7 +299,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: ProtobufGeneratedMessage,
   ///   unparseable -- should be reported by writing a message to stderr and
   ///   exiting with a non-zero status code.
   private var _error: String? = nil
-  public var error: String {
+  var error: String {
     get {return _error ?? ""}
     set {_error = newValue}
   }
@@ -310,9 +310,9 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: ProtobufGeneratedMessage,
     return _error = nil
   }
 
-  public var file: [Google_Protobuf_Compiler_CodeGeneratorResponse.File] = []
+  var file: [Google_Protobuf_Compiler_CodeGeneratorResponse.File] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -63,9 +63,9 @@ struct Google_Protobuf_FileDescriptorSet: ProtobufGeneratedMessage, ProtobufProt
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var file: [Google_Protobuf_FileDescriptorProto] = []
+  var file: [Google_Protobuf_FileDescriptorProto] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -242,7 +242,7 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
   }
 
   ///   file name, relative to root of source tree
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -254,7 +254,7 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
   }
 
   ///   e.g. "foo", "foo.bar", etc.
-  public var package: String {
+  var package: String {
     get {return _storage._package ?? ""}
     set {_uniqueStorage()._package = newValue}
   }
@@ -266,46 +266,46 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
   }
 
   ///   Names of files imported by this file.
-  public var dependency: [String] {
+  var dependency: [String] {
     get {return _storage._dependency}
     set {_uniqueStorage()._dependency = newValue}
   }
 
   ///   Indexes of the public imported files in the dependency list above.
-  public var publicDependency: [Int32] {
+  var publicDependency: [Int32] {
     get {return _storage._publicDependency}
     set {_uniqueStorage()._publicDependency = newValue}
   }
 
   ///   Indexes of the weak imported files in the dependency list.
   ///   For Google-internal migration only. Do not use.
-  public var weakDependency: [Int32] {
+  var weakDependency: [Int32] {
     get {return _storage._weakDependency}
     set {_uniqueStorage()._weakDependency = newValue}
   }
 
   ///   All top-level definitions in this file.
-  public var messageType: [Google_Protobuf_DescriptorProto] {
+  var messageType: [Google_Protobuf_DescriptorProto] {
     get {return _storage._messageType}
     set {_uniqueStorage()._messageType = newValue}
   }
 
-  public var enumType: [Google_Protobuf_EnumDescriptorProto] {
+  var enumType: [Google_Protobuf_EnumDescriptorProto] {
     get {return _storage._enumType}
     set {_uniqueStorage()._enumType = newValue}
   }
 
-  public var service: [Google_Protobuf_ServiceDescriptorProto] {
+  var service: [Google_Protobuf_ServiceDescriptorProto] {
     get {return _storage._service}
     set {_uniqueStorage()._service = newValue}
   }
 
-  public var extension_p: [Google_Protobuf_FieldDescriptorProto] {
+  var extension_p: [Google_Protobuf_FieldDescriptorProto] {
     get {return _storage._extension_p}
     set {_uniqueStorage()._extension_p = newValue}
   }
 
-  public var options: Google_Protobuf_FileOptions {
+  var options: Google_Protobuf_FileOptions {
     get {return _storage._options ?? Google_Protobuf_FileOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -320,7 +320,7 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
   ///   You may safely remove this entire field without harming runtime
   ///   functionality of the descriptors -- the information is needed only by
   ///   development tools.
-  public var sourceCodeInfo: Google_Protobuf_SourceCodeInfo {
+  var sourceCodeInfo: Google_Protobuf_SourceCodeInfo {
     get {return _storage._sourceCodeInfo ?? Google_Protobuf_SourceCodeInfo()}
     set {_uniqueStorage()._sourceCodeInfo = newValue}
   }
@@ -333,7 +333,7 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
 
   ///   The syntax of the proto file.
   ///   The supported values are "proto2" and "proto3".
-  public var syntax: String {
+  var syntax: String {
     get {return _storage._syntax ?? ""}
     set {_uniqueStorage()._syntax = newValue}
   }
@@ -344,7 +344,7 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
     return _storage._syntax = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -517,7 +517,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
     public var unknown = ProtobufUnknownStorage()
 
     private var _start: Int32? = nil
-    public var start: Int32 {
+    var start: Int32 {
       get {return _start ?? 0}
       set {_start = newValue}
     }
@@ -529,7 +529,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
     }
 
     private var _end: Int32? = nil
-    public var end: Int32 {
+    var end: Int32 {
       get {return _end ?? 0}
       set {_end = newValue}
     }
@@ -540,7 +540,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
       return _end = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -588,7 +588,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
 
     ///   Inclusive.
     private var _start: Int32? = nil
-    public var start: Int32 {
+    var start: Int32 {
       get {return _start ?? 0}
       set {_start = newValue}
     }
@@ -601,7 +601,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
 
     ///   Exclusive.
     private var _end: Int32? = nil
-    public var end: Int32 {
+    var end: Int32 {
       get {return _end ?? 0}
       set {_end = newValue}
     }
@@ -612,7 +612,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
       return _end = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -640,7 +640,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
     }
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -651,37 +651,37 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
     return _storage._name = nil
   }
 
-  public var field: [Google_Protobuf_FieldDescriptorProto] {
+  var field: [Google_Protobuf_FieldDescriptorProto] {
     get {return _storage._field}
     set {_uniqueStorage()._field = newValue}
   }
 
-  public var extension_p: [Google_Protobuf_FieldDescriptorProto] {
+  var extension_p: [Google_Protobuf_FieldDescriptorProto] {
     get {return _storage._extension_p}
     set {_uniqueStorage()._extension_p = newValue}
   }
 
-  public var nestedType: [Google_Protobuf_DescriptorProto] {
+  var nestedType: [Google_Protobuf_DescriptorProto] {
     get {return _storage._nestedType}
     set {_uniqueStorage()._nestedType = newValue}
   }
 
-  public var enumType: [Google_Protobuf_EnumDescriptorProto] {
+  var enumType: [Google_Protobuf_EnumDescriptorProto] {
     get {return _storage._enumType}
     set {_uniqueStorage()._enumType = newValue}
   }
 
-  public var extensionRange: [Google_Protobuf_DescriptorProto.ExtensionRange] {
+  var extensionRange: [Google_Protobuf_DescriptorProto.ExtensionRange] {
     get {return _storage._extensionRange}
     set {_uniqueStorage()._extensionRange = newValue}
   }
 
-  public var oneofDecl: [Google_Protobuf_OneofDescriptorProto] {
+  var oneofDecl: [Google_Protobuf_OneofDescriptorProto] {
     get {return _storage._oneofDecl}
     set {_uniqueStorage()._oneofDecl = newValue}
   }
 
-  public var options: Google_Protobuf_MessageOptions {
+  var options: Google_Protobuf_MessageOptions {
     get {return _storage._options ?? Google_Protobuf_MessageOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -692,19 +692,19 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
     return _storage._options = nil
   }
 
-  public var reservedRange: [Google_Protobuf_DescriptorProto.ReservedRange] {
+  var reservedRange: [Google_Protobuf_DescriptorProto.ReservedRange] {
     get {return _storage._reservedRange}
     set {_uniqueStorage()._reservedRange = newValue}
   }
 
   ///   Reserved field names, which may not be used by fields in the same message.
   ///   A given name may only be reserved once.
-  public var reservedName: [String] {
+  var reservedName: [String] {
     get {return _storage._reservedName}
     set {_uniqueStorage()._reservedName = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -862,7 +862,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
   }
 
   enum TypeEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   0 is reserved for errors.
     ///   Order is weird for historical reasons.
@@ -901,11 +901,11 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     ///   Uses ZigZag encoding.
     case sint64 // = 18
 
-    public init() {
+    init() {
       self = .double
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .double
       case 2: self = .float
@@ -929,7 +929,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "double": self = .double
       case "float": self = .float
@@ -953,7 +953,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "TYPE_DOUBLE": self = .double
       case "TYPE_FLOAT": self = .float
@@ -977,7 +977,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "TYPE_DOUBLE": self = .double
       case "TYPE_FLOAT": self = .float
@@ -1001,7 +1001,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .double: return 1
@@ -1026,7 +1026,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .double: return "\"TYPE_DOUBLE\""
@@ -1051,9 +1051,9 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .double: return ".double"
@@ -1081,7 +1081,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
   }
 
   enum Label: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   0 is reserved for errors
     case `optional` // = 1
@@ -1090,11 +1090,11 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     ///   TODO(sanjay): Should we add LABEL_MAP?
     case repeated // = 3
 
-    public init() {
+    init() {
       self = .`optional`
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .`optional`
       case 2: self = .`required`
@@ -1103,7 +1103,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "optional": self = .`optional`
       case "required": self = .`required`
@@ -1112,7 +1112,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "LABEL_OPTIONAL": self = .`optional`
       case "LABEL_REQUIRED": self = .`required`
@@ -1121,7 +1121,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "LABEL_OPTIONAL": self = .`optional`
       case "LABEL_REQUIRED": self = .`required`
@@ -1130,7 +1130,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .`optional`: return 1
@@ -1140,7 +1140,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .`optional`: return "\"LABEL_OPTIONAL\""
@@ -1150,9 +1150,9 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .`optional`: return ".optional"
@@ -1164,7 +1164,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
 
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1175,7 +1175,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._name = nil
   }
 
-  public var number: Int32 {
+  var number: Int32 {
     get {return _storage._number ?? 0}
     set {_uniqueStorage()._number = newValue}
   }
@@ -1186,7 +1186,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._number = nil
   }
 
-  public var label: Google_Protobuf_FieldDescriptorProto.Label {
+  var label: Google_Protobuf_FieldDescriptorProto.Label {
     get {return _storage._label ?? Google_Protobuf_FieldDescriptorProto.Label.`optional`}
     set {_uniqueStorage()._label = newValue}
   }
@@ -1199,7 +1199,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
 
   ///   If type_name is set, this need not be set.  If both this and type_name
   ///   are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
-  public var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
+  var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
     get {return _storage._type ?? Google_Protobuf_FieldDescriptorProto.TypeEnum.double}
     set {_uniqueStorage()._type = newValue}
   }
@@ -1215,7 +1215,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
   ///   rules are used to find the type (i.e. first the nested types within this
   ///   message are searched, then within the parent, on up to the root
   ///   namespace).
-  public var typeName: String {
+  var typeName: String {
     get {return _storage._typeName ?? ""}
     set {_uniqueStorage()._typeName = newValue}
   }
@@ -1228,7 +1228,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
 
   ///   For extensions, this is the name of the type being extended.  It is
   ///   resolved in the same manner as type_name.
-  public var extendee: String {
+  var extendee: String {
     get {return _storage._extendee ?? ""}
     set {_uniqueStorage()._extendee = newValue}
   }
@@ -1244,7 +1244,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
   ///   For strings, contains the default text contents (not escaped in any way).
   ///   For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
   ///   TODO(kenton):  Base-64 encode?
-  public var defaultValue: String {
+  var defaultValue: String {
     get {return _storage._defaultValue ?? ""}
     set {_uniqueStorage()._defaultValue = newValue}
   }
@@ -1257,7 +1257,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
 
   ///   If set, gives the index of a oneof in the containing type's oneof_decl
   ///   list.  This field is a member of that oneof.
-  public var oneofIndex: Int32 {
+  var oneofIndex: Int32 {
     get {return _storage._oneofIndex ?? 0}
     set {_uniqueStorage()._oneofIndex = newValue}
   }
@@ -1272,7 +1272,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
   ///   user has set a "json_name" option on this field, that option's value
   ///   will be used. Otherwise, it's deduced from the field's name by converting
   ///   it to camelCase.
-  public var jsonName: String {
+  var jsonName: String {
     get {return _storage._jsonName ?? ""}
     set {_uniqueStorage()._jsonName = newValue}
   }
@@ -1283,7 +1283,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._jsonName = nil
   }
 
-  public var options: Google_Protobuf_FieldOptions {
+  var options: Google_Protobuf_FieldOptions {
     get {return _storage._options ?? Google_Protobuf_FieldOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1294,7 +1294,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._options = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1379,7 +1379,7 @@ struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     set {_storage.unknown = newValue}
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1390,7 +1390,7 @@ struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._name = nil
   }
 
-  public var options: Google_Protobuf_OneofOptions {
+  var options: Google_Protobuf_OneofOptions {
     get {return _storage._options ?? Google_Protobuf_OneofOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1401,7 +1401,7 @@ struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._options = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1495,7 +1495,7 @@ struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
     set {_storage.unknown = newValue}
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1506,12 +1506,12 @@ struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
     return _storage._name = nil
   }
 
-  public var value: [Google_Protobuf_EnumValueDescriptorProto] {
+  var value: [Google_Protobuf_EnumValueDescriptorProto] {
     get {return _storage._value}
     set {_uniqueStorage()._value = newValue}
   }
 
-  public var options: Google_Protobuf_EnumOptions {
+  var options: Google_Protobuf_EnumOptions {
     get {return _storage._options ?? Google_Protobuf_EnumOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1522,7 +1522,7 @@ struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
     return _storage._options = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1616,7 +1616,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage, Proto
     set {_storage.unknown = newValue}
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1627,7 +1627,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage, Proto
     return _storage._name = nil
   }
 
-  public var number: Int32 {
+  var number: Int32 {
     get {return _storage._number ?? 0}
     set {_uniqueStorage()._number = newValue}
   }
@@ -1638,7 +1638,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage, Proto
     return _storage._number = nil
   }
 
-  public var options: Google_Protobuf_EnumValueOptions {
+  var options: Google_Protobuf_EnumValueOptions {
     get {return _storage._options ?? Google_Protobuf_EnumValueOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1649,7 +1649,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage, Proto
     return _storage._options = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1743,7 +1743,7 @@ struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage, Protobu
     set {_storage.unknown = newValue}
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1754,12 +1754,12 @@ struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage, Protobu
     return _storage._name = nil
   }
 
-  public var method: [Google_Protobuf_MethodDescriptorProto] {
+  var method: [Google_Protobuf_MethodDescriptorProto] {
     get {return _storage._method}
     set {_uniqueStorage()._method = newValue}
   }
 
-  public var options: Google_Protobuf_ServiceOptions {
+  var options: Google_Protobuf_ServiceOptions {
     get {return _storage._options ?? Google_Protobuf_ServiceOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1770,7 +1770,7 @@ struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage, Protobu
     return _storage._options = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1891,7 +1891,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
     set {_storage.unknown = newValue}
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1904,7 +1904,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
 
   ///   Input and output type names.  These are resolved in the same way as
   ///   FieldDescriptorProto.type_name, but must refer to a message type.
-  public var inputType: String {
+  var inputType: String {
     get {return _storage._inputType ?? ""}
     set {_uniqueStorage()._inputType = newValue}
   }
@@ -1915,7 +1915,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
     return _storage._inputType = nil
   }
 
-  public var outputType: String {
+  var outputType: String {
     get {return _storage._outputType ?? ""}
     set {_uniqueStorage()._outputType = newValue}
   }
@@ -1926,7 +1926,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
     return _storage._outputType = nil
   }
 
-  public var options: Google_Protobuf_MethodOptions {
+  var options: Google_Protobuf_MethodOptions {
     get {return _storage._options ?? Google_Protobuf_MethodOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1938,7 +1938,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
   }
 
   ///   Identifies if client streams multiple client messages
-  public var clientStreaming: Bool {
+  var clientStreaming: Bool {
     get {return _storage._clientStreaming ?? false}
     set {_uniqueStorage()._clientStreaming = newValue}
   }
@@ -1950,7 +1950,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
   }
 
   ///   Identifies if server streams multiple server messages
-  public var serverStreaming: Bool {
+  var serverStreaming: Bool {
     get {return _storage._serverStreaming ?? false}
     set {_uniqueStorage()._serverStreaming = newValue}
   }
@@ -1961,7 +1961,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
     return _storage._serverStreaming = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2060,7 +2060,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
 
   ///   Generated classes can be optimized for speed or code size.
   enum OptimizeMode: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   Generate complete code for parsing, serialization,
     case speed // = 1
@@ -2071,11 +2071,11 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
     ///   Generate code using MessageLite and the lite runtime.
     case liteRuntime // = 3
 
-    public init() {
+    init() {
       self = .speed
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .speed
       case 2: self = .codeSize
@@ -2084,7 +2084,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "speed": self = .speed
       case "codeSize": self = .codeSize
@@ -2093,7 +2093,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "SPEED": self = .speed
       case "CODE_SIZE": self = .codeSize
@@ -2102,7 +2102,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "SPEED": self = .speed
       case "CODE_SIZE": self = .codeSize
@@ -2111,7 +2111,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .speed: return 1
@@ -2121,7 +2121,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .speed: return "\"SPEED\""
@@ -2131,9 +2131,9 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .speed: return ".speed"
@@ -2150,7 +2150,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   inappropriate because proto packages do not normally start with backwards
   ///   domain names.
   private var _javaPackage: String? = nil
-  public var javaPackage: String {
+  var javaPackage: String {
     get {return _javaPackage ?? ""}
     set {_javaPackage = newValue}
   }
@@ -2167,7 +2167,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   a .proto always translates to a single class, but you may want to
   ///   explicitly choose the class name).
   private var _javaOuterClassname: String? = nil
-  public var javaOuterClassname: String {
+  var javaOuterClassname: String {
     get {return _javaOuterClassname ?? ""}
     set {_javaOuterClassname = newValue}
   }
@@ -2185,7 +2185,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   generated to contain the file's getDescriptor() method as well as any
   ///   top-level extensions defined in the file.
   private var _javaMultipleFiles: Bool? = nil
-  public var javaMultipleFiles: Bool {
+  var javaMultipleFiles: Bool {
     get {return _javaMultipleFiles ?? false}
     set {_javaMultipleFiles = newValue}
   }
@@ -2209,7 +2209,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   than object identity. (Implementations should not assume that hashcodes
   ///   will be consistent across runtimes or versions of the protocol compiler.)
   private var _javaGenerateEqualsAndHash: Bool? = nil
-  public var javaGenerateEqualsAndHash: Bool {
+  var javaGenerateEqualsAndHash: Bool {
     get {return _javaGenerateEqualsAndHash ?? false}
     set {_javaGenerateEqualsAndHash = newValue}
   }
@@ -2227,7 +2227,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   However, an extension field still accepts non-UTF-8 byte sequences.
   ///   This option has no effect on when used with the lite runtime.
   private var _javaStringCheckUtf8: Bool? = nil
-  public var javaStringCheckUtf8: Bool {
+  var javaStringCheckUtf8: Bool {
     get {return _javaStringCheckUtf8 ?? false}
     set {_javaStringCheckUtf8 = newValue}
   }
@@ -2239,7 +2239,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   private var _optimizeFor: Google_Protobuf_FileOptions.OptimizeMode? = nil
-  public var optimizeFor: Google_Protobuf_FileOptions.OptimizeMode {
+  var optimizeFor: Google_Protobuf_FileOptions.OptimizeMode {
     get {return _optimizeFor ?? Google_Protobuf_FileOptions.OptimizeMode.speed}
     set {_optimizeFor = newValue}
   }
@@ -2256,7 +2256,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///     - Otherwise, the package statement in the .proto file, if present.
   ///     - Otherwise, the basename of the .proto file, without extension.
   private var _goPackage: String? = nil
-  public var goPackage: String {
+  var goPackage: String {
     get {return _goPackage ?? ""}
     set {_goPackage = newValue}
   }
@@ -2278,7 +2278,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   these default to false.  Old code which depends on generic services should
   ///   explicitly set them to true.
   private var _ccGenericServices: Bool? = nil
-  public var ccGenericServices: Bool {
+  var ccGenericServices: Bool {
     get {return _ccGenericServices ?? false}
     set {_ccGenericServices = newValue}
   }
@@ -2290,7 +2290,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   private var _javaGenericServices: Bool? = nil
-  public var javaGenericServices: Bool {
+  var javaGenericServices: Bool {
     get {return _javaGenericServices ?? false}
     set {_javaGenericServices = newValue}
   }
@@ -2302,7 +2302,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   private var _pyGenericServices: Bool? = nil
-  public var pyGenericServices: Bool {
+  var pyGenericServices: Bool {
     get {return _pyGenericServices ?? false}
     set {_pyGenericServices = newValue}
   }
@@ -2318,7 +2318,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   for everything in the file, or it will be completely ignored; in the very
   ///   least, this is a formalization for deprecating files.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -2332,7 +2332,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   Enables the use of arenas for the proto messages in this file. This applies
   ///   only to generated classes for C++.
   private var _ccEnableArenas: Bool? = nil
-  public var ccEnableArenas: Bool {
+  var ccEnableArenas: Bool {
     get {return _ccEnableArenas ?? false}
     set {_ccEnableArenas = newValue}
   }
@@ -2346,7 +2346,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   Sets the objective c class prefix which is prepended to all objective c
   ///   generated classes from this .proto. There is no default.
   private var _objcClassPrefix: String? = nil
-  public var objcClassPrefix: String {
+  var objcClassPrefix: String {
     get {return _objcClassPrefix ?? ""}
     set {_objcClassPrefix = newValue}
   }
@@ -2359,7 +2359,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
 
   ///   Namespace for generated classes; defaults to the package.
   private var _csharpNamespace: String? = nil
-  public var csharpNamespace: String {
+  var csharpNamespace: String {
     get {return _csharpNamespace ?? ""}
     set {_csharpNamespace = newValue}
   }
@@ -2373,7 +2373,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   Prefix prepended to all Swift generated top-level types.
   ///   Default is CamelCased package name.
   private var _swiftPrefix: String? = nil
-  public var swiftPrefix: String {
+  var swiftPrefix: String {
     get {return _swiftPrefix ?? ""}
     set {_swiftPrefix = newValue}
   }
@@ -2385,9 +2385,9 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2550,7 +2550,7 @@ struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufProto2M
   ///   Because this is an option, the above two restrictions are not enforced by
   ///   the protocol compiler.
   private var _messageSetWireFormat: Bool? = nil
-  public var messageSetWireFormat: Bool {
+  var messageSetWireFormat: Bool {
     get {return _messageSetWireFormat ?? false}
     set {_messageSetWireFormat = newValue}
   }
@@ -2565,7 +2565,7 @@ struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufProto2M
   ///   conflict with a field of the same name.  This is meant to make migration
   ///   from proto1 easier; new code should avoid fields named "descriptor".
   private var _noStandardDescriptorAccessor: Bool? = nil
-  public var noStandardDescriptorAccessor: Bool {
+  var noStandardDescriptorAccessor: Bool {
     get {return _noStandardDescriptorAccessor ?? false}
     set {_noStandardDescriptorAccessor = newValue}
   }
@@ -2581,7 +2581,7 @@ struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufProto2M
   ///   for the message, or it will be completely ignored; in the very least,
   ///   this is a formalization for deprecating messages.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -2614,7 +2614,7 @@ struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufProto2M
   ///   instead. The option should only be implicitly set by the proto compiler
   ///   parser.
   private var _mapEntry: Bool? = nil
-  public var mapEntry: Bool {
+  var mapEntry: Bool {
     get {return _mapEntry ?? false}
     set {_mapEntry = newValue}
   }
@@ -2626,9 +2626,9 @@ struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2722,18 +2722,18 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   public var unknown = ProtobufUnknownStorage()
 
   enum CType: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   Default mode.
     case string // = 0
     case cord // = 1
     case stringPiece // = 2
 
-    public init() {
+    init() {
       self = .string
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .string
       case 1: self = .cord
@@ -2742,7 +2742,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "string": self = .string
       case "cord": self = .cord
@@ -2751,7 +2751,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "STRING": self = .string
       case "CORD": self = .cord
@@ -2760,7 +2760,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "STRING": self = .string
       case "CORD": self = .cord
@@ -2769,7 +2769,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .string: return 0
@@ -2779,7 +2779,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .string: return "\"STRING\""
@@ -2789,9 +2789,9 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .string: return ".string"
@@ -2804,7 +2804,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   }
 
   enum JSType: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   Use the default type.
     case jsNormal // = 0
@@ -2815,11 +2815,11 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
     ///   Use JavaScript numbers.
     case jsNumber // = 2
 
-    public init() {
+    init() {
       self = .jsNormal
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .jsNormal
       case 1: self = .jsString
@@ -2828,7 +2828,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "jsNormal": self = .jsNormal
       case "jsString": self = .jsString
@@ -2837,7 +2837,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "JS_NORMAL": self = .jsNormal
       case "JS_STRING": self = .jsString
@@ -2846,7 +2846,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "JS_NORMAL": self = .jsNormal
       case "JS_STRING": self = .jsString
@@ -2855,7 +2855,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .jsNormal: return 0
@@ -2865,7 +2865,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .jsNormal: return "\"JS_NORMAL\""
@@ -2875,9 +2875,9 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .jsNormal: return ".jsNormal"
@@ -2894,7 +2894,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   ///   options below.  This option is not yet implemented in the open source
   ///   release -- sorry, we'll try to include it in a future version!
   private var _ctype: Google_Protobuf_FieldOptions.CType? = nil
-  public var ctype: Google_Protobuf_FieldOptions.CType {
+  var ctype: Google_Protobuf_FieldOptions.CType {
     get {return _ctype ?? Google_Protobuf_FieldOptions.CType.string}
     set {_ctype = newValue}
   }
@@ -2911,7 +2911,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   ///   a single length-delimited blob. In proto3, only explicit setting it to
   ///   false will avoid using packed encoding.
   private var _packed: Bool? = nil
-  public var packed: Bool {
+  var packed: Bool {
     get {return _packed ?? false}
     set {_packed = newValue}
   }
@@ -2932,7 +2932,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   ///   This option is an enum to permit additional types to be added,
   ///   e.g. goog.math.Integer.
   private var _jstype: Google_Protobuf_FieldOptions.JSType? = nil
-  public var jstype: Google_Protobuf_FieldOptions.JSType {
+  var jstype: Google_Protobuf_FieldOptions.JSType {
     get {return _jstype ?? Google_Protobuf_FieldOptions.JSType.jsNormal}
     set {_jstype = newValue}
   }
@@ -2972,7 +2972,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   ///   check its required fields, regardless of whether or not the message has
   ///   been parsed.
   private var _lazy: Bool? = nil
-  public var lazy: Bool {
+  var lazy: Bool {
     get {return _lazy ?? false}
     set {_lazy = newValue}
   }
@@ -2988,7 +2988,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   ///   for accessors, or it will be completely ignored; in the very least, this
   ///   is a formalization for deprecating fields.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -3001,7 +3001,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
 
   ///   For Google-internal migration only. Do not use.
   private var _weak: Bool? = nil
-  public var weak: Bool {
+  var weak: Bool {
     get {return _weak ?? false}
     set {_weak = newValue}
   }
@@ -3013,9 +3013,9 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3107,9 +3107,9 @@ struct Google_Protobuf_OneofOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   public var unknown = ProtobufUnknownStorage()
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3177,7 +3177,7 @@ struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   Set this option to true to allow mapping different tag names to the same
   ///   value.
   private var _allowAlias: Bool? = nil
-  public var allowAlias: Bool {
+  var allowAlias: Bool {
     get {return _allowAlias ?? false}
     set {_allowAlias = newValue}
   }
@@ -3193,7 +3193,7 @@ struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   for the enum, or it will be completely ignored; in the very least, this
   ///   is a formalization for deprecating enums.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -3205,9 +3205,9 @@ struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3285,7 +3285,7 @@ struct Google_Protobuf_EnumValueOptions: ProtobufGeneratedMessage, ProtobufProto
   ///   for the enum value, or it will be completely ignored; in the very least,
   ///   this is a formalization for deprecating enum values.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -3297,9 +3297,9 @@ struct Google_Protobuf_EnumValueOptions: ProtobufGeneratedMessage, ProtobufProto
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3377,7 +3377,7 @@ struct Google_Protobuf_ServiceOptions: ProtobufGeneratedMessage, ProtobufProto2M
   ///   for the service, or it will be completely ignored; in the very least,
   ///   this is a formalization for deprecating services.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -3389,9 +3389,9 @@ struct Google_Protobuf_ServiceOptions: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3469,7 +3469,7 @@ struct Google_Protobuf_MethodOptions: ProtobufGeneratedMessage, ProtobufProto2Me
   ///   for the method, or it will be completely ignored; in the very least,
   ///   this is a formalization for deprecating methods.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -3481,9 +3481,9 @@ struct Google_Protobuf_MethodOptions: ProtobufGeneratedMessage, ProtobufProto2Me
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3588,7 +3588,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
     public var unknown = ProtobufUnknownStorage()
 
     private var _namePart: String? = nil
-    public var namePart: String {
+    var namePart: String {
       get {return _namePart ?? ""}
       set {_namePart = newValue}
     }
@@ -3600,7 +3600,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
     }
 
     private var _isExtension: Bool? = nil
-    public var isExtension: Bool {
+    var isExtension: Bool {
       get {return _isExtension ?? false}
       set {_isExtension = newValue}
     }
@@ -3611,7 +3611,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
       return _isExtension = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -3635,12 +3635,12 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
     }
   }
 
-  public var name: [Google_Protobuf_UninterpretedOption.NamePart] = []
+  var name: [Google_Protobuf_UninterpretedOption.NamePart] = []
 
   ///   The value of the uninterpreted option, in whatever type the tokenizer
   ///   identified it as during parsing. Exactly one of these should be set.
   private var _identifierValue: String? = nil
-  public var identifierValue: String {
+  var identifierValue: String {
     get {return _identifierValue ?? ""}
     set {_identifierValue = newValue}
   }
@@ -3652,7 +3652,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _positiveIntValue: UInt64? = nil
-  public var positiveIntValue: UInt64 {
+  var positiveIntValue: UInt64 {
     get {return _positiveIntValue ?? 0}
     set {_positiveIntValue = newValue}
   }
@@ -3664,7 +3664,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _negativeIntValue: Int64? = nil
-  public var negativeIntValue: Int64 {
+  var negativeIntValue: Int64 {
     get {return _negativeIntValue ?? 0}
     set {_negativeIntValue = newValue}
   }
@@ -3676,7 +3676,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _doubleValue: Double? = nil
-  public var doubleValue: Double {
+  var doubleValue: Double {
     get {return _doubleValue ?? 0}
     set {_doubleValue = newValue}
   }
@@ -3688,7 +3688,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _stringValue: Data? = nil
-  public var stringValue: Data {
+  var stringValue: Data {
     get {return _stringValue ?? Data()}
     set {_stringValue = newValue}
   }
@@ -3700,7 +3700,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _aggregateValue: String? = nil
-  public var aggregateValue: String {
+  var aggregateValue: String {
     get {return _aggregateValue ?? ""}
     set {_aggregateValue = newValue}
   }
@@ -3711,7 +3711,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
     return _aggregateValue = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3826,14 +3826,14 @@ struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage, ProtobufProto2M
     ///     [ 4, 3, 2, 7 ]
     ///   this path refers to the whole field declaration (from the beginning
     ///   of the label to the terminating semicolon).
-    public var path: [Int32] = []
+    var path: [Int32] = []
 
     ///   Always has exactly three or four elements: start line, start column,
     ///   end line (optional, otherwise assumed same as start line), end column.
     ///   These are packed into a single field for efficiency.  Note that line
     ///   and column numbers are zero-based -- typically you will want to add
     ///   1 to each before displaying to a user.
-    public var span: [Int32] = []
+    var span: [Int32] = []
 
     ///   If this SourceCodeInfo represents a complete declaration, these are any
     ///   comments appearing before and after the declaration which appear to be
@@ -3883,7 +3883,7 @@ struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage, ProtobufProto2M
     ///  
     ///     // ignored detached comments.
     private var _leadingComments: String? = nil
-    public var leadingComments: String {
+    var leadingComments: String {
       get {return _leadingComments ?? ""}
       set {_leadingComments = newValue}
     }
@@ -3895,7 +3895,7 @@ struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage, ProtobufProto2M
     }
 
     private var _trailingComments: String? = nil
-    public var trailingComments: String {
+    var trailingComments: String {
       get {return _trailingComments ?? ""}
       set {_trailingComments = newValue}
     }
@@ -3906,9 +3906,9 @@ struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage, ProtobufProto2M
       return _trailingComments = nil
     }
 
-    public var leadingDetachedComments: [String] = []
+    var leadingDetachedComments: [String] = []
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -3994,9 +3994,9 @@ struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage, ProtobufProto2M
   ///   - Code which tries to interpret locations should probably be designed to
   ///     ignore those that it doesn't understand, as more types of locations could
   ///     be recorded in the future.
-  public var location: [Google_Protobuf_SourceCodeInfo.Location] = []
+  var location: [Google_Protobuf_SourceCodeInfo.Location] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -4056,11 +4056,11 @@ struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage, ProtobufProt
 
     ///   Identifies the element in the original source .proto file. This field
     ///   is formatted the same as SourceCodeInfo.Location.path.
-    public var path: [Int32] = []
+    var path: [Int32] = []
 
     ///   Identifies the filesystem path to the original source .proto.
     private var _sourceFile: String? = nil
-    public var sourceFile: String {
+    var sourceFile: String {
       get {return _sourceFile ?? ""}
       set {_sourceFile = newValue}
     }
@@ -4074,7 +4074,7 @@ struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage, ProtobufProt
     ///   Identifies the starting offset in bytes in the generated code
     ///   that relates to the identified object.
     private var _begin: Int32? = nil
-    public var begin: Int32 {
+    var begin: Int32 {
       get {return _begin ?? 0}
       set {_begin = newValue}
     }
@@ -4089,7 +4089,7 @@ struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage, ProtobufProt
     ///   relates to the identified offset. The end offset should be one past
     ///   the last relevant byte (so the length of the text = end - begin).
     private var _end: Int32? = nil
-    public var end: Int32 {
+    var end: Int32 {
       get {return _end ?? 0}
       set {_end = newValue}
     }
@@ -4100,7 +4100,7 @@ struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage, ProtobufProt
       return _end = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4140,9 +4140,9 @@ struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage, ProtobufProt
 
   ///   An Annotation connects some span of text in generated code to an element
   ///   of its generating .proto file.
-  public var annotation: [Google_Protobuf_GeneratedCodeInfo.Annotation] = []
+  var annotation: [Google_Protobuf_GeneratedCodeInfo.Annotation] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/duration.pb.swift
+++ b/Reference/google/protobuf/duration.pb.swift
@@ -95,7 +95,7 @@ struct Google_Protobuf_Duration: ProtobufGeneratedMessage, ProtobufProto3Message
 
   ///   Signed seconds of the span of time. Must be from -315,576,000,000
   ///   to +315,576,000,000 inclusive.
-  public var seconds: Int64 = 0
+  var seconds: Int64 = 0
 
   ///   Signed fractions of a second at nanosecond resolution of the span
   ///   of time. Durations less than one second are represented with a 0
@@ -103,9 +103,9 @@ struct Google_Protobuf_Duration: ProtobufGeneratedMessage, ProtobufProto3Message
   ///   of one second or more, a non-zero value for the `nanos` field must be
   ///   of the same sign as the `seconds` field. Must be from -999,999,999
   ///   to +999,999,999 inclusive.
-  public var nanos: Int32 = 0
+  var nanos: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/empty.pb.swift
+++ b/Reference/google/protobuf/empty.pb.swift
@@ -56,7 +56,7 @@ struct Google_Protobuf_Empty: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/google/protobuf/field_mask.pb.swift
+++ b/Reference/google/protobuf/field_mask.pb.swift
@@ -253,9 +253,9 @@ struct Google_Protobuf_FieldMask: ProtobufGeneratedMessage, ProtobufProto3Messag
 
 
   ///   The set of field mask paths.
-  public var paths: [String] = []
+  var paths: [String] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/map_lite_unittest.pb.swift
+++ b/Reference/google/protobuf/map_lite_unittest.pb.swift
@@ -41,16 +41,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case proto2MapEnumFooLite // = 0
   case proto2MapEnumBarLite // = 1
   case proto2MapEnumBazLite // = 2
 
-  public init() {
+  init() {
     self = .proto2MapEnumFooLite
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .proto2MapEnumFooLite
     case 1: self = .proto2MapEnumBarLite
@@ -59,7 +59,7 @@ enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "proto2MapEnumFooLite": self = .proto2MapEnumFooLite
     case "proto2MapEnumBarLite": self = .proto2MapEnumBarLite
@@ -68,7 +68,7 @@ enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "PROTO2_MAP_ENUM_FOO_LITE": self = .proto2MapEnumFooLite
     case "PROTO2_MAP_ENUM_BAR_LITE": self = .proto2MapEnumBarLite
@@ -77,7 +77,7 @@ enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "PROTO2_MAP_ENUM_FOO_LITE": self = .proto2MapEnumFooLite
     case "PROTO2_MAP_ENUM_BAR_LITE": self = .proto2MapEnumBarLite
@@ -86,7 +86,7 @@ enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .proto2MapEnumFooLite: return 0
@@ -96,7 +96,7 @@ enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .proto2MapEnumFooLite: return "\"PROTO2_MAP_ENUM_FOO_LITE\""
@@ -106,9 +106,9 @@ enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .proto2MapEnumFooLite: return ".proto2MapEnumFooLite"
@@ -121,17 +121,17 @@ enum ProtobufUnittest_Proto2MapEnumLite: ProtobufEnum {
 }
 
 enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case eProto2MapEnumFooLite // = 0
   case eProto2MapEnumBarLite // = 1
   case eProto2MapEnumBazLite // = 2
   case eProto2MapEnumExtraLite // = 3
 
-  public init() {
+  init() {
     self = .eProto2MapEnumFooLite
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .eProto2MapEnumFooLite
     case 1: self = .eProto2MapEnumBarLite
@@ -141,7 +141,7 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "eProto2MapEnumFooLite": self = .eProto2MapEnumFooLite
     case "eProto2MapEnumBarLite": self = .eProto2MapEnumBarLite
@@ -151,7 +151,7 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "E_PROTO2_MAP_ENUM_FOO_LITE": self = .eProto2MapEnumFooLite
     case "E_PROTO2_MAP_ENUM_BAR_LITE": self = .eProto2MapEnumBarLite
@@ -161,7 +161,7 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "E_PROTO2_MAP_ENUM_FOO_LITE": self = .eProto2MapEnumFooLite
     case "E_PROTO2_MAP_ENUM_BAR_LITE": self = .eProto2MapEnumBarLite
@@ -171,7 +171,7 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .eProto2MapEnumFooLite: return 0
@@ -182,7 +182,7 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .eProto2MapEnumFooLite: return "\"E_PROTO2_MAP_ENUM_FOO_LITE\""
@@ -193,9 +193,9 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .eProto2MapEnumFooLite: return ".eProto2MapEnumFooLite"
@@ -209,16 +209,16 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: ProtobufEnum {
 }
 
 enum ProtobufUnittest_MapEnumLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case mapEnumFooLite // = 0
   case mapEnumBarLite // = 1
   case mapEnumBazLite // = 2
 
-  public init() {
+  init() {
     self = .mapEnumFooLite
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .mapEnumFooLite
     case 1: self = .mapEnumBarLite
@@ -227,7 +227,7 @@ enum ProtobufUnittest_MapEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "mapEnumFooLite": self = .mapEnumFooLite
     case "mapEnumBarLite": self = .mapEnumBarLite
@@ -236,7 +236,7 @@ enum ProtobufUnittest_MapEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "MAP_ENUM_FOO_LITE": self = .mapEnumFooLite
     case "MAP_ENUM_BAR_LITE": self = .mapEnumBarLite
@@ -245,7 +245,7 @@ enum ProtobufUnittest_MapEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "MAP_ENUM_FOO_LITE": self = .mapEnumFooLite
     case "MAP_ENUM_BAR_LITE": self = .mapEnumBarLite
@@ -254,7 +254,7 @@ enum ProtobufUnittest_MapEnumLite: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .mapEnumFooLite: return 0
@@ -264,7 +264,7 @@ enum ProtobufUnittest_MapEnumLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .mapEnumFooLite: return "\"MAP_ENUM_FOO_LITE\""
@@ -274,9 +274,9 @@ enum ProtobufUnittest_MapEnumLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .mapEnumFooLite: return ".mapEnumFooLite"
@@ -494,97 +494,97 @@ struct ProtobufUnittest_TestMapLite: ProtobufGeneratedMessage, ProtobufProto2Mes
     set {_storage.unknown = newValue}
   }
 
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnumLite> {
+  var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnumLite> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessageLite> {
+  var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessageLite> {
     get {return _storage._mapInt32ForeignMessage}
     set {_uniqueStorage()._mapInt32ForeignMessage = newValue}
   }
 
-  public var teboring: Dictionary<Int32,Int32> {
+  var teboring: Dictionary<Int32,Int32> {
     get {return _storage._teboring}
     set {_uniqueStorage()._teboring = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -812,97 +812,97 @@ struct ProtobufUnittest_TestArenaMapLite: ProtobufGeneratedMessage, ProtobufProt
     set {_storage.unknown = newValue}
   }
 
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnumLite> {
+  var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnumLite> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessageArenaLite> {
+  var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessageArenaLite> {
     get {return _storage._mapInt32ForeignMessage}
     set {_uniqueStorage()._mapInt32ForeignMessage = newValue}
   }
 
-  public var mapInt32ForeignMessageNoArena: Dictionary<Int32,ProtobufUnittestNoArena_ForeignMessageLite> {
+  var mapInt32ForeignMessageNoArena: Dictionary<Int32,ProtobufUnittestNoArena_ForeignMessageLite> {
     get {return _storage._mapInt32ForeignMessageNoArena}
     set {_uniqueStorage()._mapInt32ForeignMessageNoArena = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -938,9 +938,9 @@ struct ProtobufUnittest_TestRequiredMessageMapLite: ProtobufGeneratedMessage, Pr
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var mapField: Dictionary<Int32,ProtobufUnittest_TestRequiredLite> = [:]
+  var mapField: Dictionary<Int32,ProtobufUnittest_TestRequiredLite> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -978,11 +978,11 @@ struct ProtobufUnittest_TestEnumMapLite: ProtobufGeneratedMessage, ProtobufProto
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var knownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumLite> = [:]
+  var knownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumLite> = [:]
 
-  public var unknownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumLite> = [:]
+  var unknownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumLite> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1025,11 +1025,11 @@ struct ProtobufUnittest_TestEnumMapPlusExtraLite: ProtobufGeneratedMessage, Prot
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var knownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumPlusExtraLite> = [:]
+  var knownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumPlusExtraLite> = [:]
 
-  public var unknownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumPlusExtraLite> = [:]
+  var unknownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumPlusExtraLite> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1070,9 +1070,9 @@ struct ProtobufUnittest_TestMessageMapLite: ProtobufGeneratedMessage, ProtobufPr
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var mapInt32Message: Dictionary<Int32,ProtobufUnittest_TestAllTypesLite> = [:]
+  var mapInt32Message: Dictionary<Int32,ProtobufUnittest_TestAllTypesLite> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1113,7 +1113,7 @@ struct ProtobufUnittest_TestRequiredLite: ProtobufGeneratedMessage, ProtobufProt
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -1125,7 +1125,7 @@ struct ProtobufUnittest_TestRequiredLite: ProtobufGeneratedMessage, ProtobufProt
   }
 
   private var _b: Int32? = nil
-  public var b: Int32 {
+  var b: Int32 {
     get {return _b ?? 0}
     set {_b = newValue}
   }
@@ -1137,7 +1137,7 @@ struct ProtobufUnittest_TestRequiredLite: ProtobufGeneratedMessage, ProtobufProt
   }
 
   private var _c: Int32? = nil
-  public var c: Int32 {
+  var c: Int32 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -1148,7 +1148,7 @@ struct ProtobufUnittest_TestRequiredLite: ProtobufGeneratedMessage, ProtobufProt
     return _c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1189,7 +1189,7 @@ struct ProtobufUnittest_ForeignMessageArenaLite: ProtobufGeneratedMessage, Proto
   public var unknown = ProtobufUnknownStorage()
 
   private var _c: Int32? = nil
-  public var c: Int32 {
+  var c: Int32 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -1200,7 +1200,7 @@ struct ProtobufUnittest_ForeignMessageArenaLite: ProtobufGeneratedMessage, Proto
     return _c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/map_proto2_unittest.pb.swift
+++ b/Reference/google/protobuf/map_proto2_unittest.pb.swift
@@ -41,16 +41,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foo
     case 1: self = .bar
@@ -59,7 +59,7 @@ enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     case "bar": self = .bar
@@ -68,7 +68,7 @@ enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "PROTO2_MAP_ENUM_FOO": self = .foo
     case "PROTO2_MAP_ENUM_BAR": self = .bar
@@ -77,7 +77,7 @@ enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "PROTO2_MAP_ENUM_FOO": self = .foo
     case "PROTO2_MAP_ENUM_BAR": self = .bar
@@ -86,7 +86,7 @@ enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 0
@@ -96,7 +96,7 @@ enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"PROTO2_MAP_ENUM_FOO\""
@@ -106,9 +106,9 @@ enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -121,17 +121,17 @@ enum ProtobufUnittest_Proto2MapEnum: ProtobufEnum {
 }
 
 enum ProtobufUnittest_Proto2MapEnumPlusExtra: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case eProto2MapEnumFoo // = 0
   case eProto2MapEnumBar // = 1
   case eProto2MapEnumBaz // = 2
   case eProto2MapEnumExtra // = 3
 
-  public init() {
+  init() {
     self = .eProto2MapEnumFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .eProto2MapEnumFoo
     case 1: self = .eProto2MapEnumBar
@@ -141,7 +141,7 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "eProto2MapEnumFoo": self = .eProto2MapEnumFoo
     case "eProto2MapEnumBar": self = .eProto2MapEnumBar
@@ -151,7 +151,7 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "E_PROTO2_MAP_ENUM_FOO": self = .eProto2MapEnumFoo
     case "E_PROTO2_MAP_ENUM_BAR": self = .eProto2MapEnumBar
@@ -161,7 +161,7 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "E_PROTO2_MAP_ENUM_FOO": self = .eProto2MapEnumFoo
     case "E_PROTO2_MAP_ENUM_BAR": self = .eProto2MapEnumBar
@@ -171,7 +171,7 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .eProto2MapEnumFoo: return 0
@@ -182,7 +182,7 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .eProto2MapEnumFoo: return "\"E_PROTO2_MAP_ENUM_FOO\""
@@ -193,9 +193,9 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .eProto2MapEnumFoo: return ".eProto2MapEnumFoo"
@@ -223,11 +223,11 @@ struct ProtobufUnittest_TestEnumMap: ProtobufGeneratedMessage, ProtobufProto2Mes
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var knownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnum> = [:]
+  var knownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnum> = [:]
 
-  public var unknownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnum> = [:]
+  var unknownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnum> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -270,11 +270,11 @@ struct ProtobufUnittest_TestEnumMapPlusExtra: ProtobufGeneratedMessage, Protobuf
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var knownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumPlusExtra> = [:]
+  var knownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumPlusExtra> = [:]
 
-  public var unknownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumPlusExtra> = [:]
+  var unknownMapField: Dictionary<Int32,ProtobufUnittest_Proto2MapEnumPlusExtra> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -315,9 +315,9 @@ struct ProtobufUnittest_TestImportEnumMap: ProtobufGeneratedMessage, ProtobufPro
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var importEnumAmp: Dictionary<Int32,ProtobufUnittestImport_ImportEnumForMap> = [:]
+  var importEnumAmp: Dictionary<Int32,ProtobufUnittestImport_ImportEnumForMap> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/map_unittest.pb.swift
+++ b/Reference/google/protobuf/map_unittest.pb.swift
@@ -41,17 +41,17 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittest_MapEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foo
     case 1: self = .bar
@@ -60,7 +60,7 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     case "bar": self = .bar
@@ -69,7 +69,7 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "MAP_ENUM_FOO": self = .foo
     case "MAP_ENUM_BAR": self = .bar
@@ -78,7 +78,7 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "MAP_ENUM_FOO": self = .foo
     case "MAP_ENUM_BAR": self = .bar
@@ -87,7 +87,7 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 0
@@ -98,7 +98,7 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"MAP_ENUM_FOO\""
@@ -109,9 +109,9 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -323,97 +323,97 @@ struct ProtobufUnittest_TestMap: ProtobufGeneratedMessage, ProtobufProto3Message
   private var _storage = _StorageClass()
 
 
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnum> {
+  var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnum> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessage> {
+  var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessage> {
     get {return _storage._mapInt32ForeignMessage}
     set {_uniqueStorage()._mapInt32ForeignMessage = newValue}
   }
 
-  public var mapStringForeignMessage: Dictionary<String,ProtobufUnittest_ForeignMessage> {
+  var mapStringForeignMessage: Dictionary<String,ProtobufUnittest_ForeignMessage> {
     get {return _storage._mapStringForeignMessage}
     set {_uniqueStorage()._mapStringForeignMessage = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -480,7 +480,7 @@ struct ProtobufUnittest_TestMapSubmessage: ProtobufGeneratedMessage, ProtobufPro
   private var _storage = _StorageClass()
 
 
-  public var testMap: ProtobufUnittest_TestMap {
+  var testMap: ProtobufUnittest_TestMap {
     get {return _storage._testMap ?? ProtobufUnittest_TestMap()}
     set {_uniqueStorage()._testMap = newValue}
   }
@@ -491,7 +491,7 @@ struct ProtobufUnittest_TestMapSubmessage: ProtobufGeneratedMessage, ProtobufPro
     return _storage._testMap = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -525,9 +525,9 @@ struct ProtobufUnittest_TestMessageMap: ProtobufGeneratedMessage, ProtobufProto3
   ]}
 
 
-  public var mapInt32Message: Dictionary<Int32,ProtobufUnittest_TestAllTypes> = [:]
+  var mapInt32Message: Dictionary<Int32,ProtobufUnittest_TestAllTypes> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -563,11 +563,11 @@ struct ProtobufUnittest_TestSameTypeMap: ProtobufGeneratedMessage, ProtobufProto
   ]}
 
 
-  public var map1: Dictionary<Int32,Int32> = [:]
+  var map1: Dictionary<Int32,Int32> = [:]
 
-  public var map2: Dictionary<Int32,Int32> = [:]
+  var map2: Dictionary<Int32,Int32> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -606,9 +606,9 @@ struct ProtobufUnittest_TestRequiredMessageMap: ProtobufGeneratedMessage, Protob
   ]}
 
 
-  public var mapField: Dictionary<Int32,ProtobufUnittest_TestRequired> = [:]
+  var mapField: Dictionary<Int32,ProtobufUnittest_TestRequired> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -827,97 +827,97 @@ struct ProtobufUnittest_TestArenaMap: ProtobufGeneratedMessage, ProtobufProto3Me
   private var _storage = _StorageClass()
 
 
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnum> {
+  var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnum> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessage> {
+  var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessage> {
     get {return _storage._mapInt32ForeignMessage}
     set {_uniqueStorage()._mapInt32ForeignMessage = newValue}
   }
 
-  public var mapInt32ForeignMessageNoArena: Dictionary<Int32,ProtobufUnittestNoArena_ForeignMessage> {
+  var mapInt32ForeignMessageNoArena: Dictionary<Int32,ProtobufUnittestNoArena_ForeignMessage> {
     get {return _storage._mapInt32ForeignMessageNoArena}
     set {_uniqueStorage()._mapInt32ForeignMessageNoArena = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -954,43 +954,43 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessag
 
 
   enum TypeEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "TYPE_FOO": self = .foo
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "TYPE_FOO": self = .foo
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -999,7 +999,7 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessag
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"TYPE_FOO\""
@@ -1008,9 +1008,9 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessag
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1021,9 +1021,9 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessag
 
   }
 
-  public var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
+  var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1057,9 +1057,9 @@ struct ProtobufUnittest_MessageContainingMapCalledEntry: ProtobufGeneratedMessag
   ]}
 
 
-  public var entry: Dictionary<Int32,Int32> = [:]
+  var entry: Dictionary<Int32,Int32> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1092,9 +1092,9 @@ struct ProtobufUnittest_TestRecursiveMapMessage: ProtobufGeneratedMessage, Proto
   ]}
 
 
-  public var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
+  var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/map_unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/map_unittest_proto3.pb.swift
@@ -48,17 +48,17 @@ import SwiftProtobuf
 
 
 enum Proto3MapEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foo
     case 1: self = .bar
@@ -67,7 +67,7 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     case "bar": self = .bar
@@ -76,7 +76,7 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "MAP_ENUM_FOO": self = .foo
     case "MAP_ENUM_BAR": self = .bar
@@ -85,7 +85,7 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "MAP_ENUM_FOO": self = .foo
     case "MAP_ENUM_BAR": self = .bar
@@ -94,7 +94,7 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 0
@@ -105,7 +105,7 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"MAP_ENUM_FOO\""
@@ -116,9 +116,9 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -321,92 +321,92 @@ struct Proto3TestMap: ProtobufGeneratedMessage, ProtobufProto3Message {
   private var _storage = _StorageClass()
 
 
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,Proto3MapEnum> {
+  var mapInt32Enum: Dictionary<Int32,Proto3MapEnum> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32ForeignMessage: Dictionary<Int32,Proto3ForeignMessage> {
+  var mapInt32ForeignMessage: Dictionary<Int32,Proto3ForeignMessage> {
     get {return _storage._mapInt32ForeignMessage}
     set {_uniqueStorage()._mapInt32ForeignMessage = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -473,7 +473,7 @@ struct Proto3TestMapSubmessage: ProtobufGeneratedMessage, ProtobufProto3Message 
   private var _storage = _StorageClass()
 
 
-  public var testMap: Proto3TestMap {
+  var testMap: Proto3TestMap {
     get {return _storage._testMap ?? Proto3TestMap()}
     set {_uniqueStorage()._testMap = newValue}
   }
@@ -484,7 +484,7 @@ struct Proto3TestMapSubmessage: ProtobufGeneratedMessage, ProtobufProto3Message 
     return _storage._testMap = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -518,9 +518,9 @@ struct Proto3TestMessageMap: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var mapInt32Message: Dictionary<Int32,Proto3TestAllTypes> = [:]
+  var mapInt32Message: Dictionary<Int32,Proto3TestAllTypes> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -556,11 +556,11 @@ struct Proto3TestSameTypeMap: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var map1: Dictionary<Int32,Int32> = [:]
+  var map1: Dictionary<Int32,Int32> = [:]
 
-  public var map2: Dictionary<Int32,Int32> = [:]
+  var map2: Dictionary<Int32,Int32> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -626,37 +626,37 @@ struct Proto3TestArenaMap: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var mapInt32Int32: Dictionary<Int32,Int32> = [:]
+  var mapInt32Int32: Dictionary<Int32,Int32> = [:]
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> = [:]
+  var mapInt64Int64: Dictionary<Int64,Int64> = [:]
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> = [:]
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> = [:]
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> = [:]
+  var mapSint32Sint32: Dictionary<Int32,Int32> = [:]
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> = [:]
+  var mapSint64Sint64: Dictionary<Int64,Int64> = [:]
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> = [:]
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> = [:]
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> = [:]
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> = [:]
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> = [:]
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> = [:]
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> = [:]
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> = [:]
 
-  public var mapInt32Float: Dictionary<Int32,Float> = [:]
+  var mapInt32Float: Dictionary<Int32,Float> = [:]
 
-  public var mapInt32Double: Dictionary<Int32,Double> = [:]
+  var mapInt32Double: Dictionary<Int32,Double> = [:]
 
-  public var mapBoolBool: Dictionary<Bool,Bool> = [:]
+  var mapBoolBool: Dictionary<Bool,Bool> = [:]
 
-  public var mapInt32Enum: Dictionary<Int32,Proto3MapEnum> = [:]
+  var mapInt32Enum: Dictionary<Int32,Proto3MapEnum> = [:]
 
-  public var mapInt32ForeignMessage: Dictionary<Int32,Proto3ForeignMessage> = [:]
+  var mapInt32ForeignMessage: Dictionary<Int32,Proto3ForeignMessage> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -762,43 +762,43 @@ struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage, Protobuf
 
 
   enum TypeEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "TYPE_FOO": self = .foo
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "TYPE_FOO": self = .foo
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -807,7 +807,7 @@ struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"TYPE_FOO\""
@@ -816,9 +816,9 @@ struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -829,9 +829,9 @@ struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage, Protobuf
 
   }
 
-  public var type: Dictionary<Int32,Proto3MessageContainingEnumCalledType> = [:]
+  var type: Dictionary<Int32,Proto3MessageContainingEnumCalledType> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -865,9 +865,9 @@ struct Proto3MessageContainingMapCalledEntry: ProtobufGeneratedMessage, Protobuf
   ]}
 
 
-  public var entry: Dictionary<Int32,Int32> = [:]
+  var entry: Dictionary<Int32,Int32> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/source_context.pb.swift
+++ b/Reference/google/protobuf/source_context.pb.swift
@@ -55,9 +55,9 @@ struct Google_Protobuf_SourceContext: ProtobufGeneratedMessage, ProtobufProto3Me
 
   ///   The path-qualified name of the .proto file that contained the associated
   ///   protobuf element.  For example: `"google/protobuf/source_context.proto"`.
-  public var fileName: String = ""
+  var fileName: String = ""
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -44,45 +44,45 @@ import Foundation
 ///  
 ///    The JSON representation for `NullValue` is JSON `null`.
 enum Google_Protobuf_NullValue: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
 
   ///   Null value.
   case nullValue // = 0
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .nullValue
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .nullValue
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "nullValue": self = .nullValue
     default: return nil
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "NULL_VALUE": self = .nullValue
     default: return nil
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "NULL_VALUE": self = .nullValue
     default: return nil
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .nullValue: return 0
@@ -91,7 +91,7 @@ enum Google_Protobuf_NullValue: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .nullValue: return "\"NULL_VALUE\""
@@ -100,9 +100,9 @@ enum Google_Protobuf_NullValue: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .nullValue: return ".nullValue"
@@ -134,9 +134,9 @@ struct Google_Protobuf_Struct: ProtobufGeneratedMessage, ProtobufProto3Message {
 
 
   ///   Unordered map of dynamically typed values.
-  public var fields: Dictionary<String,Google_Protobuf_Value> = [:]
+  var fields: Dictionary<String,Google_Protobuf_Value> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -304,7 +304,7 @@ struct Google_Protobuf_Value: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Represents a null value.
-  public var nullValue: Google_Protobuf_NullValue {
+  var nullValue: Google_Protobuf_NullValue {
     get {
       if case .nullValue(let v) = _storage._kind {
         return v
@@ -317,7 +317,7 @@ struct Google_Protobuf_Value: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Represents a double value.
-  public var numberValue: Double {
+  var numberValue: Double {
     get {
       if case .numberValue(let v) = _storage._kind {
         return v
@@ -330,7 +330,7 @@ struct Google_Protobuf_Value: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Represents a string value.
-  public var stringValue: String {
+  var stringValue: String {
     get {
       if case .stringValue(let v) = _storage._kind {
         return v
@@ -343,7 +343,7 @@ struct Google_Protobuf_Value: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Represents a boolean value.
-  public var boolValue: Bool {
+  var boolValue: Bool {
     get {
       if case .boolValue(let v) = _storage._kind {
         return v
@@ -356,7 +356,7 @@ struct Google_Protobuf_Value: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Represents a structured value.
-  public var structValue: Google_Protobuf_Struct {
+  var structValue: Google_Protobuf_Struct {
     get {
       if case .structValue(let v) = _storage._kind {
         return v
@@ -369,7 +369,7 @@ struct Google_Protobuf_Value: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Represents a repeated `Value`.
-  public var listValue: Google_Protobuf_ListValue {
+  var listValue: Google_Protobuf_ListValue {
     get {
       if case .listValue(let v) = _storage._kind {
         return v
@@ -388,7 +388,7 @@ struct Google_Protobuf_Value: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -426,9 +426,9 @@ struct Google_Protobuf_ListValue: ProtobufGeneratedMessage, ProtobufProto3Messag
 
 
   ///   Repeated field of dynamically typed values.
-  public var values: [Google_Protobuf_Value] = []
+  var values: [Google_Protobuf_Value] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/timestamp.pb.swift
+++ b/Reference/google/protobuf/timestamp.pb.swift
@@ -109,15 +109,15 @@ struct Google_Protobuf_Timestamp: ProtobufGeneratedMessage, ProtobufProto3Messag
   ///   Represents seconds of UTC time since Unix epoch
   ///   1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to
   ///   9999-12-31T23:59:59Z inclusive.
-  public var seconds: Int64 = 0
+  var seconds: Int64 = 0
 
   ///   Non-negative fractions of a second at nanosecond resolution. Negative
   ///   second values with fractions must still have non-negative nanos values
   ///   that count forward in time. Must be from 0 to 999,999,999
   ///   inclusive.
-  public var nanos: Int32 = 0
+  var nanos: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/type.pb.swift
+++ b/Reference/google/protobuf/type.pb.swift
@@ -41,7 +41,7 @@ import Foundation
 
 ///   The syntax in which a protocol buffer element is defined.
 enum Google_Protobuf_Syntax: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
 
   ///   Syntax `proto2`.
   case proto2 // = 0
@@ -50,11 +50,11 @@ enum Google_Protobuf_Syntax: ProtobufEnum {
   case proto3 // = 1
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .proto2
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .proto2
     case 1: self = .proto3
@@ -62,7 +62,7 @@ enum Google_Protobuf_Syntax: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "proto2": self = .proto2
     case "proto3": self = .proto3
@@ -70,7 +70,7 @@ enum Google_Protobuf_Syntax: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "SYNTAX_PROTO2": self = .proto2
     case "SYNTAX_PROTO3": self = .proto3
@@ -78,7 +78,7 @@ enum Google_Protobuf_Syntax: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "SYNTAX_PROTO2": self = .proto2
     case "SYNTAX_PROTO3": self = .proto3
@@ -86,7 +86,7 @@ enum Google_Protobuf_Syntax: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .proto2: return 0
@@ -96,7 +96,7 @@ enum Google_Protobuf_Syntax: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .proto2: return "\"SYNTAX_PROTO2\""
@@ -106,9 +106,9 @@ enum Google_Protobuf_Syntax: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .proto2: return ".proto2"
@@ -212,31 +212,31 @@ struct Google_Protobuf_Type: ProtobufGeneratedMessage, ProtobufProto3Message {
 
 
   ///   The fully qualified message name.
-  public var name: String {
+  var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
   ///   The list of fields.
-  public var fields: [Google_Protobuf_Field] {
+  var fields: [Google_Protobuf_Field] {
     get {return _storage._fields}
     set {_uniqueStorage()._fields = newValue}
   }
 
   ///   The list of types appearing in `oneof` definitions in this type.
-  public var oneofs: [String] {
+  var oneofs: [String] {
     get {return _storage._oneofs}
     set {_uniqueStorage()._oneofs = newValue}
   }
 
   ///   The protocol buffer options.
-  public var options: [Google_Protobuf_Option] {
+  var options: [Google_Protobuf_Option] {
     get {return _storage._options}
     set {_uniqueStorage()._options = newValue}
   }
 
   ///   The source context.
-  public var sourceContext: Google_Protobuf_SourceContext {
+  var sourceContext: Google_Protobuf_SourceContext {
     get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContext = newValue}
   }
@@ -248,12 +248,12 @@ struct Google_Protobuf_Type: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   The source syntax.
-  public var syntax: Google_Protobuf_Syntax {
+  var syntax: Google_Protobuf_Syntax {
     get {return _storage._syntax}
     set {_uniqueStorage()._syntax = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -308,7 +308,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
 
   ///   Basic field types.
   enum Kind: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   Field type unknown.
     case typeUnknown // = 0
@@ -368,11 +368,11 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
     case typeSint64 // = 18
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .typeUnknown
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .typeUnknown
       case 1: self = .typeDouble
@@ -397,7 +397,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "typeUnknown": self = .typeUnknown
       case "typeDouble": self = .typeDouble
@@ -422,7 +422,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "TYPE_UNKNOWN": self = .typeUnknown
       case "TYPE_DOUBLE": self = .typeDouble
@@ -447,7 +447,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "TYPE_UNKNOWN": self = .typeUnknown
       case "TYPE_DOUBLE": self = .typeDouble
@@ -472,7 +472,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .typeUnknown: return 0
@@ -499,7 +499,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .typeUnknown: return "\"TYPE_UNKNOWN\""
@@ -526,9 +526,9 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .typeUnknown: return ".typeUnknown"
@@ -559,7 +559,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
 
   ///   Whether a field is optional, required, or repeated.
   enum Cardinality: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   For fields with unknown cardinality.
     case unknown // = 0
@@ -574,11 +574,11 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
     case repeated // = 3
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .unknown
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .unknown
       case 1: self = .`optional`
@@ -588,7 +588,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "unknown": self = .unknown
       case "optional": self = .`optional`
@@ -598,7 +598,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "CARDINALITY_UNKNOWN": self = .unknown
       case "CARDINALITY_OPTIONAL": self = .`optional`
@@ -608,7 +608,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "CARDINALITY_UNKNOWN": self = .unknown
       case "CARDINALITY_OPTIONAL": self = .`optional`
@@ -618,7 +618,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .unknown: return 0
@@ -630,7 +630,7 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .unknown: return "\"CARDINALITY_UNKNOWN\""
@@ -642,9 +642,9 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .unknown: return ".unknown"
@@ -659,38 +659,38 @@ struct Google_Protobuf_Field: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   The field type.
-  public var kind: Google_Protobuf_Field.Kind = Google_Protobuf_Field.Kind.typeUnknown
+  var kind: Google_Protobuf_Field.Kind = Google_Protobuf_Field.Kind.typeUnknown
 
   ///   The field cardinality.
-  public var cardinality: Google_Protobuf_Field.Cardinality = Google_Protobuf_Field.Cardinality.unknown
+  var cardinality: Google_Protobuf_Field.Cardinality = Google_Protobuf_Field.Cardinality.unknown
 
   ///   The field number.
-  public var number: Int32 = 0
+  var number: Int32 = 0
 
   ///   The field name.
-  public var name: String = ""
+  var name: String = ""
 
   ///   The field type URL, without the scheme, for message or enumeration
   ///   types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
-  public var typeURL: String = ""
+  var typeURL: String = ""
 
   ///   The index of the field type in `Type.oneofs`, for message or enumeration
   ///   types. The first type has index 1; zero means the type is not in the list.
-  public var oneofIndex: Int32 = 0
+  var oneofIndex: Int32 = 0
 
   ///   Whether to use alternative packed wire representation.
-  public var packed: Bool = false
+  var packed: Bool = false
 
   ///   The protocol buffer options.
-  public var options: [Google_Protobuf_Option] = []
+  var options: [Google_Protobuf_Option] = []
 
   ///   The field JSON name.
-  public var jsonName: String = ""
+  var jsonName: String = ""
 
   ///   The string value of the default value of this field. Proto2 syntax only.
-  public var defaultValue: String = ""
+  var defaultValue: String = ""
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -839,25 +839,25 @@ struct Google_Protobuf_Enum: ProtobufGeneratedMessage, ProtobufProto3Message {
 
 
   ///   Enum type name.
-  public var name: String {
+  var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
   ///   Enum value definitions.
-  public var enumvalue: [Google_Protobuf_EnumValue] {
+  var enumvalue: [Google_Protobuf_EnumValue] {
     get {return _storage._enumvalue}
     set {_uniqueStorage()._enumvalue = newValue}
   }
 
   ///   Protocol buffer options.
-  public var options: [Google_Protobuf_Option] {
+  var options: [Google_Protobuf_Option] {
     get {return _storage._options}
     set {_uniqueStorage()._options = newValue}
   }
 
   ///   The source context.
-  public var sourceContext: Google_Protobuf_SourceContext {
+  var sourceContext: Google_Protobuf_SourceContext {
     get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContext = newValue}
   }
@@ -869,12 +869,12 @@ struct Google_Protobuf_Enum: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   The source syntax.
-  public var syntax: Google_Protobuf_Syntax {
+  var syntax: Google_Protobuf_Syntax {
     get {return _storage._syntax}
     set {_uniqueStorage()._syntax = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -914,15 +914,15 @@ struct Google_Protobuf_EnumValue: ProtobufGeneratedMessage, ProtobufProto3Messag
 
 
   ///   Enum value name.
-  public var name: String = ""
+  var name: String = ""
 
   ///   Enum value number.
-  public var number: Int32 = 0
+  var number: Int32 = 0
 
   ///   Protocol buffer options.
-  public var options: [Google_Protobuf_Option] = []
+  var options: [Google_Protobuf_Option] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1010,13 +1010,13 @@ struct Google_Protobuf_Option: ProtobufGeneratedMessage, ProtobufProto3Message {
 
 
   ///   The option's name. For example, `"java_package"`.
-  public var name: String {
+  var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
   ///   The option's value. For example, `"com.google.protobuf"`.
-  public var value: Google_Protobuf_Any {
+  var value: Google_Protobuf_Any {
     get {return _storage._value ?? Google_Protobuf_Any()}
     set {_uniqueStorage()._value = newValue}
   }
@@ -1027,7 +1027,7 @@ struct Google_Protobuf_Option: ProtobufGeneratedMessage, ProtobufProto3Message {
     return _storage._value = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -47,16 +47,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
 
-  public init() {
+  init() {
     self = .foreignFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 4: self = .foreignFoo
     case 5: self = .foreignBar
@@ -65,7 +65,7 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignFoo": self = .foreignFoo
     case "foreignBar": self = .foreignBar
@@ -74,7 +74,7 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -83,7 +83,7 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -92,7 +92,7 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignFoo: return 4
@@ -102,7 +102,7 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignFoo: return "\"FOREIGN_FOO\""
@@ -112,9 +112,9 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignFoo: return ".foreignFoo"
@@ -128,18 +128,18 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
 
 ///   Test an enum that has multiple values with the same number.
 enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo1 // = 1
   case bar1 // = 2
   case baz // = 3
   case foo2 // = 1
   case bar2 // = 2
 
-  public init() {
+  init() {
     self = .foo1
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .foo1
     case 2: self = .bar1
@@ -148,7 +148,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo1": self = .foo1
     case "bar1": self = .bar1
@@ -159,7 +159,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOO1": self = .foo1
     case "BAR1": self = .bar1
@@ -170,7 +170,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOO1": self = .foo1
     case "BAR1": self = .bar1
@@ -181,7 +181,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo1: return 1
@@ -193,7 +193,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo1: return "\"FOO1\""
@@ -205,9 +205,9 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo1: return ".foo1"
@@ -223,7 +223,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
 
 ///   Test an enum with large, unordered values.
 enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case sparseA // = 123
   case sparseB // = 62374
   case sparseC // = 12589234
@@ -232,11 +232,11 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
   case sparseF // = 0
   case sparseG // = 2
 
-  public init() {
+  init() {
     self = .sparseA
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 123: self = .sparseA
     case 62374: self = .sparseB
@@ -249,7 +249,7 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "sparseA": self = .sparseA
     case "sparseB": self = .sparseB
@@ -262,7 +262,7 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "SPARSE_A": self = .sparseA
     case "SPARSE_B": self = .sparseB
@@ -275,7 +275,7 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "SPARSE_A": self = .sparseA
     case "SPARSE_B": self = .sparseB
@@ -288,7 +288,7 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .sparseA: return 123
@@ -302,7 +302,7 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .sparseA: return "\"SPARSE_A\""
@@ -316,9 +316,9 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .sparseA: return ".sparseA"
@@ -1106,7 +1106,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
@@ -1114,11 +1114,11 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     ///   Intentionally negative.
     case neg // = -1
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       case 2: self = .bar
@@ -1128,7 +1128,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -1138,7 +1138,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1148,7 +1148,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1158,7 +1158,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -1169,7 +1169,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -1180,9 +1180,9 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1212,7 +1212,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -1223,7 +1223,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       return _bb = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1260,7 +1260,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1271,7 +1271,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1308,7 +1308,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1319,7 +1319,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1343,7 +1343,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
@@ -1354,7 +1354,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalInt32 = nil
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64 ?? 0}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
@@ -1365,7 +1365,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalInt64 = nil
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32 ?? 0}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
@@ -1376,7 +1376,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalUint32 = nil
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64 ?? 0}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
@@ -1387,7 +1387,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalUint64 = nil
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32 ?? 0}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
@@ -1398,7 +1398,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalSint32 = nil
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64 ?? 0}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
@@ -1409,7 +1409,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalSint64 = nil
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32 ?? 0}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
@@ -1420,7 +1420,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalFixed32 = nil
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64 ?? 0}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
@@ -1431,7 +1431,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalFixed64 = nil
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32 ?? 0}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
@@ -1442,7 +1442,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalSfixed32 = nil
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64 ?? 0}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
@@ -1453,7 +1453,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalSfixed64 = nil
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat ?? 0}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
@@ -1464,7 +1464,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalFloat = nil
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble ?? 0}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
@@ -1475,7 +1475,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalDouble = nil
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool ?? false}
     set {_uniqueStorage()._optionalBool = newValue}
   }
@@ -1486,7 +1486,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalBool = nil
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString ?? ""}
     set {_uniqueStorage()._optionalString = newValue}
   }
@@ -1497,7 +1497,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalString = nil
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes ?? Data()}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -1508,7 +1508,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalBytes = nil
   }
 
-  public var optionalGroup: ProtobufUnittest_TestAllTypes.OptionalGroup {
+  var optionalGroup: ProtobufUnittest_TestAllTypes.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittest_TestAllTypes.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -1519,7 +1519,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalGroup = nil
   }
 
-  public var optionalNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -1530,7 +1530,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: ProtobufUnittest_ForeignMessage {
+  var optionalForeignMessage: ProtobufUnittest_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? ProtobufUnittest_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -1541,7 +1541,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
+  var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
     get {return _storage._optionalImportMessage ?? ProtobufUnittestImport_ImportMessage()}
     set {_uniqueStorage()._optionalImportMessage = newValue}
   }
@@ -1552,7 +1552,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalImportMessage = nil
   }
 
-  public var optionalNestedEnum: ProtobufUnittest_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum ?? ProtobufUnittest_TestAllTypes.NestedEnum.foo}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
@@ -1563,7 +1563,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalNestedEnum = nil
   }
 
-  public var optionalForeignEnum: ProtobufUnittest_ForeignEnum {
+  var optionalForeignEnum: ProtobufUnittest_ForeignEnum {
     get {return _storage._optionalForeignEnum ?? ProtobufUnittest_ForeignEnum.foreignFoo}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
@@ -1574,7 +1574,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalForeignEnum = nil
   }
 
-  public var optionalImportEnum: ProtobufUnittestImport_ImportEnum {
+  var optionalImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._optionalImportEnum ?? ProtobufUnittestImport_ImportEnum.importFoo}
     set {_uniqueStorage()._optionalImportEnum = newValue}
   }
@@ -1585,7 +1585,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalImportEnum = nil
   }
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece ?? ""}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
@@ -1596,7 +1596,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalStringPiece = nil
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord ?? ""}
     set {_uniqueStorage()._optionalCord = newValue}
   }
@@ -1608,7 +1608,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
   }
 
   ///   Defined in unittest_import_public.proto
-  public var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
+  var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
   }
@@ -1619,7 +1619,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalPublicImportMessage = nil
   }
 
-  public var optionalLazyMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var optionalLazyMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalLazyMessage ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalLazyMessage = newValue}
   }
@@ -1631,133 +1631,133 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedGroup: [ProtobufUnittest_TestAllTypes.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittest_TestAllTypes.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public var repeatedNestedMessage: [ProtobufUnittest_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [ProtobufUnittest_ForeignMessage] {
+  var repeatedForeignMessage: [ProtobufUnittest_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
+  var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [ProtobufUnittest_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [ProtobufUnittest_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [ProtobufUnittest_ForeignEnum] {
+  var repeatedForeignEnum: [ProtobufUnittest_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedImportEnum: [ProtobufUnittestImport_ImportEnum] {
+  var repeatedImportEnum: [ProtobufUnittestImport_ImportEnum] {
     get {return _storage._repeatedImportEnum}
     set {_uniqueStorage()._repeatedImportEnum = newValue}
   }
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [ProtobufUnittest_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessage: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
   ///   Singular with defaults
-  public var defaultInt32: Int32 {
+  var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
   }
@@ -1768,7 +1768,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultInt32 = nil
   }
 
-  public var defaultInt64: Int64 {
+  var defaultInt64: Int64 {
     get {return _storage._defaultInt64 ?? 42}
     set {_uniqueStorage()._defaultInt64 = newValue}
   }
@@ -1779,7 +1779,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultInt64 = nil
   }
 
-  public var defaultUint32: UInt32 {
+  var defaultUint32: UInt32 {
     get {return _storage._defaultUint32 ?? 43}
     set {_uniqueStorage()._defaultUint32 = newValue}
   }
@@ -1790,7 +1790,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultUint32 = nil
   }
 
-  public var defaultUint64: UInt64 {
+  var defaultUint64: UInt64 {
     get {return _storage._defaultUint64 ?? 44}
     set {_uniqueStorage()._defaultUint64 = newValue}
   }
@@ -1801,7 +1801,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultUint64 = nil
   }
 
-  public var defaultSint32: Int32 {
+  var defaultSint32: Int32 {
     get {return _storage._defaultSint32 ?? -45}
     set {_uniqueStorage()._defaultSint32 = newValue}
   }
@@ -1812,7 +1812,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultSint32 = nil
   }
 
-  public var defaultSint64: Int64 {
+  var defaultSint64: Int64 {
     get {return _storage._defaultSint64 ?? 46}
     set {_uniqueStorage()._defaultSint64 = newValue}
   }
@@ -1823,7 +1823,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultSint64 = nil
   }
 
-  public var defaultFixed32: UInt32 {
+  var defaultFixed32: UInt32 {
     get {return _storage._defaultFixed32 ?? 47}
     set {_uniqueStorage()._defaultFixed32 = newValue}
   }
@@ -1834,7 +1834,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultFixed32 = nil
   }
 
-  public var defaultFixed64: UInt64 {
+  var defaultFixed64: UInt64 {
     get {return _storage._defaultFixed64 ?? 48}
     set {_uniqueStorage()._defaultFixed64 = newValue}
   }
@@ -1845,7 +1845,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultFixed64 = nil
   }
 
-  public var defaultSfixed32: Int32 {
+  var defaultSfixed32: Int32 {
     get {return _storage._defaultSfixed32 ?? 49}
     set {_uniqueStorage()._defaultSfixed32 = newValue}
   }
@@ -1856,7 +1856,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultSfixed32 = nil
   }
 
-  public var defaultSfixed64: Int64 {
+  var defaultSfixed64: Int64 {
     get {return _storage._defaultSfixed64 ?? -50}
     set {_uniqueStorage()._defaultSfixed64 = newValue}
   }
@@ -1867,7 +1867,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultSfixed64 = nil
   }
 
-  public var defaultFloat: Float {
+  var defaultFloat: Float {
     get {return _storage._defaultFloat ?? 51.5}
     set {_uniqueStorage()._defaultFloat = newValue}
   }
@@ -1878,7 +1878,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultFloat = nil
   }
 
-  public var defaultDouble: Double {
+  var defaultDouble: Double {
     get {return _storage._defaultDouble ?? 52000}
     set {_uniqueStorage()._defaultDouble = newValue}
   }
@@ -1889,7 +1889,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultDouble = nil
   }
 
-  public var defaultBool: Bool {
+  var defaultBool: Bool {
     get {return _storage._defaultBool ?? true}
     set {_uniqueStorage()._defaultBool = newValue}
   }
@@ -1900,7 +1900,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultBool = nil
   }
 
-  public var defaultString: String {
+  var defaultString: String {
     get {return _storage._defaultString ?? "hello"}
     set {_uniqueStorage()._defaultString = newValue}
   }
@@ -1911,7 +1911,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultString = nil
   }
 
-  public var defaultBytes: Data {
+  var defaultBytes: Data {
     get {return _storage._defaultBytes ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {_uniqueStorage()._defaultBytes = newValue}
   }
@@ -1922,7 +1922,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultBytes = nil
   }
 
-  public var defaultNestedEnum: ProtobufUnittest_TestAllTypes.NestedEnum {
+  var defaultNestedEnum: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return _storage._defaultNestedEnum ?? ProtobufUnittest_TestAllTypes.NestedEnum.bar}
     set {_uniqueStorage()._defaultNestedEnum = newValue}
   }
@@ -1933,7 +1933,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultNestedEnum = nil
   }
 
-  public var defaultForeignEnum: ProtobufUnittest_ForeignEnum {
+  var defaultForeignEnum: ProtobufUnittest_ForeignEnum {
     get {return _storage._defaultForeignEnum ?? ProtobufUnittest_ForeignEnum.foreignBar}
     set {_uniqueStorage()._defaultForeignEnum = newValue}
   }
@@ -1944,7 +1944,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultForeignEnum = nil
   }
 
-  public var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
+  var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._defaultImportEnum ?? ProtobufUnittestImport_ImportEnum.importBar}
     set {_uniqueStorage()._defaultImportEnum = newValue}
   }
@@ -1955,7 +1955,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultImportEnum = nil
   }
 
-  public var defaultStringPiece: String {
+  var defaultStringPiece: String {
     get {return _storage._defaultStringPiece ?? "abc"}
     set {_uniqueStorage()._defaultStringPiece = newValue}
   }
@@ -1966,7 +1966,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultStringPiece = nil
   }
 
-  public var defaultCord: String {
+  var defaultCord: String {
     get {return _storage._defaultCord ?? "123"}
     set {_uniqueStorage()._defaultCord = newValue}
   }
@@ -1977,7 +1977,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultCord = nil
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1989,7 +1989,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     }
   }
 
-  public var oneofNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -2001,7 +2001,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -2013,7 +2013,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -2032,7 +2032,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2126,7 +2126,7 @@ struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufPr
     set {_storage.unknown = newValue}
   }
 
-  public var child: ProtobufUnittest_NestedTestAllTypes {
+  var child: ProtobufUnittest_NestedTestAllTypes {
     get {return _storage._child ?? ProtobufUnittest_NestedTestAllTypes()}
     set {_uniqueStorage()._child = newValue}
   }
@@ -2137,7 +2137,7 @@ struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._child = nil
   }
 
-  public var payload: ProtobufUnittest_TestAllTypes {
+  var payload: ProtobufUnittest_TestAllTypes {
     get {return _storage._payload ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._payload = newValue}
   }
@@ -2148,12 +2148,12 @@ struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._payload = nil
   }
 
-  public var repeatedChild: [ProtobufUnittest_NestedTestAllTypes] {
+  var repeatedChild: [ProtobufUnittest_NestedTestAllTypes] {
     get {return _storage._repeatedChild}
     set {_uniqueStorage()._repeatedChild = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2189,7 +2189,7 @@ struct ProtobufUnittest_TestDeprecatedFields: ProtobufGeneratedMessage, Protobuf
   public var unknown = ProtobufUnknownStorage()
 
   private var _deprecatedInt32: Int32? = nil
-  public var deprecatedInt32: Int32 {
+  var deprecatedInt32: Int32 {
     get {return _deprecatedInt32 ?? 0}
     set {_deprecatedInt32 = newValue}
   }
@@ -2200,7 +2200,7 @@ struct ProtobufUnittest_TestDeprecatedFields: ProtobufGeneratedMessage, Protobuf
     return _deprecatedInt32 = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2241,7 +2241,7 @@ struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage, ProtobufProto2
   public var unknown = ProtobufUnknownStorage()
 
   private var _c: Int32? = nil
-  public var c: Int32 {
+  var c: Int32 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -2253,7 +2253,7 @@ struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage, ProtobufProto2
   }
 
   private var _d: Int32? = nil
-  public var d: Int32 {
+  var d: Int32 {
     get {return _d ?? 0}
     set {_d = newValue}
   }
@@ -2264,7 +2264,7 @@ struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage, ProtobufProto2
     return _d = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2301,7 +2301,7 @@ struct ProtobufUnittest_TestReservedFields: ProtobufGeneratedMessage, ProtobufPr
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -2325,7 +2325,7 @@ struct ProtobufUnittest_TestAllExtensions: ProtobufGeneratedMessage, ProtobufPro
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -2380,7 +2380,7 @@ struct ProtobufUnittest_OptionalGroup_extension: ProtobufGeneratedMessage, Proto
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -2391,7 +2391,7 @@ struct ProtobufUnittest_OptionalGroup_extension: ProtobufGeneratedMessage, Proto
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2428,7 +2428,7 @@ struct ProtobufUnittest_RepeatedGroup_extension: ProtobufGeneratedMessage, Proto
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -2439,7 +2439,7 @@ struct ProtobufUnittest_RepeatedGroup_extension: ProtobufGeneratedMessage, Proto
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2482,7 +2482,7 @@ struct ProtobufUnittest_TestNestedExtension: ProtobufGeneratedMessage, ProtobufP
     static let ProtobufUnittest_TestAllExtensions_nestedStringExtension = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufString>, ProtobufUnittest_TestAllExtensions>(protoFieldNumber: 1003, protoFieldName: "nested_string_extension", jsonFieldName: "nestedStringExtension", swiftFieldName: "ProtobufUnittest_TestNestedExtension_nestedStringExtension", defaultValue: "")
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -2844,7 +2844,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     static let ProtobufUnittest_TestAllExtensions_multi = ProtobufGenericMessageExtension<ProtobufRepeatedMessageField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(protoFieldNumber: 1001, protoFieldName: "multi", jsonFieldName: "multi", swiftFieldName: "ProtobufUnittest_TestRequired_multi", defaultValue: [])
   }
 
-  public var a: Int32 {
+  var a: Int32 {
     get {return _storage._a ?? 0}
     set {_uniqueStorage()._a = newValue}
   }
@@ -2855,7 +2855,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._a = nil
   }
 
-  public var dummy2: Int32 {
+  var dummy2: Int32 {
     get {return _storage._dummy2 ?? 0}
     set {_uniqueStorage()._dummy2 = newValue}
   }
@@ -2866,7 +2866,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy2 = nil
   }
 
-  public var b: Int32 {
+  var b: Int32 {
     get {return _storage._b ?? 0}
     set {_uniqueStorage()._b = newValue}
   }
@@ -2879,7 +2879,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
 
   ///   Pad the field count to 32 so that we can test that IsInitialized()
   ///   properly checks multiple elements of has_bits_.
-  public var dummy4: Int32 {
+  var dummy4: Int32 {
     get {return _storage._dummy4 ?? 0}
     set {_uniqueStorage()._dummy4 = newValue}
   }
@@ -2890,7 +2890,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy4 = nil
   }
 
-  public var dummy5: Int32 {
+  var dummy5: Int32 {
     get {return _storage._dummy5 ?? 0}
     set {_uniqueStorage()._dummy5 = newValue}
   }
@@ -2901,7 +2901,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy5 = nil
   }
 
-  public var dummy6: Int32 {
+  var dummy6: Int32 {
     get {return _storage._dummy6 ?? 0}
     set {_uniqueStorage()._dummy6 = newValue}
   }
@@ -2912,7 +2912,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy6 = nil
   }
 
-  public var dummy7: Int32 {
+  var dummy7: Int32 {
     get {return _storage._dummy7 ?? 0}
     set {_uniqueStorage()._dummy7 = newValue}
   }
@@ -2923,7 +2923,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy7 = nil
   }
 
-  public var dummy8: Int32 {
+  var dummy8: Int32 {
     get {return _storage._dummy8 ?? 0}
     set {_uniqueStorage()._dummy8 = newValue}
   }
@@ -2934,7 +2934,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy8 = nil
   }
 
-  public var dummy9: Int32 {
+  var dummy9: Int32 {
     get {return _storage._dummy9 ?? 0}
     set {_uniqueStorage()._dummy9 = newValue}
   }
@@ -2945,7 +2945,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy9 = nil
   }
 
-  public var dummy10: Int32 {
+  var dummy10: Int32 {
     get {return _storage._dummy10 ?? 0}
     set {_uniqueStorage()._dummy10 = newValue}
   }
@@ -2956,7 +2956,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy10 = nil
   }
 
-  public var dummy11: Int32 {
+  var dummy11: Int32 {
     get {return _storage._dummy11 ?? 0}
     set {_uniqueStorage()._dummy11 = newValue}
   }
@@ -2967,7 +2967,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy11 = nil
   }
 
-  public var dummy12: Int32 {
+  var dummy12: Int32 {
     get {return _storage._dummy12 ?? 0}
     set {_uniqueStorage()._dummy12 = newValue}
   }
@@ -2978,7 +2978,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy12 = nil
   }
 
-  public var dummy13: Int32 {
+  var dummy13: Int32 {
     get {return _storage._dummy13 ?? 0}
     set {_uniqueStorage()._dummy13 = newValue}
   }
@@ -2989,7 +2989,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy13 = nil
   }
 
-  public var dummy14: Int32 {
+  var dummy14: Int32 {
     get {return _storage._dummy14 ?? 0}
     set {_uniqueStorage()._dummy14 = newValue}
   }
@@ -3000,7 +3000,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy14 = nil
   }
 
-  public var dummy15: Int32 {
+  var dummy15: Int32 {
     get {return _storage._dummy15 ?? 0}
     set {_uniqueStorage()._dummy15 = newValue}
   }
@@ -3011,7 +3011,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy15 = nil
   }
 
-  public var dummy16: Int32 {
+  var dummy16: Int32 {
     get {return _storage._dummy16 ?? 0}
     set {_uniqueStorage()._dummy16 = newValue}
   }
@@ -3022,7 +3022,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy16 = nil
   }
 
-  public var dummy17: Int32 {
+  var dummy17: Int32 {
     get {return _storage._dummy17 ?? 0}
     set {_uniqueStorage()._dummy17 = newValue}
   }
@@ -3033,7 +3033,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy17 = nil
   }
 
-  public var dummy18: Int32 {
+  var dummy18: Int32 {
     get {return _storage._dummy18 ?? 0}
     set {_uniqueStorage()._dummy18 = newValue}
   }
@@ -3044,7 +3044,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy18 = nil
   }
 
-  public var dummy19: Int32 {
+  var dummy19: Int32 {
     get {return _storage._dummy19 ?? 0}
     set {_uniqueStorage()._dummy19 = newValue}
   }
@@ -3055,7 +3055,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy19 = nil
   }
 
-  public var dummy20: Int32 {
+  var dummy20: Int32 {
     get {return _storage._dummy20 ?? 0}
     set {_uniqueStorage()._dummy20 = newValue}
   }
@@ -3066,7 +3066,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy20 = nil
   }
 
-  public var dummy21: Int32 {
+  var dummy21: Int32 {
     get {return _storage._dummy21 ?? 0}
     set {_uniqueStorage()._dummy21 = newValue}
   }
@@ -3077,7 +3077,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy21 = nil
   }
 
-  public var dummy22: Int32 {
+  var dummy22: Int32 {
     get {return _storage._dummy22 ?? 0}
     set {_uniqueStorage()._dummy22 = newValue}
   }
@@ -3088,7 +3088,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy22 = nil
   }
 
-  public var dummy23: Int32 {
+  var dummy23: Int32 {
     get {return _storage._dummy23 ?? 0}
     set {_uniqueStorage()._dummy23 = newValue}
   }
@@ -3099,7 +3099,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy23 = nil
   }
 
-  public var dummy24: Int32 {
+  var dummy24: Int32 {
     get {return _storage._dummy24 ?? 0}
     set {_uniqueStorage()._dummy24 = newValue}
   }
@@ -3110,7 +3110,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy24 = nil
   }
 
-  public var dummy25: Int32 {
+  var dummy25: Int32 {
     get {return _storage._dummy25 ?? 0}
     set {_uniqueStorage()._dummy25 = newValue}
   }
@@ -3121,7 +3121,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy25 = nil
   }
 
-  public var dummy26: Int32 {
+  var dummy26: Int32 {
     get {return _storage._dummy26 ?? 0}
     set {_uniqueStorage()._dummy26 = newValue}
   }
@@ -3132,7 +3132,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy26 = nil
   }
 
-  public var dummy27: Int32 {
+  var dummy27: Int32 {
     get {return _storage._dummy27 ?? 0}
     set {_uniqueStorage()._dummy27 = newValue}
   }
@@ -3143,7 +3143,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy27 = nil
   }
 
-  public var dummy28: Int32 {
+  var dummy28: Int32 {
     get {return _storage._dummy28 ?? 0}
     set {_uniqueStorage()._dummy28 = newValue}
   }
@@ -3154,7 +3154,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy28 = nil
   }
 
-  public var dummy29: Int32 {
+  var dummy29: Int32 {
     get {return _storage._dummy29 ?? 0}
     set {_uniqueStorage()._dummy29 = newValue}
   }
@@ -3165,7 +3165,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy29 = nil
   }
 
-  public var dummy30: Int32 {
+  var dummy30: Int32 {
     get {return _storage._dummy30 ?? 0}
     set {_uniqueStorage()._dummy30 = newValue}
   }
@@ -3176,7 +3176,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy30 = nil
   }
 
-  public var dummy31: Int32 {
+  var dummy31: Int32 {
     get {return _storage._dummy31 ?? 0}
     set {_uniqueStorage()._dummy31 = newValue}
   }
@@ -3187,7 +3187,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy31 = nil
   }
 
-  public var dummy32: Int32 {
+  var dummy32: Int32 {
     get {return _storage._dummy32 ?? 0}
     set {_uniqueStorage()._dummy32 = newValue}
   }
@@ -3198,7 +3198,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy32 = nil
   }
 
-  public var c: Int32 {
+  var c: Int32 {
     get {return _storage._c ?? 0}
     set {_uniqueStorage()._c = newValue}
   }
@@ -3209,7 +3209,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3302,7 +3302,7 @@ struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage, ProtobufP
     set {_storage.unknown = newValue}
   }
 
-  public var optionalMessage: ProtobufUnittest_TestRequired {
+  var optionalMessage: ProtobufUnittest_TestRequired {
     get {return _storage._optionalMessage ?? ProtobufUnittest_TestRequired()}
     set {_uniqueStorage()._optionalMessage = newValue}
   }
@@ -3313,12 +3313,12 @@ struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalMessage = nil
   }
 
-  public var repeatedMessage: [ProtobufUnittest_TestRequired] {
+  var repeatedMessage: [ProtobufUnittest_TestRequired] {
     get {return _storage._repeatedMessage}
     set {_uniqueStorage()._repeatedMessage = newValue}
   }
 
-  public var dummy: Int32 {
+  var dummy: Int32 {
     get {return _storage._dummy ?? 0}
     set {_uniqueStorage()._dummy = newValue}
   }
@@ -3329,7 +3329,7 @@ struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage, ProtobufP
     return _storage._dummy = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3405,7 +3405,7 @@ struct ProtobufUnittest_TestForeignNested: ProtobufGeneratedMessage, ProtobufPro
     set {_storage.unknown = newValue}
   }
 
-  public var foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return _storage._foreignNested ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._foreignNested = newValue}
   }
@@ -3416,7 +3416,7 @@ struct ProtobufUnittest_TestForeignNested: ProtobufGeneratedMessage, ProtobufPro
     return _storage._foreignNested = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3448,7 +3448,7 @@ struct ProtobufUnittest_TestEmptyMessage: ProtobufGeneratedMessage, ProtobufProt
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3474,7 +3474,7 @@ struct ProtobufUnittest_TestEmptyMessageWithExtensions: ProtobufGeneratedMessage
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -3524,7 +3524,7 @@ struct ProtobufUnittest_TestMultipleExtensionRanges: ProtobufGeneratedMessage, P
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (42 <= protoFieldNumber && protoFieldNumber < 43) || (4143 <= protoFieldNumber && protoFieldNumber < 4244) || (65536 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -3586,7 +3586,7 @@ struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessage, Prot
   ///   The largest possible tag number is 2^28 - 1, since the wire format uses
   ///   three bits to communicate wire type.
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -3598,7 +3598,7 @@ struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessage, Prot
   }
 
   private var _bb: Int32? = nil
-  public var bb: Int32 {
+  var bb: Int32 {
     get {return _bb ?? 0}
     set {_bb = newValue}
   }
@@ -3609,7 +3609,7 @@ struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessage, Prot
     return _bb = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3699,7 +3699,7 @@ struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage, Protobuf
     set {_storage.unknown = newValue}
   }
 
-  public var a: ProtobufUnittest_TestRecursiveMessage {
+  var a: ProtobufUnittest_TestRecursiveMessage {
     get {return _storage._a ?? ProtobufUnittest_TestRecursiveMessage()}
     set {_uniqueStorage()._a = newValue}
   }
@@ -3710,7 +3710,7 @@ struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage, Protobuf
     return _storage._a = nil
   }
 
-  public var i: Int32 {
+  var i: Int32 {
     get {return _storage._i ?? 0}
     set {_uniqueStorage()._i = newValue}
   }
@@ -3721,7 +3721,7 @@ struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage, Protobuf
     return _storage._i = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3797,7 +3797,7 @@ struct ProtobufUnittest_TestMutualRecursionA: ProtobufGeneratedMessage, Protobuf
     set {_storage.unknown = newValue}
   }
 
-  public var bb: ProtobufUnittest_TestMutualRecursionB {
+  var bb: ProtobufUnittest_TestMutualRecursionB {
     get {return _storage._bb ?? ProtobufUnittest_TestMutualRecursionB()}
     set {_uniqueStorage()._bb = newValue}
   }
@@ -3808,7 +3808,7 @@ struct ProtobufUnittest_TestMutualRecursionA: ProtobufGeneratedMessage, Protobuf
     return _storage._bb = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3892,7 +3892,7 @@ struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage, Protobuf
     set {_storage.unknown = newValue}
   }
 
-  public var a: ProtobufUnittest_TestMutualRecursionA {
+  var a: ProtobufUnittest_TestMutualRecursionA {
     get {return _storage._a ?? ProtobufUnittest_TestMutualRecursionA()}
     set {_uniqueStorage()._a = newValue}
   }
@@ -3903,7 +3903,7 @@ struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage, Protobuf
     return _storage._a = nil
   }
 
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
@@ -3914,7 +3914,7 @@ struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage, Protobuf
     return _storage._optionalInt32 = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4025,7 +4025,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -4036,7 +4036,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4073,7 +4073,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -4084,7 +4084,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4108,7 +4108,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
   }
 
   ///   NO_PROTO1
-  public var a: Int32 {
+  var a: Int32 {
     get {return _storage._a ?? 0}
     set {_uniqueStorage()._a = newValue}
   }
@@ -4119,7 +4119,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
     return _storage._a = nil
   }
 
-  public var foo: ProtobufUnittest_TestDupFieldNumber.Foo {
+  var foo: ProtobufUnittest_TestDupFieldNumber.Foo {
     get {return _storage._foo ?? ProtobufUnittest_TestDupFieldNumber.Foo()}
     set {_uniqueStorage()._foo = newValue}
   }
@@ -4130,7 +4130,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
     return _storage._foo = nil
   }
 
-  public var bar: ProtobufUnittest_TestDupFieldNumber.Bar {
+  var bar: ProtobufUnittest_TestDupFieldNumber.Bar {
     get {return _storage._bar ?? ProtobufUnittest_TestDupFieldNumber.Bar()}
     set {_uniqueStorage()._bar = newValue}
   }
@@ -4141,7 +4141,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
     return _storage._bar = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4217,7 +4217,7 @@ struct ProtobufUnittest_TestEagerMessage: ProtobufGeneratedMessage, ProtobufProt
     set {_storage.unknown = newValue}
   }
 
-  public var subMessage: ProtobufUnittest_TestAllTypes {
+  var subMessage: ProtobufUnittest_TestAllTypes {
     get {return _storage._subMessage ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._subMessage = newValue}
   }
@@ -4228,7 +4228,7 @@ struct ProtobufUnittest_TestEagerMessage: ProtobufGeneratedMessage, ProtobufProt
     return _storage._subMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4303,7 +4303,7 @@ struct ProtobufUnittest_TestLazyMessage: ProtobufGeneratedMessage, ProtobufProto
     set {_storage.unknown = newValue}
   }
 
-  public var subMessage: ProtobufUnittest_TestAllTypes {
+  var subMessage: ProtobufUnittest_TestAllTypes {
     get {return _storage._subMessage ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._subMessage = newValue}
   }
@@ -4314,7 +4314,7 @@ struct ProtobufUnittest_TestLazyMessage: ProtobufGeneratedMessage, ProtobufProto
     return _storage._subMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4405,11 +4405,11 @@ struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessage, Prot
 
     public var unknown = ProtobufUnknownStorage()
 
-    public var nestedmessageRepeatedInt32: [Int32] = []
+    var nestedmessageRepeatedInt32: [Int32] = []
 
-    public var nestedmessageRepeatedForeignmessage: [ProtobufUnittest_ForeignMessage] = []
+    var nestedmessageRepeatedForeignmessage: [ProtobufUnittest_ForeignMessage] = []
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4437,7 +4437,7 @@ struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessage, Prot
     }
   }
 
-  public var optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage {
+  var optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage {
     get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestNestedMessageHasBits.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -4448,7 +4448,7 @@ struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessage, Prot
     return _storage._optionalNestedMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4624,7 +4624,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     set {_storage.unknown = newValue}
   }
 
-  public var primitiveField: Int32 {
+  var primitiveField: Int32 {
     get {return _storage._primitiveField ?? 0}
     set {_uniqueStorage()._primitiveField = newValue}
   }
@@ -4635,7 +4635,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._primitiveField = nil
   }
 
-  public var stringField: String {
+  var stringField: String {
     get {return _storage._stringField ?? ""}
     set {_uniqueStorage()._stringField = newValue}
   }
@@ -4646,7 +4646,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._stringField = nil
   }
 
-  public var enumField: ProtobufUnittest_ForeignEnum {
+  var enumField: ProtobufUnittest_ForeignEnum {
     get {return _storage._enumField ?? ProtobufUnittest_ForeignEnum.foreignFoo}
     set {_uniqueStorage()._enumField = newValue}
   }
@@ -4657,7 +4657,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._enumField = nil
   }
 
-  public var messageField: ProtobufUnittest_ForeignMessage {
+  var messageField: ProtobufUnittest_ForeignMessage {
     get {return _storage._messageField ?? ProtobufUnittest_ForeignMessage()}
     set {_uniqueStorage()._messageField = newValue}
   }
@@ -4668,7 +4668,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._messageField = nil
   }
 
-  public var stringPieceField: String {
+  var stringPieceField: String {
     get {return _storage._stringPieceField ?? ""}
     set {_uniqueStorage()._stringPieceField = newValue}
   }
@@ -4679,7 +4679,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._stringPieceField = nil
   }
 
-  public var cordField: String {
+  var cordField: String {
     get {return _storage._cordField ?? ""}
     set {_uniqueStorage()._cordField = newValue}
   }
@@ -4690,37 +4690,37 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._cordField = nil
   }
 
-  public var repeatedPrimitiveField: [Int32] {
+  var repeatedPrimitiveField: [Int32] {
     get {return _storage._repeatedPrimitiveField}
     set {_uniqueStorage()._repeatedPrimitiveField = newValue}
   }
 
-  public var repeatedStringField: [String] {
+  var repeatedStringField: [String] {
     get {return _storage._repeatedStringField}
     set {_uniqueStorage()._repeatedStringField = newValue}
   }
 
-  public var repeatedEnumField: [ProtobufUnittest_ForeignEnum] {
+  var repeatedEnumField: [ProtobufUnittest_ForeignEnum] {
     get {return _storage._repeatedEnumField}
     set {_uniqueStorage()._repeatedEnumField = newValue}
   }
 
-  public var repeatedMessageField: [ProtobufUnittest_ForeignMessage] {
+  var repeatedMessageField: [ProtobufUnittest_ForeignMessage] {
     get {return _storage._repeatedMessageField}
     set {_uniqueStorage()._repeatedMessageField = newValue}
   }
 
-  public var repeatedStringPieceField: [String] {
+  var repeatedStringPieceField: [String] {
     get {return _storage._repeatedStringPieceField}
     set {_uniqueStorage()._repeatedStringPieceField = newValue}
   }
 
-  public var repeatedCordField: [String] {
+  var repeatedCordField: [String] {
     get {return _storage._repeatedCordField}
     set {_uniqueStorage()._repeatedCordField = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4847,7 +4847,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     public var unknown = ProtobufUnknownStorage()
 
     private var _oo: Int64? = nil
-    public var oo: Int64 {
+    var oo: Int64 {
       get {return _oo ?? 0}
       set {_oo = newValue}
     }
@@ -4862,7 +4862,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -4873,7 +4873,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
       return _bb = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4901,7 +4901,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     }
   }
 
-  public var myString: String {
+  var myString: String {
     get {return _storage._myString ?? ""}
     set {_uniqueStorage()._myString = newValue}
   }
@@ -4912,7 +4912,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     return _storage._myString = nil
   }
 
-  public var myInt: Int64 {
+  var myInt: Int64 {
     get {return _storage._myInt ?? 0}
     set {_uniqueStorage()._myInt = newValue}
   }
@@ -4923,7 +4923,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     return _storage._myInt = nil
   }
 
-  public var myFloat: Float {
+  var myFloat: Float {
     get {return _storage._myFloat ?? 0}
     set {_uniqueStorage()._myFloat = newValue}
   }
@@ -4934,7 +4934,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     return _storage._myFloat = nil
   }
 
-  public var optionalNestedMessage: ProtobufUnittest_TestFieldOrderings.NestedMessage {
+  var optionalNestedMessage: ProtobufUnittest_TestFieldOrderings.NestedMessage {
     get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestFieldOrderings.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -4945,7 +4945,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     return _storage._optionalNestedMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -5270,7 +5270,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     set {_storage.unknown = newValue}
   }
 
-  public var escapedBytes: Data {
+  var escapedBytes: Data {
     get {return _storage._escapedBytes ?? Data(bytes: [0, 1, 7, 8, 12, 10, 13, 9, 11, 92, 39, 34, 254])}
     set {_uniqueStorage()._escapedBytes = newValue}
   }
@@ -5281,7 +5281,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._escapedBytes = nil
   }
 
-  public var largeUint32: UInt32 {
+  var largeUint32: UInt32 {
     get {return _storage._largeUint32 ?? 4294967295}
     set {_uniqueStorage()._largeUint32 = newValue}
   }
@@ -5292,7 +5292,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._largeUint32 = nil
   }
 
-  public var largeUint64: UInt64 {
+  var largeUint64: UInt64 {
     get {return _storage._largeUint64 ?? 18446744073709551615}
     set {_uniqueStorage()._largeUint64 = newValue}
   }
@@ -5303,7 +5303,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._largeUint64 = nil
   }
 
-  public var smallInt32: Int32 {
+  var smallInt32: Int32 {
     get {return _storage._smallInt32 ?? -2147483647}
     set {_uniqueStorage()._smallInt32 = newValue}
   }
@@ -5314,7 +5314,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._smallInt32 = nil
   }
 
-  public var smallInt64: Int64 {
+  var smallInt64: Int64 {
     get {return _storage._smallInt64 ?? -9223372036854775807}
     set {_uniqueStorage()._smallInt64 = newValue}
   }
@@ -5325,7 +5325,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._smallInt64 = nil
   }
 
-  public var reallySmallInt32: Int32 {
+  var reallySmallInt32: Int32 {
     get {return _storage._reallySmallInt32 ?? -2147483648}
     set {_uniqueStorage()._reallySmallInt32 = newValue}
   }
@@ -5336,7 +5336,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._reallySmallInt32 = nil
   }
 
-  public var reallySmallInt64: Int64 {
+  var reallySmallInt64: Int64 {
     get {return _storage._reallySmallInt64 ?? -9223372036854775808}
     set {_uniqueStorage()._reallySmallInt64 = newValue}
   }
@@ -5350,7 +5350,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   ///   The default value here is UTF-8 for "\u1234".  (We could also just type
   ///   the UTF-8 text directly into this text file rather than escape it, but
   ///   lots of people use editors that would be confused by this.)
-  public var utf8String: String {
+  var utf8String: String {
     get {return _storage._utf8String ?? "ሴ"}
     set {_uniqueStorage()._utf8String = newValue}
   }
@@ -5362,7 +5362,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   }
 
   ///   Tests for single-precision floating-point values.
-  public var zeroFloat: Float {
+  var zeroFloat: Float {
     get {return _storage._zeroFloat ?? 0}
     set {_uniqueStorage()._zeroFloat = newValue}
   }
@@ -5373,7 +5373,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._zeroFloat = nil
   }
 
-  public var oneFloat: Float {
+  var oneFloat: Float {
     get {return _storage._oneFloat ?? 1}
     set {_uniqueStorage()._oneFloat = newValue}
   }
@@ -5384,7 +5384,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._oneFloat = nil
   }
 
-  public var smallFloat: Float {
+  var smallFloat: Float {
     get {return _storage._smallFloat ?? 1.5}
     set {_uniqueStorage()._smallFloat = newValue}
   }
@@ -5395,7 +5395,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._smallFloat = nil
   }
 
-  public var negativeOneFloat: Float {
+  var negativeOneFloat: Float {
     get {return _storage._negativeOneFloat ?? -1}
     set {_uniqueStorage()._negativeOneFloat = newValue}
   }
@@ -5406,7 +5406,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._negativeOneFloat = nil
   }
 
-  public var negativeFloat: Float {
+  var negativeFloat: Float {
     get {return _storage._negativeFloat ?? -1.5}
     set {_uniqueStorage()._negativeFloat = newValue}
   }
@@ -5418,7 +5418,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   }
 
   ///   Using exponents
-  public var largeFloat: Float {
+  var largeFloat: Float {
     get {return _storage._largeFloat ?? 2e+08}
     set {_uniqueStorage()._largeFloat = newValue}
   }
@@ -5429,7 +5429,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._largeFloat = nil
   }
 
-  public var smallNegativeFloat: Float {
+  var smallNegativeFloat: Float {
     get {return _storage._smallNegativeFloat ?? -8e-28}
     set {_uniqueStorage()._smallNegativeFloat = newValue}
   }
@@ -5441,7 +5441,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   }
 
   ///   Text for nonfinite floating-point values.
-  public var infDouble: Double {
+  var infDouble: Double {
     get {return _storage._infDouble ?? Double.infinity}
     set {_uniqueStorage()._infDouble = newValue}
   }
@@ -5452,7 +5452,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._infDouble = nil
   }
 
-  public var negInfDouble: Double {
+  var negInfDouble: Double {
     get {return _storage._negInfDouble ?? -Double.infinity}
     set {_uniqueStorage()._negInfDouble = newValue}
   }
@@ -5463,7 +5463,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._negInfDouble = nil
   }
 
-  public var nanDouble: Double {
+  var nanDouble: Double {
     get {return _storage._nanDouble ?? Double.nan}
     set {_uniqueStorage()._nanDouble = newValue}
   }
@@ -5474,7 +5474,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._nanDouble = nil
   }
 
-  public var infFloat: Float {
+  var infFloat: Float {
     get {return _storage._infFloat ?? Float.infinity}
     set {_uniqueStorage()._infFloat = newValue}
   }
@@ -5485,7 +5485,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._infFloat = nil
   }
 
-  public var negInfFloat: Float {
+  var negInfFloat: Float {
     get {return _storage._negInfFloat ?? -Float.infinity}
     set {_uniqueStorage()._negInfFloat = newValue}
   }
@@ -5496,7 +5496,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._negInfFloat = nil
   }
 
-  public var nanFloat: Float {
+  var nanFloat: Float {
     get {return _storage._nanFloat ?? Float.nan}
     set {_uniqueStorage()._nanFloat = newValue}
   }
@@ -5512,7 +5512,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   ///   escaped for other languages.
   ///   Note that in .proto file, "\?" is a valid way to escape ? in string
   ///   literals.
-  public var cppTrigraph: String {
+  var cppTrigraph: String {
     get {return _storage._cppTrigraph ?? "? ? ?? ?? ??? ??/ ??-"}
     set {_uniqueStorage()._cppTrigraph = newValue}
   }
@@ -5524,7 +5524,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   }
 
   ///   String defaults containing the character '\000'
-  public var stringWithZero: String {
+  var stringWithZero: String {
     get {return _storage._stringWithZero ?? "hel\0lo"}
     set {_uniqueStorage()._stringWithZero = newValue}
   }
@@ -5535,7 +5535,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._stringWithZero = nil
   }
 
-  public var bytesWithZero: Data {
+  var bytesWithZero: Data {
     get {return _storage._bytesWithZero ?? Data(bytes: [119, 111, 114, 0, 108, 100])}
     set {_uniqueStorage()._bytesWithZero = newValue}
   }
@@ -5546,7 +5546,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._bytesWithZero = nil
   }
 
-  public var stringPieceWithZero: String {
+  var stringPieceWithZero: String {
     get {return _storage._stringPieceWithZero ?? "ab\0c"}
     set {_uniqueStorage()._stringPieceWithZero = newValue}
   }
@@ -5557,7 +5557,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._stringPieceWithZero = nil
   }
 
-  public var cordWithZero: String {
+  var cordWithZero: String {
     get {return _storage._cordWithZero ?? "12\03"}
     set {_uniqueStorage()._cordWithZero = newValue}
   }
@@ -5568,7 +5568,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._cordWithZero = nil
   }
 
-  public var replacementString: String {
+  var replacementString: String {
     get {return _storage._replacementString ?? "${unknown}"}
     set {_uniqueStorage()._replacementString = newValue}
   }
@@ -5579,7 +5579,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._replacementString = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -5615,7 +5615,7 @@ struct ProtobufUnittest_SparseEnumMessage: ProtobufGeneratedMessage, ProtobufPro
   public var unknown = ProtobufUnknownStorage()
 
   private var _sparseEnum: ProtobufUnittest_TestSparseEnum? = nil
-  public var sparseEnum: ProtobufUnittest_TestSparseEnum {
+  var sparseEnum: ProtobufUnittest_TestSparseEnum {
     get {return _sparseEnum ?? ProtobufUnittest_TestSparseEnum.sparseA}
     set {_sparseEnum = newValue}
   }
@@ -5626,7 +5626,7 @@ struct ProtobufUnittest_SparseEnumMessage: ProtobufGeneratedMessage, ProtobufPro
     return _sparseEnum = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5664,7 +5664,7 @@ struct ProtobufUnittest_OneString: ProtobufGeneratedMessage, ProtobufProto2Messa
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: String? = nil
-  public var data: String {
+  var data: String {
     get {return _data ?? ""}
     set {_data = newValue}
   }
@@ -5675,7 +5675,7 @@ struct ProtobufUnittest_OneString: ProtobufGeneratedMessage, ProtobufProto2Messa
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5711,9 +5711,9 @@ struct ProtobufUnittest_MoreString: ProtobufGeneratedMessage, ProtobufProto2Mess
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var data: [String] = []
+  var data: [String] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5750,7 +5750,7 @@ struct ProtobufUnittest_OneBytes: ProtobufGeneratedMessage, ProtobufProto2Messag
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: Data? = nil
-  public var data: Data {
+  var data: Data {
     get {return _data ?? Data()}
     set {_data = newValue}
   }
@@ -5761,7 +5761,7 @@ struct ProtobufUnittest_OneBytes: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5797,9 +5797,9 @@ struct ProtobufUnittest_MoreBytes: ProtobufGeneratedMessage, ProtobufProto2Messa
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var data: [Data] = []
+  var data: [Data] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5837,7 +5837,7 @@ struct ProtobufUnittest_Int32Message: ProtobufGeneratedMessage, ProtobufProto2Me
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: Int32? = nil
-  public var data: Int32 {
+  var data: Int32 {
     get {return _data ?? 0}
     set {_data = newValue}
   }
@@ -5848,7 +5848,7 @@ struct ProtobufUnittest_Int32Message: ProtobufGeneratedMessage, ProtobufProto2Me
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5885,7 +5885,7 @@ struct ProtobufUnittest_Uint32Message: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: UInt32? = nil
-  public var data: UInt32 {
+  var data: UInt32 {
     get {return _data ?? 0}
     set {_data = newValue}
   }
@@ -5896,7 +5896,7 @@ struct ProtobufUnittest_Uint32Message: ProtobufGeneratedMessage, ProtobufProto2M
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5933,7 +5933,7 @@ struct ProtobufUnittest_Int64Message: ProtobufGeneratedMessage, ProtobufProto2Me
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: Int64? = nil
-  public var data: Int64 {
+  var data: Int64 {
     get {return _data ?? 0}
     set {_data = newValue}
   }
@@ -5944,7 +5944,7 @@ struct ProtobufUnittest_Int64Message: ProtobufGeneratedMessage, ProtobufProto2Me
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5981,7 +5981,7 @@ struct ProtobufUnittest_Uint64Message: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: UInt64? = nil
-  public var data: UInt64 {
+  var data: UInt64 {
     get {return _data ?? 0}
     set {_data = newValue}
   }
@@ -5992,7 +5992,7 @@ struct ProtobufUnittest_Uint64Message: ProtobufGeneratedMessage, ProtobufProto2M
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -6029,7 +6029,7 @@ struct ProtobufUnittest_BoolMessage: ProtobufGeneratedMessage, ProtobufProto2Mes
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: Bool? = nil
-  public var data: Bool {
+  var data: Bool {
     get {return _data ?? false}
     set {_data = newValue}
   }
@@ -6040,7 +6040,7 @@ struct ProtobufUnittest_BoolMessage: ProtobufGeneratedMessage, ProtobufProto2Mes
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -6210,7 +6210,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -6222,7 +6222,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
 
     private var _b: String? = nil
-    public var b: String {
+    var b: String {
       get {return _b ?? ""}
       set {_b = newValue}
     }
@@ -6233,7 +6233,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
       return _b = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6261,7 +6261,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
   }
 
-  public var fooInt: Int32 {
+  var fooInt: Int32 {
     get {
       if case .fooInt(let v) = _storage._foo {
         return v
@@ -6273,7 +6273,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
   }
 
-  public var fooString: String {
+  var fooString: String {
     get {
       if case .fooString(let v) = _storage._foo {
         return v
@@ -6285,7 +6285,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
   }
 
-  public var fooMessage: ProtobufUnittest_TestAllTypes {
+  var fooMessage: ProtobufUnittest_TestAllTypes {
     get {
       if case .fooMessage(let v) = _storage._foo {
         return v
@@ -6297,7 +6297,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
   }
 
-  public var fooGroup: ProtobufUnittest_TestOneof.FooGroup {
+  var fooGroup: ProtobufUnittest_TestOneof.FooGroup {
     get {
       if case .fooGroup(let v) = _storage._foo {
         return v
@@ -6316,7 +6316,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -6434,7 +6434,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -6446,7 +6446,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     }
 
     private var _b: String? = nil
-    public var b: String {
+    var b: String {
       get {return _b ?? ""}
       set {_b = newValue}
     }
@@ -6457,7 +6457,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
       return _b = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6485,7 +6485,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     }
   }
 
-  public var fooInt: Int32 {
+  var fooInt: Int32 {
     get {return _storage._fooInt ?? 0}
     set {_uniqueStorage()._fooInt = newValue}
   }
@@ -6496,7 +6496,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     return _storage._fooInt = nil
   }
 
-  public var fooString: String {
+  var fooString: String {
     get {return _storage._fooString ?? ""}
     set {_uniqueStorage()._fooString = newValue}
   }
@@ -6507,7 +6507,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     return _storage._fooString = nil
   }
 
-  public var fooMessage: ProtobufUnittest_TestAllTypes {
+  var fooMessage: ProtobufUnittest_TestAllTypes {
     get {return _storage._fooMessage ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._fooMessage = newValue}
   }
@@ -6518,7 +6518,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     return _storage._fooMessage = nil
   }
 
-  public var fooGroup: ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup {
+  var fooGroup: ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup {
     get {return _storage._fooGroup ?? ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup()}
     set {_uniqueStorage()._fooGroup = newValue}
   }
@@ -6529,7 +6529,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     return _storage._fooGroup = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -6877,16 +6877,16 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       case 2: self = .bar
@@ -6895,7 +6895,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -6904,7 +6904,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -6913,7 +6913,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -6922,7 +6922,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -6932,7 +6932,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -6942,9 +6942,9 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -6972,7 +6972,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -6984,7 +6984,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
 
     private var _b: String? = nil
-    public var b: String {
+    var b: String {
       get {return _b ?? ""}
       set {_b = newValue}
     }
@@ -6995,7 +6995,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       return _b = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7039,7 +7039,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     public var unknown = ProtobufUnknownStorage()
 
     private var _quxInt: Int64? = nil
-    public var quxInt: Int64 {
+    var quxInt: Int64 {
       get {return _quxInt ?? 0}
       set {_quxInt = newValue}
     }
@@ -7050,9 +7050,9 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       return _quxInt = nil
     }
 
-    public var corgeInt: [Int32] = []
+    var corgeInt: [Int32] = []
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7080,7 +7080,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooInt: Int32 {
+  var fooInt: Int32 {
     get {
       if case .fooInt(let v) = _storage._foo {
         return v
@@ -7092,7 +7092,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooString: String {
+  var fooString: String {
     get {
       if case .fooString(let v) = _storage._foo {
         return v
@@ -7104,7 +7104,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooCord: String {
+  var fooCord: String {
     get {
       if case .fooCord(let v) = _storage._foo {
         return v
@@ -7116,7 +7116,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooStringPiece: String {
+  var fooStringPiece: String {
     get {
       if case .fooStringPiece(let v) = _storage._foo {
         return v
@@ -7128,7 +7128,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooBytes: Data {
+  var fooBytes: Data {
     get {
       if case .fooBytes(let v) = _storage._foo {
         return v
@@ -7140,7 +7140,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooEnum: ProtobufUnittest_TestOneof2.NestedEnum {
+  var fooEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
       if case .fooEnum(let v) = _storage._foo {
         return v
@@ -7152,7 +7152,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooMessage: ProtobufUnittest_TestOneof2.NestedMessage {
+  var fooMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
       if case .fooMessage(let v) = _storage._foo {
         return v
@@ -7164,7 +7164,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooGroup: ProtobufUnittest_TestOneof2.FooGroup {
+  var fooGroup: ProtobufUnittest_TestOneof2.FooGroup {
     get {
       if case .fooGroup(let v) = _storage._foo {
         return v
@@ -7176,7 +7176,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooLazyMessage: ProtobufUnittest_TestOneof2.NestedMessage {
+  var fooLazyMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
       if case .fooLazyMessage(let v) = _storage._foo {
         return v
@@ -7188,7 +7188,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barInt: Int32 {
+  var barInt: Int32 {
     get {
       if case .barInt(let v) = _storage._bar {
         return v
@@ -7200,7 +7200,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barString: String {
+  var barString: String {
     get {
       if case .barString(let v) = _storage._bar {
         return v
@@ -7212,7 +7212,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barCord: String {
+  var barCord: String {
     get {
       if case .barCord(let v) = _storage._bar {
         return v
@@ -7224,7 +7224,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barStringPiece: String {
+  var barStringPiece: String {
     get {
       if case .barStringPiece(let v) = _storage._bar {
         return v
@@ -7236,7 +7236,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barBytes: Data {
+  var barBytes: Data {
     get {
       if case .barBytes(let v) = _storage._bar {
         return v
@@ -7248,7 +7248,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barEnum: ProtobufUnittest_TestOneof2.NestedEnum {
+  var barEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
       if case .barEnum(let v) = _storage._bar {
         return v
@@ -7260,7 +7260,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var bazInt: Int32 {
+  var bazInt: Int32 {
     get {return _storage._bazInt ?? 0}
     set {_uniqueStorage()._bazInt = newValue}
   }
@@ -7271,7 +7271,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     return _storage._bazInt = nil
   }
 
-  public var bazString: String {
+  var bazString: String {
     get {return _storage._bazString ?? "BAZ"}
     set {_uniqueStorage()._bazString = newValue}
   }
@@ -7296,7 +7296,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -7449,7 +7449,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
     public var unknown = ProtobufUnknownStorage()
 
     private var _requiredDouble: Double? = nil
-    public var requiredDouble: Double {
+    var requiredDouble: Double {
       get {return _requiredDouble ?? 0}
       set {_requiredDouble = newValue}
     }
@@ -7460,7 +7460,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
       return _requiredDouble = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7481,7 +7481,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
     }
   }
 
-  public var fooInt: Int32 {
+  var fooInt: Int32 {
     get {
       if case .fooInt(let v) = _storage._foo {
         return v
@@ -7493,7 +7493,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
     }
   }
 
-  public var fooString: String {
+  var fooString: String {
     get {
       if case .fooString(let v) = _storage._foo {
         return v
@@ -7505,7 +7505,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
     }
   }
 
-  public var fooMessage: ProtobufUnittest_TestRequiredOneof.NestedMessage {
+  var fooMessage: ProtobufUnittest_TestRequiredOneof.NestedMessage {
     get {
       if case .fooMessage(let v) = _storage._foo {
         return v
@@ -7524,7 +7524,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -7587,35 +7587,35 @@ struct ProtobufUnittest_TestPackedTypes: ProtobufGeneratedMessage, ProtobufProto
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var packedInt32: [Int32] = []
+  var packedInt32: [Int32] = []
 
-  public var packedInt64: [Int64] = []
+  var packedInt64: [Int64] = []
 
-  public var packedUint32: [UInt32] = []
+  var packedUint32: [UInt32] = []
 
-  public var packedUint64: [UInt64] = []
+  var packedUint64: [UInt64] = []
 
-  public var packedSint32: [Int32] = []
+  var packedSint32: [Int32] = []
 
-  public var packedSint64: [Int64] = []
+  var packedSint64: [Int64] = []
 
-  public var packedFixed32: [UInt32] = []
+  var packedFixed32: [UInt32] = []
 
-  public var packedFixed64: [UInt64] = []
+  var packedFixed64: [UInt64] = []
 
-  public var packedSfixed32: [Int32] = []
+  var packedSfixed32: [Int32] = []
 
-  public var packedSfixed64: [Int64] = []
+  var packedSfixed64: [Int64] = []
 
-  public var packedFloat: [Float] = []
+  var packedFloat: [Float] = []
 
-  public var packedDouble: [Double] = []
+  var packedDouble: [Double] = []
 
-  public var packedBool: [Bool] = []
+  var packedBool: [Bool] = []
 
-  public var packedEnum: [ProtobufUnittest_ForeignEnum] = []
+  var packedEnum: [ProtobufUnittest_ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -7744,35 +7744,35 @@ struct ProtobufUnittest_TestUnpackedTypes: ProtobufGeneratedMessage, ProtobufPro
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var unpackedInt32: [Int32] = []
+  var unpackedInt32: [Int32] = []
 
-  public var unpackedInt64: [Int64] = []
+  var unpackedInt64: [Int64] = []
 
-  public var unpackedUint32: [UInt32] = []
+  var unpackedUint32: [UInt32] = []
 
-  public var unpackedUint64: [UInt64] = []
+  var unpackedUint64: [UInt64] = []
 
-  public var unpackedSint32: [Int32] = []
+  var unpackedSint32: [Int32] = []
 
-  public var unpackedSint64: [Int64] = []
+  var unpackedSint64: [Int64] = []
 
-  public var unpackedFixed32: [UInt32] = []
+  var unpackedFixed32: [UInt32] = []
 
-  public var unpackedFixed64: [UInt64] = []
+  var unpackedFixed64: [UInt64] = []
 
-  public var unpackedSfixed32: [Int32] = []
+  var unpackedSfixed32: [Int32] = []
 
-  public var unpackedSfixed64: [Int64] = []
+  var unpackedSfixed64: [Int64] = []
 
-  public var unpackedFloat: [Float] = []
+  var unpackedFloat: [Float] = []
 
-  public var unpackedDouble: [Double] = []
+  var unpackedDouble: [Double] = []
 
-  public var unpackedBool: [Bool] = []
+  var unpackedBool: [Bool] = []
 
-  public var unpackedEnum: [ProtobufUnittest_ForeignEnum] = []
+  var unpackedEnum: [ProtobufUnittest_ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -7869,7 +7869,7 @@ struct ProtobufUnittest_TestPackedExtensions: ProtobufGeneratedMessage, Protobuf
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -7919,7 +7919,7 @@ struct ProtobufUnittest_TestUnpackedExtensions: ProtobufGeneratedMessage, Protob
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -8071,16 +8071,16 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
   }
 
   enum DynamicEnumType: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case dynamicFoo // = 2200
     case dynamicBar // = 2201
     case dynamicBaz // = 2202
 
-    public init() {
+    init() {
       self = .dynamicFoo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 2200: self = .dynamicFoo
       case 2201: self = .dynamicBar
@@ -8089,7 +8089,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "dynamicFoo": self = .dynamicFoo
       case "dynamicBar": self = .dynamicBar
@@ -8098,7 +8098,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "DYNAMIC_FOO": self = .dynamicFoo
       case "DYNAMIC_BAR": self = .dynamicBar
@@ -8107,7 +8107,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "DYNAMIC_FOO": self = .dynamicFoo
       case "DYNAMIC_BAR": self = .dynamicBar
@@ -8116,7 +8116,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .dynamicFoo: return 2200
@@ -8126,7 +8126,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .dynamicFoo: return "\"DYNAMIC_FOO\""
@@ -8136,9 +8136,9 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .dynamicFoo: return ".dynamicFoo"
@@ -8164,7 +8164,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     public var unknown = ProtobufUnknownStorage()
 
     private var _dynamicField: Int32? = nil
-    public var dynamicField: Int32 {
+    var dynamicField: Int32 {
       get {return _dynamicField ?? 0}
       set {_dynamicField = newValue}
     }
@@ -8175,7 +8175,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       return _dynamicField = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8198,7 +8198,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     }
   }
 
-  public var scalarExtension: UInt32 {
+  var scalarExtension: UInt32 {
     get {return _storage._scalarExtension ?? 0}
     set {_uniqueStorage()._scalarExtension = newValue}
   }
@@ -8209,7 +8209,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     return _storage._scalarExtension = nil
   }
 
-  public var enumExtension: ProtobufUnittest_ForeignEnum {
+  var enumExtension: ProtobufUnittest_ForeignEnum {
     get {return _storage._enumExtension ?? ProtobufUnittest_ForeignEnum.foreignFoo}
     set {_uniqueStorage()._enumExtension = newValue}
   }
@@ -8220,7 +8220,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     return _storage._enumExtension = nil
   }
 
-  public var dynamicEnumExtension: ProtobufUnittest_TestDynamicExtensions.DynamicEnumType {
+  var dynamicEnumExtension: ProtobufUnittest_TestDynamicExtensions.DynamicEnumType {
     get {return _storage._dynamicEnumExtension ?? ProtobufUnittest_TestDynamicExtensions.DynamicEnumType.dynamicFoo}
     set {_uniqueStorage()._dynamicEnumExtension = newValue}
   }
@@ -8231,7 +8231,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     return _storage._dynamicEnumExtension = nil
   }
 
-  public var messageExtension: ProtobufUnittest_ForeignMessage {
+  var messageExtension: ProtobufUnittest_ForeignMessage {
     get {return _storage._messageExtension ?? ProtobufUnittest_ForeignMessage()}
     set {_uniqueStorage()._messageExtension = newValue}
   }
@@ -8242,7 +8242,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     return _storage._messageExtension = nil
   }
 
-  public var dynamicMessageExtension: ProtobufUnittest_TestDynamicExtensions.DynamicMessageType {
+  var dynamicMessageExtension: ProtobufUnittest_TestDynamicExtensions.DynamicMessageType {
     get {return _storage._dynamicMessageExtension ?? ProtobufUnittest_TestDynamicExtensions.DynamicMessageType()}
     set {_uniqueStorage()._dynamicMessageExtension = newValue}
   }
@@ -8253,17 +8253,17 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     return _storage._dynamicMessageExtension = nil
   }
 
-  public var repeatedExtension: [String] {
+  var repeatedExtension: [String] {
     get {return _storage._repeatedExtension}
     set {_uniqueStorage()._repeatedExtension = newValue}
   }
 
-  public var packedExtension: [Int32] {
+  var packedExtension: [Int32] {
     get {return _storage._packedExtension}
     set {_uniqueStorage()._packedExtension = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -8311,22 +8311,22 @@ struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMe
   ///   Parsing repeated fixed size values used to fail. This message needs to be
   ///   used in order to get a tag of the right size; all of the repeated fields
   ///   in TestAllTypes didn't trigger the check.
-  public var repeatedFixed32: [UInt32] = []
+  var repeatedFixed32: [UInt32] = []
 
   ///   Check for a varint type, just for good measure.
-  public var repeatedInt32: [Int32] = []
+  var repeatedInt32: [Int32] = []
 
   ///   These have two-byte tags.
-  public var repeatedFixed64: [UInt64] = []
+  var repeatedFixed64: [UInt64] = []
 
-  public var repeatedInt64: [Int64] = []
+  var repeatedInt64: [Int64] = []
 
   ///   Three byte tags.
-  public var repeatedFloat: [Float] = []
+  var repeatedFloat: [Float] = []
 
-  public var repeatedUint64: [UInt64] = []
+  var repeatedUint64: [UInt64] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -8554,7 +8554,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
         set {_storage.unknown = newValue}
       }
 
-      public var field1: ProtobufUnittest_TestAllTypes {
+      var field1: ProtobufUnittest_TestAllTypes {
         get {return _storage._field1 ?? ProtobufUnittest_TestAllTypes()}
         set {_uniqueStorage()._field1 = newValue}
       }
@@ -8565,7 +8565,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
         return _storage._field1 = nil
       }
 
-      public init() {}
+      init() {}
 
       public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
         try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -8640,7 +8640,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
         set {_storage.unknown = newValue}
       }
 
-      public var field1: ProtobufUnittest_TestAllTypes {
+      var field1: ProtobufUnittest_TestAllTypes {
         get {return _storage._field1 ?? ProtobufUnittest_TestAllTypes()}
         set {_uniqueStorage()._field1 = newValue}
       }
@@ -8651,7 +8651,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
         return _storage._field1 = nil
       }
 
-      public init() {}
+      init() {}
 
       public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
         try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -8673,21 +8673,21 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var field1: [ProtobufUnittest_TestAllTypes] = []
+    var field1: [ProtobufUnittest_TestAllTypes] = []
 
-    public var field2: [ProtobufUnittest_TestAllTypes] = []
+    var field2: [ProtobufUnittest_TestAllTypes] = []
 
-    public var field3: [ProtobufUnittest_TestAllTypes] = []
+    var field3: [ProtobufUnittest_TestAllTypes] = []
 
-    public var group1: [ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1] = []
+    var group1: [ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1] = []
 
-    public var group2: [ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2] = []
+    var group2: [ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2] = []
 
-    public var ext1: [ProtobufUnittest_TestAllTypes] = []
+    var ext1: [ProtobufUnittest_TestAllTypes] = []
 
-    public var ext2: [ProtobufUnittest_TestAllTypes] = []
+    var ext2: [ProtobufUnittest_TestAllTypes] = []
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8793,7 +8793,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
       set {_storage.unknown = newValue}
     }
 
-    public var optionalGroupAllTypes: ProtobufUnittest_TestAllTypes {
+    var optionalGroupAllTypes: ProtobufUnittest_TestAllTypes {
       get {return _storage._optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
       set {_uniqueStorage()._optionalGroupAllTypes = newValue}
     }
@@ -8804,7 +8804,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
       return _storage._optionalGroupAllTypes = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -8879,7 +8879,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
       set {_storage.unknown = newValue}
     }
 
-    public var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes {
+    var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes {
       get {return _storage._repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
       set {_uniqueStorage()._repeatedGroupAllTypes = newValue}
     }
@@ -8890,7 +8890,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
       return _storage._repeatedGroupAllTypes = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -8919,7 +8919,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
     static let ProtobufUnittest_TestParsingMerge_repeatedExt = ProtobufGenericMessageExtension<ProtobufRepeatedMessageField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(protoFieldNumber: 1001, protoFieldName: "repeated_ext", jsonFieldName: "repeatedExt", swiftFieldName: "ProtobufUnittest_TestParsingMerge_repeatedExt", defaultValue: [])
   }
 
-  public var requiredAllTypes: ProtobufUnittest_TestAllTypes {
+  var requiredAllTypes: ProtobufUnittest_TestAllTypes {
     get {return _storage._requiredAllTypes ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._requiredAllTypes = newValue}
   }
@@ -8930,7 +8930,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
     return _storage._requiredAllTypes = nil
   }
 
-  public var optionalAllTypes: ProtobufUnittest_TestAllTypes {
+  var optionalAllTypes: ProtobufUnittest_TestAllTypes {
     get {return _storage._optionalAllTypes ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._optionalAllTypes = newValue}
   }
@@ -8941,12 +8941,12 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalAllTypes = nil
   }
 
-  public var repeatedAllTypes: [ProtobufUnittest_TestAllTypes] {
+  var repeatedAllTypes: [ProtobufUnittest_TestAllTypes] {
     get {return _storage._repeatedAllTypes}
     set {_uniqueStorage()._repeatedAllTypes = newValue}
   }
 
-  public var optionalGroup: ProtobufUnittest_TestParsingMerge.OptionalGroup {
+  var optionalGroup: ProtobufUnittest_TestParsingMerge.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittest_TestParsingMerge.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -8957,12 +8957,12 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalGroup = nil
   }
 
-  public var repeatedGroup: [ProtobufUnittest_TestParsingMerge.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittest_TestParsingMerge.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -9015,7 +9015,7 @@ struct ProtobufUnittest_TestCommentInjectionMessage: ProtobufGeneratedMessage, P
 
   ///   */ <- This should not close the generated doc comment
   private var _a: String? = nil
-  public var a: String {
+  var a: String {
     get {return _a ?? "*/ <- Neither should this."}
     set {_a = newValue}
   }
@@ -9026,7 +9026,7 @@ struct ProtobufUnittest_TestCommentInjectionMessage: ProtobufGeneratedMessage, P
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -9059,7 +9059,7 @@ struct ProtobufUnittest_FooRequest: ProtobufGeneratedMessage, ProtobufProto2Mess
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -9083,7 +9083,7 @@ struct ProtobufUnittest_FooResponse: ProtobufGeneratedMessage, ProtobufProto2Mes
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -9107,7 +9107,7 @@ struct ProtobufUnittest_FooClientMessage: ProtobufGeneratedMessage, ProtobufProt
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -9131,7 +9131,7 @@ struct ProtobufUnittest_FooServerMessage: ProtobufGeneratedMessage, ProtobufProt
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -9155,7 +9155,7 @@ struct ProtobufUnittest_BarRequest: ProtobufGeneratedMessage, ProtobufProto2Mess
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -9179,7 +9179,7 @@ struct ProtobufUnittest_BarResponse: ProtobufGeneratedMessage, ProtobufProto2Mes
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/google/protobuf/unittest_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_arena.pb.swift
@@ -54,7 +54,7 @@ struct Proto2ArenaUnittest_NestedMessage: ProtobufGeneratedMessage, ProtobufProt
   public var unknown = ProtobufUnknownStorage()
 
   private var _d: Int32? = nil
-  public var d: Int32 {
+  var d: Int32 {
     get {return _d ?? 0}
     set {_d = newValue}
   }
@@ -65,7 +65,7 @@ struct Proto2ArenaUnittest_NestedMessage: ProtobufGeneratedMessage, ProtobufProt
     return _d = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -103,11 +103,11 @@ struct Proto2ArenaUnittest_ArenaMessage: ProtobufGeneratedMessage, ProtobufProto
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var repeatedNestedMessage: [Proto2ArenaUnittest_NestedMessage] = []
+  var repeatedNestedMessage: [Proto2ArenaUnittest_NestedMessage] = []
 
-  public var repeatedImportNoArenaMessage: [Proto2ArenaUnittest_ImportNoArenaNestedMessage] = []
+  var repeatedImportNoArenaMessage: [Proto2ArenaUnittest_ImportNoArenaNestedMessage] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -47,15 +47,15 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case val1 // = 1
   case val2 // = 2
 
-  public init() {
+  init() {
     self = .val1
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .val1
     case 2: self = .val2
@@ -63,7 +63,7 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "val1": self = .val1
     case "val2": self = .val2
@@ -71,7 +71,7 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "METHODOPT1_VAL1": self = .val1
     case "METHODOPT1_VAL2": self = .val2
@@ -79,7 +79,7 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "METHODOPT1_VAL1": self = .val1
     case "METHODOPT1_VAL2": self = .val2
@@ -87,7 +87,7 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .val1: return 1
@@ -96,7 +96,7 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .val1: return "\"METHODOPT1_VAL1\""
@@ -105,9 +105,9 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .val1: return ".val1"
@@ -119,42 +119,42 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
 }
 
 enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case value // = 1
 
-  public init() {
+  init() {
     self = .value
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .value
     default: return nil
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "value": self = .value
     default: return nil
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "VALUE": self = .value
     default: return nil
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "VALUE": self = .value
     default: return nil
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .value: return 1
@@ -162,7 +162,7 @@ enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .value: return "\"VALUE\""
@@ -170,9 +170,9 @@ enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .value: return ".value"
@@ -240,15 +240,15 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
   }
 
   enum AnEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case val1 // = 1
     case val2 // = 2
 
-    public init() {
+    init() {
       self = .val1
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .val1
       case 2: self = .val2
@@ -256,7 +256,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "val1": self = .val1
       case "val2": self = .val2
@@ -264,7 +264,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ANENUM_VAL1": self = .val1
       case "ANENUM_VAL2": self = .val2
@@ -272,7 +272,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ANENUM_VAL1": self = .val1
       case "ANENUM_VAL2": self = .val2
@@ -280,7 +280,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .val1: return 1
@@ -289,7 +289,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .val1: return "\"ANENUM_VAL1\""
@@ -298,9 +298,9 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .val1: return ".val1"
@@ -312,7 +312,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
   }
 
   private var _field1: String? = nil
-  public var field1: String {
+  var field1: String {
     get {return _field1 ?? ""}
     set {_field1 = newValue}
   }
@@ -323,7 +323,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
     return _field1 = nil
   }
 
-  public var oneofField: Int32 {
+  var oneofField: Int32 {
     get {
       if case .oneofField(let v) = anOneof {
         return v
@@ -337,7 +337,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
 
   public var anOneof: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof = .None
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -374,7 +374,7 @@ struct ProtobufUnittest_CustomOptionFooRequest: ProtobufGeneratedMessage, Protob
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -398,7 +398,7 @@ struct ProtobufUnittest_CustomOptionFooResponse: ProtobufGeneratedMessage, Proto
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -422,7 +422,7 @@ struct ProtobufUnittest_CustomOptionFooClientMessage: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -446,7 +446,7 @@ struct ProtobufUnittest_CustomOptionFooServerMessage: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -473,15 +473,15 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
   public var unknown = ProtobufUnknownStorage()
 
   enum TestEnumType: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case testOptionEnumType1 // = 22
     case testOptionEnumType2 // = -23
 
-    public init() {
+    init() {
       self = .testOptionEnumType1
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 22: self = .testOptionEnumType1
       case -23: self = .testOptionEnumType2
@@ -489,7 +489,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "testOptionEnumType1": self = .testOptionEnumType1
       case "testOptionEnumType2": self = .testOptionEnumType2
@@ -497,7 +497,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "TEST_OPTION_ENUM_TYPE1": self = .testOptionEnumType1
       case "TEST_OPTION_ENUM_TYPE2": self = .testOptionEnumType2
@@ -505,7 +505,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "TEST_OPTION_ENUM_TYPE1": self = .testOptionEnumType1
       case "TEST_OPTION_ENUM_TYPE2": self = .testOptionEnumType2
@@ -513,7 +513,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .testOptionEnumType1: return 22
@@ -522,7 +522,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .testOptionEnumType1: return "\"TEST_OPTION_ENUM_TYPE1\""
@@ -531,9 +531,9 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .testOptionEnumType1: return ".testOptionEnumType1"
@@ -544,7 +544,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
 
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -568,7 +568,7 @@ struct ProtobufUnittest_DummyMessageInvalidAsOptionType: ProtobufGeneratedMessag
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -592,7 +592,7 @@ struct ProtobufUnittest_CustomOptionMinIntegerValues: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -616,7 +616,7 @@ struct ProtobufUnittest_CustomOptionMaxIntegerValues: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -640,7 +640,7 @@ struct ProtobufUnittest_CustomOptionOtherValues: ProtobufGeneratedMessage, Proto
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -664,7 +664,7 @@ struct ProtobufUnittest_SettingRealsFromPositiveInts: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -688,7 +688,7 @@ struct ProtobufUnittest_SettingRealsFromNegativeInts: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -726,7 +726,7 @@ struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufPr
   public var unknown = ProtobufUnknownStorage()
 
   private var _foo: Int32? = nil
-  public var foo: Int32 {
+  var foo: Int32 {
     get {return _foo ?? 0}
     set {_foo = newValue}
   }
@@ -738,7 +738,7 @@ struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _foo2: Int32? = nil
-  public var foo2: Int32 {
+  var foo2: Int32 {
     get {return _foo2 ?? 0}
     set {_foo2 = newValue}
   }
@@ -750,7 +750,7 @@ struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _foo3: Int32? = nil
-  public var foo3: Int32 {
+  var foo3: Int32 {
     get {return _foo3 ?? 0}
     set {_foo3 = newValue}
   }
@@ -761,9 +761,9 @@ struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufPr
     return _foo3 = nil
   }
 
-  public var foo4: [Int32] = []
+  var foo4: [Int32] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -931,7 +931,7 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
     }
 
     private var _waldo: Int32? = nil
-    public var waldo: Int32 {
+    var waldo: Int32 {
       get {return _waldo ?? 0}
       set {_waldo = newValue}
     }
@@ -942,7 +942,7 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
       return _waldo = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -965,7 +965,7 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
     }
   }
 
-  public var bar: ProtobufUnittest_ComplexOptionType1 {
+  var bar: ProtobufUnittest_ComplexOptionType1 {
     get {return _storage._bar ?? ProtobufUnittest_ComplexOptionType1()}
     set {_uniqueStorage()._bar = newValue}
   }
@@ -976,7 +976,7 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
     return _storage._bar = nil
   }
 
-  public var baz: Int32 {
+  var baz: Int32 {
     get {return _storage._baz ?? 0}
     set {_uniqueStorage()._baz = newValue}
   }
@@ -987,7 +987,7 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
     return _storage._baz = nil
   }
 
-  public var fred: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
+  var fred: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
     get {return _storage._fred ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
     set {_uniqueStorage()._fred = newValue}
   }
@@ -998,12 +998,12 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
     return _storage._fred = nil
   }
 
-  public var barney: [ProtobufUnittest_ComplexOptionType2.ComplexOptionType4] {
+  var barney: [ProtobufUnittest_ComplexOptionType2.ComplexOptionType4] {
     get {return _storage._barney}
     set {_uniqueStorage()._barney = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1117,7 +1117,7 @@ struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage, ProtobufPr
     public var unknown = ProtobufUnknownStorage()
 
     private var _plugh: Int32? = nil
-    public var plugh: Int32 {
+    var plugh: Int32 {
       get {return _plugh ?? 0}
       set {_plugh = newValue}
     }
@@ -1128,7 +1128,7 @@ struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage, ProtobufPr
       return _plugh = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1151,7 +1151,7 @@ struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage, ProtobufPr
     }
   }
 
-  public var qux: Int32 {
+  var qux: Int32 {
     get {return _storage._qux ?? 0}
     set {_uniqueStorage()._qux = newValue}
   }
@@ -1162,7 +1162,7 @@ struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage, ProtobufPr
     return _storage._qux = nil
   }
 
-  public var complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5 {
+  var complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5 {
     get {return _storage._complexOptionType5 ?? ProtobufUnittest_ComplexOptionType3.ComplexOptionType5()}
     set {_uniqueStorage()._complexOptionType5 = newValue}
   }
@@ -1173,7 +1173,7 @@ struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage, ProtobufPr
     return _storage._complexOptionType5 = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1209,7 +1209,7 @@ struct ProtobufUnittest_ComplexOpt6: ProtobufGeneratedMessage, ProtobufProto2Mes
   public var unknown = ProtobufUnknownStorage()
 
   private var _xyzzy: Int32? = nil
-  public var xyzzy: Int32 {
+  var xyzzy: Int32 {
     get {return _xyzzy ?? 0}
     set {_xyzzy = newValue}
   }
@@ -1220,7 +1220,7 @@ struct ProtobufUnittest_ComplexOpt6: ProtobufGeneratedMessage, ProtobufProto2Mes
     return _xyzzy = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1253,7 +1253,7 @@ struct ProtobufUnittest_VariousComplexOptions: ProtobufGeneratedMessage, Protobu
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -1281,7 +1281,7 @@ struct ProtobufUnittest_AggregateMessageSet: ProtobufGeneratedMessage, ProtobufP
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (4 <= protoFieldNumber && protoFieldNumber < 2147483647) {
@@ -1341,7 +1341,7 @@ struct ProtobufUnittest_AggregateMessageSetElement: ProtobufGeneratedMessage, Pr
   }
 
   private var _s: String? = nil
-  public var s: String {
+  var s: String {
     get {return _s ?? ""}
     set {_s = newValue}
   }
@@ -1352,7 +1352,7 @@ struct ProtobufUnittest_AggregateMessageSetElement: ProtobufGeneratedMessage, Pr
     return _s = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1470,7 +1470,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
     static let Google_Protobuf_FileOptions_nested = ProtobufGenericMessageExtension<ProtobufOptionalMessageField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(protoFieldNumber: 15476903, protoFieldName: "nested", jsonFieldName: "nested", swiftFieldName: "ProtobufUnittest_Aggregate_nested", defaultValue: ProtobufUnittest_Aggregate())
   }
 
-  public var i: Int32 {
+  var i: Int32 {
     get {return _storage._i ?? 0}
     set {_uniqueStorage()._i = newValue}
   }
@@ -1481,7 +1481,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
     return _storage._i = nil
   }
 
-  public var s: String {
+  var s: String {
     get {return _storage._s ?? ""}
     set {_uniqueStorage()._s = newValue}
   }
@@ -1493,7 +1493,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
   }
 
   ///   A nested object
-  public var sub: ProtobufUnittest_Aggregate {
+  var sub: ProtobufUnittest_Aggregate {
     get {return _storage._sub ?? ProtobufUnittest_Aggregate()}
     set {_uniqueStorage()._sub = newValue}
   }
@@ -1505,7 +1505,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
   }
 
   ///   To test the parsing of extensions inside aggregate values
-  public var file: Google_Protobuf_FileOptions {
+  var file: Google_Protobuf_FileOptions {
     get {return _storage._file ?? Google_Protobuf_FileOptions()}
     set {_uniqueStorage()._file = newValue}
   }
@@ -1517,7 +1517,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
   }
 
   ///   An embedded message set
-  public var mset: ProtobufUnittest_AggregateMessageSet {
+  var mset: ProtobufUnittest_AggregateMessageSet {
     get {return _storage._mset ?? ProtobufUnittest_AggregateMessageSet()}
     set {_uniqueStorage()._mset = newValue}
   }
@@ -1528,7 +1528,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
     return _storage._mset = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1564,7 +1564,7 @@ struct ProtobufUnittest_AggregateMessage: ProtobufGeneratedMessage, ProtobufProt
   public var unknown = ProtobufUnknownStorage()
 
   private var _fieldname: Int32? = nil
-  public var fieldname: Int32 {
+  var fieldname: Int32 {
     get {return _fieldname ?? 0}
     set {_fieldname = newValue}
   }
@@ -1575,7 +1575,7 @@ struct ProtobufUnittest_AggregateMessage: ProtobufGeneratedMessage, ProtobufProt
     return _fieldname = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1609,42 +1609,42 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
   public var unknown = ProtobufUnknownStorage()
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case value // = 1
 
-    public init() {
+    init() {
       self = .value
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .value
       default: return nil
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "value": self = .value
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "NESTED_ENUM_VALUE": self = .value
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "NESTED_ENUM_VALUE": self = .value
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .value: return 1
@@ -1652,7 +1652,7 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .value: return "\"NESTED_ENUM_VALUE\""
@@ -1660,9 +1660,9 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .value: return ".value"
@@ -1686,7 +1686,7 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
     public var unknown = ProtobufUnknownStorage()
 
     private var _nestedField: Int32? = nil
-    public var nestedField: Int32 {
+    var nestedField: Int32 {
       get {return _nestedField ?? 0}
       set {_nestedField = newValue}
     }
@@ -1697,7 +1697,7 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
       return _nestedField = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1725,7 +1725,7 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
     static let Google_Protobuf_FileOptions_nestedExtension = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufInt32>, Google_Protobuf_FileOptions>(protoFieldNumber: 7912573, protoFieldName: "nested_extension", jsonFieldName: "nestedExtension", swiftFieldName: "ProtobufUnittest_NestedOptionType_nestedExtension", defaultValue: 0)
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -1756,42 +1756,42 @@ struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   enum TestEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case oldValue // = 0
 
-    public init() {
+    init() {
       self = .oldValue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .oldValue
       default: return nil
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "oldValue": self = .oldValue
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "OLD_VALUE": self = .oldValue
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "OLD_VALUE": self = .oldValue
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .oldValue: return 0
@@ -1799,7 +1799,7 @@ struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .oldValue: return "\"OLD_VALUE\""
@@ -1807,9 +1807,9 @@ struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .oldValue: return ".oldValue"
@@ -1820,7 +1820,7 @@ struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   private var _value: ProtobufUnittest_OldOptionType.TestEnum? = nil
-  public var value: ProtobufUnittest_OldOptionType.TestEnum {
+  var value: ProtobufUnittest_OldOptionType.TestEnum {
     get {return _value ?? ProtobufUnittest_OldOptionType.TestEnum.oldValue}
     set {_value = newValue}
   }
@@ -1831,7 +1831,7 @@ struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage, ProtobufProto2M
     return _value = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1867,15 +1867,15 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   enum TestEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case oldValue // = 0
     case newValue // = 1
 
-    public init() {
+    init() {
       self = .oldValue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .oldValue
       case 1: self = .newValue
@@ -1883,7 +1883,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "oldValue": self = .oldValue
       case "newValue": self = .newValue
@@ -1891,7 +1891,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "OLD_VALUE": self = .oldValue
       case "NEW_VALUE": self = .newValue
@@ -1899,7 +1899,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "OLD_VALUE": self = .oldValue
       case "NEW_VALUE": self = .newValue
@@ -1907,7 +1907,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .oldValue: return 0
@@ -1916,7 +1916,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .oldValue: return "\"OLD_VALUE\""
@@ -1925,9 +1925,9 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .oldValue: return ".oldValue"
@@ -1939,7 +1939,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   private var _value: ProtobufUnittest_NewOptionType.TestEnum? = nil
-  public var value: ProtobufUnittest_NewOptionType.TestEnum {
+  var value: ProtobufUnittest_NewOptionType.TestEnum {
     get {return _value ?? ProtobufUnittest_NewOptionType.TestEnum.oldValue}
     set {_value = newValue}
   }
@@ -1950,7 +1950,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
     return _value = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1981,7 +1981,7 @@ struct ProtobufUnittest_TestMessageWithRequiredEnumOption: ProtobufGeneratedMess
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/google/protobuf/unittest_drop_unknown_fields.pb.swift
+++ b/Reference/google/protobuf/unittest_drop_unknown_fields.pb.swift
@@ -55,17 +55,17 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
 
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -74,7 +74,7 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -83,7 +83,7 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -92,7 +92,7 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -101,7 +101,7 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -112,7 +112,7 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -123,9 +123,9 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -138,11 +138,11 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
 
   }
 
-  public var int32Value: Int32 = 0
+  var int32Value: Int32 = 0
 
-  public var enumValue: UnittestDropUnknownFields_Foo.NestedEnum = UnittestDropUnknownFields_Foo.NestedEnum.foo
+  var enumValue: UnittestDropUnknownFields_Foo.NestedEnum = UnittestDropUnknownFields_Foo.NestedEnum.foo
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -185,18 +185,18 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
 
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case qux // = 3
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -206,7 +206,7 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -216,7 +216,7 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -226,7 +226,7 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -236,7 +236,7 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -248,7 +248,7 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -260,9 +260,9 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -276,13 +276,13 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
 
   }
 
-  public var int32Value: Int32 = 0
+  var int32Value: Int32 = 0
 
-  public var enumValue: UnittestDropUnknownFields_FooWithExtraFields.NestedEnum = UnittestDropUnknownFields_FooWithExtraFields.NestedEnum.foo
+  var enumValue: UnittestDropUnknownFields_FooWithExtraFields.NestedEnum = UnittestDropUnknownFields_FooWithExtraFields.NestedEnum.foo
 
-  public var extraInt32Value: Int32 = 0
+  var extraInt32Value: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_embed_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_embed_optimize_for.pb.swift
@@ -110,7 +110,7 @@ struct ProtobufUnittest_TestEmbedOptimizedForSize: ProtobufGeneratedMessage, Pro
 
   ///   Test that embedding a message which has optimize_for = CODE_SIZE into
   ///   one optimized for speed works.
-  public var optionalMessage: ProtobufUnittest_TestOptimizedForSize {
+  var optionalMessage: ProtobufUnittest_TestOptimizedForSize {
     get {return _storage._optionalMessage ?? ProtobufUnittest_TestOptimizedForSize()}
     set {_uniqueStorage()._optionalMessage = newValue}
   }
@@ -121,12 +121,12 @@ struct ProtobufUnittest_TestEmbedOptimizedForSize: ProtobufGeneratedMessage, Pro
     return _storage._optionalMessage = nil
   }
 
-  public var repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] {
+  var repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] {
     get {return _storage._repeatedMessage}
     set {_uniqueStorage()._repeatedMessage = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/google/protobuf/unittest_enormous_descriptor.pb.swift
+++ b/Reference/google/protobuf/unittest_enormous_descriptor.pb.swift
@@ -9091,7 +9091,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     set {_storage.unknown = newValue}
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 = newValue}
   }
@@ -9102,7 +9102,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2 = newValue}
   }
@@ -9113,7 +9113,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3 = newValue}
   }
@@ -9124,7 +9124,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong3 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4 = newValue}
   }
@@ -9135,7 +9135,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong4 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5 = newValue}
   }
@@ -9146,7 +9146,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong5 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6 = newValue}
   }
@@ -9157,7 +9157,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong6 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7 = newValue}
   }
@@ -9168,7 +9168,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong7 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8 = newValue}
   }
@@ -9179,7 +9179,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong8 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9 = newValue}
   }
@@ -9190,7 +9190,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong9 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10 = newValue}
   }
@@ -9201,7 +9201,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong10 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11 = newValue}
   }
@@ -9212,7 +9212,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong11 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12 = newValue}
   }
@@ -9223,7 +9223,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong12 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13 = newValue}
   }
@@ -9234,7 +9234,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong13 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14 = newValue}
   }
@@ -9245,7 +9245,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong14 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15 = newValue}
   }
@@ -9256,7 +9256,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong15 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16 = newValue}
   }
@@ -9267,7 +9267,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong16 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17 = newValue}
   }
@@ -9278,7 +9278,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong17 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18 = newValue}
   }
@@ -9289,7 +9289,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong18 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19 = newValue}
   }
@@ -9300,7 +9300,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong19 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20 = newValue}
   }
@@ -9311,7 +9311,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong20 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21 = newValue}
   }
@@ -9322,7 +9322,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong21 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22 = newValue}
   }
@@ -9333,7 +9333,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong22 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23 = newValue}
   }
@@ -9344,7 +9344,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong23 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24 = newValue}
   }
@@ -9355,7 +9355,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong24 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25 = newValue}
   }
@@ -9366,7 +9366,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong25 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26 = newValue}
   }
@@ -9377,7 +9377,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong26 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27 = newValue}
   }
@@ -9388,7 +9388,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong27 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28 = newValue}
   }
@@ -9399,7 +9399,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong28 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29 = newValue}
   }
@@ -9410,7 +9410,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong29 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30 = newValue}
   }
@@ -9421,7 +9421,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong30 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31 = newValue}
   }
@@ -9432,7 +9432,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong31 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32 = newValue}
   }
@@ -9443,7 +9443,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong32 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33 = newValue}
   }
@@ -9454,7 +9454,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong33 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34 = newValue}
   }
@@ -9465,7 +9465,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong34 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35 = newValue}
   }
@@ -9476,7 +9476,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong35 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36 = newValue}
   }
@@ -9487,7 +9487,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong36 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37 = newValue}
   }
@@ -9498,7 +9498,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong37 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38 = newValue}
   }
@@ -9509,7 +9509,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong38 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39 = newValue}
   }
@@ -9520,7 +9520,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong39 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40 = newValue}
   }
@@ -9531,7 +9531,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong40 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41 = newValue}
   }
@@ -9542,7 +9542,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong41 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42 = newValue}
   }
@@ -9553,7 +9553,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong42 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43 = newValue}
   }
@@ -9564,7 +9564,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong43 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44 = newValue}
   }
@@ -9575,7 +9575,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong44 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45 = newValue}
   }
@@ -9586,7 +9586,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong45 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46 = newValue}
   }
@@ -9597,7 +9597,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong46 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47 = newValue}
   }
@@ -9608,7 +9608,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong47 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48 = newValue}
   }
@@ -9619,7 +9619,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong48 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49 = newValue}
   }
@@ -9630,7 +9630,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong49 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50 = newValue}
   }
@@ -9641,7 +9641,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong50 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51 = newValue}
   }
@@ -9652,7 +9652,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong51 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52 = newValue}
   }
@@ -9663,7 +9663,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong52 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53 = newValue}
   }
@@ -9674,7 +9674,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong53 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54 = newValue}
   }
@@ -9685,7 +9685,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong54 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55 = newValue}
   }
@@ -9696,7 +9696,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong55 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56 = newValue}
   }
@@ -9707,7 +9707,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong56 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57 = newValue}
   }
@@ -9718,7 +9718,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong57 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58 = newValue}
   }
@@ -9729,7 +9729,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong58 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59 = newValue}
   }
@@ -9740,7 +9740,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong59 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60 = newValue}
   }
@@ -9751,7 +9751,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong60 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61 = newValue}
   }
@@ -9762,7 +9762,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong61 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62 = newValue}
   }
@@ -9773,7 +9773,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong62 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63 = newValue}
   }
@@ -9784,7 +9784,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong63 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64 = newValue}
   }
@@ -9795,7 +9795,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong64 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65 = newValue}
   }
@@ -9806,7 +9806,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong65 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66 = newValue}
   }
@@ -9817,7 +9817,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong66 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67 = newValue}
   }
@@ -9828,7 +9828,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong67 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68 = newValue}
   }
@@ -9839,7 +9839,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong68 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69 = newValue}
   }
@@ -9850,7 +9850,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong69 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70 = newValue}
   }
@@ -9861,7 +9861,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong70 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71 = newValue}
   }
@@ -9872,7 +9872,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong71 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72 = newValue}
   }
@@ -9883,7 +9883,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong72 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73 = newValue}
   }
@@ -9894,7 +9894,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong73 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74 = newValue}
   }
@@ -9905,7 +9905,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong74 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75 = newValue}
   }
@@ -9916,7 +9916,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong75 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76 = newValue}
   }
@@ -9927,7 +9927,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong76 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77 = newValue}
   }
@@ -9938,7 +9938,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong77 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78 = newValue}
   }
@@ -9949,7 +9949,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong78 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79 = newValue}
   }
@@ -9960,7 +9960,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong79 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80 = newValue}
   }
@@ -9971,7 +9971,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong80 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81 = newValue}
   }
@@ -9982,7 +9982,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong81 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82 = newValue}
   }
@@ -9993,7 +9993,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong82 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83 = newValue}
   }
@@ -10004,7 +10004,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong83 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84 = newValue}
   }
@@ -10015,7 +10015,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong84 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85 = newValue}
   }
@@ -10026,7 +10026,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong85 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86 = newValue}
   }
@@ -10037,7 +10037,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong86 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87 = newValue}
   }
@@ -10048,7 +10048,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong87 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88 = newValue}
   }
@@ -10059,7 +10059,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong88 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89 = newValue}
   }
@@ -10070,7 +10070,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong89 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90 = newValue}
   }
@@ -10081,7 +10081,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong90 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91 = newValue}
   }
@@ -10092,7 +10092,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong91 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92 = newValue}
   }
@@ -10103,7 +10103,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong92 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93 = newValue}
   }
@@ -10114,7 +10114,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong93 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94 = newValue}
   }
@@ -10125,7 +10125,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong94 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95 = newValue}
   }
@@ -10136,7 +10136,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong95 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96 = newValue}
   }
@@ -10147,7 +10147,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong96 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97 = newValue}
   }
@@ -10158,7 +10158,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong97 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98 = newValue}
   }
@@ -10169,7 +10169,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong98 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99 = newValue}
   }
@@ -10180,7 +10180,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong99 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100 = newValue}
   }
@@ -10191,7 +10191,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong100 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101 = newValue}
   }
@@ -10202,7 +10202,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong101 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102 = newValue}
   }
@@ -10213,7 +10213,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong102 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103 = newValue}
   }
@@ -10224,7 +10224,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong103 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104 = newValue}
   }
@@ -10235,7 +10235,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong104 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105 = newValue}
   }
@@ -10246,7 +10246,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong105 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106 = newValue}
   }
@@ -10257,7 +10257,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong106 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107 = newValue}
   }
@@ -10268,7 +10268,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong107 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108 = newValue}
   }
@@ -10279,7 +10279,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong108 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109 = newValue}
   }
@@ -10290,7 +10290,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong109 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110 = newValue}
   }
@@ -10301,7 +10301,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong110 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111 = newValue}
   }
@@ -10312,7 +10312,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong111 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112 = newValue}
   }
@@ -10323,7 +10323,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong112 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113 = newValue}
   }
@@ -10334,7 +10334,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong113 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114 = newValue}
   }
@@ -10345,7 +10345,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong114 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115 = newValue}
   }
@@ -10356,7 +10356,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong115 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116 = newValue}
   }
@@ -10367,7 +10367,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong116 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117 = newValue}
   }
@@ -10378,7 +10378,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong117 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118 = newValue}
   }
@@ -10389,7 +10389,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong118 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119 = newValue}
   }
@@ -10400,7 +10400,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong119 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120 = newValue}
   }
@@ -10411,7 +10411,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong120 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121 = newValue}
   }
@@ -10422,7 +10422,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong121 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122 = newValue}
   }
@@ -10433,7 +10433,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong122 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123 = newValue}
   }
@@ -10444,7 +10444,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong123 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124 = newValue}
   }
@@ -10455,7 +10455,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong124 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125 = newValue}
   }
@@ -10466,7 +10466,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong125 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126 = newValue}
   }
@@ -10477,7 +10477,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong126 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127 = newValue}
   }
@@ -10488,7 +10488,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong127 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128 = newValue}
   }
@@ -10499,7 +10499,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong128 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129 = newValue}
   }
@@ -10510,7 +10510,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong129 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130 = newValue}
   }
@@ -10521,7 +10521,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong130 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131 = newValue}
   }
@@ -10532,7 +10532,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong131 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132 = newValue}
   }
@@ -10543,7 +10543,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong132 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133 = newValue}
   }
@@ -10554,7 +10554,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong133 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134 = newValue}
   }
@@ -10565,7 +10565,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong134 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135 = newValue}
   }
@@ -10576,7 +10576,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong135 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136 = newValue}
   }
@@ -10587,7 +10587,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong136 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137 = newValue}
   }
@@ -10598,7 +10598,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong137 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138 = newValue}
   }
@@ -10609,7 +10609,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong138 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139 = newValue}
   }
@@ -10620,7 +10620,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong139 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140 = newValue}
   }
@@ -10631,7 +10631,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong140 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141 = newValue}
   }
@@ -10642,7 +10642,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong141 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142 = newValue}
   }
@@ -10653,7 +10653,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong142 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143 = newValue}
   }
@@ -10664,7 +10664,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong143 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144 = newValue}
   }
@@ -10675,7 +10675,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong144 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145 = newValue}
   }
@@ -10686,7 +10686,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong145 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146 = newValue}
   }
@@ -10697,7 +10697,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong146 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147 = newValue}
   }
@@ -10708,7 +10708,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong147 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148 = newValue}
   }
@@ -10719,7 +10719,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong148 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149 = newValue}
   }
@@ -10730,7 +10730,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong149 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150 = newValue}
   }
@@ -10741,7 +10741,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong150 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151 = newValue}
   }
@@ -10752,7 +10752,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong151 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152 = newValue}
   }
@@ -10763,7 +10763,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong152 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153 = newValue}
   }
@@ -10774,7 +10774,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong153 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154 = newValue}
   }
@@ -10785,7 +10785,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong154 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155 = newValue}
   }
@@ -10796,7 +10796,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong155 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156 = newValue}
   }
@@ -10807,7 +10807,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong156 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157 = newValue}
   }
@@ -10818,7 +10818,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong157 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158 = newValue}
   }
@@ -10829,7 +10829,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong158 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159 = newValue}
   }
@@ -10840,7 +10840,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong159 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160 = newValue}
   }
@@ -10851,7 +10851,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong160 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161 = newValue}
   }
@@ -10862,7 +10862,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong161 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162 = newValue}
   }
@@ -10873,7 +10873,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong162 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163 = newValue}
   }
@@ -10884,7 +10884,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong163 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164 = newValue}
   }
@@ -10895,7 +10895,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong164 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165 = newValue}
   }
@@ -10906,7 +10906,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong165 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166 = newValue}
   }
@@ -10917,7 +10917,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong166 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167 = newValue}
   }
@@ -10928,7 +10928,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong167 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168 = newValue}
   }
@@ -10939,7 +10939,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong168 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169 = newValue}
   }
@@ -10950,7 +10950,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong169 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170 = newValue}
   }
@@ -10961,7 +10961,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong170 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171 = newValue}
   }
@@ -10972,7 +10972,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong171 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172 = newValue}
   }
@@ -10983,7 +10983,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong172 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173 = newValue}
   }
@@ -10994,7 +10994,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong173 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174 = newValue}
   }
@@ -11005,7 +11005,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong174 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175 = newValue}
   }
@@ -11016,7 +11016,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong175 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176 = newValue}
   }
@@ -11027,7 +11027,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong176 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177 = newValue}
   }
@@ -11038,7 +11038,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong177 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178 = newValue}
   }
@@ -11049,7 +11049,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong178 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179 = newValue}
   }
@@ -11060,7 +11060,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong179 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180 = newValue}
   }
@@ -11071,7 +11071,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong180 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181 = newValue}
   }
@@ -11082,7 +11082,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong181 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182 = newValue}
   }
@@ -11093,7 +11093,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong182 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183 = newValue}
   }
@@ -11104,7 +11104,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong183 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184 = newValue}
   }
@@ -11115,7 +11115,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong184 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185 = newValue}
   }
@@ -11126,7 +11126,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong185 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186 = newValue}
   }
@@ -11137,7 +11137,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong186 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187 = newValue}
   }
@@ -11148,7 +11148,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong187 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188 = newValue}
   }
@@ -11159,7 +11159,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong188 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189 = newValue}
   }
@@ -11170,7 +11170,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong189 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190 = newValue}
   }
@@ -11181,7 +11181,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong190 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191 = newValue}
   }
@@ -11192,7 +11192,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong191 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192 = newValue}
   }
@@ -11203,7 +11203,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong192 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193 = newValue}
   }
@@ -11214,7 +11214,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong193 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194 = newValue}
   }
@@ -11225,7 +11225,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong194 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195 = newValue}
   }
@@ -11236,7 +11236,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong195 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196 = newValue}
   }
@@ -11247,7 +11247,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong196 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197 = newValue}
   }
@@ -11258,7 +11258,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong197 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198 = newValue}
   }
@@ -11269,7 +11269,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong198 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199 = newValue}
   }
@@ -11280,7 +11280,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong199 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200 = newValue}
   }
@@ -11291,7 +11291,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong200 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201 = newValue}
   }
@@ -11302,7 +11302,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong201 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202 = newValue}
   }
@@ -11313,7 +11313,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong202 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203 = newValue}
   }
@@ -11324,7 +11324,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong203 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204 = newValue}
   }
@@ -11335,7 +11335,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong204 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205 = newValue}
   }
@@ -11346,7 +11346,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong205 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206 = newValue}
   }
@@ -11357,7 +11357,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong206 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207 = newValue}
   }
@@ -11368,7 +11368,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong207 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208 = newValue}
   }
@@ -11379,7 +11379,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong208 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209 = newValue}
   }
@@ -11390,7 +11390,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong209 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210 = newValue}
   }
@@ -11401,7 +11401,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong210 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211 = newValue}
   }
@@ -11412,7 +11412,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong211 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212 = newValue}
   }
@@ -11423,7 +11423,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong212 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213 = newValue}
   }
@@ -11434,7 +11434,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong213 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214 = newValue}
   }
@@ -11445,7 +11445,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong214 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215 = newValue}
   }
@@ -11456,7 +11456,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong215 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216 = newValue}
   }
@@ -11467,7 +11467,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong216 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217 = newValue}
   }
@@ -11478,7 +11478,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong217 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218 = newValue}
   }
@@ -11489,7 +11489,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong218 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219 = newValue}
   }
@@ -11500,7 +11500,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong219 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220 = newValue}
   }
@@ -11511,7 +11511,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong220 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221 = newValue}
   }
@@ -11522,7 +11522,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong221 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222 = newValue}
   }
@@ -11533,7 +11533,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong222 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223 = newValue}
   }
@@ -11544,7 +11544,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong223 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224 = newValue}
   }
@@ -11555,7 +11555,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong224 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225 = newValue}
   }
@@ -11566,7 +11566,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong225 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226 = newValue}
   }
@@ -11577,7 +11577,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong226 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227 = newValue}
   }
@@ -11588,7 +11588,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong227 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228 = newValue}
   }
@@ -11599,7 +11599,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong228 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229 = newValue}
   }
@@ -11610,7 +11610,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong229 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230 = newValue}
   }
@@ -11621,7 +11621,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong230 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231 = newValue}
   }
@@ -11632,7 +11632,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong231 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232 = newValue}
   }
@@ -11643,7 +11643,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong232 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233 = newValue}
   }
@@ -11654,7 +11654,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong233 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234 = newValue}
   }
@@ -11665,7 +11665,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong234 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235 = newValue}
   }
@@ -11676,7 +11676,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong235 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236 = newValue}
   }
@@ -11687,7 +11687,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong236 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237 = newValue}
   }
@@ -11698,7 +11698,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong237 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238 = newValue}
   }
@@ -11709,7 +11709,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong238 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239 = newValue}
   }
@@ -11720,7 +11720,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong239 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240 = newValue}
   }
@@ -11731,7 +11731,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong240 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241 = newValue}
   }
@@ -11742,7 +11742,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong241 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242 = newValue}
   }
@@ -11753,7 +11753,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong242 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243 = newValue}
   }
@@ -11764,7 +11764,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong243 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244 = newValue}
   }
@@ -11775,7 +11775,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong244 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245 = newValue}
   }
@@ -11786,7 +11786,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong245 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246 = newValue}
   }
@@ -11797,7 +11797,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong246 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247 = newValue}
   }
@@ -11808,7 +11808,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong247 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248 = newValue}
   }
@@ -11819,7 +11819,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong248 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249 = newValue}
   }
@@ -11830,7 +11830,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong249 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250 = newValue}
   }
@@ -11841,7 +11841,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong250 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251 = newValue}
   }
@@ -11852,7 +11852,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong251 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252 = newValue}
   }
@@ -11863,7 +11863,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong252 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253 = newValue}
   }
@@ -11874,7 +11874,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong253 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254 = newValue}
   }
@@ -11885,7 +11885,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong254 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255 = newValue}
   }
@@ -11896,7 +11896,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong255 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256 = newValue}
   }
@@ -11907,7 +11907,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong256 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257 = newValue}
   }
@@ -11918,7 +11918,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong257 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258 = newValue}
   }
@@ -11929,7 +11929,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong258 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259 = newValue}
   }
@@ -11940,7 +11940,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong259 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260 = newValue}
   }
@@ -11951,7 +11951,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong260 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261 = newValue}
   }
@@ -11962,7 +11962,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong261 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262 = newValue}
   }
@@ -11973,7 +11973,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong262 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263 = newValue}
   }
@@ -11984,7 +11984,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong263 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264 = newValue}
   }
@@ -11995,7 +11995,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong264 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265 = newValue}
   }
@@ -12006,7 +12006,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong265 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266 = newValue}
   }
@@ -12017,7 +12017,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong266 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267 = newValue}
   }
@@ -12028,7 +12028,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong267 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268 = newValue}
   }
@@ -12039,7 +12039,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong268 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269 = newValue}
   }
@@ -12050,7 +12050,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong269 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270 = newValue}
   }
@@ -12061,7 +12061,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong270 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271 = newValue}
   }
@@ -12072,7 +12072,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong271 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272 = newValue}
   }
@@ -12083,7 +12083,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong272 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273 = newValue}
   }
@@ -12094,7 +12094,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong273 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274 = newValue}
   }
@@ -12105,7 +12105,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong274 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275 = newValue}
   }
@@ -12116,7 +12116,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong275 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276 = newValue}
   }
@@ -12127,7 +12127,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong276 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277 = newValue}
   }
@@ -12138,7 +12138,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong277 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278 = newValue}
   }
@@ -12149,7 +12149,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong278 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279 = newValue}
   }
@@ -12160,7 +12160,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong279 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280 = newValue}
   }
@@ -12171,7 +12171,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong280 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281 = newValue}
   }
@@ -12182,7 +12182,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong281 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282 = newValue}
   }
@@ -12193,7 +12193,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong282 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283 = newValue}
   }
@@ -12204,7 +12204,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong283 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284 = newValue}
   }
@@ -12215,7 +12215,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong284 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285 = newValue}
   }
@@ -12226,7 +12226,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong285 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286 = newValue}
   }
@@ -12237,7 +12237,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong286 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287 = newValue}
   }
@@ -12248,7 +12248,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong287 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288 = newValue}
   }
@@ -12259,7 +12259,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong288 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289 = newValue}
   }
@@ -12270,7 +12270,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong289 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290 = newValue}
   }
@@ -12281,7 +12281,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong290 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291 = newValue}
   }
@@ -12292,7 +12292,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong291 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292 = newValue}
   }
@@ -12303,7 +12303,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong292 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293 = newValue}
   }
@@ -12314,7 +12314,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong293 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294 = newValue}
   }
@@ -12325,7 +12325,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong294 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295 = newValue}
   }
@@ -12336,7 +12336,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong295 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296 = newValue}
   }
@@ -12347,7 +12347,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong296 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297 = newValue}
   }
@@ -12358,7 +12358,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong297 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298 = newValue}
   }
@@ -12369,7 +12369,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong298 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299 = newValue}
   }
@@ -12380,7 +12380,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong299 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300 = newValue}
   }
@@ -12391,7 +12391,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong300 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301 = newValue}
   }
@@ -12402,7 +12402,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong301 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302 = newValue}
   }
@@ -12413,7 +12413,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong302 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303 = newValue}
   }
@@ -12424,7 +12424,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong303 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304 = newValue}
   }
@@ -12435,7 +12435,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong304 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305 = newValue}
   }
@@ -12446,7 +12446,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong305 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306 = newValue}
   }
@@ -12457,7 +12457,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong306 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307 = newValue}
   }
@@ -12468,7 +12468,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong307 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308 = newValue}
   }
@@ -12479,7 +12479,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong308 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309 = newValue}
   }
@@ -12490,7 +12490,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong309 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310 = newValue}
   }
@@ -12501,7 +12501,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong310 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311 = newValue}
   }
@@ -12512,7 +12512,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong311 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312 = newValue}
   }
@@ -12523,7 +12523,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong312 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313 = newValue}
   }
@@ -12534,7 +12534,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong313 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314 = newValue}
   }
@@ -12545,7 +12545,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong314 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315 = newValue}
   }
@@ -12556,7 +12556,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong315 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316 = newValue}
   }
@@ -12567,7 +12567,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong316 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317 = newValue}
   }
@@ -12578,7 +12578,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong317 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318 = newValue}
   }
@@ -12589,7 +12589,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong318 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319 = newValue}
   }
@@ -12600,7 +12600,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong319 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320 = newValue}
   }
@@ -12611,7 +12611,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong320 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321 = newValue}
   }
@@ -12622,7 +12622,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong321 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322 = newValue}
   }
@@ -12633,7 +12633,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong322 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323 = newValue}
   }
@@ -12644,7 +12644,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong323 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324 = newValue}
   }
@@ -12655,7 +12655,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong324 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325 = newValue}
   }
@@ -12666,7 +12666,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong325 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326 = newValue}
   }
@@ -12677,7 +12677,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong326 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327 = newValue}
   }
@@ -12688,7 +12688,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong327 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328 = newValue}
   }
@@ -12699,7 +12699,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong328 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329 = newValue}
   }
@@ -12710,7 +12710,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong329 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330 = newValue}
   }
@@ -12721,7 +12721,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong330 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331 = newValue}
   }
@@ -12732,7 +12732,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong331 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332 = newValue}
   }
@@ -12743,7 +12743,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong332 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333 = newValue}
   }
@@ -12754,7 +12754,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong333 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334 = newValue}
   }
@@ -12765,7 +12765,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong334 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335 = newValue}
   }
@@ -12776,7 +12776,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong335 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336 = newValue}
   }
@@ -12787,7 +12787,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong336 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337 = newValue}
   }
@@ -12798,7 +12798,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong337 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338 = newValue}
   }
@@ -12809,7 +12809,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong338 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339 = newValue}
   }
@@ -12820,7 +12820,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong339 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340 = newValue}
   }
@@ -12831,7 +12831,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong340 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341 = newValue}
   }
@@ -12842,7 +12842,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong341 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342 = newValue}
   }
@@ -12853,7 +12853,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong342 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343 = newValue}
   }
@@ -12864,7 +12864,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong343 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344 = newValue}
   }
@@ -12875,7 +12875,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong344 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345 = newValue}
   }
@@ -12886,7 +12886,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong345 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346 = newValue}
   }
@@ -12897,7 +12897,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong346 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347 = newValue}
   }
@@ -12908,7 +12908,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong347 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348 = newValue}
   }
@@ -12919,7 +12919,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong348 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349 = newValue}
   }
@@ -12930,7 +12930,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong349 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350 = newValue}
   }
@@ -12941,7 +12941,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong350 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351 = newValue}
   }
@@ -12952,7 +12952,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong351 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352 = newValue}
   }
@@ -12963,7 +12963,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong352 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353 = newValue}
   }
@@ -12974,7 +12974,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong353 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354 = newValue}
   }
@@ -12985,7 +12985,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong354 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355 = newValue}
   }
@@ -12996,7 +12996,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong355 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356 = newValue}
   }
@@ -13007,7 +13007,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong356 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357 = newValue}
   }
@@ -13018,7 +13018,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong357 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358 = newValue}
   }
@@ -13029,7 +13029,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong358 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359 = newValue}
   }
@@ -13040,7 +13040,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong359 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360 = newValue}
   }
@@ -13051,7 +13051,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong360 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361 = newValue}
   }
@@ -13062,7 +13062,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong361 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362 = newValue}
   }
@@ -13073,7 +13073,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong362 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363 = newValue}
   }
@@ -13084,7 +13084,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong363 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364 = newValue}
   }
@@ -13095,7 +13095,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong364 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365 = newValue}
   }
@@ -13106,7 +13106,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong365 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366 = newValue}
   }
@@ -13117,7 +13117,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong366 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367 = newValue}
   }
@@ -13128,7 +13128,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong367 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368 = newValue}
   }
@@ -13139,7 +13139,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong368 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369 = newValue}
   }
@@ -13150,7 +13150,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong369 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370 = newValue}
   }
@@ -13161,7 +13161,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong370 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371 = newValue}
   }
@@ -13172,7 +13172,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong371 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372 = newValue}
   }
@@ -13183,7 +13183,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong372 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373 = newValue}
   }
@@ -13194,7 +13194,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong373 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374 = newValue}
   }
@@ -13205,7 +13205,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong374 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375 = newValue}
   }
@@ -13216,7 +13216,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong375 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376 = newValue}
   }
@@ -13227,7 +13227,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong376 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377 = newValue}
   }
@@ -13238,7 +13238,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong377 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378 = newValue}
   }
@@ -13249,7 +13249,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong378 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379 = newValue}
   }
@@ -13260,7 +13260,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong379 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380 = newValue}
   }
@@ -13271,7 +13271,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong380 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381 = newValue}
   }
@@ -13282,7 +13282,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong381 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382 = newValue}
   }
@@ -13293,7 +13293,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong382 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383 = newValue}
   }
@@ -13304,7 +13304,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong383 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384 = newValue}
   }
@@ -13315,7 +13315,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong384 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385 = newValue}
   }
@@ -13326,7 +13326,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong385 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386 = newValue}
   }
@@ -13337,7 +13337,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong386 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387 = newValue}
   }
@@ -13348,7 +13348,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong387 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388 = newValue}
   }
@@ -13359,7 +13359,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong388 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389 = newValue}
   }
@@ -13370,7 +13370,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong389 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390 = newValue}
   }
@@ -13381,7 +13381,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong390 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391 = newValue}
   }
@@ -13392,7 +13392,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong391 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392 = newValue}
   }
@@ -13403,7 +13403,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong392 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393 = newValue}
   }
@@ -13414,7 +13414,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong393 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394 = newValue}
   }
@@ -13425,7 +13425,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong394 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395 = newValue}
   }
@@ -13436,7 +13436,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong395 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396 = newValue}
   }
@@ -13447,7 +13447,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong396 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397 = newValue}
   }
@@ -13458,7 +13458,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong397 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398 = newValue}
   }
@@ -13469,7 +13469,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong398 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399 = newValue}
   }
@@ -13480,7 +13480,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong399 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400 = newValue}
   }
@@ -13491,7 +13491,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong400 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401 = newValue}
   }
@@ -13502,7 +13502,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong401 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402 = newValue}
   }
@@ -13513,7 +13513,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong402 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403 = newValue}
   }
@@ -13524,7 +13524,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong403 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404 = newValue}
   }
@@ -13535,7 +13535,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong404 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405 = newValue}
   }
@@ -13546,7 +13546,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong405 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406 = newValue}
   }
@@ -13557,7 +13557,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong406 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407 = newValue}
   }
@@ -13568,7 +13568,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong407 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408 = newValue}
   }
@@ -13579,7 +13579,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong408 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409 = newValue}
   }
@@ -13590,7 +13590,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong409 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410 = newValue}
   }
@@ -13601,7 +13601,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong410 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411 = newValue}
   }
@@ -13612,7 +13612,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong411 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412 = newValue}
   }
@@ -13623,7 +13623,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong412 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413 = newValue}
   }
@@ -13634,7 +13634,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong413 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414 = newValue}
   }
@@ -13645,7 +13645,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong414 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415 = newValue}
   }
@@ -13656,7 +13656,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong415 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416 = newValue}
   }
@@ -13667,7 +13667,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong416 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417 = newValue}
   }
@@ -13678,7 +13678,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong417 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418 = newValue}
   }
@@ -13689,7 +13689,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong418 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419 = newValue}
   }
@@ -13700,7 +13700,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong419 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420 = newValue}
   }
@@ -13711,7 +13711,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong420 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421 = newValue}
   }
@@ -13722,7 +13722,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong421 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422 = newValue}
   }
@@ -13733,7 +13733,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong422 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423 = newValue}
   }
@@ -13744,7 +13744,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong423 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424 = newValue}
   }
@@ -13755,7 +13755,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong424 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425 = newValue}
   }
@@ -13766,7 +13766,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong425 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426 = newValue}
   }
@@ -13777,7 +13777,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong426 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427 = newValue}
   }
@@ -13788,7 +13788,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong427 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428 = newValue}
   }
@@ -13799,7 +13799,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong428 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429 = newValue}
   }
@@ -13810,7 +13810,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong429 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430 = newValue}
   }
@@ -13821,7 +13821,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong430 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431 = newValue}
   }
@@ -13832,7 +13832,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong431 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432 = newValue}
   }
@@ -13843,7 +13843,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong432 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433 = newValue}
   }
@@ -13854,7 +13854,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong433 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434 = newValue}
   }
@@ -13865,7 +13865,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong434 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435 = newValue}
   }
@@ -13876,7 +13876,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong435 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436 = newValue}
   }
@@ -13887,7 +13887,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong436 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437 = newValue}
   }
@@ -13898,7 +13898,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong437 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438 = newValue}
   }
@@ -13909,7 +13909,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong438 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439 = newValue}
   }
@@ -13920,7 +13920,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong439 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440 = newValue}
   }
@@ -13931,7 +13931,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong440 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441 = newValue}
   }
@@ -13942,7 +13942,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong441 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442 = newValue}
   }
@@ -13953,7 +13953,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong442 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443 = newValue}
   }
@@ -13964,7 +13964,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong443 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444 = newValue}
   }
@@ -13975,7 +13975,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong444 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445 = newValue}
   }
@@ -13986,7 +13986,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong445 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446 = newValue}
   }
@@ -13997,7 +13997,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong446 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447 = newValue}
   }
@@ -14008,7 +14008,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong447 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448 = newValue}
   }
@@ -14019,7 +14019,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong448 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449 = newValue}
   }
@@ -14030,7 +14030,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong449 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450 = newValue}
   }
@@ -14041,7 +14041,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong450 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451 = newValue}
   }
@@ -14052,7 +14052,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong451 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452 = newValue}
   }
@@ -14063,7 +14063,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong452 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453 = newValue}
   }
@@ -14074,7 +14074,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong453 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454 = newValue}
   }
@@ -14085,7 +14085,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong454 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455 = newValue}
   }
@@ -14096,7 +14096,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong455 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456 = newValue}
   }
@@ -14107,7 +14107,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong456 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457 = newValue}
   }
@@ -14118,7 +14118,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong457 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458 = newValue}
   }
@@ -14129,7 +14129,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong458 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459 = newValue}
   }
@@ -14140,7 +14140,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong459 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460 = newValue}
   }
@@ -14151,7 +14151,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong460 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461 = newValue}
   }
@@ -14162,7 +14162,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong461 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462 = newValue}
   }
@@ -14173,7 +14173,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong462 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463 = newValue}
   }
@@ -14184,7 +14184,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong463 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464 = newValue}
   }
@@ -14195,7 +14195,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong464 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465 = newValue}
   }
@@ -14206,7 +14206,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong465 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466 = newValue}
   }
@@ -14217,7 +14217,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong466 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467 = newValue}
   }
@@ -14228,7 +14228,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong467 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468 = newValue}
   }
@@ -14239,7 +14239,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong468 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469 = newValue}
   }
@@ -14250,7 +14250,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong469 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470 = newValue}
   }
@@ -14261,7 +14261,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong470 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471 = newValue}
   }
@@ -14272,7 +14272,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong471 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472 = newValue}
   }
@@ -14283,7 +14283,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong472 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473 = newValue}
   }
@@ -14294,7 +14294,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong473 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474 = newValue}
   }
@@ -14305,7 +14305,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong474 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475 = newValue}
   }
@@ -14316,7 +14316,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong475 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476 = newValue}
   }
@@ -14327,7 +14327,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong476 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477 = newValue}
   }
@@ -14338,7 +14338,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong477 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478 = newValue}
   }
@@ -14349,7 +14349,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong478 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479 = newValue}
   }
@@ -14360,7 +14360,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong479 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480 = newValue}
   }
@@ -14371,7 +14371,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong480 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481 = newValue}
   }
@@ -14382,7 +14382,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong481 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482 = newValue}
   }
@@ -14393,7 +14393,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong482 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483 = newValue}
   }
@@ -14404,7 +14404,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong483 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484 = newValue}
   }
@@ -14415,7 +14415,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong484 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485 = newValue}
   }
@@ -14426,7 +14426,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong485 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486 = newValue}
   }
@@ -14437,7 +14437,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong486 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487 = newValue}
   }
@@ -14448,7 +14448,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong487 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488 = newValue}
   }
@@ -14459,7 +14459,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong488 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489 = newValue}
   }
@@ -14470,7 +14470,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong489 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490 = newValue}
   }
@@ -14481,7 +14481,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong490 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491 = newValue}
   }
@@ -14492,7 +14492,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong491 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492 = newValue}
   }
@@ -14503,7 +14503,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong492 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493 = newValue}
   }
@@ -14514,7 +14514,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong493 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494 = newValue}
   }
@@ -14525,7 +14525,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong494 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495 = newValue}
   }
@@ -14536,7 +14536,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong495 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496 = newValue}
   }
@@ -14547,7 +14547,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong496 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497 = newValue}
   }
@@ -14558,7 +14558,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong497 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498 = newValue}
   }
@@ -14569,7 +14569,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong498 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499 = newValue}
   }
@@ -14580,7 +14580,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong499 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500 = newValue}
   }
@@ -14591,7 +14591,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong500 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501 = newValue}
   }
@@ -14602,7 +14602,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong501 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502 = newValue}
   }
@@ -14613,7 +14613,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong502 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503 = newValue}
   }
@@ -14624,7 +14624,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong503 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504 = newValue}
   }
@@ -14635,7 +14635,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong504 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505 = newValue}
   }
@@ -14646,7 +14646,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong505 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506 = newValue}
   }
@@ -14657,7 +14657,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong506 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507 = newValue}
   }
@@ -14668,7 +14668,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong507 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508 = newValue}
   }
@@ -14679,7 +14679,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong508 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509 = newValue}
   }
@@ -14690,7 +14690,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong509 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510 = newValue}
   }
@@ -14701,7 +14701,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong510 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511 = newValue}
   }
@@ -14712,7 +14712,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong511 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512 = newValue}
   }
@@ -14723,7 +14723,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong512 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513 = newValue}
   }
@@ -14734,7 +14734,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong513 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514 = newValue}
   }
@@ -14745,7 +14745,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong514 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515 = newValue}
   }
@@ -14756,7 +14756,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong515 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516 = newValue}
   }
@@ -14767,7 +14767,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong516 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517 = newValue}
   }
@@ -14778,7 +14778,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong517 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518 = newValue}
   }
@@ -14789,7 +14789,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong518 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519 = newValue}
   }
@@ -14800,7 +14800,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong519 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520 = newValue}
   }
@@ -14811,7 +14811,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong520 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521 = newValue}
   }
@@ -14822,7 +14822,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong521 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522 = newValue}
   }
@@ -14833,7 +14833,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong522 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523 = newValue}
   }
@@ -14844,7 +14844,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong523 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524 = newValue}
   }
@@ -14855,7 +14855,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong524 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525 = newValue}
   }
@@ -14866,7 +14866,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong525 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526 = newValue}
   }
@@ -14877,7 +14877,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong526 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527 = newValue}
   }
@@ -14888,7 +14888,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong527 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528 = newValue}
   }
@@ -14899,7 +14899,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong528 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529 = newValue}
   }
@@ -14910,7 +14910,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong529 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530 = newValue}
   }
@@ -14921,7 +14921,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong530 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531 = newValue}
   }
@@ -14932,7 +14932,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong531 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532 = newValue}
   }
@@ -14943,7 +14943,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong532 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533 = newValue}
   }
@@ -14954,7 +14954,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong533 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534 = newValue}
   }
@@ -14965,7 +14965,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong534 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535 = newValue}
   }
@@ -14976,7 +14976,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong535 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536 = newValue}
   }
@@ -14987,7 +14987,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong536 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537 = newValue}
   }
@@ -14998,7 +14998,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong537 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538 = newValue}
   }
@@ -15009,7 +15009,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong538 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539 = newValue}
   }
@@ -15020,7 +15020,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong539 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540 = newValue}
   }
@@ -15031,7 +15031,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong540 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541 = newValue}
   }
@@ -15042,7 +15042,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong541 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542 = newValue}
   }
@@ -15053,7 +15053,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong542 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543 = newValue}
   }
@@ -15064,7 +15064,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong543 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544 = newValue}
   }
@@ -15075,7 +15075,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong544 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545 = newValue}
   }
@@ -15086,7 +15086,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong545 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546 = newValue}
   }
@@ -15097,7 +15097,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong546 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547 = newValue}
   }
@@ -15108,7 +15108,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong547 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548 = newValue}
   }
@@ -15119,7 +15119,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong548 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549 = newValue}
   }
@@ -15130,7 +15130,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong549 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550 = newValue}
   }
@@ -15141,7 +15141,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong550 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551 = newValue}
   }
@@ -15152,7 +15152,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong551 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552 = newValue}
   }
@@ -15163,7 +15163,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong552 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553 = newValue}
   }
@@ -15174,7 +15174,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong553 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554 = newValue}
   }
@@ -15185,7 +15185,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong554 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555 = newValue}
   }
@@ -15196,7 +15196,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong555 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556 = newValue}
   }
@@ -15207,7 +15207,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong556 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557 = newValue}
   }
@@ -15218,7 +15218,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong557 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558 = newValue}
   }
@@ -15229,7 +15229,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong558 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559 = newValue}
   }
@@ -15240,7 +15240,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong559 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560 = newValue}
   }
@@ -15251,7 +15251,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong560 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561 = newValue}
   }
@@ -15262,7 +15262,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong561 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562 = newValue}
   }
@@ -15273,7 +15273,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong562 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563 = newValue}
   }
@@ -15284,7 +15284,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong563 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564 = newValue}
   }
@@ -15295,7 +15295,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong564 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565 = newValue}
   }
@@ -15306,7 +15306,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong565 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566 = newValue}
   }
@@ -15317,7 +15317,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong566 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567 = newValue}
   }
@@ -15328,7 +15328,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong567 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568 = newValue}
   }
@@ -15339,7 +15339,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong568 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569 = newValue}
   }
@@ -15350,7 +15350,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong569 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570 = newValue}
   }
@@ -15361,7 +15361,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong570 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571 = newValue}
   }
@@ -15372,7 +15372,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong571 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572 = newValue}
   }
@@ -15383,7 +15383,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong572 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573 = newValue}
   }
@@ -15394,7 +15394,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong573 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574 = newValue}
   }
@@ -15405,7 +15405,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong574 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575 = newValue}
   }
@@ -15416,7 +15416,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong575 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576 = newValue}
   }
@@ -15427,7 +15427,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong576 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577 = newValue}
   }
@@ -15438,7 +15438,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong577 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578 = newValue}
   }
@@ -15449,7 +15449,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong578 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579 = newValue}
   }
@@ -15460,7 +15460,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong579 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580 = newValue}
   }
@@ -15471,7 +15471,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong580 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581 = newValue}
   }
@@ -15482,7 +15482,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong581 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582 = newValue}
   }
@@ -15493,7 +15493,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong582 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583 = newValue}
   }
@@ -15504,7 +15504,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong583 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584 = newValue}
   }
@@ -15515,7 +15515,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong584 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585 = newValue}
   }
@@ -15526,7 +15526,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong585 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586 = newValue}
   }
@@ -15537,7 +15537,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong586 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587 = newValue}
   }
@@ -15548,7 +15548,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong587 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588 = newValue}
   }
@@ -15559,7 +15559,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong588 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589 = newValue}
   }
@@ -15570,7 +15570,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong589 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590 = newValue}
   }
@@ -15581,7 +15581,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong590 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591 = newValue}
   }
@@ -15592,7 +15592,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong591 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592 = newValue}
   }
@@ -15603,7 +15603,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong592 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593 = newValue}
   }
@@ -15614,7 +15614,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong593 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594 = newValue}
   }
@@ -15625,7 +15625,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong594 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595 = newValue}
   }
@@ -15636,7 +15636,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong595 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596 = newValue}
   }
@@ -15647,7 +15647,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong596 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597 = newValue}
   }
@@ -15658,7 +15658,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong597 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598 = newValue}
   }
@@ -15669,7 +15669,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong598 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599 = newValue}
   }
@@ -15680,7 +15680,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong599 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600 = newValue}
   }
@@ -15691,7 +15691,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong600 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601 = newValue}
   }
@@ -15702,7 +15702,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong601 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602 = newValue}
   }
@@ -15713,7 +15713,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong602 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603 = newValue}
   }
@@ -15724,7 +15724,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong603 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604 = newValue}
   }
@@ -15735,7 +15735,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong604 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605 = newValue}
   }
@@ -15746,7 +15746,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong605 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606 = newValue}
   }
@@ -15757,7 +15757,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong606 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607 = newValue}
   }
@@ -15768,7 +15768,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong607 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608 = newValue}
   }
@@ -15779,7 +15779,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong608 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609 = newValue}
   }
@@ -15790,7 +15790,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong609 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610 = newValue}
   }
@@ -15801,7 +15801,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong610 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611 = newValue}
   }
@@ -15812,7 +15812,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong611 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612 = newValue}
   }
@@ -15823,7 +15823,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong612 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613 = newValue}
   }
@@ -15834,7 +15834,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong613 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614 = newValue}
   }
@@ -15845,7 +15845,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong614 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615 = newValue}
   }
@@ -15856,7 +15856,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong615 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616 = newValue}
   }
@@ -15867,7 +15867,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong616 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617 = newValue}
   }
@@ -15878,7 +15878,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong617 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618 = newValue}
   }
@@ -15889,7 +15889,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong618 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619 = newValue}
   }
@@ -15900,7 +15900,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong619 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620 = newValue}
   }
@@ -15911,7 +15911,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong620 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621 = newValue}
   }
@@ -15922,7 +15922,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong621 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622 = newValue}
   }
@@ -15933,7 +15933,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong622 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623 = newValue}
   }
@@ -15944,7 +15944,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong623 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624 = newValue}
   }
@@ -15955,7 +15955,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong624 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625 = newValue}
   }
@@ -15966,7 +15966,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong625 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626 = newValue}
   }
@@ -15977,7 +15977,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong626 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627 = newValue}
   }
@@ -15988,7 +15988,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong627 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628 = newValue}
   }
@@ -15999,7 +15999,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong628 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629 = newValue}
   }
@@ -16010,7 +16010,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong629 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630 = newValue}
   }
@@ -16021,7 +16021,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong630 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631 = newValue}
   }
@@ -16032,7 +16032,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong631 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632 = newValue}
   }
@@ -16043,7 +16043,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong632 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633 = newValue}
   }
@@ -16054,7 +16054,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong633 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634 = newValue}
   }
@@ -16065,7 +16065,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong634 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635 = newValue}
   }
@@ -16076,7 +16076,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong635 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636 = newValue}
   }
@@ -16087,7 +16087,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong636 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637 = newValue}
   }
@@ -16098,7 +16098,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong637 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638 = newValue}
   }
@@ -16109,7 +16109,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong638 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639 = newValue}
   }
@@ -16120,7 +16120,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong639 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640 = newValue}
   }
@@ -16131,7 +16131,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong640 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641 = newValue}
   }
@@ -16142,7 +16142,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong641 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642 = newValue}
   }
@@ -16153,7 +16153,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong642 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643 = newValue}
   }
@@ -16164,7 +16164,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong643 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644 = newValue}
   }
@@ -16175,7 +16175,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong644 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645 = newValue}
   }
@@ -16186,7 +16186,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong645 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646 = newValue}
   }
@@ -16197,7 +16197,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong646 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647 = newValue}
   }
@@ -16208,7 +16208,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong647 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648 = newValue}
   }
@@ -16219,7 +16219,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong648 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649 = newValue}
   }
@@ -16230,7 +16230,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong649 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650 = newValue}
   }
@@ -16241,7 +16241,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong650 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651 = newValue}
   }
@@ -16252,7 +16252,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong651 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652 = newValue}
   }
@@ -16263,7 +16263,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong652 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653 = newValue}
   }
@@ -16274,7 +16274,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong653 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654 = newValue}
   }
@@ -16285,7 +16285,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong654 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655 = newValue}
   }
@@ -16296,7 +16296,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong655 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656 = newValue}
   }
@@ -16307,7 +16307,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong656 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657 = newValue}
   }
@@ -16318,7 +16318,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong657 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658 = newValue}
   }
@@ -16329,7 +16329,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong658 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659 = newValue}
   }
@@ -16340,7 +16340,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong659 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660 = newValue}
   }
@@ -16351,7 +16351,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong660 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661 = newValue}
   }
@@ -16362,7 +16362,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong661 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662 = newValue}
   }
@@ -16373,7 +16373,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong662 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663 = newValue}
   }
@@ -16384,7 +16384,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong663 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664 = newValue}
   }
@@ -16395,7 +16395,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong664 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665 = newValue}
   }
@@ -16406,7 +16406,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong665 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666 = newValue}
   }
@@ -16417,7 +16417,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong666 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667 = newValue}
   }
@@ -16428,7 +16428,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong667 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668 = newValue}
   }
@@ -16439,7 +16439,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong668 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669 = newValue}
   }
@@ -16450,7 +16450,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong669 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670 = newValue}
   }
@@ -16461,7 +16461,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong670 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671 = newValue}
   }
@@ -16472,7 +16472,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong671 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672 = newValue}
   }
@@ -16483,7 +16483,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong672 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673 = newValue}
   }
@@ -16494,7 +16494,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong673 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674 = newValue}
   }
@@ -16505,7 +16505,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong674 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675 = newValue}
   }
@@ -16516,7 +16516,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong675 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676 = newValue}
   }
@@ -16527,7 +16527,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong676 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677 = newValue}
   }
@@ -16538,7 +16538,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong677 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678 = newValue}
   }
@@ -16549,7 +16549,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong678 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679 = newValue}
   }
@@ -16560,7 +16560,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong679 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680 = newValue}
   }
@@ -16571,7 +16571,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong680 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681 = newValue}
   }
@@ -16582,7 +16582,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong681 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682 = newValue}
   }
@@ -16593,7 +16593,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong682 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683 = newValue}
   }
@@ -16604,7 +16604,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong683 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684 = newValue}
   }
@@ -16615,7 +16615,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong684 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685 = newValue}
   }
@@ -16626,7 +16626,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong685 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686 = newValue}
   }
@@ -16637,7 +16637,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong686 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687 = newValue}
   }
@@ -16648,7 +16648,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong687 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688 = newValue}
   }
@@ -16659,7 +16659,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong688 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689 = newValue}
   }
@@ -16670,7 +16670,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong689 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690 = newValue}
   }
@@ -16681,7 +16681,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong690 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691 = newValue}
   }
@@ -16692,7 +16692,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong691 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692 = newValue}
   }
@@ -16703,7 +16703,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong692 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693 = newValue}
   }
@@ -16714,7 +16714,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong693 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694 = newValue}
   }
@@ -16725,7 +16725,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong694 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695 = newValue}
   }
@@ -16736,7 +16736,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong695 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696 = newValue}
   }
@@ -16747,7 +16747,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong696 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697 = newValue}
   }
@@ -16758,7 +16758,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong697 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698 = newValue}
   }
@@ -16769,7 +16769,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong698 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699 = newValue}
   }
@@ -16780,7 +16780,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong699 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700 = newValue}
   }
@@ -16791,7 +16791,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong700 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701 = newValue}
   }
@@ -16802,7 +16802,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong701 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702 = newValue}
   }
@@ -16813,7 +16813,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong702 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703 = newValue}
   }
@@ -16824,7 +16824,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong703 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704 = newValue}
   }
@@ -16835,7 +16835,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong704 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705 = newValue}
   }
@@ -16846,7 +16846,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong705 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706 = newValue}
   }
@@ -16857,7 +16857,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong706 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707 = newValue}
   }
@@ -16868,7 +16868,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong707 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708 = newValue}
   }
@@ -16879,7 +16879,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong708 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709 = newValue}
   }
@@ -16890,7 +16890,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong709 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710 = newValue}
   }
@@ -16901,7 +16901,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong710 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711 = newValue}
   }
@@ -16912,7 +16912,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong711 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712 = newValue}
   }
@@ -16923,7 +16923,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong712 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713 = newValue}
   }
@@ -16934,7 +16934,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong713 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714 = newValue}
   }
@@ -16945,7 +16945,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong714 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715 = newValue}
   }
@@ -16956,7 +16956,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong715 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716 = newValue}
   }
@@ -16967,7 +16967,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong716 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717 = newValue}
   }
@@ -16978,7 +16978,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong717 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718 = newValue}
   }
@@ -16989,7 +16989,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong718 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719 = newValue}
   }
@@ -17000,7 +17000,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong719 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720 = newValue}
   }
@@ -17011,7 +17011,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong720 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721 = newValue}
   }
@@ -17022,7 +17022,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong721 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722 = newValue}
   }
@@ -17033,7 +17033,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong722 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723 = newValue}
   }
@@ -17044,7 +17044,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong723 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724 = newValue}
   }
@@ -17055,7 +17055,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong724 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725 = newValue}
   }
@@ -17066,7 +17066,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong725 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726 = newValue}
   }
@@ -17077,7 +17077,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong726 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727 = newValue}
   }
@@ -17088,7 +17088,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong727 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728 = newValue}
   }
@@ -17099,7 +17099,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong728 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729 = newValue}
   }
@@ -17110,7 +17110,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong729 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730 = newValue}
   }
@@ -17121,7 +17121,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong730 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731 = newValue}
   }
@@ -17132,7 +17132,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong731 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732 = newValue}
   }
@@ -17143,7 +17143,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong732 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733 = newValue}
   }
@@ -17154,7 +17154,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong733 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734 = newValue}
   }
@@ -17165,7 +17165,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong734 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735 = newValue}
   }
@@ -17176,7 +17176,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong735 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736 = newValue}
   }
@@ -17187,7 +17187,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong736 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737 = newValue}
   }
@@ -17198,7 +17198,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong737 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738 = newValue}
   }
@@ -17209,7 +17209,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong738 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739 = newValue}
   }
@@ -17220,7 +17220,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong739 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740 = newValue}
   }
@@ -17231,7 +17231,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong740 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741 = newValue}
   }
@@ -17242,7 +17242,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong741 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742 = newValue}
   }
@@ -17253,7 +17253,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong742 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743 = newValue}
   }
@@ -17264,7 +17264,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong743 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744 = newValue}
   }
@@ -17275,7 +17275,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong744 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745 = newValue}
   }
@@ -17286,7 +17286,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong745 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746 = newValue}
   }
@@ -17297,7 +17297,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong746 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747 = newValue}
   }
@@ -17308,7 +17308,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong747 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748 = newValue}
   }
@@ -17319,7 +17319,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong748 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749 = newValue}
   }
@@ -17330,7 +17330,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong749 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750 = newValue}
   }
@@ -17341,7 +17341,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong750 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751 = newValue}
   }
@@ -17352,7 +17352,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong751 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752 = newValue}
   }
@@ -17363,7 +17363,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong752 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753 = newValue}
   }
@@ -17374,7 +17374,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong753 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754 = newValue}
   }
@@ -17385,7 +17385,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong754 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755 = newValue}
   }
@@ -17396,7 +17396,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong755 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756 = newValue}
   }
@@ -17407,7 +17407,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong756 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757 = newValue}
   }
@@ -17418,7 +17418,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong757 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758 = newValue}
   }
@@ -17429,7 +17429,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong758 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759 = newValue}
   }
@@ -17440,7 +17440,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong759 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760 = newValue}
   }
@@ -17451,7 +17451,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong760 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761 = newValue}
   }
@@ -17462,7 +17462,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong761 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762 = newValue}
   }
@@ -17473,7 +17473,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong762 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763 = newValue}
   }
@@ -17484,7 +17484,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong763 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764 = newValue}
   }
@@ -17495,7 +17495,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong764 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765 = newValue}
   }
@@ -17506,7 +17506,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong765 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766 = newValue}
   }
@@ -17517,7 +17517,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong766 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767 = newValue}
   }
@@ -17528,7 +17528,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong767 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768 = newValue}
   }
@@ -17539,7 +17539,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong768 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769 = newValue}
   }
@@ -17550,7 +17550,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong769 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770 = newValue}
   }
@@ -17561,7 +17561,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong770 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771 = newValue}
   }
@@ -17572,7 +17572,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong771 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772 = newValue}
   }
@@ -17583,7 +17583,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong772 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773 = newValue}
   }
@@ -17594,7 +17594,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong773 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774 = newValue}
   }
@@ -17605,7 +17605,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong774 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775 = newValue}
   }
@@ -17616,7 +17616,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong775 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776 = newValue}
   }
@@ -17627,7 +17627,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong776 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777 = newValue}
   }
@@ -17638,7 +17638,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong777 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778 = newValue}
   }
@@ -17649,7 +17649,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong778 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779 = newValue}
   }
@@ -17660,7 +17660,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong779 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780 = newValue}
   }
@@ -17671,7 +17671,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong780 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781 = newValue}
   }
@@ -17682,7 +17682,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong781 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782 = newValue}
   }
@@ -17693,7 +17693,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong782 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783 = newValue}
   }
@@ -17704,7 +17704,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong783 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784 = newValue}
   }
@@ -17715,7 +17715,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong784 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785 = newValue}
   }
@@ -17726,7 +17726,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong785 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786 = newValue}
   }
@@ -17737,7 +17737,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong786 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787 = newValue}
   }
@@ -17748,7 +17748,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong787 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788 = newValue}
   }
@@ -17759,7 +17759,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong788 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789 = newValue}
   }
@@ -17770,7 +17770,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong789 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790 = newValue}
   }
@@ -17781,7 +17781,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong790 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791 = newValue}
   }
@@ -17792,7 +17792,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong791 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792 = newValue}
   }
@@ -17803,7 +17803,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong792 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793 = newValue}
   }
@@ -17814,7 +17814,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong793 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794 = newValue}
   }
@@ -17825,7 +17825,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong794 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795 = newValue}
   }
@@ -17836,7 +17836,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong795 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796 = newValue}
   }
@@ -17847,7 +17847,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong796 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797 = newValue}
   }
@@ -17858,7 +17858,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong797 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798 = newValue}
   }
@@ -17869,7 +17869,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong798 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799 = newValue}
   }
@@ -17880,7 +17880,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong799 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800 = newValue}
   }
@@ -17891,7 +17891,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong800 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801 = newValue}
   }
@@ -17902,7 +17902,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong801 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802 = newValue}
   }
@@ -17913,7 +17913,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong802 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803 = newValue}
   }
@@ -17924,7 +17924,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong803 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804 = newValue}
   }
@@ -17935,7 +17935,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong804 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805 = newValue}
   }
@@ -17946,7 +17946,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong805 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806 = newValue}
   }
@@ -17957,7 +17957,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong806 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807 = newValue}
   }
@@ -17968,7 +17968,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong807 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808 = newValue}
   }
@@ -17979,7 +17979,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong808 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809 = newValue}
   }
@@ -17990,7 +17990,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong809 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810 = newValue}
   }
@@ -18001,7 +18001,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong810 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811 = newValue}
   }
@@ -18012,7 +18012,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong811 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812 = newValue}
   }
@@ -18023,7 +18023,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong812 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813 = newValue}
   }
@@ -18034,7 +18034,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong813 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814 = newValue}
   }
@@ -18045,7 +18045,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong814 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815 = newValue}
   }
@@ -18056,7 +18056,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong815 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816 = newValue}
   }
@@ -18067,7 +18067,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong816 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817 = newValue}
   }
@@ -18078,7 +18078,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong817 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818 = newValue}
   }
@@ -18089,7 +18089,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong818 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819 = newValue}
   }
@@ -18100,7 +18100,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong819 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820 = newValue}
   }
@@ -18111,7 +18111,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong820 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821 = newValue}
   }
@@ -18122,7 +18122,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong821 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822 = newValue}
   }
@@ -18133,7 +18133,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong822 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823 = newValue}
   }
@@ -18144,7 +18144,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong823 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824 = newValue}
   }
@@ -18155,7 +18155,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong824 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825 = newValue}
   }
@@ -18166,7 +18166,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong825 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826 = newValue}
   }
@@ -18177,7 +18177,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong826 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827 = newValue}
   }
@@ -18188,7 +18188,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong827 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828 = newValue}
   }
@@ -18199,7 +18199,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong828 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829 = newValue}
   }
@@ -18210,7 +18210,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong829 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830 = newValue}
   }
@@ -18221,7 +18221,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong830 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831 = newValue}
   }
@@ -18232,7 +18232,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong831 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832 = newValue}
   }
@@ -18243,7 +18243,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong832 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833 = newValue}
   }
@@ -18254,7 +18254,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong833 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834 = newValue}
   }
@@ -18265,7 +18265,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong834 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835 = newValue}
   }
@@ -18276,7 +18276,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong835 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836 = newValue}
   }
@@ -18287,7 +18287,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong836 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837 = newValue}
   }
@@ -18298,7 +18298,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong837 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838 = newValue}
   }
@@ -18309,7 +18309,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong838 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839 = newValue}
   }
@@ -18320,7 +18320,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong839 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840 = newValue}
   }
@@ -18331,7 +18331,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong840 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841 = newValue}
   }
@@ -18342,7 +18342,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong841 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842 = newValue}
   }
@@ -18353,7 +18353,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong842 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843 = newValue}
   }
@@ -18364,7 +18364,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong843 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844 = newValue}
   }
@@ -18375,7 +18375,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong844 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845 = newValue}
   }
@@ -18386,7 +18386,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong845 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846 = newValue}
   }
@@ -18397,7 +18397,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong846 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847 = newValue}
   }
@@ -18408,7 +18408,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong847 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848 = newValue}
   }
@@ -18419,7 +18419,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong848 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849 = newValue}
   }
@@ -18430,7 +18430,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong849 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850 = newValue}
   }
@@ -18441,7 +18441,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong850 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851 = newValue}
   }
@@ -18452,7 +18452,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong851 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852 = newValue}
   }
@@ -18463,7 +18463,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong852 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853 = newValue}
   }
@@ -18474,7 +18474,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong853 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854 = newValue}
   }
@@ -18485,7 +18485,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong854 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855 = newValue}
   }
@@ -18496,7 +18496,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong855 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856 = newValue}
   }
@@ -18507,7 +18507,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong856 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857 = newValue}
   }
@@ -18518,7 +18518,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong857 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858 = newValue}
   }
@@ -18529,7 +18529,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong858 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859 = newValue}
   }
@@ -18540,7 +18540,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong859 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860 = newValue}
   }
@@ -18551,7 +18551,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong860 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861 = newValue}
   }
@@ -18562,7 +18562,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong861 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862 = newValue}
   }
@@ -18573,7 +18573,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong862 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863 = newValue}
   }
@@ -18584,7 +18584,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong863 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864 = newValue}
   }
@@ -18595,7 +18595,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong864 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865 = newValue}
   }
@@ -18606,7 +18606,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong865 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866 = newValue}
   }
@@ -18617,7 +18617,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong866 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867 = newValue}
   }
@@ -18628,7 +18628,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong867 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868 = newValue}
   }
@@ -18639,7 +18639,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong868 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869 = newValue}
   }
@@ -18650,7 +18650,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong869 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870 = newValue}
   }
@@ -18661,7 +18661,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong870 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871 = newValue}
   }
@@ -18672,7 +18672,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong871 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872 = newValue}
   }
@@ -18683,7 +18683,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong872 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873 = newValue}
   }
@@ -18694,7 +18694,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong873 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874 = newValue}
   }
@@ -18705,7 +18705,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong874 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875 = newValue}
   }
@@ -18716,7 +18716,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong875 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876 = newValue}
   }
@@ -18727,7 +18727,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong876 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877 = newValue}
   }
@@ -18738,7 +18738,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong877 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878 = newValue}
   }
@@ -18749,7 +18749,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong878 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879 = newValue}
   }
@@ -18760,7 +18760,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong879 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880 = newValue}
   }
@@ -18771,7 +18771,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong880 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881 = newValue}
   }
@@ -18782,7 +18782,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong881 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882 = newValue}
   }
@@ -18793,7 +18793,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong882 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883 = newValue}
   }
@@ -18804,7 +18804,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong883 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884 = newValue}
   }
@@ -18815,7 +18815,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong884 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885 = newValue}
   }
@@ -18826,7 +18826,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong885 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886 = newValue}
   }
@@ -18837,7 +18837,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong886 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887 = newValue}
   }
@@ -18848,7 +18848,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong887 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888 = newValue}
   }
@@ -18859,7 +18859,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong888 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889 = newValue}
   }
@@ -18870,7 +18870,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong889 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890 = newValue}
   }
@@ -18881,7 +18881,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong890 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891 = newValue}
   }
@@ -18892,7 +18892,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong891 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892 = newValue}
   }
@@ -18903,7 +18903,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong892 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893 = newValue}
   }
@@ -18914,7 +18914,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong893 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894 = newValue}
   }
@@ -18925,7 +18925,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong894 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895 = newValue}
   }
@@ -18936,7 +18936,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong895 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896 = newValue}
   }
@@ -18947,7 +18947,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong896 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897 = newValue}
   }
@@ -18958,7 +18958,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong897 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898 = newValue}
   }
@@ -18969,7 +18969,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong898 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899 = newValue}
   }
@@ -18980,7 +18980,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong899 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900 = newValue}
   }
@@ -18991,7 +18991,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong900 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901 = newValue}
   }
@@ -19002,7 +19002,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong901 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902 = newValue}
   }
@@ -19013,7 +19013,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong902 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903 = newValue}
   }
@@ -19024,7 +19024,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong903 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904 = newValue}
   }
@@ -19035,7 +19035,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong904 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905 = newValue}
   }
@@ -19046,7 +19046,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong905 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906 = newValue}
   }
@@ -19057,7 +19057,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong906 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907 = newValue}
   }
@@ -19068,7 +19068,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong907 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908 = newValue}
   }
@@ -19079,7 +19079,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong908 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909 = newValue}
   }
@@ -19090,7 +19090,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong909 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910 = newValue}
   }
@@ -19101,7 +19101,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong910 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911 = newValue}
   }
@@ -19112,7 +19112,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong911 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912 = newValue}
   }
@@ -19123,7 +19123,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong912 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913 = newValue}
   }
@@ -19134,7 +19134,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong913 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914 = newValue}
   }
@@ -19145,7 +19145,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong914 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915 = newValue}
   }
@@ -19156,7 +19156,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong915 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916 = newValue}
   }
@@ -19167,7 +19167,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong916 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917 = newValue}
   }
@@ -19178,7 +19178,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong917 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918 = newValue}
   }
@@ -19189,7 +19189,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong918 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919 = newValue}
   }
@@ -19200,7 +19200,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong919 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920 = newValue}
   }
@@ -19211,7 +19211,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong920 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921 = newValue}
   }
@@ -19222,7 +19222,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong921 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922 = newValue}
   }
@@ -19233,7 +19233,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong922 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923 = newValue}
   }
@@ -19244,7 +19244,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong923 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924 = newValue}
   }
@@ -19255,7 +19255,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong924 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925 = newValue}
   }
@@ -19266,7 +19266,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong925 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926 = newValue}
   }
@@ -19277,7 +19277,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong926 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927 = newValue}
   }
@@ -19288,7 +19288,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong927 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928 = newValue}
   }
@@ -19299,7 +19299,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong928 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929 = newValue}
   }
@@ -19310,7 +19310,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong929 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930 = newValue}
   }
@@ -19321,7 +19321,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong930 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931 = newValue}
   }
@@ -19332,7 +19332,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong931 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932 = newValue}
   }
@@ -19343,7 +19343,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong932 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933 = newValue}
   }
@@ -19354,7 +19354,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong933 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934 = newValue}
   }
@@ -19365,7 +19365,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong934 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935 = newValue}
   }
@@ -19376,7 +19376,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong935 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936 = newValue}
   }
@@ -19387,7 +19387,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong936 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937 = newValue}
   }
@@ -19398,7 +19398,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong937 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938 = newValue}
   }
@@ -19409,7 +19409,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong938 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939 = newValue}
   }
@@ -19420,7 +19420,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong939 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940 = newValue}
   }
@@ -19431,7 +19431,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong940 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941 = newValue}
   }
@@ -19442,7 +19442,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong941 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942 = newValue}
   }
@@ -19453,7 +19453,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong942 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943 = newValue}
   }
@@ -19464,7 +19464,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong943 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944 = newValue}
   }
@@ -19475,7 +19475,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong944 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945 = newValue}
   }
@@ -19486,7 +19486,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong945 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946 = newValue}
   }
@@ -19497,7 +19497,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong946 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947 = newValue}
   }
@@ -19508,7 +19508,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong947 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948 = newValue}
   }
@@ -19519,7 +19519,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong948 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949 = newValue}
   }
@@ -19530,7 +19530,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong949 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950 = newValue}
   }
@@ -19541,7 +19541,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong950 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951 = newValue}
   }
@@ -19552,7 +19552,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong951 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952 = newValue}
   }
@@ -19563,7 +19563,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong952 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953 = newValue}
   }
@@ -19574,7 +19574,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong953 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954 = newValue}
   }
@@ -19585,7 +19585,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong954 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955 = newValue}
   }
@@ -19596,7 +19596,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong955 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956 = newValue}
   }
@@ -19607,7 +19607,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong956 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957 = newValue}
   }
@@ -19618,7 +19618,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong957 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958 = newValue}
   }
@@ -19629,7 +19629,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong958 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959 = newValue}
   }
@@ -19640,7 +19640,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong959 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960 = newValue}
   }
@@ -19651,7 +19651,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong960 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961 = newValue}
   }
@@ -19662,7 +19662,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong961 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962 = newValue}
   }
@@ -19673,7 +19673,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong962 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963 = newValue}
   }
@@ -19684,7 +19684,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong963 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964 = newValue}
   }
@@ -19695,7 +19695,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong964 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965 = newValue}
   }
@@ -19706,7 +19706,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong965 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966 = newValue}
   }
@@ -19717,7 +19717,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong966 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967 = newValue}
   }
@@ -19728,7 +19728,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong967 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968 = newValue}
   }
@@ -19739,7 +19739,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong968 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969 = newValue}
   }
@@ -19750,7 +19750,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong969 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970 = newValue}
   }
@@ -19761,7 +19761,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong970 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971 = newValue}
   }
@@ -19772,7 +19772,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong971 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972 = newValue}
   }
@@ -19783,7 +19783,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong972 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973 = newValue}
   }
@@ -19794,7 +19794,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong973 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974 = newValue}
   }
@@ -19805,7 +19805,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong974 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975 = newValue}
   }
@@ -19816,7 +19816,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong975 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976 = newValue}
   }
@@ -19827,7 +19827,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong976 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977 = newValue}
   }
@@ -19838,7 +19838,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong977 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978 = newValue}
   }
@@ -19849,7 +19849,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong978 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979 = newValue}
   }
@@ -19860,7 +19860,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong979 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980 = newValue}
   }
@@ -19871,7 +19871,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong980 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981 = newValue}
   }
@@ -19882,7 +19882,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong981 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982 = newValue}
   }
@@ -19893,7 +19893,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong982 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983 = newValue}
   }
@@ -19904,7 +19904,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong983 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984 = newValue}
   }
@@ -19915,7 +19915,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong984 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985 = newValue}
   }
@@ -19926,7 +19926,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong985 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986 = newValue}
   }
@@ -19937,7 +19937,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong986 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987 = newValue}
   }
@@ -19948,7 +19948,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong987 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988 = newValue}
   }
@@ -19959,7 +19959,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong988 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989 = newValue}
   }
@@ -19970,7 +19970,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong989 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990 = newValue}
   }
@@ -19981,7 +19981,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong990 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991 = newValue}
   }
@@ -19992,7 +19992,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong991 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992 = newValue}
   }
@@ -20003,7 +20003,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong992 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993 = newValue}
   }
@@ -20014,7 +20014,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong993 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994 = newValue}
   }
@@ -20025,7 +20025,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong994 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995 = newValue}
   }
@@ -20036,7 +20036,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong995 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996 = newValue}
   }
@@ -20047,7 +20047,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong996 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997 = newValue}
   }
@@ -20058,7 +20058,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong997 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998 = newValue}
   }
@@ -20069,7 +20069,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong998 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999 = newValue}
   }
@@ -20080,7 +20080,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong999 = nil
   }
 
-  public var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000: String {
+  var longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000: String {
     get {return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000 ?? "long default value is also loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}
     set {_uniqueStorage()._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000 = newValue}
   }
@@ -20091,7 +20091,7 @@ struct Google_Protobuf_TestEnormousDescriptor: ProtobufGeneratedMessage, Protobu
     return _storage._longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1000 = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/google/protobuf/unittest_import.pb.swift
+++ b/Reference/google/protobuf/unittest_import.pb.swift
@@ -47,16 +47,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case importFoo // = 7
   case importBar // = 8
   case importBaz // = 9
 
-  public init() {
+  init() {
     self = .importFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 7: self = .importFoo
     case 8: self = .importBar
@@ -65,7 +65,7 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "importFoo": self = .importFoo
     case "importBar": self = .importBar
@@ -74,7 +74,7 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "IMPORT_FOO": self = .importFoo
     case "IMPORT_BAR": self = .importBar
@@ -83,7 +83,7 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "IMPORT_FOO": self = .importFoo
     case "IMPORT_BAR": self = .importBar
@@ -92,7 +92,7 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .importFoo: return 7
@@ -102,7 +102,7 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .importFoo: return "\"IMPORT_FOO\""
@@ -112,9 +112,9 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .importFoo: return ".importFoo"
@@ -128,16 +128,16 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
 
 ///   To use an enum in a map, it must has the first value as 0.
 enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case unknown // = 0
   case foo // = 1
   case bar // = 2
 
-  public init() {
+  init() {
     self = .unknown
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .unknown
     case 1: self = .foo
@@ -146,7 +146,7 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "unknown": self = .unknown
     case "foo": self = .foo
@@ -155,7 +155,7 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "UNKNOWN": self = .unknown
     case "FOO": self = .foo
@@ -164,7 +164,7 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "UNKNOWN": self = .unknown
     case "FOO": self = .foo
@@ -173,7 +173,7 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .unknown: return 0
@@ -183,7 +183,7 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .unknown: return "\"UNKNOWN\""
@@ -193,9 +193,9 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .unknown: return ".unknown"
@@ -221,7 +221,7 @@ struct ProtobufUnittestImport_ImportMessage: ProtobufGeneratedMessage, ProtobufP
   public var unknown = ProtobufUnknownStorage()
 
   private var _d: Int32? = nil
-  public var d: Int32 {
+  var d: Int32 {
     get {return _d ?? 0}
     set {_d = newValue}
   }
@@ -232,7 +232,7 @@ struct ProtobufUnittestImport_ImportMessage: ProtobufGeneratedMessage, ProtobufP
     return _d = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_import_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_import_lite.pb.swift
@@ -45,16 +45,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case importLiteFoo // = 7
   case importLiteBar // = 8
   case importLiteBaz // = 9
 
-  public init() {
+  init() {
     self = .importLiteFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 7: self = .importLiteFoo
     case 8: self = .importLiteBar
@@ -63,7 +63,7 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "importLiteFoo": self = .importLiteFoo
     case "importLiteBar": self = .importLiteBar
@@ -72,7 +72,7 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "IMPORT_LITE_FOO": self = .importLiteFoo
     case "IMPORT_LITE_BAR": self = .importLiteBar
@@ -81,7 +81,7 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "IMPORT_LITE_FOO": self = .importLiteFoo
     case "IMPORT_LITE_BAR": self = .importLiteBar
@@ -90,7 +90,7 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .importLiteFoo: return 7
@@ -100,7 +100,7 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .importLiteFoo: return "\"IMPORT_LITE_FOO\""
@@ -110,9 +110,9 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .importLiteFoo: return ".importLiteFoo"
@@ -138,7 +138,7 @@ struct ProtobufUnittestImport_ImportMessageLite: ProtobufGeneratedMessage, Proto
   public var unknown = ProtobufUnknownStorage()
 
   private var _d: Int32? = nil
-  public var d: Int32 {
+  var d: Int32 {
     get {return _d ?? 0}
     set {_d = newValue}
   }
@@ -149,7 +149,7 @@ struct ProtobufUnittestImport_ImportMessageLite: ProtobufGeneratedMessage, Proto
     return _d = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_import_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_import_proto3.pb.swift
@@ -47,18 +47,18 @@ import SwiftProtobuf
 
 
 enum Proto3ImportEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case importEnumUnspecified // = 0
   case importFoo // = 7
   case importBar // = 8
   case importBaz // = 9
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .importEnumUnspecified
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .importEnumUnspecified
     case 7: self = .importFoo
@@ -68,7 +68,7 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "importEnumUnspecified": self = .importEnumUnspecified
     case "importFoo": self = .importFoo
@@ -78,7 +78,7 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "IMPORT_ENUM_UNSPECIFIED": self = .importEnumUnspecified
     case "IMPORT_FOO": self = .importFoo
@@ -88,7 +88,7 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "IMPORT_ENUM_UNSPECIFIED": self = .importEnumUnspecified
     case "IMPORT_FOO": self = .importFoo
@@ -98,7 +98,7 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .importEnumUnspecified: return 0
@@ -110,7 +110,7 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .importEnumUnspecified: return "\"IMPORT_ENUM_UNSPECIFIED\""
@@ -122,9 +122,9 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .importEnumUnspecified: return ".importEnumUnspecified"
@@ -150,9 +150,9 @@ struct Proto3ImportMessage: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var d: Int32 = 0
+  var d: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_import_public.pb.swift
+++ b/Reference/google/protobuf/unittest_import_public.pb.swift
@@ -56,7 +56,7 @@ struct ProtobufUnittestImport_PublicImportMessage: ProtobufGeneratedMessage, Pro
   public var unknown = ProtobufUnknownStorage()
 
   private var _e: Int32? = nil
-  public var e: Int32 {
+  var e: Int32 {
     get {return _e ?? 0}
     set {_e = newValue}
   }
@@ -67,7 +67,7 @@ struct ProtobufUnittestImport_PublicImportMessage: ProtobufGeneratedMessage, Pro
     return _e = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_import_public_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_import_public_lite.pb.swift
@@ -56,7 +56,7 @@ struct ProtobufUnittestImport_PublicImportMessageLite: ProtobufGeneratedMessage,
   public var unknown = ProtobufUnknownStorage()
 
   private var _e: Int32? = nil
-  public var e: Int32 {
+  var e: Int32 {
     get {return _e ?? 0}
     set {_e = newValue}
   }
@@ -67,7 +67,7 @@ struct ProtobufUnittestImport_PublicImportMessageLite: ProtobufGeneratedMessage,
     return _e = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_import_public_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_import_public_proto3.pb.swift
@@ -54,9 +54,9 @@ struct Proto3PublicImportMessage: ProtobufGeneratedMessage, ProtobufProto3Messag
   ]}
 
 
-  public var e: Int32 = 0
+  var e: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -45,16 +45,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignLiteFoo // = 4
   case foreignLiteBar // = 5
   case foreignLiteBaz // = 6
 
-  public init() {
+  init() {
     self = .foreignLiteFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 4: self = .foreignLiteFoo
     case 5: self = .foreignLiteBar
@@ -63,7 +63,7 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignLiteFoo": self = .foreignLiteFoo
     case "foreignLiteBar": self = .foreignLiteBar
@@ -72,7 +72,7 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_LITE_FOO": self = .foreignLiteFoo
     case "FOREIGN_LITE_BAR": self = .foreignLiteBar
@@ -81,7 +81,7 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_LITE_FOO": self = .foreignLiteFoo
     case "FOREIGN_LITE_BAR": self = .foreignLiteBar
@@ -90,7 +90,7 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignLiteFoo: return 4
@@ -100,7 +100,7 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignLiteFoo: return "\"FOREIGN_LITE_FOO\""
@@ -110,9 +110,9 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignLiteFoo: return ".foreignLiteFoo"
@@ -125,42 +125,42 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
 }
 
 enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case v1First // = 1
 
-  public init() {
+  init() {
     self = .v1First
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .v1First
     default: return nil
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "v1First": self = .v1First
     default: return nil
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "V1_FIRST": self = .v1First
     default: return nil
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "V1_FIRST": self = .v1First
     default: return nil
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .v1First: return 1
@@ -168,7 +168,7 @@ enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .v1First: return "\"V1_FIRST\""
@@ -176,9 +176,9 @@ enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .v1First: return ".v1First"
@@ -189,15 +189,15 @@ enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
 }
 
 enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case v2First // = 1
   case v2Second // = 2
 
-  public init() {
+  init() {
     self = .v2First
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .v2First
     case 2: self = .v2Second
@@ -205,7 +205,7 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "v2First": self = .v2First
     case "v2Second": self = .v2Second
@@ -213,7 +213,7 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "V2_FIRST": self = .v2First
     case "V2_SECOND": self = .v2Second
@@ -221,7 +221,7 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "V2_FIRST": self = .v2First
     case "V2_SECOND": self = .v2Second
@@ -229,7 +229,7 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .v2First: return 1
@@ -238,7 +238,7 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .v2First: return "\"V2_FIRST\""
@@ -247,9 +247,9 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .v2First: return ".v2First"
@@ -1044,16 +1044,16 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       case 2: self = .bar
@@ -1062,7 +1062,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -1071,7 +1071,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1080,7 +1080,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1089,7 +1089,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -1099,7 +1099,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -1109,9 +1109,9 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1139,7 +1139,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     public var unknown = ProtobufUnknownStorage()
 
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -1151,7 +1151,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
 
     private var _cc: Int64? = nil
-    public var cc: Int64 {
+    var cc: Int64 {
       get {return _cc ?? 0}
       set {_cc = newValue}
     }
@@ -1162,7 +1162,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       return _cc = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1204,7 +1204,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1215,7 +1215,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1252,7 +1252,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1263,7 +1263,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1287,7 +1287,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
@@ -1298,7 +1298,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalInt32 = nil
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64 ?? 0}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
@@ -1309,7 +1309,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalInt64 = nil
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32 ?? 0}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
@@ -1320,7 +1320,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalUint32 = nil
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64 ?? 0}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
@@ -1331,7 +1331,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalUint64 = nil
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32 ?? 0}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
@@ -1342,7 +1342,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalSint32 = nil
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64 ?? 0}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
@@ -1353,7 +1353,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalSint64 = nil
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32 ?? 0}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
@@ -1364,7 +1364,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalFixed32 = nil
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64 ?? 0}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
@@ -1375,7 +1375,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalFixed64 = nil
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32 ?? 0}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
@@ -1386,7 +1386,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalSfixed32 = nil
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64 ?? 0}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
@@ -1397,7 +1397,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalSfixed64 = nil
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat ?? 0}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
@@ -1408,7 +1408,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalFloat = nil
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble ?? 0}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
@@ -1419,7 +1419,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalDouble = nil
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool ?? false}
     set {_uniqueStorage()._optionalBool = newValue}
   }
@@ -1430,7 +1430,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalBool = nil
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString ?? ""}
     set {_uniqueStorage()._optionalString = newValue}
   }
@@ -1441,7 +1441,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalString = nil
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes ?? Data()}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -1452,7 +1452,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalBytes = nil
   }
 
-  public var optionalGroup: ProtobufUnittest_TestAllTypesLite.OptionalGroup {
+  var optionalGroup: ProtobufUnittest_TestAllTypesLite.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittest_TestAllTypesLite.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -1463,7 +1463,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalGroup = nil
   }
 
-  public var optionalNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var optionalNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -1474,7 +1474,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: ProtobufUnittest_ForeignMessageLite {
+  var optionalForeignMessage: ProtobufUnittest_ForeignMessageLite {
     get {return _storage._optionalForeignMessage ?? ProtobufUnittest_ForeignMessageLite()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -1485,7 +1485,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalImportMessage: ProtobufUnittestImport_ImportMessageLite {
+  var optionalImportMessage: ProtobufUnittestImport_ImportMessageLite {
     get {return _storage._optionalImportMessage ?? ProtobufUnittestImport_ImportMessageLite()}
     set {_uniqueStorage()._optionalImportMessage = newValue}
   }
@@ -1496,7 +1496,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalImportMessage = nil
   }
 
-  public var optionalNestedEnum: ProtobufUnittest_TestAllTypesLite.NestedEnum {
+  var optionalNestedEnum: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return _storage._optionalNestedEnum ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.foo}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
@@ -1507,7 +1507,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalNestedEnum = nil
   }
 
-  public var optionalForeignEnum: ProtobufUnittest_ForeignEnumLite {
+  var optionalForeignEnum: ProtobufUnittest_ForeignEnumLite {
     get {return _storage._optionalForeignEnum ?? ProtobufUnittest_ForeignEnumLite.foreignLiteFoo}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
@@ -1518,7 +1518,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalForeignEnum = nil
   }
 
-  public var optionalImportEnum: ProtobufUnittestImport_ImportEnumLite {
+  var optionalImportEnum: ProtobufUnittestImport_ImportEnumLite {
     get {return _storage._optionalImportEnum ?? ProtobufUnittestImport_ImportEnumLite.importLiteFoo}
     set {_uniqueStorage()._optionalImportEnum = newValue}
   }
@@ -1529,7 +1529,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalImportEnum = nil
   }
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece ?? ""}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
@@ -1540,7 +1540,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalStringPiece = nil
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord ?? ""}
     set {_uniqueStorage()._optionalCord = newValue}
   }
@@ -1552,7 +1552,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
   }
 
   ///   Defined in unittest_import_public.proto
-  public var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessageLite {
+  var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessageLite {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessageLite()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
   }
@@ -1563,7 +1563,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalPublicImportMessage = nil
   }
 
-  public var optionalLazyMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var optionalLazyMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return _storage._optionalLazyMessage ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {_uniqueStorage()._optionalLazyMessage = newValue}
   }
@@ -1575,133 +1575,133 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedGroup: [ProtobufUnittest_TestAllTypesLite.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittest_TestAllTypesLite.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public var repeatedNestedMessage: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
+  var repeatedNestedMessage: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [ProtobufUnittest_ForeignMessageLite] {
+  var repeatedForeignMessage: [ProtobufUnittest_ForeignMessageLite] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [ProtobufUnittestImport_ImportMessageLite] {
+  var repeatedImportMessage: [ProtobufUnittestImport_ImportMessageLite] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
+  var repeatedNestedEnum: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [ProtobufUnittest_ForeignEnumLite] {
+  var repeatedForeignEnum: [ProtobufUnittest_ForeignEnumLite] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedImportEnum: [ProtobufUnittestImport_ImportEnumLite] {
+  var repeatedImportEnum: [ProtobufUnittestImport_ImportEnumLite] {
     get {return _storage._repeatedImportEnum}
     set {_uniqueStorage()._repeatedImportEnum = newValue}
   }
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
+  var repeatedLazyMessage: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
   ///   Singular with defaults
-  public var defaultInt32: Int32 {
+  var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
   }
@@ -1712,7 +1712,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultInt32 = nil
   }
 
-  public var defaultInt64: Int64 {
+  var defaultInt64: Int64 {
     get {return _storage._defaultInt64 ?? 42}
     set {_uniqueStorage()._defaultInt64 = newValue}
   }
@@ -1723,7 +1723,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultInt64 = nil
   }
 
-  public var defaultUint32: UInt32 {
+  var defaultUint32: UInt32 {
     get {return _storage._defaultUint32 ?? 43}
     set {_uniqueStorage()._defaultUint32 = newValue}
   }
@@ -1734,7 +1734,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultUint32 = nil
   }
 
-  public var defaultUint64: UInt64 {
+  var defaultUint64: UInt64 {
     get {return _storage._defaultUint64 ?? 44}
     set {_uniqueStorage()._defaultUint64 = newValue}
   }
@@ -1745,7 +1745,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultUint64 = nil
   }
 
-  public var defaultSint32: Int32 {
+  var defaultSint32: Int32 {
     get {return _storage._defaultSint32 ?? -45}
     set {_uniqueStorage()._defaultSint32 = newValue}
   }
@@ -1756,7 +1756,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultSint32 = nil
   }
 
-  public var defaultSint64: Int64 {
+  var defaultSint64: Int64 {
     get {return _storage._defaultSint64 ?? 46}
     set {_uniqueStorage()._defaultSint64 = newValue}
   }
@@ -1767,7 +1767,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultSint64 = nil
   }
 
-  public var defaultFixed32: UInt32 {
+  var defaultFixed32: UInt32 {
     get {return _storage._defaultFixed32 ?? 47}
     set {_uniqueStorage()._defaultFixed32 = newValue}
   }
@@ -1778,7 +1778,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultFixed32 = nil
   }
 
-  public var defaultFixed64: UInt64 {
+  var defaultFixed64: UInt64 {
     get {return _storage._defaultFixed64 ?? 48}
     set {_uniqueStorage()._defaultFixed64 = newValue}
   }
@@ -1789,7 +1789,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultFixed64 = nil
   }
 
-  public var defaultSfixed32: Int32 {
+  var defaultSfixed32: Int32 {
     get {return _storage._defaultSfixed32 ?? 49}
     set {_uniqueStorage()._defaultSfixed32 = newValue}
   }
@@ -1800,7 +1800,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultSfixed32 = nil
   }
 
-  public var defaultSfixed64: Int64 {
+  var defaultSfixed64: Int64 {
     get {return _storage._defaultSfixed64 ?? -50}
     set {_uniqueStorage()._defaultSfixed64 = newValue}
   }
@@ -1811,7 +1811,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultSfixed64 = nil
   }
 
-  public var defaultFloat: Float {
+  var defaultFloat: Float {
     get {return _storage._defaultFloat ?? 51.5}
     set {_uniqueStorage()._defaultFloat = newValue}
   }
@@ -1822,7 +1822,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultFloat = nil
   }
 
-  public var defaultDouble: Double {
+  var defaultDouble: Double {
     get {return _storage._defaultDouble ?? 52000}
     set {_uniqueStorage()._defaultDouble = newValue}
   }
@@ -1833,7 +1833,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultDouble = nil
   }
 
-  public var defaultBool: Bool {
+  var defaultBool: Bool {
     get {return _storage._defaultBool ?? true}
     set {_uniqueStorage()._defaultBool = newValue}
   }
@@ -1844,7 +1844,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultBool = nil
   }
 
-  public var defaultString: String {
+  var defaultString: String {
     get {return _storage._defaultString ?? "hello"}
     set {_uniqueStorage()._defaultString = newValue}
   }
@@ -1855,7 +1855,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultString = nil
   }
 
-  public var defaultBytes: Data {
+  var defaultBytes: Data {
     get {return _storage._defaultBytes ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {_uniqueStorage()._defaultBytes = newValue}
   }
@@ -1866,7 +1866,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultBytes = nil
   }
 
-  public var defaultNestedEnum: ProtobufUnittest_TestAllTypesLite.NestedEnum {
+  var defaultNestedEnum: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return _storage._defaultNestedEnum ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.bar}
     set {_uniqueStorage()._defaultNestedEnum = newValue}
   }
@@ -1877,7 +1877,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultNestedEnum = nil
   }
 
-  public var defaultForeignEnum: ProtobufUnittest_ForeignEnumLite {
+  var defaultForeignEnum: ProtobufUnittest_ForeignEnumLite {
     get {return _storage._defaultForeignEnum ?? ProtobufUnittest_ForeignEnumLite.foreignLiteBar}
     set {_uniqueStorage()._defaultForeignEnum = newValue}
   }
@@ -1888,7 +1888,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultForeignEnum = nil
   }
 
-  public var defaultImportEnum: ProtobufUnittestImport_ImportEnumLite {
+  var defaultImportEnum: ProtobufUnittestImport_ImportEnumLite {
     get {return _storage._defaultImportEnum ?? ProtobufUnittestImport_ImportEnumLite.importLiteBar}
     set {_uniqueStorage()._defaultImportEnum = newValue}
   }
@@ -1899,7 +1899,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultImportEnum = nil
   }
 
-  public var defaultStringPiece: String {
+  var defaultStringPiece: String {
     get {return _storage._defaultStringPiece ?? "abc"}
     set {_uniqueStorage()._defaultStringPiece = newValue}
   }
@@ -1910,7 +1910,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultStringPiece = nil
   }
 
-  public var defaultCord: String {
+  var defaultCord: String {
     get {return _storage._defaultCord ?? "123"}
     set {_uniqueStorage()._defaultCord = newValue}
   }
@@ -1921,7 +1921,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultCord = nil
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1933,7 +1933,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var oneofNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1945,7 +1945,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1957,7 +1957,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1969,7 +1969,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofLazyNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var oneofLazyNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
       if case .oneofLazyNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1988,7 +1988,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2024,7 +2024,7 @@ struct ProtobufUnittest_ForeignMessageLite: ProtobufGeneratedMessage, ProtobufPr
   public var unknown = ProtobufUnknownStorage()
 
   private var _c: Int32? = nil
-  public var c: Int32 {
+  var c: Int32 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -2035,7 +2035,7 @@ struct ProtobufUnittest_ForeignMessageLite: ProtobufGeneratedMessage, ProtobufPr
     return _c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2097,35 +2097,35 @@ struct ProtobufUnittest_TestPackedTypesLite: ProtobufGeneratedMessage, ProtobufP
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var packedInt32: [Int32] = []
+  var packedInt32: [Int32] = []
 
-  public var packedInt64: [Int64] = []
+  var packedInt64: [Int64] = []
 
-  public var packedUint32: [UInt32] = []
+  var packedUint32: [UInt32] = []
 
-  public var packedUint64: [UInt64] = []
+  var packedUint64: [UInt64] = []
 
-  public var packedSint32: [Int32] = []
+  var packedSint32: [Int32] = []
 
-  public var packedSint64: [Int64] = []
+  var packedSint64: [Int64] = []
 
-  public var packedFixed32: [UInt32] = []
+  var packedFixed32: [UInt32] = []
 
-  public var packedFixed64: [UInt64] = []
+  var packedFixed64: [UInt64] = []
 
-  public var packedSfixed32: [Int32] = []
+  var packedSfixed32: [Int32] = []
 
-  public var packedSfixed64: [Int64] = []
+  var packedSfixed64: [Int64] = []
 
-  public var packedFloat: [Float] = []
+  var packedFloat: [Float] = []
 
-  public var packedDouble: [Double] = []
+  var packedDouble: [Double] = []
 
-  public var packedBool: [Bool] = []
+  var packedBool: [Bool] = []
 
-  public var packedEnum: [ProtobufUnittest_ForeignEnumLite] = []
+  var packedEnum: [ProtobufUnittest_ForeignEnumLite] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2222,7 +2222,7 @@ struct ProtobufUnittest_TestAllExtensionsLite: ProtobufGeneratedMessage, Protobu
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -2277,7 +2277,7 @@ struct ProtobufUnittest_OptionalGroup_extension_lite: ProtobufGeneratedMessage, 
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -2288,7 +2288,7 @@ struct ProtobufUnittest_OptionalGroup_extension_lite: ProtobufGeneratedMessage, 
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2325,7 +2325,7 @@ struct ProtobufUnittest_RepeatedGroup_extension_lite: ProtobufGeneratedMessage, 
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -2336,7 +2336,7 @@ struct ProtobufUnittest_RepeatedGroup_extension_lite: ProtobufGeneratedMessage, 
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2368,7 +2368,7 @@ struct ProtobufUnittest_TestPackedExtensionsLite: ProtobufGeneratedMessage, Prot
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -2423,7 +2423,7 @@ struct ProtobufUnittest_TestNestedExtensionLite: ProtobufGeneratedMessage, Proto
     static let ProtobufUnittest_TestAllExtensionsLite_nestedExtension = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(protoFieldNumber: 12345, protoFieldName: "nested_extension", jsonFieldName: "nestedExtension", swiftFieldName: "ProtobufUnittest_TestNestedExtensionLite_nestedExtension", defaultValue: 0)
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -2454,7 +2454,7 @@ struct ProtobufUnittest_TestDeprecatedLite: ProtobufGeneratedMessage, ProtobufPr
   public var unknown = ProtobufUnknownStorage()
 
   private var _deprecatedField: Int32? = nil
-  public var deprecatedField: Int32 {
+  var deprecatedField: Int32 {
     get {return _deprecatedField ?? 0}
     set {_deprecatedField = newValue}
   }
@@ -2465,7 +2465,7 @@ struct ProtobufUnittest_TestDeprecatedLite: ProtobufGeneratedMessage, ProtobufPr
     return _deprecatedField = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2662,7 +2662,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
         set {_storage.unknown = newValue}
       }
 
-      public var field1: ProtobufUnittest_TestAllTypesLite {
+      var field1: ProtobufUnittest_TestAllTypesLite {
         get {return _storage._field1 ?? ProtobufUnittest_TestAllTypesLite()}
         set {_uniqueStorage()._field1 = newValue}
       }
@@ -2673,7 +2673,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
         return _storage._field1 = nil
       }
 
-      public init() {}
+      init() {}
 
       public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
         try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2748,7 +2748,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
         set {_storage.unknown = newValue}
       }
 
-      public var field1: ProtobufUnittest_TestAllTypesLite {
+      var field1: ProtobufUnittest_TestAllTypesLite {
         get {return _storage._field1 ?? ProtobufUnittest_TestAllTypesLite()}
         set {_uniqueStorage()._field1 = newValue}
       }
@@ -2759,7 +2759,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
         return _storage._field1 = nil
       }
 
-      public init() {}
+      init() {}
 
       public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
         try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2781,21 +2781,21 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var field1: [ProtobufUnittest_TestAllTypesLite] = []
+    var field1: [ProtobufUnittest_TestAllTypesLite] = []
 
-    public var field2: [ProtobufUnittest_TestAllTypesLite] = []
+    var field2: [ProtobufUnittest_TestAllTypesLite] = []
 
-    public var field3: [ProtobufUnittest_TestAllTypesLite] = []
+    var field3: [ProtobufUnittest_TestAllTypesLite] = []
 
-    public var group1: [ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1] = []
+    var group1: [ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1] = []
 
-    public var group2: [ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2] = []
+    var group2: [ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2] = []
 
-    public var ext1: [ProtobufUnittest_TestAllTypesLite] = []
+    var ext1: [ProtobufUnittest_TestAllTypesLite] = []
 
-    public var ext2: [ProtobufUnittest_TestAllTypesLite] = []
+    var ext2: [ProtobufUnittest_TestAllTypesLite] = []
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -2901,7 +2901,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
       set {_storage.unknown = newValue}
     }
 
-    public var optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
+    var optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
       get {return _storage._optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
       set {_uniqueStorage()._optionalGroupAllTypes = newValue}
     }
@@ -2912,7 +2912,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
       return _storage._optionalGroupAllTypes = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2987,7 +2987,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
       set {_storage.unknown = newValue}
     }
 
-    public var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
+    var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
       get {return _storage._repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
       set {_uniqueStorage()._repeatedGroupAllTypes = newValue}
     }
@@ -2998,7 +2998,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
       return _storage._repeatedGroupAllTypes = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3027,7 +3027,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
     static let ProtobufUnittest_TestParsingMergeLite_repeatedExt = ProtobufGenericMessageExtension<ProtobufRepeatedMessageField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(protoFieldNumber: 1001, protoFieldName: "repeated_ext", jsonFieldName: "repeatedExt", swiftFieldName: "ProtobufUnittest_TestParsingMergeLite_repeatedExt", defaultValue: [])
   }
 
-  public var requiredAllTypes: ProtobufUnittest_TestAllTypesLite {
+  var requiredAllTypes: ProtobufUnittest_TestAllTypesLite {
     get {return _storage._requiredAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
     set {_uniqueStorage()._requiredAllTypes = newValue}
   }
@@ -3038,7 +3038,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredAllTypes = nil
   }
 
-  public var optionalAllTypes: ProtobufUnittest_TestAllTypesLite {
+  var optionalAllTypes: ProtobufUnittest_TestAllTypesLite {
     get {return _storage._optionalAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
     set {_uniqueStorage()._optionalAllTypes = newValue}
   }
@@ -3049,12 +3049,12 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
     return _storage._optionalAllTypes = nil
   }
 
-  public var repeatedAllTypes: [ProtobufUnittest_TestAllTypesLite] {
+  var repeatedAllTypes: [ProtobufUnittest_TestAllTypesLite] {
     get {return _storage._repeatedAllTypes}
     set {_uniqueStorage()._repeatedAllTypes = newValue}
   }
 
-  public var optionalGroup: ProtobufUnittest_TestParsingMergeLite.OptionalGroup {
+  var optionalGroup: ProtobufUnittest_TestParsingMergeLite.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittest_TestParsingMergeLite.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -3065,12 +3065,12 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
     return _storage._optionalGroup = nil
   }
 
-  public var repeatedGroup: [ProtobufUnittest_TestParsingMergeLite.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittest_TestParsingMergeLite.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3118,7 +3118,7 @@ struct ProtobufUnittest_TestEmptyMessageLite: ProtobufGeneratedMessage, Protobuf
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3144,7 +3144,7 @@ struct ProtobufUnittest_TestEmptyMessageWithExtensionsLite: ProtobufGeneratedMes
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -3201,7 +3201,7 @@ struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   private var _intField: Int32? = nil
-  public var intField: Int32 {
+  var intField: Int32 {
     get {return _intField ?? 0}
     set {_intField = newValue}
   }
@@ -3213,7 +3213,7 @@ struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   private var _enumField: ProtobufUnittest_V1EnumLite? = nil
-  public var enumField: ProtobufUnittest_V1EnumLite {
+  var enumField: ProtobufUnittest_V1EnumLite {
     get {return _enumField ?? ProtobufUnittest_V1EnumLite.v1First}
     set {_enumField = newValue}
   }
@@ -3224,7 +3224,7 @@ struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
     return _enumField = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3266,7 +3266,7 @@ struct ProtobufUnittest_V2MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   private var _intField: Int32? = nil
-  public var intField: Int32 {
+  var intField: Int32 {
     get {return _intField ?? 0}
     set {_intField = newValue}
   }
@@ -3278,7 +3278,7 @@ struct ProtobufUnittest_V2MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   private var _enumField: ProtobufUnittest_V2EnumLite? = nil
-  public var enumField: ProtobufUnittest_V2EnumLite {
+  var enumField: ProtobufUnittest_V2EnumLite {
     get {return _enumField ?? ProtobufUnittest_V2EnumLite.v2First}
     set {_enumField = newValue}
   }
@@ -3289,7 +3289,7 @@ struct ProtobufUnittest_V2MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
     return _enumField = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_lite_imports_nonlite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite_imports_nonlite.pb.swift
@@ -97,7 +97,7 @@ struct ProtobufUnittest_TestLiteImportsNonlite: ProtobufGeneratedMessage, Protob
     set {_storage.unknown = newValue}
   }
 
-  public var message: ProtobufUnittest_TestAllTypes {
+  var message: ProtobufUnittest_TestAllTypes {
     get {return _storage._message ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._message = newValue}
   }
@@ -108,7 +108,7 @@ struct ProtobufUnittest_TestLiteImportsNonlite: ProtobufGeneratedMessage, Protob
     return _storage._message = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -100,7 +100,7 @@ struct ProtobufUnittest_TestMessageSetContainer: ProtobufGeneratedMessage, Proto
     set {_storage.unknown = newValue}
   }
 
-  public var messageSet: Proto2WireformatUnittest_TestMessageSet {
+  var messageSet: Proto2WireformatUnittest_TestMessageSet {
     get {return _storage._messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
     set {_uniqueStorage()._messageSet = newValue}
   }
@@ -111,7 +111,7 @@ struct ProtobufUnittest_TestMessageSetContainer: ProtobufGeneratedMessage, Proto
     return _storage._messageSet = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -152,7 +152,7 @@ struct ProtobufUnittest_TestMessageSetExtension1: ProtobufGeneratedMessage, Prot
   }
 
   private var _i: Int32? = nil
-  public var i: Int32 {
+  var i: Int32 {
     get {return _i ?? 0}
     set {_i = newValue}
   }
@@ -163,7 +163,7 @@ struct ProtobufUnittest_TestMessageSetExtension1: ProtobufGeneratedMessage, Prot
     return _i = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -205,7 +205,7 @@ struct ProtobufUnittest_TestMessageSetExtension2: ProtobufGeneratedMessage, Prot
   }
 
   private var _str: String? = nil
-  public var str: String {
+  var str: String {
     get {return _str ?? ""}
     set {_str = newValue}
   }
@@ -216,7 +216,7 @@ struct ProtobufUnittest_TestMessageSetExtension2: ProtobufGeneratedMessage, Prot
     return _str = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -280,7 +280,7 @@ struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage, ProtobufProto2M
     public var unknown = ProtobufUnknownStorage()
 
     private var _typeId: Int32? = nil
-    public var typeId: Int32 {
+    var typeId: Int32 {
       get {return _typeId ?? 0}
       set {_typeId = newValue}
     }
@@ -292,7 +292,7 @@ struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage, ProtobufProto2M
     }
 
     private var _message: Data? = nil
-    public var message: Data {
+    var message: Data {
       get {return _message ?? Data()}
       set {_message = newValue}
     }
@@ -303,7 +303,7 @@ struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage, ProtobufProto2M
       return _message = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -327,9 +327,9 @@ struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage, ProtobufProto2M
     }
   }
 
-  public var item: [ProtobufUnittest_RawMessageSet.Item] = []
+  var item: [ProtobufUnittest_RawMessageSet.Item] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_mset_wire_format.pb.swift
+++ b/Reference/google/protobuf/unittest_mset_wire_format.pb.swift
@@ -56,7 +56,7 @@ struct Proto2WireformatUnittest_TestMessageSet: ProtobufGeneratedMessage, Protob
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (4 <= protoFieldNumber && protoFieldNumber < 2147483647) {
@@ -150,7 +150,7 @@ struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer: ProtobufGener
     set {_storage.unknown = newValue}
   }
 
-  public var messageSet: Proto2WireformatUnittest_TestMessageSet {
+  var messageSet: Proto2WireformatUnittest_TestMessageSet {
     get {return _storage._messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
     set {_uniqueStorage()._messageSet = newValue}
   }
@@ -161,7 +161,7 @@ struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer: ProtobufGener
     return _storage._messageSet = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -49,16 +49,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
 
-  public init() {
+  init() {
     self = .foreignFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 4: self = .foreignFoo
     case 5: self = .foreignBar
@@ -67,7 +67,7 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignFoo": self = .foreignFoo
     case "foreignBar": self = .foreignBar
@@ -76,7 +76,7 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -85,7 +85,7 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -94,7 +94,7 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignFoo: return 4
@@ -104,7 +104,7 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignFoo: return "\"FOREIGN_FOO\""
@@ -114,9 +114,9 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignFoo: return ".foreignFoo"
@@ -913,7 +913,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
@@ -921,11 +921,11 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     ///   Intentionally negative.
     case neg // = -1
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       case 2: self = .bar
@@ -935,7 +935,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -945,7 +945,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -955,7 +955,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -965,7 +965,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -976,7 +976,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -987,9 +987,9 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1019,7 +1019,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -1030,7 +1030,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       return _bb = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1067,7 +1067,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1078,7 +1078,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1115,7 +1115,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1126,7 +1126,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1150,7 +1150,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
@@ -1161,7 +1161,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalInt32 = nil
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64 ?? 0}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
@@ -1172,7 +1172,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalInt64 = nil
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32 ?? 0}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
@@ -1183,7 +1183,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalUint32 = nil
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64 ?? 0}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
@@ -1194,7 +1194,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalUint64 = nil
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32 ?? 0}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
@@ -1205,7 +1205,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalSint32 = nil
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64 ?? 0}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
@@ -1216,7 +1216,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalSint64 = nil
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32 ?? 0}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
@@ -1227,7 +1227,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalFixed32 = nil
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64 ?? 0}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
@@ -1238,7 +1238,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalFixed64 = nil
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32 ?? 0}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
@@ -1249,7 +1249,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalSfixed32 = nil
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64 ?? 0}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
@@ -1260,7 +1260,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalSfixed64 = nil
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat ?? 0}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
@@ -1271,7 +1271,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalFloat = nil
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble ?? 0}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
@@ -1282,7 +1282,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalDouble = nil
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool ?? false}
     set {_uniqueStorage()._optionalBool = newValue}
   }
@@ -1293,7 +1293,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalBool = nil
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString ?? ""}
     set {_uniqueStorage()._optionalString = newValue}
   }
@@ -1304,7 +1304,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalString = nil
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes ?? Data()}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -1315,7 +1315,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalBytes = nil
   }
 
-  public var optionalGroup: ProtobufUnittestNoArena_TestAllTypes.OptionalGroup {
+  var optionalGroup: ProtobufUnittestNoArena_TestAllTypes.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittestNoArena_TestAllTypes.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -1326,7 +1326,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalGroup = nil
   }
 
-  public var optionalNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? ProtobufUnittestNoArena_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -1337,7 +1337,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: ProtobufUnittestNoArena_ForeignMessage {
+  var optionalForeignMessage: ProtobufUnittestNoArena_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? ProtobufUnittestNoArena_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -1348,7 +1348,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
+  var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
     get {return _storage._optionalImportMessage ?? ProtobufUnittestImport_ImportMessage()}
     set {_uniqueStorage()._optionalImportMessage = newValue}
   }
@@ -1359,7 +1359,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalImportMessage = nil
   }
 
-  public var optionalNestedEnum: ProtobufUnittestNoArena_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: ProtobufUnittestNoArena_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum ?? ProtobufUnittestNoArena_TestAllTypes.NestedEnum.foo}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
@@ -1370,7 +1370,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalNestedEnum = nil
   }
 
-  public var optionalForeignEnum: ProtobufUnittestNoArena_ForeignEnum {
+  var optionalForeignEnum: ProtobufUnittestNoArena_ForeignEnum {
     get {return _storage._optionalForeignEnum ?? ProtobufUnittestNoArena_ForeignEnum.foreignFoo}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
@@ -1381,7 +1381,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalForeignEnum = nil
   }
 
-  public var optionalImportEnum: ProtobufUnittestImport_ImportEnum {
+  var optionalImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._optionalImportEnum ?? ProtobufUnittestImport_ImportEnum.importFoo}
     set {_uniqueStorage()._optionalImportEnum = newValue}
   }
@@ -1392,7 +1392,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalImportEnum = nil
   }
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece ?? ""}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
@@ -1403,7 +1403,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalStringPiece = nil
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord ?? ""}
     set {_uniqueStorage()._optionalCord = newValue}
   }
@@ -1415,7 +1415,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   ///   Defined in unittest_import_public.proto
-  public var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
+  var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
   }
@@ -1426,7 +1426,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalPublicImportMessage = nil
   }
 
-  public var optionalMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
+  var optionalMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {return _storage._optionalMessage ?? ProtobufUnittestNoArena_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalMessage = newValue}
   }
@@ -1438,133 +1438,133 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedGroup: [ProtobufUnittestNoArena_TestAllTypes.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittestNoArena_TestAllTypes.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public var repeatedNestedMessage: [ProtobufUnittestNoArena_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [ProtobufUnittestNoArena_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [ProtobufUnittestNoArena_ForeignMessage] {
+  var repeatedForeignMessage: [ProtobufUnittestNoArena_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
+  var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [ProtobufUnittestNoArena_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [ProtobufUnittestNoArena_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [ProtobufUnittestNoArena_ForeignEnum] {
+  var repeatedForeignEnum: [ProtobufUnittestNoArena_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedImportEnum: [ProtobufUnittestImport_ImportEnum] {
+  var repeatedImportEnum: [ProtobufUnittestImport_ImportEnum] {
     get {return _storage._repeatedImportEnum}
     set {_uniqueStorage()._repeatedImportEnum = newValue}
   }
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [ProtobufUnittestNoArena_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessage: [ProtobufUnittestNoArena_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
   ///   Singular with defaults
-  public var defaultInt32: Int32 {
+  var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
   }
@@ -1575,7 +1575,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultInt32 = nil
   }
 
-  public var defaultInt64: Int64 {
+  var defaultInt64: Int64 {
     get {return _storage._defaultInt64 ?? 42}
     set {_uniqueStorage()._defaultInt64 = newValue}
   }
@@ -1586,7 +1586,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultInt64 = nil
   }
 
-  public var defaultUint32: UInt32 {
+  var defaultUint32: UInt32 {
     get {return _storage._defaultUint32 ?? 43}
     set {_uniqueStorage()._defaultUint32 = newValue}
   }
@@ -1597,7 +1597,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultUint32 = nil
   }
 
-  public var defaultUint64: UInt64 {
+  var defaultUint64: UInt64 {
     get {return _storage._defaultUint64 ?? 44}
     set {_uniqueStorage()._defaultUint64 = newValue}
   }
@@ -1608,7 +1608,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultUint64 = nil
   }
 
-  public var defaultSint32: Int32 {
+  var defaultSint32: Int32 {
     get {return _storage._defaultSint32 ?? -45}
     set {_uniqueStorage()._defaultSint32 = newValue}
   }
@@ -1619,7 +1619,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultSint32 = nil
   }
 
-  public var defaultSint64: Int64 {
+  var defaultSint64: Int64 {
     get {return _storage._defaultSint64 ?? 46}
     set {_uniqueStorage()._defaultSint64 = newValue}
   }
@@ -1630,7 +1630,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultSint64 = nil
   }
 
-  public var defaultFixed32: UInt32 {
+  var defaultFixed32: UInt32 {
     get {return _storage._defaultFixed32 ?? 47}
     set {_uniqueStorage()._defaultFixed32 = newValue}
   }
@@ -1641,7 +1641,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultFixed32 = nil
   }
 
-  public var defaultFixed64: UInt64 {
+  var defaultFixed64: UInt64 {
     get {return _storage._defaultFixed64 ?? 48}
     set {_uniqueStorage()._defaultFixed64 = newValue}
   }
@@ -1652,7 +1652,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultFixed64 = nil
   }
 
-  public var defaultSfixed32: Int32 {
+  var defaultSfixed32: Int32 {
     get {return _storage._defaultSfixed32 ?? 49}
     set {_uniqueStorage()._defaultSfixed32 = newValue}
   }
@@ -1663,7 +1663,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultSfixed32 = nil
   }
 
-  public var defaultSfixed64: Int64 {
+  var defaultSfixed64: Int64 {
     get {return _storage._defaultSfixed64 ?? -50}
     set {_uniqueStorage()._defaultSfixed64 = newValue}
   }
@@ -1674,7 +1674,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultSfixed64 = nil
   }
 
-  public var defaultFloat: Float {
+  var defaultFloat: Float {
     get {return _storage._defaultFloat ?? 51.5}
     set {_uniqueStorage()._defaultFloat = newValue}
   }
@@ -1685,7 +1685,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultFloat = nil
   }
 
-  public var defaultDouble: Double {
+  var defaultDouble: Double {
     get {return _storage._defaultDouble ?? 52000}
     set {_uniqueStorage()._defaultDouble = newValue}
   }
@@ -1696,7 +1696,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultDouble = nil
   }
 
-  public var defaultBool: Bool {
+  var defaultBool: Bool {
     get {return _storage._defaultBool ?? true}
     set {_uniqueStorage()._defaultBool = newValue}
   }
@@ -1707,7 +1707,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultBool = nil
   }
 
-  public var defaultString: String {
+  var defaultString: String {
     get {return _storage._defaultString ?? "hello"}
     set {_uniqueStorage()._defaultString = newValue}
   }
@@ -1718,7 +1718,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultString = nil
   }
 
-  public var defaultBytes: Data {
+  var defaultBytes: Data {
     get {return _storage._defaultBytes ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {_uniqueStorage()._defaultBytes = newValue}
   }
@@ -1729,7 +1729,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultBytes = nil
   }
 
-  public var defaultNestedEnum: ProtobufUnittestNoArena_TestAllTypes.NestedEnum {
+  var defaultNestedEnum: ProtobufUnittestNoArena_TestAllTypes.NestedEnum {
     get {return _storage._defaultNestedEnum ?? ProtobufUnittestNoArena_TestAllTypes.NestedEnum.bar}
     set {_uniqueStorage()._defaultNestedEnum = newValue}
   }
@@ -1740,7 +1740,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultNestedEnum = nil
   }
 
-  public var defaultForeignEnum: ProtobufUnittestNoArena_ForeignEnum {
+  var defaultForeignEnum: ProtobufUnittestNoArena_ForeignEnum {
     get {return _storage._defaultForeignEnum ?? ProtobufUnittestNoArena_ForeignEnum.foreignBar}
     set {_uniqueStorage()._defaultForeignEnum = newValue}
   }
@@ -1751,7 +1751,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultForeignEnum = nil
   }
 
-  public var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
+  var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._defaultImportEnum ?? ProtobufUnittestImport_ImportEnum.importBar}
     set {_uniqueStorage()._defaultImportEnum = newValue}
   }
@@ -1762,7 +1762,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultImportEnum = nil
   }
 
-  public var defaultStringPiece: String {
+  var defaultStringPiece: String {
     get {return _storage._defaultStringPiece ?? "abc"}
     set {_uniqueStorage()._defaultStringPiece = newValue}
   }
@@ -1773,7 +1773,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultStringPiece = nil
   }
 
-  public var defaultCord: String {
+  var defaultCord: String {
     get {return _storage._defaultCord ?? "123"}
     set {_uniqueStorage()._defaultCord = newValue}
   }
@@ -1784,7 +1784,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultCord = nil
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1796,7 +1796,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var oneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1808,7 +1808,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1820,7 +1820,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1832,7 +1832,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var lazyOneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
+  var lazyOneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
       if case .lazyOneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1851,7 +1851,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1889,7 +1889,7 @@ struct ProtobufUnittestNoArena_ForeignMessage: ProtobufGeneratedMessage, Protobu
   public var unknown = ProtobufUnknownStorage()
 
   private var _c: Int32? = nil
-  public var c: Int32 {
+  var c: Int32 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -1900,7 +1900,7 @@ struct ProtobufUnittestNoArena_ForeignMessage: ProtobufGeneratedMessage, Protobu
     return _c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1976,7 +1976,7 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage: ProtobufGeneratedMessage, Pro
     set {_storage.unknown = newValue}
   }
 
-  public var arenaMessage: Proto2ArenaUnittest_ArenaMessage {
+  var arenaMessage: Proto2ArenaUnittest_ArenaMessage {
     get {return _storage._arenaMessage ?? Proto2ArenaUnittest_ArenaMessage()}
     set {_uniqueStorage()._arenaMessage = newValue}
   }
@@ -1987,7 +1987,7 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage: ProtobufGeneratedMessage, Pro
     return _storage._arenaMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/google/protobuf/unittest_no_arena_import.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena_import.pb.swift
@@ -54,7 +54,7 @@ struct Proto2ArenaUnittest_ImportNoArenaNestedMessage: ProtobufGeneratedMessage,
   public var unknown = ProtobufUnknownStorage()
 
   private var _d: Int32? = nil
-  public var d: Int32 {
+  var d: Int32 {
     get {return _d ?? 0}
     set {_d = newValue}
   }
@@ -65,7 +65,7 @@ struct Proto2ArenaUnittest_ImportNoArenaNestedMessage: ProtobufGeneratedMessage,
     return _d = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_no_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena_lite.pb.swift
@@ -54,7 +54,7 @@ struct ProtobufUnittestNoArena_ForeignMessageLite: ProtobufGeneratedMessage, Pro
   public var unknown = ProtobufUnknownStorage()
 
   private var _c: Int32? = nil
-  public var c: Int32 {
+  var c: Int32 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -65,7 +65,7 @@ struct ProtobufUnittestNoArena_ForeignMessageLite: ProtobufGeneratedMessage, Pro
     return _c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -43,17 +43,17 @@ import SwiftProtobuf
 
 
 enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
   case foreignBaz // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foreignFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foreignFoo
     case 1: self = .foreignBar
@@ -62,7 +62,7 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignFoo": self = .foreignFoo
     case "foreignBar": self = .foreignBar
@@ -71,7 +71,7 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -80,7 +80,7 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -89,7 +89,7 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignFoo: return 0
@@ -100,7 +100,7 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignFoo: return "\"FOREIGN_FOO\""
@@ -111,9 +111,9 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignFoo: return ".foreignFoo"
@@ -659,17 +659,17 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -678,7 +678,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -687,7 +687,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -696,7 +696,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -705,7 +705,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -716,7 +716,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -727,9 +727,9 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -754,9 +754,9 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     ]}
 
 
-    public var bb: Int32 = 0
+    var bb: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -780,82 +780,82 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
   ///   Singular
   ///   TODO: remove 'optional' labels as soon as CL 69188077 is LGTM'd to make
   ///   'optional' optional.
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  public var optionalNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -866,7 +866,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: Proto2NofieldpresenceUnittest_ForeignMessage {
+  var optionalForeignMessage: Proto2NofieldpresenceUnittest_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? Proto2NofieldpresenceUnittest_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -877,7 +877,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalProto2Message: ProtobufUnittest_TestAllTypes {
+  var optionalProto2Message: ProtobufUnittest_TestAllTypes {
     get {return _storage._optionalProto2Message ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._optionalProto2Message = newValue}
   }
@@ -888,7 +888,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     return _storage._optionalProto2Message = nil
   }
 
-  public var optionalNestedEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
@@ -896,22 +896,22 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
   ///   N.B.: proto2-enum-type fields not allowed, because their default values
   ///   might not be zero.
   ///  optional protobuf_unittest.ForeignEnum          optional_proto2_enum     = 23;
-  public var optionalForeignEnum: Proto2NofieldpresenceUnittest_ForeignEnum {
+  var optionalForeignEnum: Proto2NofieldpresenceUnittest_ForeignEnum {
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord}
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
-  public var optionalLazyMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
+  var optionalLazyMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalLazyMessage ?? Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalLazyMessage = newValue}
   }
@@ -923,122 +923,122 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedNestedMessage: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [Proto2NofieldpresenceUnittest_ForeignMessage] {
+  var repeatedForeignMessage: [Proto2NofieldpresenceUnittest_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedProto2Message: [ProtobufUnittest_TestAllTypes] {
+  var repeatedProto2Message: [ProtobufUnittest_TestAllTypes] {
     get {return _storage._repeatedProto2Message}
     set {_uniqueStorage()._repeatedProto2Message = newValue}
   }
 
-  public var repeatedNestedEnum: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [Proto2NofieldpresenceUnittest_ForeignEnum] {
+  var repeatedForeignEnum: [Proto2NofieldpresenceUnittest_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessage: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1050,7 +1050,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     }
   }
 
-  public var oneofNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1062,7 +1062,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1074,7 +1074,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     }
   }
 
-  public var oneofEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
+  var oneofEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
     get {
       if case .oneofEnum(let v) = _storage._oneofField {
         return v
@@ -1093,7 +1093,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1160,7 +1160,7 @@ struct Proto2NofieldpresenceUnittest_TestProto2Required: ProtobufGeneratedMessag
   private var _storage = _StorageClass()
 
 
-  public var proto2: ProtobufUnittest_TestRequired {
+  var proto2: ProtobufUnittest_TestRequired {
     get {return _storage._proto2 ?? ProtobufUnittest_TestRequired()}
     set {_uniqueStorage()._proto2 = newValue}
   }
@@ -1171,7 +1171,7 @@ struct Proto2NofieldpresenceUnittest_TestProto2Required: ProtobufGeneratedMessag
     return _storage._proto2 = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1207,9 +1207,9 @@ struct Proto2NofieldpresenceUnittest_ForeignMessage: ProtobufGeneratedMessage, P
   ]}
 
 
-  public var c: Int32 = 0
+  var c: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -43,42 +43,42 @@ import SwiftProtobuf
 
 
 enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 1
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .foo
     default: return nil
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     default: return nil
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOO": self = .foo
     default: return nil
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOO": self = .foo
     default: return nil
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 1
@@ -86,7 +86,7 @@ enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"FOO\""
@@ -94,9 +94,9 @@ enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -122,7 +122,7 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: ProtobufGeneratedMessa
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -133,7 +133,7 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: ProtobufGeneratedMessa
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -181,7 +181,7 @@ struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, Protobuf
     static let ProtobufUnittest_TestOptimizedForSize_testExtension2 = ProtobufGenericMessageExtension<ProtobufOptionalMessageField<ProtobufUnittest_TestRequiredOptimizedForSize>, ProtobufUnittest_TestOptimizedForSize>(protoFieldNumber: 1235, protoFieldName: "test_extension2", jsonFieldName: "testExtension2", swiftFieldName: "ProtobufUnittest_TestOptimizedForSize_testExtension2", defaultValue: ProtobufUnittest_TestRequiredOptimizedForSize())
   }
 
-  public var i: Int32 {
+  var i: Int32 {
     get {return _storage._i ?? 0}
     set {_uniqueStorage()._i = newValue}
   }
@@ -192,7 +192,7 @@ struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, Protobuf
     return _storage._i = nil
   }
 
-  public var msg: ProtobufUnittest_ForeignMessage {
+  var msg: ProtobufUnittest_ForeignMessage {
     get {return _storage._msg ?? ProtobufUnittest_ForeignMessage()}
     set {_uniqueStorage()._msg = newValue}
   }
@@ -203,7 +203,7 @@ struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, Protobuf
     return _storage._msg = nil
   }
 
-  public var integerField: Int32 {
+  var integerField: Int32 {
     get {
       if case .integerField(let v) = _storage._foo {
         return v
@@ -215,7 +215,7 @@ struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public var stringField: String {
+  var stringField: String {
     get {
       if case .stringField(let v) = _storage._foo {
         return v
@@ -234,7 +234,7 @@ struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -286,7 +286,7 @@ struct ProtobufUnittest_TestRequiredOptimizedForSize: ProtobufGeneratedMessage, 
   public var unknown = ProtobufUnknownStorage()
 
   private var _x: Int32? = nil
-  public var x: Int32 {
+  var x: Int32 {
     get {return _x ?? 0}
     set {_x = newValue}
   }
@@ -297,7 +297,7 @@ struct ProtobufUnittest_TestRequiredOptimizedForSize: ProtobufGeneratedMessage, 
     return _x = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -371,7 +371,7 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: ProtobufGeneratedMessage, 
     set {_storage.unknown = newValue}
   }
 
-  public var o: ProtobufUnittest_TestRequiredOptimizedForSize {
+  var o: ProtobufUnittest_TestRequiredOptimizedForSize {
     get {return _storage._o ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
     set {_uniqueStorage()._o = newValue}
   }
@@ -382,7 +382,7 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: ProtobufGeneratedMessage, 
     return _storage._o = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -41,17 +41,17 @@ import SwiftProtobuf
 
 
 enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foo
     case 1: self = .bar
@@ -60,7 +60,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     case "bar": self = .bar
@@ -69,7 +69,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOO": self = .foo
     case "BAR": self = .bar
@@ -78,7 +78,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOO": self = .foo
     case "BAR": self = .bar
@@ -87,7 +87,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 0
@@ -98,7 +98,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"FOO\""
@@ -109,9 +109,9 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -125,18 +125,18 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
 }
 
 enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case eFoo // = 0
   case eBar // = 1
   case eBaz // = 2
   case eExtra // = 3
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .eFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .eFoo
     case 1: self = .eBar
@@ -146,7 +146,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "eFoo": self = .eFoo
     case "eBar": self = .eBar
@@ -156,7 +156,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "E_FOO": self = .eFoo
     case "E_BAR": self = .eBar
@@ -166,7 +166,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "E_FOO": self = .eFoo
     case "E_BAR": self = .eBar
@@ -176,7 +176,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .eFoo: return 0
@@ -188,7 +188,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .eFoo: return "\"E_FOO\""
@@ -200,9 +200,9 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .eFoo: return ".eFoo"
@@ -285,16 +285,16 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
     }
   }
 
-  public var e: Proto3PreserveUnknownEnumUnittest_MyEnum = Proto3PreserveUnknownEnumUnittest_MyEnum.foo
+  var e: Proto3PreserveUnknownEnumUnittest_MyEnum = Proto3PreserveUnknownEnumUnittest_MyEnum.foo
 
-  public var repeatedE: [Proto3PreserveUnknownEnumUnittest_MyEnum] = []
+  var repeatedE: [Proto3PreserveUnknownEnumUnittest_MyEnum] = []
 
-  public var repeatedPackedE: [Proto3PreserveUnknownEnumUnittest_MyEnum] = []
+  var repeatedPackedE: [Proto3PreserveUnknownEnumUnittest_MyEnum] = []
 
   ///   not packed
-  public var repeatedPackedUnexpectedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
+  var repeatedPackedUnexpectedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
 
-  public var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnum {
+  var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
       if case .oneofE1(let v) = o {
         return v
@@ -308,7 +308,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
 
   public var o: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O = .None
 
-  public var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnum {
+  var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
       if case .oneofE2(let v) = o {
         return v
@@ -320,7 +320,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -428,15 +428,15 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGeneratedMe
     }
   }
 
-  public var e: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
+  var e: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
 
-  public var repeatedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
+  var repeatedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
 
-  public var repeatedPackedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
+  var repeatedPackedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
 
-  public var repeatedPackedUnexpectedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
+  var repeatedPackedUnexpectedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
 
-  public var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
+  var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
       if case .oneofE1(let v) = o {
         return v
@@ -450,7 +450,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGeneratedMe
 
   public var o: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O = .None
 
-  public var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
+  var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
       if case .oneofE2(let v) = o {
         return v
@@ -462,7 +462,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGeneratedMe
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -41,16 +41,16 @@ import SwiftProtobuf
 
 
 enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foo
     case 1: self = .bar
@@ -59,7 +59,7 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     case "bar": self = .bar
@@ -68,7 +68,7 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOO": self = .foo
     case "BAR": self = .bar
@@ -77,7 +77,7 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOO": self = .foo
     case "BAR": self = .bar
@@ -86,7 +86,7 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 0
@@ -96,7 +96,7 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"FOO\""
@@ -106,9 +106,9 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -195,7 +195,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
   }
 
   private var _e: Proto2PreserveUnknownEnumUnittest_MyEnum? = nil
-  public var e: Proto2PreserveUnknownEnumUnittest_MyEnum {
+  var e: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {return _e ?? Proto2PreserveUnknownEnumUnittest_MyEnum.foo}
     set {_e = newValue}
   }
@@ -206,14 +206,14 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
     return _e = nil
   }
 
-  public var repeatedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
+  var repeatedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
 
-  public var repeatedPackedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
+  var repeatedPackedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
 
   ///   not packed
-  public var repeatedPackedUnexpectedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
+  var repeatedPackedUnexpectedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
 
-  public var oneofE1: Proto2PreserveUnknownEnumUnittest_MyEnum {
+  var oneofE1: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
       if case .oneofE1(let v) = o {
         return v
@@ -227,7 +227,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
 
   public var o: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O = .None
 
-  public var oneofE2: Proto2PreserveUnknownEnumUnittest_MyEnum {
+  var oneofE2: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
       if case .oneofE2(let v) = o {
         return v
@@ -239,7 +239,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -47,18 +47,18 @@ import SwiftProtobuf
 
 
 enum Proto3ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignUnspecified // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foreignUnspecified
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foreignUnspecified
     case 4: self = .foreignFoo
@@ -68,7 +68,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignUnspecified": self = .foreignUnspecified
     case "foreignFoo": self = .foreignFoo
@@ -78,7 +78,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_UNSPECIFIED": self = .foreignUnspecified
     case "FOREIGN_FOO": self = .foreignFoo
@@ -88,7 +88,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_UNSPECIFIED": self = .foreignUnspecified
     case "FOREIGN_FOO": self = .foreignFoo
@@ -98,7 +98,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignUnspecified: return 0
@@ -110,7 +110,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignUnspecified: return "\"FOREIGN_UNSPECIFIED\""
@@ -122,9 +122,9 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignUnspecified: return ".foreignUnspecified"
@@ -140,7 +140,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
 
 ///   Test an enum that has multiple values with the same number.
 enum Proto3TestEnumWithDupValue: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case testEnumWithDupValueUnspecified // = 0
   case foo1 // = 1
   case bar1 // = 2
@@ -149,11 +149,11 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
   case bar2 // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .testEnumWithDupValueUnspecified
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .testEnumWithDupValueUnspecified
     case 1: self = .foo1
@@ -163,7 +163,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "testEnumWithDupValueUnspecified": self = .testEnumWithDupValueUnspecified
     case "foo1": self = .foo1
@@ -175,7 +175,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED": self = .testEnumWithDupValueUnspecified
     case "FOO1": self = .foo1
@@ -187,7 +187,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED": self = .testEnumWithDupValueUnspecified
     case "FOO1": self = .foo1
@@ -199,7 +199,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .testEnumWithDupValueUnspecified: return 0
@@ -213,7 +213,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .testEnumWithDupValueUnspecified: return "\"TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED\""
@@ -227,9 +227,9 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .testEnumWithDupValueUnspecified: return ".testEnumWithDupValueUnspecified"
@@ -247,7 +247,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
 
 ///   Test an enum with large, unordered values.
 enum Proto3TestSparseEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case testSparseEnumUnspecified // = 0
   case sparseA // = 123
   case sparseB // = 62374
@@ -260,11 +260,11 @@ enum Proto3TestSparseEnum: ProtobufEnum {
   case sparseG // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .testSparseEnumUnspecified
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .testSparseEnumUnspecified
     case 123: self = .sparseA
@@ -277,7 +277,7 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "testSparseEnumUnspecified": self = .testSparseEnumUnspecified
     case "sparseA": self = .sparseA
@@ -290,7 +290,7 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "TEST_SPARSE_ENUM_UNSPECIFIED": self = .testSparseEnumUnspecified
     case "SPARSE_A": self = .sparseA
@@ -303,7 +303,7 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "TEST_SPARSE_ENUM_UNSPECIFIED": self = .testSparseEnumUnspecified
     case "SPARSE_A": self = .sparseA
@@ -316,7 +316,7 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .testSparseEnumUnspecified: return 0
@@ -331,7 +331,7 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .testSparseEnumUnspecified: return "\"TEST_SPARSE_ENUM_UNSPECIFIED\""
@@ -346,9 +346,9 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .testSparseEnumUnspecified: return ".testSparseEnumUnspecified"
@@ -880,7 +880,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case nestedEnumUnspecified // = 0
     case foo // = 1
     case bar // = 2
@@ -890,11 +890,11 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     case neg // = -1
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .nestedEnumUnspecified
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .nestedEnumUnspecified
       case 1: self = .foo
@@ -905,7 +905,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "nestedEnumUnspecified": self = .nestedEnumUnspecified
       case "foo": self = .foo
@@ -916,7 +916,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "NESTED_ENUM_UNSPECIFIED": self = .nestedEnumUnspecified
       case "FOO": self = .foo
@@ -927,7 +927,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "NESTED_ENUM_UNSPECIFIED": self = .nestedEnumUnspecified
       case "FOO": self = .foo
@@ -938,7 +938,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .nestedEnumUnspecified: return 0
@@ -951,7 +951,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .nestedEnumUnspecified: return "\"NESTED_ENUM_UNSPECIFIED\""
@@ -964,9 +964,9 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .nestedEnumUnspecified: return ".nestedEnumUnspecified"
@@ -996,9 +996,9 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     ///   The field name "b" fails to compile in proto1 because it conflicts with
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
-    public var bb: Int32 = 0
+    var bb: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1020,82 +1020,82 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Singular
-  public var singleInt32: Int32 {
+  var singleInt32: Int32 {
     get {return _storage._singleInt32}
     set {_uniqueStorage()._singleInt32 = newValue}
   }
 
-  public var singleInt64: Int64 {
+  var singleInt64: Int64 {
     get {return _storage._singleInt64}
     set {_uniqueStorage()._singleInt64 = newValue}
   }
 
-  public var singleUint32: UInt32 {
+  var singleUint32: UInt32 {
     get {return _storage._singleUint32}
     set {_uniqueStorage()._singleUint32 = newValue}
   }
 
-  public var singleUint64: UInt64 {
+  var singleUint64: UInt64 {
     get {return _storage._singleUint64}
     set {_uniqueStorage()._singleUint64 = newValue}
   }
 
-  public var singleSint32: Int32 {
+  var singleSint32: Int32 {
     get {return _storage._singleSint32}
     set {_uniqueStorage()._singleSint32 = newValue}
   }
 
-  public var singleSint64: Int64 {
+  var singleSint64: Int64 {
     get {return _storage._singleSint64}
     set {_uniqueStorage()._singleSint64 = newValue}
   }
 
-  public var singleFixed32: UInt32 {
+  var singleFixed32: UInt32 {
     get {return _storage._singleFixed32}
     set {_uniqueStorage()._singleFixed32 = newValue}
   }
 
-  public var singleFixed64: UInt64 {
+  var singleFixed64: UInt64 {
     get {return _storage._singleFixed64}
     set {_uniqueStorage()._singleFixed64 = newValue}
   }
 
-  public var singleSfixed32: Int32 {
+  var singleSfixed32: Int32 {
     get {return _storage._singleSfixed32}
     set {_uniqueStorage()._singleSfixed32 = newValue}
   }
 
-  public var singleSfixed64: Int64 {
+  var singleSfixed64: Int64 {
     get {return _storage._singleSfixed64}
     set {_uniqueStorage()._singleSfixed64 = newValue}
   }
 
-  public var singleFloat: Float {
+  var singleFloat: Float {
     get {return _storage._singleFloat}
     set {_uniqueStorage()._singleFloat = newValue}
   }
 
-  public var singleDouble: Double {
+  var singleDouble: Double {
     get {return _storage._singleDouble}
     set {_uniqueStorage()._singleDouble = newValue}
   }
 
-  public var singleBool: Bool {
+  var singleBool: Bool {
     get {return _storage._singleBool}
     set {_uniqueStorage()._singleBool = newValue}
   }
 
-  public var singleString: String {
+  var singleString: String {
     get {return _storage._singleString}
     set {_uniqueStorage()._singleString = newValue}
   }
 
-  public var singleBytes: Data {
+  var singleBytes: Data {
     get {return _storage._singleBytes}
     set {_uniqueStorage()._singleBytes = newValue}
   }
 
-  public var singleNestedMessage: Proto3TestAllTypes.NestedMessage {
+  var singleNestedMessage: Proto3TestAllTypes.NestedMessage {
     get {return _storage._singleNestedMessage ?? Proto3TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._singleNestedMessage = newValue}
   }
@@ -1106,7 +1106,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     return _storage._singleNestedMessage = nil
   }
 
-  public var singleForeignMessage: Proto3ForeignMessage {
+  var singleForeignMessage: Proto3ForeignMessage {
     get {return _storage._singleForeignMessage ?? Proto3ForeignMessage()}
     set {_uniqueStorage()._singleForeignMessage = newValue}
   }
@@ -1117,7 +1117,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     return _storage._singleForeignMessage = nil
   }
 
-  public var singleImportMessage: Proto3ImportMessage {
+  var singleImportMessage: Proto3ImportMessage {
     get {return _storage._singleImportMessage ?? Proto3ImportMessage()}
     set {_uniqueStorage()._singleImportMessage = newValue}
   }
@@ -1128,23 +1128,23 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     return _storage._singleImportMessage = nil
   }
 
-  public var singleNestedEnum: Proto3TestAllTypes.NestedEnum {
+  var singleNestedEnum: Proto3TestAllTypes.NestedEnum {
     get {return _storage._singleNestedEnum}
     set {_uniqueStorage()._singleNestedEnum = newValue}
   }
 
-  public var singleForeignEnum: Proto3ForeignEnum {
+  var singleForeignEnum: Proto3ForeignEnum {
     get {return _storage._singleForeignEnum}
     set {_uniqueStorage()._singleForeignEnum = newValue}
   }
 
-  public var singleImportEnum: Proto3ImportEnum {
+  var singleImportEnum: Proto3ImportEnum {
     get {return _storage._singleImportEnum}
     set {_uniqueStorage()._singleImportEnum = newValue}
   }
 
   ///   Defined in unittest_import_public.proto
-  public var singlePublicImportMessage: Proto3PublicImportMessage {
+  var singlePublicImportMessage: Proto3PublicImportMessage {
     get {return _storage._singlePublicImportMessage ?? Proto3PublicImportMessage()}
     set {_uniqueStorage()._singlePublicImportMessage = newValue}
   }
@@ -1156,118 +1156,118 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedNestedMessage: [Proto3TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [Proto3TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [Proto3ForeignMessage] {
+  var repeatedForeignMessage: [Proto3ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [Proto3ImportMessage] {
+  var repeatedImportMessage: [Proto3ImportMessage] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [Proto3TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [Proto3TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [Proto3ForeignEnum] {
+  var repeatedForeignEnum: [Proto3ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedImportEnum: [Proto3ImportEnum] {
+  var repeatedImportEnum: [Proto3ImportEnum] {
     get {return _storage._repeatedImportEnum}
     set {_uniqueStorage()._repeatedImportEnum = newValue}
   }
 
   ///   Defined in unittest_import_public.proto
-  public var repeatedPublicImportMessage: [Proto3PublicImportMessage] {
+  var repeatedPublicImportMessage: [Proto3PublicImportMessage] {
     get {return _storage._repeatedPublicImportMessage}
     set {_uniqueStorage()._repeatedPublicImportMessage = newValue}
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1279,7 +1279,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var oneofNestedMessage: Proto3TestAllTypes.NestedMessage {
+  var oneofNestedMessage: Proto3TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1291,7 +1291,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1303,7 +1303,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1322,7 +1322,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1408,7 +1408,7 @@ struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
   private var _storage = _StorageClass()
 
 
-  public var child: Proto3NestedTestAllTypes {
+  var child: Proto3NestedTestAllTypes {
     get {return _storage._child ?? Proto3NestedTestAllTypes()}
     set {_uniqueStorage()._child = newValue}
   }
@@ -1419,7 +1419,7 @@ struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._child = nil
   }
 
-  public var payload: Proto3TestAllTypes {
+  var payload: Proto3TestAllTypes {
     get {return _storage._payload ?? Proto3TestAllTypes()}
     set {_uniqueStorage()._payload = newValue}
   }
@@ -1430,12 +1430,12 @@ struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._payload = nil
   }
 
-  public var repeatedChild: [Proto3NestedTestAllTypes] {
+  var repeatedChild: [Proto3NestedTestAllTypes] {
     get {return _storage._repeatedChild}
     set {_uniqueStorage()._repeatedChild = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1469,9 +1469,9 @@ struct Proto3TestDeprecatedFields: ProtobufGeneratedMessage, ProtobufProto3Messa
   ]}
 
 
-  public var deprecatedInt32: Int32 = 0
+  var deprecatedInt32: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1506,9 +1506,9 @@ struct Proto3ForeignMessage: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var c: Int32 = 0
+  var c: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1537,7 +1537,7 @@ struct Proto3TestReservedFields: ProtobufGeneratedMessage, ProtobufProto3Message
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -1596,7 +1596,7 @@ struct Proto3TestForeignNested: ProtobufGeneratedMessage, ProtobufProto3Message 
   private var _storage = _StorageClass()
 
 
-  public var foreignNested: Proto3TestAllTypes.NestedMessage {
+  var foreignNested: Proto3TestAllTypes.NestedMessage {
     get {return _storage._foreignNested ?? Proto3TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._foreignNested = newValue}
   }
@@ -1607,7 +1607,7 @@ struct Proto3TestForeignNested: ProtobufGeneratedMessage, ProtobufProto3Message 
     return _storage._foreignNested = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1646,11 +1646,11 @@ struct Proto3TestReallyLargeTagNumber: ProtobufGeneratedMessage, ProtobufProto3M
 
   ///   The largest possible tag number is 2^28 - 1, since the wire format uses
   ///   three bits to communicate wire type.
-  public var a: Int32 = 0
+  var a: Int32 = 0
 
-  public var bb: Int32 = 0
+  var bb: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1730,7 +1730,7 @@ struct Proto3TestRecursiveMessage: ProtobufGeneratedMessage, ProtobufProto3Messa
   private var _storage = _StorageClass()
 
 
-  public var a: Proto3TestRecursiveMessage {
+  var a: Proto3TestRecursiveMessage {
     get {return _storage._a ?? Proto3TestRecursiveMessage()}
     set {_uniqueStorage()._a = newValue}
   }
@@ -1741,12 +1741,12 @@ struct Proto3TestRecursiveMessage: ProtobufGeneratedMessage, ProtobufProto3Messa
     return _storage._a = nil
   }
 
-  public var i: Int32 {
+  var i: Int32 {
     get {return _storage._i}
     set {_uniqueStorage()._i = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1814,7 +1814,7 @@ struct Proto3TestMutualRecursionA: ProtobufGeneratedMessage, ProtobufProto3Messa
   private var _storage = _StorageClass()
 
 
-  public var bb: Proto3TestMutualRecursionB {
+  var bb: Proto3TestMutualRecursionB {
     get {return _storage._bb ?? Proto3TestMutualRecursionB()}
     set {_uniqueStorage()._bb = newValue}
   }
@@ -1825,7 +1825,7 @@ struct Proto3TestMutualRecursionA: ProtobufGeneratedMessage, ProtobufProto3Messa
     return _storage._bb = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1901,7 +1901,7 @@ struct Proto3TestMutualRecursionB: ProtobufGeneratedMessage, ProtobufProto3Messa
   private var _storage = _StorageClass()
 
 
-  public var a: Proto3TestMutualRecursionA {
+  var a: Proto3TestMutualRecursionA {
     get {return _storage._a ?? Proto3TestMutualRecursionA()}
     set {_uniqueStorage()._a = newValue}
   }
@@ -1912,12 +1912,12 @@ struct Proto3TestMutualRecursionB: ProtobufGeneratedMessage, ProtobufProto3Messa
     return _storage._a = nil
   }
 
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2049,22 +2049,22 @@ struct Proto3TestCamelCaseFieldNames: ProtobufGeneratedMessage, ProtobufProto3Me
   private var _storage = _StorageClass()
 
 
-  public var primitiveField: Int32 {
+  var primitiveField: Int32 {
     get {return _storage._primitiveField}
     set {_uniqueStorage()._primitiveField = newValue}
   }
 
-  public var stringField: String {
+  var stringField: String {
     get {return _storage._stringField}
     set {_uniqueStorage()._stringField = newValue}
   }
 
-  public var enumField: Proto3ForeignEnum {
+  var enumField: Proto3ForeignEnum {
     get {return _storage._enumField}
     set {_uniqueStorage()._enumField = newValue}
   }
 
-  public var messageField: Proto3ForeignMessage {
+  var messageField: Proto3ForeignMessage {
     get {return _storage._messageField ?? Proto3ForeignMessage()}
     set {_uniqueStorage()._messageField = newValue}
   }
@@ -2075,27 +2075,27 @@ struct Proto3TestCamelCaseFieldNames: ProtobufGeneratedMessage, ProtobufProto3Me
     return _storage._messageField = nil
   }
 
-  public var repeatedPrimitiveField: [Int32] {
+  var repeatedPrimitiveField: [Int32] {
     get {return _storage._repeatedPrimitiveField}
     set {_uniqueStorage()._repeatedPrimitiveField = newValue}
   }
 
-  public var repeatedStringField: [String] {
+  var repeatedStringField: [String] {
     get {return _storage._repeatedStringField}
     set {_uniqueStorage()._repeatedStringField = newValue}
   }
 
-  public var repeatedEnumField: [Proto3ForeignEnum] {
+  var repeatedEnumField: [Proto3ForeignEnum] {
     get {return _storage._repeatedEnumField}
     set {_uniqueStorage()._repeatedEnumField = newValue}
   }
 
-  public var repeatedMessageField: [Proto3ForeignMessage] {
+  var repeatedMessageField: [Proto3ForeignMessage] {
     get {return _storage._repeatedMessageField}
     set {_uniqueStorage()._repeatedMessageField = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2205,14 +2205,14 @@ struct Proto3TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProto3Message
     ]}
 
 
-    public var oo: Int64 = 0
+    var oo: Int64 = 0
 
     ///   The field name "b" fails to compile in proto1 because it conflicts with
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
-    public var bb: Int32 = 0
+    var bb: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -2238,22 +2238,22 @@ struct Proto3TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProto3Message
     }
   }
 
-  public var myString: String {
+  var myString: String {
     get {return _storage._myString}
     set {_uniqueStorage()._myString = newValue}
   }
 
-  public var myInt: Int64 {
+  var myInt: Int64 {
     get {return _storage._myInt}
     set {_uniqueStorage()._myInt = newValue}
   }
 
-  public var myFloat: Float {
+  var myFloat: Float {
     get {return _storage._myFloat}
     set {_uniqueStorage()._myFloat = newValue}
   }
 
-  public var singleNestedMessage: Proto3TestFieldOrderings.NestedMessage {
+  var singleNestedMessage: Proto3TestFieldOrderings.NestedMessage {
     get {return _storage._singleNestedMessage ?? Proto3TestFieldOrderings.NestedMessage()}
     set {_uniqueStorage()._singleNestedMessage = newValue}
   }
@@ -2264,7 +2264,7 @@ struct Proto3TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._singleNestedMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2298,9 +2298,9 @@ struct Proto3SparseEnumMessage: ProtobufGeneratedMessage, ProtobufProto3Message 
   ]}
 
 
-  public var sparseEnum: Proto3TestSparseEnum = Proto3TestSparseEnum.testSparseEnumUnspecified
+  var sparseEnum: Proto3TestSparseEnum = Proto3TestSparseEnum.testSparseEnumUnspecified
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2334,9 +2334,9 @@ struct Proto3OneString: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: String = ""
+  var data: String = ""
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2369,9 +2369,9 @@ struct Proto3MoreString: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: [String] = []
+  var data: [String] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2404,9 +2404,9 @@ struct Proto3OneBytes: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: Data = Data()
+  var data: Data = Data()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2439,9 +2439,9 @@ struct Proto3MoreBytes: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: Data = Data()
+  var data: Data = Data()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2475,9 +2475,9 @@ struct Proto3Int32Message: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: Int32 = 0
+  var data: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2510,9 +2510,9 @@ struct Proto3Uint32Message: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: UInt32 = 0
+  var data: UInt32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2545,9 +2545,9 @@ struct Proto3Int64Message: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: Int64 = 0
+  var data: Int64 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2580,9 +2580,9 @@ struct Proto3Uint64Message: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: UInt64 = 0
+  var data: UInt64 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2615,9 +2615,9 @@ struct Proto3BoolMessage: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: Bool = false
+  var data: Bool = false
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2744,7 +2744,7 @@ struct Proto3TestOneof: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var fooInt: Int32 {
+  var fooInt: Int32 {
     get {
       if case .fooInt(let v) = _storage._foo {
         return v
@@ -2756,7 +2756,7 @@ struct Proto3TestOneof: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var fooString: String {
+  var fooString: String {
     get {
       if case .fooString(let v) = _storage._foo {
         return v
@@ -2768,7 +2768,7 @@ struct Proto3TestOneof: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var fooMessage: Proto3TestAllTypes {
+  var fooMessage: Proto3TestAllTypes {
     get {
       if case .fooMessage(let v) = _storage._foo {
         return v
@@ -2787,7 +2787,7 @@ struct Proto3TestOneof: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2849,35 +2849,35 @@ struct Proto3TestPackedTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var packedInt32: [Int32] = []
+  var packedInt32: [Int32] = []
 
-  public var packedInt64: [Int64] = []
+  var packedInt64: [Int64] = []
 
-  public var packedUint32: [UInt32] = []
+  var packedUint32: [UInt32] = []
 
-  public var packedUint64: [UInt64] = []
+  var packedUint64: [UInt64] = []
 
-  public var packedSint32: [Int32] = []
+  var packedSint32: [Int32] = []
 
-  public var packedSint64: [Int64] = []
+  var packedSint64: [Int64] = []
 
-  public var packedFixed32: [UInt32] = []
+  var packedFixed32: [UInt32] = []
 
-  public var packedFixed64: [UInt64] = []
+  var packedFixed64: [UInt64] = []
 
-  public var packedSfixed32: [Int32] = []
+  var packedSfixed32: [Int32] = []
 
-  public var packedSfixed64: [Int64] = []
+  var packedSfixed64: [Int64] = []
 
-  public var packedFloat: [Float] = []
+  var packedFloat: [Float] = []
 
-  public var packedDouble: [Double] = []
+  var packedDouble: [Double] = []
 
-  public var packedBool: [Bool] = []
+  var packedBool: [Bool] = []
 
-  public var packedEnum: [Proto3ForeignEnum] = []
+  var packedEnum: [Proto3ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3003,35 +3003,35 @@ struct Proto3TestUnpackedTypes: ProtobufGeneratedMessage, ProtobufProto3Message 
   ]}
 
 
-  public var unpackedInt32: [Int32] = []
+  var unpackedInt32: [Int32] = []
 
-  public var unpackedInt64: [Int64] = []
+  var unpackedInt64: [Int64] = []
 
-  public var unpackedUint32: [UInt32] = []
+  var unpackedUint32: [UInt32] = []
 
-  public var unpackedUint64: [UInt64] = []
+  var unpackedUint64: [UInt64] = []
 
-  public var unpackedSint32: [Int32] = []
+  var unpackedSint32: [Int32] = []
 
-  public var unpackedSint64: [Int64] = []
+  var unpackedSint64: [Int64] = []
 
-  public var unpackedFixed32: [UInt32] = []
+  var unpackedFixed32: [UInt32] = []
 
-  public var unpackedFixed64: [UInt64] = []
+  var unpackedFixed64: [UInt64] = []
 
-  public var unpackedSfixed32: [Int32] = []
+  var unpackedSfixed32: [Int32] = []
 
-  public var unpackedSfixed64: [Int64] = []
+  var unpackedSfixed64: [Int64] = []
 
-  public var unpackedFloat: [Float] = []
+  var unpackedFloat: [Float] = []
 
-  public var unpackedDouble: [Double] = []
+  var unpackedDouble: [Double] = []
 
-  public var unpackedBool: [Bool] = []
+  var unpackedBool: [Bool] = []
 
-  public var unpackedEnum: [Proto3ForeignEnum] = []
+  var unpackedEnum: [Proto3ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3142,22 +3142,22 @@ struct Proto3TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessage, Prot
   ///   Parsing repeated fixed size values used to fail. This message needs to be
   ///   used in order to get a tag of the right size; all of the repeated fields
   ///   in TestAllTypes didn't trigger the check.
-  public var repeatedFixed32: [UInt32] = []
+  var repeatedFixed32: [UInt32] = []
 
   ///   Check for a varint type, just for good measure.
-  public var repeatedInt32: [Int32] = []
+  var repeatedInt32: [Int32] = []
 
   ///   These have two-byte tags.
-  public var repeatedFixed64: [UInt64] = []
+  var repeatedFixed64: [UInt64] = []
 
-  public var repeatedInt64: [Int64] = []
+  var repeatedInt64: [Int64] = []
 
   ///   Three byte tags.
-  public var repeatedFloat: [Float] = []
+  var repeatedFloat: [Float] = []
 
-  public var repeatedUint64: [UInt64] = []
+  var repeatedUint64: [UInt64] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3216,9 +3216,9 @@ struct Proto3TestCommentInjectionMessage: ProtobufGeneratedMessage, ProtobufProt
 
 
   ///   */ <- This should not close the generated doc comment
-  public var a: String = ""
+  var a: String = ""
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3248,7 +3248,7 @@ struct Proto3FooRequest: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3269,7 +3269,7 @@ struct Proto3FooResponse: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3290,7 +3290,7 @@ struct Proto3FooClientMessage: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3311,7 +3311,7 @@ struct Proto3FooServerMessage: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3332,7 +3332,7 @@ struct Proto3BarRequest: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3353,7 +3353,7 @@ struct Proto3BarResponse: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -41,18 +41,18 @@ import SwiftProtobuf
 
 
 enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foreignZero
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foreignZero
     case 4: self = .foreignFoo
@@ -62,7 +62,7 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignZero": self = .foreignZero
     case "foreignFoo": self = .foreignFoo
@@ -72,7 +72,7 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_ZERO": self = .foreignZero
     case "FOREIGN_FOO": self = .foreignFoo
@@ -82,7 +82,7 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_ZERO": self = .foreignZero
     case "FOREIGN_FOO": self = .foreignFoo
@@ -92,7 +92,7 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignZero: return 0
@@ -104,7 +104,7 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignZero: return "\"FOREIGN_ZERO\""
@@ -116,9 +116,9 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignZero: return ".foreignZero"
@@ -674,7 +674,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case zero // = 0
     case foo // = 1
     case bar // = 2
@@ -684,11 +684,11 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     case neg // = -1
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .zero
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .zero
       case 1: self = .foo
@@ -699,7 +699,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "zero": self = .zero
       case "foo": self = .foo
@@ -710,7 +710,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ZERO": self = .zero
       case "FOO": self = .foo
@@ -721,7 +721,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ZERO": self = .zero
       case "FOO": self = .foo
@@ -732,7 +732,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .zero: return 0
@@ -745,7 +745,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .zero: return "\"ZERO\""
@@ -758,9 +758,9 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .zero: return ".zero"
@@ -790,9 +790,9 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     ///   The field name "b" fails to compile in proto1 because it conflicts with
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
-    public var bb: Int32 = 0
+    var bb: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -814,77 +814,77 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -894,7 +894,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   //    optional int32 a = 17;
   //  }
 
-  public var optionalNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Proto3ArenaUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -905,7 +905,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: Proto3ArenaUnittest_ForeignMessage {
+  var optionalForeignMessage: Proto3ArenaUnittest_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? Proto3ArenaUnittest_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -916,7 +916,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
+  var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
     get {return _storage._optionalImportMessage ?? ProtobufUnittestImport_ImportMessage()}
     set {_uniqueStorage()._optionalImportMessage = newValue}
   }
@@ -927,12 +927,12 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     return _storage._optionalImportMessage = nil
   }
 
-  public var optionalNestedEnum: Proto3ArenaUnittest_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: Proto3ArenaUnittest_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
 
-  public var optionalForeignEnum: Proto3ArenaUnittest_ForeignEnum {
+  var optionalForeignEnum: Proto3ArenaUnittest_ForeignEnum {
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
@@ -942,18 +942,18 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   // 
   //  optional protobuf_unittest_import.ImportEnum    optional_import_enum  = 23;
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord}
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
   ///   Defined in unittest_import_public.proto
-  public var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
+  var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
   }
@@ -964,7 +964,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     return _storage._optionalPublicImportMessage = nil
   }
 
-  public var optionalLazyMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
+  var optionalLazyMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalLazyMessage ?? Proto3ArenaUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalLazyMessage = newValue}
   }
@@ -976,77 +976,77 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
@@ -1056,27 +1056,27 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   //    optional int32 a = 47;
   //  }
 
-  public var repeatedNestedMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [Proto3ArenaUnittest_ForeignMessage] {
+  var repeatedForeignMessage: [Proto3ArenaUnittest_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
+  var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [Proto3ArenaUnittest_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [Proto3ArenaUnittest_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [Proto3ArenaUnittest_ForeignEnum] {
+  var repeatedForeignEnum: [Proto3ArenaUnittest_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
@@ -1086,22 +1086,22 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   // 
   //  repeated protobuf_unittest_import.ImportEnum    repeated_import_enum  = 53;
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1113,7 +1113,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     }
   }
 
-  public var oneofNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1125,7 +1125,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1137,7 +1137,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1156,7 +1156,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1218,35 +1218,35 @@ struct Proto3ArenaUnittest_TestPackedTypes: ProtobufGeneratedMessage, ProtobufPr
   ]}
 
 
-  public var packedInt32: [Int32] = []
+  var packedInt32: [Int32] = []
 
-  public var packedInt64: [Int64] = []
+  var packedInt64: [Int64] = []
 
-  public var packedUint32: [UInt32] = []
+  var packedUint32: [UInt32] = []
 
-  public var packedUint64: [UInt64] = []
+  var packedUint64: [UInt64] = []
 
-  public var packedSint32: [Int32] = []
+  var packedSint32: [Int32] = []
 
-  public var packedSint64: [Int64] = []
+  var packedSint64: [Int64] = []
 
-  public var packedFixed32: [UInt32] = []
+  var packedFixed32: [UInt32] = []
 
-  public var packedFixed64: [UInt64] = []
+  var packedFixed64: [UInt64] = []
 
-  public var packedSfixed32: [Int32] = []
+  var packedSfixed32: [Int32] = []
 
-  public var packedSfixed64: [Int64] = []
+  var packedSfixed64: [Int64] = []
 
-  public var packedFloat: [Float] = []
+  var packedFloat: [Float] = []
 
-  public var packedDouble: [Double] = []
+  var packedDouble: [Double] = []
 
-  public var packedBool: [Bool] = []
+  var packedBool: [Bool] = []
 
-  public var packedEnum: [Proto3ArenaUnittest_ForeignEnum] = []
+  var packedEnum: [Proto3ArenaUnittest_ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1371,35 +1371,35 @@ struct Proto3ArenaUnittest_TestUnpackedTypes: ProtobufGeneratedMessage, Protobuf
   ]}
 
 
-  public var repeatedInt32: [Int32] = []
+  var repeatedInt32: [Int32] = []
 
-  public var repeatedInt64: [Int64] = []
+  var repeatedInt64: [Int64] = []
 
-  public var repeatedUint32: [UInt32] = []
+  var repeatedUint32: [UInt32] = []
 
-  public var repeatedUint64: [UInt64] = []
+  var repeatedUint64: [UInt64] = []
 
-  public var repeatedSint32: [Int32] = []
+  var repeatedSint32: [Int32] = []
 
-  public var repeatedSint64: [Int64] = []
+  var repeatedSint64: [Int64] = []
 
-  public var repeatedFixed32: [UInt32] = []
+  var repeatedFixed32: [UInt32] = []
 
-  public var repeatedFixed64: [UInt64] = []
+  var repeatedFixed64: [UInt64] = []
 
-  public var repeatedSfixed32: [Int32] = []
+  var repeatedSfixed32: [Int32] = []
 
-  public var repeatedSfixed64: [Int64] = []
+  var repeatedSfixed64: [Int64] = []
 
-  public var repeatedFloat: [Float] = []
+  var repeatedFloat: [Float] = []
 
-  public var repeatedDouble: [Double] = []
+  var repeatedDouble: [Double] = []
 
-  public var repeatedBool: [Bool] = []
+  var repeatedBool: [Bool] = []
 
-  public var repeatedNestedEnum: [Proto3ArenaUnittest_TestAllTypes.NestedEnum] = []
+  var repeatedNestedEnum: [Proto3ArenaUnittest_TestAllTypes.NestedEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1540,7 +1540,7 @@ struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Protobu
   private var _storage = _StorageClass()
 
 
-  public var child: Proto3ArenaUnittest_NestedTestAllTypes {
+  var child: Proto3ArenaUnittest_NestedTestAllTypes {
     get {return _storage._child ?? Proto3ArenaUnittest_NestedTestAllTypes()}
     set {_uniqueStorage()._child = newValue}
   }
@@ -1551,7 +1551,7 @@ struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Protobu
     return _storage._child = nil
   }
 
-  public var payload: Proto3ArenaUnittest_TestAllTypes {
+  var payload: Proto3ArenaUnittest_TestAllTypes {
     get {return _storage._payload ?? Proto3ArenaUnittest_TestAllTypes()}
     set {_uniqueStorage()._payload = newValue}
   }
@@ -1562,7 +1562,7 @@ struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Protobu
     return _storage._payload = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1598,9 +1598,9 @@ struct Proto3ArenaUnittest_ForeignMessage: ProtobufGeneratedMessage, ProtobufPro
   ]}
 
 
-  public var c: Int32 = 0
+  var c: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1630,7 +1630,7 @@ struct Proto3ArenaUnittest_TestEmptyMessage: ProtobufGeneratedMessage, ProtobufP
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -41,18 +41,18 @@ import SwiftProtobuf
 
 
 enum Proto3ArenaLiteUnittest_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foreignZero
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foreignZero
     case 4: self = .foreignFoo
@@ -62,7 +62,7 @@ enum Proto3ArenaLiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignZero": self = .foreignZero
     case "foreignFoo": self = .foreignFoo
@@ -72,7 +72,7 @@ enum Proto3ArenaLiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_ZERO": self = .foreignZero
     case "FOREIGN_FOO": self = .foreignFoo
@@ -82,7 +82,7 @@ enum Proto3ArenaLiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_ZERO": self = .foreignZero
     case "FOREIGN_FOO": self = .foreignFoo
@@ -92,7 +92,7 @@ enum Proto3ArenaLiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignZero: return 0
@@ -104,7 +104,7 @@ enum Proto3ArenaLiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignZero: return "\"FOREIGN_ZERO\""
@@ -116,9 +116,9 @@ enum Proto3ArenaLiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignZero: return ".foreignZero"
@@ -674,7 +674,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case zero // = 0
     case foo // = 1
     case bar // = 2
@@ -684,11 +684,11 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     case neg // = -1
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .zero
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .zero
       case 1: self = .foo
@@ -699,7 +699,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "zero": self = .zero
       case "foo": self = .foo
@@ -710,7 +710,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ZERO": self = .zero
       case "FOO": self = .foo
@@ -721,7 +721,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ZERO": self = .zero
       case "FOO": self = .foo
@@ -732,7 +732,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .zero: return 0
@@ -745,7 +745,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .zero: return "\"ZERO\""
@@ -758,9 +758,9 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .zero: return ".zero"
@@ -790,9 +790,9 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     ///   The field name "b" fails to compile in proto1 because it conflicts with
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
-    public var bb: Int32 = 0
+    var bb: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -814,77 +814,77 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -894,7 +894,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   //    optional int32 a = 17;
   //  }
 
-  public var optionalNestedMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -905,7 +905,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: Proto3ArenaLiteUnittest_ForeignMessage {
+  var optionalForeignMessage: Proto3ArenaLiteUnittest_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? Proto3ArenaLiteUnittest_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -916,7 +916,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
+  var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
     get {return _storage._optionalImportMessage ?? ProtobufUnittestImport_ImportMessage()}
     set {_uniqueStorage()._optionalImportMessage = newValue}
   }
@@ -927,12 +927,12 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalImportMessage = nil
   }
 
-  public var optionalNestedEnum: Proto3ArenaLiteUnittest_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: Proto3ArenaLiteUnittest_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
 
-  public var optionalForeignEnum: Proto3ArenaLiteUnittest_ForeignEnum {
+  var optionalForeignEnum: Proto3ArenaLiteUnittest_ForeignEnum {
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
@@ -942,18 +942,18 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   // 
   //  optional protobuf_unittest_import.ImportEnum    optional_import_enum  = 23;
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord}
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
   ///   Defined in unittest_import_public.proto
-  public var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
+  var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
   }
@@ -964,7 +964,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalPublicImportMessage = nil
   }
 
-  public var optionalLazyMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage {
+  var optionalLazyMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalLazyMessage ?? Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalLazyMessage = newValue}
   }
@@ -976,77 +976,77 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
@@ -1056,27 +1056,27 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   //    optional int32 a = 47;
   //  }
 
-  public var repeatedNestedMessage: [Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [Proto3ArenaLiteUnittest_ForeignMessage] {
+  var repeatedForeignMessage: [Proto3ArenaLiteUnittest_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
+  var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [Proto3ArenaLiteUnittest_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [Proto3ArenaLiteUnittest_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [Proto3ArenaLiteUnittest_ForeignEnum] {
+  var repeatedForeignEnum: [Proto3ArenaLiteUnittest_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
@@ -1086,22 +1086,22 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   // 
   //  repeated protobuf_unittest_import.ImportEnum    repeated_import_enum  = 53;
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessage: [Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1113,7 +1113,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var oneofNestedMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1125,7 +1125,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1137,7 +1137,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1156,7 +1156,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1218,35 +1218,35 @@ struct Proto3ArenaLiteUnittest_TestPackedTypes: ProtobufGeneratedMessage, Protob
   ]}
 
 
-  public var packedInt32: [Int32] = []
+  var packedInt32: [Int32] = []
 
-  public var packedInt64: [Int64] = []
+  var packedInt64: [Int64] = []
 
-  public var packedUint32: [UInt32] = []
+  var packedUint32: [UInt32] = []
 
-  public var packedUint64: [UInt64] = []
+  var packedUint64: [UInt64] = []
 
-  public var packedSint32: [Int32] = []
+  var packedSint32: [Int32] = []
 
-  public var packedSint64: [Int64] = []
+  var packedSint64: [Int64] = []
 
-  public var packedFixed32: [UInt32] = []
+  var packedFixed32: [UInt32] = []
 
-  public var packedFixed64: [UInt64] = []
+  var packedFixed64: [UInt64] = []
 
-  public var packedSfixed32: [Int32] = []
+  var packedSfixed32: [Int32] = []
 
-  public var packedSfixed64: [Int64] = []
+  var packedSfixed64: [Int64] = []
 
-  public var packedFloat: [Float] = []
+  var packedFloat: [Float] = []
 
-  public var packedDouble: [Double] = []
+  var packedDouble: [Double] = []
 
-  public var packedBool: [Bool] = []
+  var packedBool: [Bool] = []
 
-  public var packedEnum: [Proto3ArenaLiteUnittest_ForeignEnum] = []
+  var packedEnum: [Proto3ArenaLiteUnittest_ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1371,35 +1371,35 @@ struct Proto3ArenaLiteUnittest_TestUnpackedTypes: ProtobufGeneratedMessage, Prot
   ]}
 
 
-  public var repeatedInt32: [Int32] = []
+  var repeatedInt32: [Int32] = []
 
-  public var repeatedInt64: [Int64] = []
+  var repeatedInt64: [Int64] = []
 
-  public var repeatedUint32: [UInt32] = []
+  var repeatedUint32: [UInt32] = []
 
-  public var repeatedUint64: [UInt64] = []
+  var repeatedUint64: [UInt64] = []
 
-  public var repeatedSint32: [Int32] = []
+  var repeatedSint32: [Int32] = []
 
-  public var repeatedSint64: [Int64] = []
+  var repeatedSint64: [Int64] = []
 
-  public var repeatedFixed32: [UInt32] = []
+  var repeatedFixed32: [UInt32] = []
 
-  public var repeatedFixed64: [UInt64] = []
+  var repeatedFixed64: [UInt64] = []
 
-  public var repeatedSfixed32: [Int32] = []
+  var repeatedSfixed32: [Int32] = []
 
-  public var repeatedSfixed64: [Int64] = []
+  var repeatedSfixed64: [Int64] = []
 
-  public var repeatedFloat: [Float] = []
+  var repeatedFloat: [Float] = []
 
-  public var repeatedDouble: [Double] = []
+  var repeatedDouble: [Double] = []
 
-  public var repeatedBool: [Bool] = []
+  var repeatedBool: [Bool] = []
 
-  public var repeatedNestedEnum: [Proto3ArenaLiteUnittest_TestAllTypes.NestedEnum] = []
+  var repeatedNestedEnum: [Proto3ArenaLiteUnittest_TestAllTypes.NestedEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1540,7 +1540,7 @@ struct Proto3ArenaLiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Pro
   private var _storage = _StorageClass()
 
 
-  public var child: Proto3ArenaLiteUnittest_NestedTestAllTypes {
+  var child: Proto3ArenaLiteUnittest_NestedTestAllTypes {
     get {return _storage._child ?? Proto3ArenaLiteUnittest_NestedTestAllTypes()}
     set {_uniqueStorage()._child = newValue}
   }
@@ -1551,7 +1551,7 @@ struct Proto3ArenaLiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Pro
     return _storage._child = nil
   }
 
-  public var payload: Proto3ArenaLiteUnittest_TestAllTypes {
+  var payload: Proto3ArenaLiteUnittest_TestAllTypes {
     get {return _storage._payload ?? Proto3ArenaLiteUnittest_TestAllTypes()}
     set {_uniqueStorage()._payload = newValue}
   }
@@ -1562,7 +1562,7 @@ struct Proto3ArenaLiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Pro
     return _storage._payload = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1598,9 +1598,9 @@ struct Proto3ArenaLiteUnittest_ForeignMessage: ProtobufGeneratedMessage, Protobu
   ]}
 
 
-  public var c: Int32 = 0
+  var c: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1630,7 +1630,7 @@ struct Proto3ArenaLiteUnittest_TestEmptyMessage: ProtobufGeneratedMessage, Proto
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -41,18 +41,18 @@ import SwiftProtobuf
 
 
 enum Proto3LiteUnittest_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foreignZero
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foreignZero
     case 4: self = .foreignFoo
@@ -62,7 +62,7 @@ enum Proto3LiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignZero": self = .foreignZero
     case "foreignFoo": self = .foreignFoo
@@ -72,7 +72,7 @@ enum Proto3LiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_ZERO": self = .foreignZero
     case "FOREIGN_FOO": self = .foreignFoo
@@ -82,7 +82,7 @@ enum Proto3LiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_ZERO": self = .foreignZero
     case "FOREIGN_FOO": self = .foreignFoo
@@ -92,7 +92,7 @@ enum Proto3LiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignZero: return 0
@@ -104,7 +104,7 @@ enum Proto3LiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignZero: return "\"FOREIGN_ZERO\""
@@ -116,9 +116,9 @@ enum Proto3LiteUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignZero: return ".foreignZero"
@@ -674,7 +674,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case zero // = 0
     case foo // = 1
     case bar // = 2
@@ -684,11 +684,11 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
     case neg // = -1
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .zero
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .zero
       case 1: self = .foo
@@ -699,7 +699,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "zero": self = .zero
       case "foo": self = .foo
@@ -710,7 +710,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ZERO": self = .zero
       case "FOO": self = .foo
@@ -721,7 +721,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ZERO": self = .zero
       case "FOO": self = .foo
@@ -732,7 +732,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .zero: return 0
@@ -745,7 +745,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .zero: return "\"ZERO\""
@@ -758,9 +758,9 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .zero: return ".zero"
@@ -790,9 +790,9 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
     ///   The field name "b" fails to compile in proto1 because it conflicts with
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
-    public var bb: Int32 = 0
+    var bb: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -814,77 +814,77 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -894,7 +894,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
   //    optional int32 a = 17;
   //  }
 
-  public var optionalNestedMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Proto3LiteUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -905,7 +905,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: Proto3LiteUnittest_ForeignMessage {
+  var optionalForeignMessage: Proto3LiteUnittest_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? Proto3LiteUnittest_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -916,7 +916,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
+  var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
     get {return _storage._optionalImportMessage ?? ProtobufUnittestImport_ImportMessage()}
     set {_uniqueStorage()._optionalImportMessage = newValue}
   }
@@ -927,12 +927,12 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
     return _storage._optionalImportMessage = nil
   }
 
-  public var optionalNestedEnum: Proto3LiteUnittest_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: Proto3LiteUnittest_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
 
-  public var optionalForeignEnum: Proto3LiteUnittest_ForeignEnum {
+  var optionalForeignEnum: Proto3LiteUnittest_ForeignEnum {
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
@@ -942,18 +942,18 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
   // 
   //  optional protobuf_unittest_import.ImportEnum    optional_import_enum  = 23;
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord}
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
   ///   Defined in unittest_import_public.proto
-  public var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
+  var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
   }
@@ -964,7 +964,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
     return _storage._optionalPublicImportMessage = nil
   }
 
-  public var optionalLazyMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage {
+  var optionalLazyMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalLazyMessage ?? Proto3LiteUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalLazyMessage = newValue}
   }
@@ -976,77 +976,77 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
@@ -1056,27 +1056,27 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
   //    optional int32 a = 47;
   //  }
 
-  public var repeatedNestedMessage: [Proto3LiteUnittest_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [Proto3LiteUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [Proto3LiteUnittest_ForeignMessage] {
+  var repeatedForeignMessage: [Proto3LiteUnittest_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
+  var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [Proto3LiteUnittest_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [Proto3LiteUnittest_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [Proto3LiteUnittest_ForeignEnum] {
+  var repeatedForeignEnum: [Proto3LiteUnittest_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
@@ -1086,22 +1086,22 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
   // 
   //  repeated protobuf_unittest_import.ImportEnum    repeated_import_enum  = 53;
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [Proto3LiteUnittest_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessage: [Proto3LiteUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1113,7 +1113,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
     }
   }
 
-  public var oneofNestedMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1125,7 +1125,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1137,7 +1137,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1156,7 +1156,7 @@ struct Proto3LiteUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1218,35 +1218,35 @@ struct Proto3LiteUnittest_TestPackedTypes: ProtobufGeneratedMessage, ProtobufPro
   ]}
 
 
-  public var packedInt32: [Int32] = []
+  var packedInt32: [Int32] = []
 
-  public var packedInt64: [Int64] = []
+  var packedInt64: [Int64] = []
 
-  public var packedUint32: [UInt32] = []
+  var packedUint32: [UInt32] = []
 
-  public var packedUint64: [UInt64] = []
+  var packedUint64: [UInt64] = []
 
-  public var packedSint32: [Int32] = []
+  var packedSint32: [Int32] = []
 
-  public var packedSint64: [Int64] = []
+  var packedSint64: [Int64] = []
 
-  public var packedFixed32: [UInt32] = []
+  var packedFixed32: [UInt32] = []
 
-  public var packedFixed64: [UInt64] = []
+  var packedFixed64: [UInt64] = []
 
-  public var packedSfixed32: [Int32] = []
+  var packedSfixed32: [Int32] = []
 
-  public var packedSfixed64: [Int64] = []
+  var packedSfixed64: [Int64] = []
 
-  public var packedFloat: [Float] = []
+  var packedFloat: [Float] = []
 
-  public var packedDouble: [Double] = []
+  var packedDouble: [Double] = []
 
-  public var packedBool: [Bool] = []
+  var packedBool: [Bool] = []
 
-  public var packedEnum: [Proto3LiteUnittest_ForeignEnum] = []
+  var packedEnum: [Proto3LiteUnittest_ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1371,35 +1371,35 @@ struct Proto3LiteUnittest_TestUnpackedTypes: ProtobufGeneratedMessage, ProtobufP
   ]}
 
 
-  public var repeatedInt32: [Int32] = []
+  var repeatedInt32: [Int32] = []
 
-  public var repeatedInt64: [Int64] = []
+  var repeatedInt64: [Int64] = []
 
-  public var repeatedUint32: [UInt32] = []
+  var repeatedUint32: [UInt32] = []
 
-  public var repeatedUint64: [UInt64] = []
+  var repeatedUint64: [UInt64] = []
 
-  public var repeatedSint32: [Int32] = []
+  var repeatedSint32: [Int32] = []
 
-  public var repeatedSint64: [Int64] = []
+  var repeatedSint64: [Int64] = []
 
-  public var repeatedFixed32: [UInt32] = []
+  var repeatedFixed32: [UInt32] = []
 
-  public var repeatedFixed64: [UInt64] = []
+  var repeatedFixed64: [UInt64] = []
 
-  public var repeatedSfixed32: [Int32] = []
+  var repeatedSfixed32: [Int32] = []
 
-  public var repeatedSfixed64: [Int64] = []
+  var repeatedSfixed64: [Int64] = []
 
-  public var repeatedFloat: [Float] = []
+  var repeatedFloat: [Float] = []
 
-  public var repeatedDouble: [Double] = []
+  var repeatedDouble: [Double] = []
 
-  public var repeatedBool: [Bool] = []
+  var repeatedBool: [Bool] = []
 
-  public var repeatedNestedEnum: [Proto3LiteUnittest_TestAllTypes.NestedEnum] = []
+  var repeatedNestedEnum: [Proto3LiteUnittest_TestAllTypes.NestedEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1540,7 +1540,7 @@ struct Proto3LiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Protobuf
   private var _storage = _StorageClass()
 
 
-  public var child: Proto3LiteUnittest_NestedTestAllTypes {
+  var child: Proto3LiteUnittest_NestedTestAllTypes {
     get {return _storage._child ?? Proto3LiteUnittest_NestedTestAllTypes()}
     set {_uniqueStorage()._child = newValue}
   }
@@ -1551,7 +1551,7 @@ struct Proto3LiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._child = nil
   }
 
-  public var payload: Proto3LiteUnittest_TestAllTypes {
+  var payload: Proto3LiteUnittest_TestAllTypes {
     get {return _storage._payload ?? Proto3LiteUnittest_TestAllTypes()}
     set {_uniqueStorage()._payload = newValue}
   }
@@ -1562,7 +1562,7 @@ struct Proto3LiteUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._payload = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1598,9 +1598,9 @@ struct Proto3LiteUnittest_ForeignMessage: ProtobufGeneratedMessage, ProtobufProt
   ]}
 
 
-  public var c: Int32 = 0
+  var c: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1630,7 +1630,7 @@ struct Proto3LiteUnittest_TestEmptyMessage: ProtobufGeneratedMessage, ProtobufPr
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -220,7 +220,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
   private var _storage = _StorageClass()
 
 
-  public var anyField: Google_Protobuf_Any {
+  var anyField: Google_Protobuf_Any {
     get {return _storage._anyField ?? Google_Protobuf_Any()}
     set {_uniqueStorage()._anyField = newValue}
   }
@@ -231,7 +231,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._anyField = nil
   }
 
-  public var apiField: Google_Protobuf_Api {
+  var apiField: Google_Protobuf_Api {
     get {return _storage._apiField ?? Google_Protobuf_Api()}
     set {_uniqueStorage()._apiField = newValue}
   }
@@ -242,7 +242,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._apiField = nil
   }
 
-  public var durationField: Google_Protobuf_Duration {
+  var durationField: Google_Protobuf_Duration {
     get {return _storage._durationField ?? Google_Protobuf_Duration()}
     set {_uniqueStorage()._durationField = newValue}
   }
@@ -253,7 +253,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._durationField = nil
   }
 
-  public var emptyField: Google_Protobuf_Empty {
+  var emptyField: Google_Protobuf_Empty {
     get {return _storage._emptyField ?? Google_Protobuf_Empty()}
     set {_uniqueStorage()._emptyField = newValue}
   }
@@ -264,7 +264,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._emptyField = nil
   }
 
-  public var fieldMaskField: Google_Protobuf_FieldMask {
+  var fieldMaskField: Google_Protobuf_FieldMask {
     get {return _storage._fieldMaskField ?? Google_Protobuf_FieldMask()}
     set {_uniqueStorage()._fieldMaskField = newValue}
   }
@@ -275,7 +275,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._fieldMaskField = nil
   }
 
-  public var sourceContextField: Google_Protobuf_SourceContext {
+  var sourceContextField: Google_Protobuf_SourceContext {
     get {return _storage._sourceContextField ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContextField = newValue}
   }
@@ -286,7 +286,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._sourceContextField = nil
   }
 
-  public var structField: Google_Protobuf_Struct {
+  var structField: Google_Protobuf_Struct {
     get {return _storage._structField ?? Google_Protobuf_Struct()}
     set {_uniqueStorage()._structField = newValue}
   }
@@ -297,7 +297,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._structField = nil
   }
 
-  public var timestampField: Google_Protobuf_Timestamp {
+  var timestampField: Google_Protobuf_Timestamp {
     get {return _storage._timestampField ?? Google_Protobuf_Timestamp()}
     set {_uniqueStorage()._timestampField = newValue}
   }
@@ -308,7 +308,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._timestampField = nil
   }
 
-  public var typeField: Google_Protobuf_Type {
+  var typeField: Google_Protobuf_Type {
     get {return _storage._typeField ?? Google_Protobuf_Type()}
     set {_uniqueStorage()._typeField = newValue}
   }
@@ -319,7 +319,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._typeField = nil
   }
 
-  public var doubleField: Google_Protobuf_DoubleValue {
+  var doubleField: Google_Protobuf_DoubleValue {
     get {return _storage._doubleField ?? Google_Protobuf_DoubleValue()}
     set {_uniqueStorage()._doubleField = newValue}
   }
@@ -330,7 +330,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._doubleField = nil
   }
 
-  public var floatField: Google_Protobuf_FloatValue {
+  var floatField: Google_Protobuf_FloatValue {
     get {return _storage._floatField ?? Google_Protobuf_FloatValue()}
     set {_uniqueStorage()._floatField = newValue}
   }
@@ -341,7 +341,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._floatField = nil
   }
 
-  public var int64Field: Google_Protobuf_Int64Value {
+  var int64Field: Google_Protobuf_Int64Value {
     get {return _storage._int64Field ?? Google_Protobuf_Int64Value()}
     set {_uniqueStorage()._int64Field = newValue}
   }
@@ -352,7 +352,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._int64Field = nil
   }
 
-  public var uint64Field: Google_Protobuf_UInt64Value {
+  var uint64Field: Google_Protobuf_UInt64Value {
     get {return _storage._uint64Field ?? Google_Protobuf_UInt64Value()}
     set {_uniqueStorage()._uint64Field = newValue}
   }
@@ -363,7 +363,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._uint64Field = nil
   }
 
-  public var int32Field: Google_Protobuf_Int32Value {
+  var int32Field: Google_Protobuf_Int32Value {
     get {return _storage._int32Field ?? Google_Protobuf_Int32Value()}
     set {_uniqueStorage()._int32Field = newValue}
   }
@@ -374,7 +374,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._int32Field = nil
   }
 
-  public var uint32Field: Google_Protobuf_UInt32Value {
+  var uint32Field: Google_Protobuf_UInt32Value {
     get {return _storage._uint32Field ?? Google_Protobuf_UInt32Value()}
     set {_uniqueStorage()._uint32Field = newValue}
   }
@@ -385,7 +385,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._uint32Field = nil
   }
 
-  public var boolField: Google_Protobuf_BoolValue {
+  var boolField: Google_Protobuf_BoolValue {
     get {return _storage._boolField ?? Google_Protobuf_BoolValue()}
     set {_uniqueStorage()._boolField = newValue}
   }
@@ -396,7 +396,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._boolField = nil
   }
 
-  public var stringField: Google_Protobuf_StringValue {
+  var stringField: Google_Protobuf_StringValue {
     get {return _storage._stringField ?? Google_Protobuf_StringValue()}
     set {_uniqueStorage()._stringField = newValue}
   }
@@ -407,7 +407,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._stringField = nil
   }
 
-  public var bytesField: Google_Protobuf_BytesValue {
+  var bytesField: Google_Protobuf_BytesValue {
     get {return _storage._bytesField ?? Google_Protobuf_BytesValue()}
     set {_uniqueStorage()._bytesField = newValue}
   }
@@ -419,7 +419,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
   }
 
   ///   Part of struct, but useful to be able to test separately
-  public var valueField: Google_Protobuf_Value {
+  var valueField: Google_Protobuf_Value {
     get {return _storage._valueField ?? Google_Protobuf_Value()}
     set {_uniqueStorage()._valueField = newValue}
   }
@@ -430,7 +430,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._valueField = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -651,98 +651,98 @@ struct ProtobufUnittest_RepeatedWellKnownTypes: ProtobufGeneratedMessage, Protob
   private var _storage = _StorageClass()
 
 
-  public var anyField: [Google_Protobuf_Any] {
+  var anyField: [Google_Protobuf_Any] {
     get {return _storage._anyField}
     set {_uniqueStorage()._anyField = newValue}
   }
 
-  public var apiField: [Google_Protobuf_Api] {
+  var apiField: [Google_Protobuf_Api] {
     get {return _storage._apiField}
     set {_uniqueStorage()._apiField = newValue}
   }
 
-  public var durationField: [Google_Protobuf_Duration] {
+  var durationField: [Google_Protobuf_Duration] {
     get {return _storage._durationField}
     set {_uniqueStorage()._durationField = newValue}
   }
 
-  public var emptyField: [Google_Protobuf_Empty] {
+  var emptyField: [Google_Protobuf_Empty] {
     get {return _storage._emptyField}
     set {_uniqueStorage()._emptyField = newValue}
   }
 
-  public var fieldMaskField: [Google_Protobuf_FieldMask] {
+  var fieldMaskField: [Google_Protobuf_FieldMask] {
     get {return _storage._fieldMaskField}
     set {_uniqueStorage()._fieldMaskField = newValue}
   }
 
-  public var sourceContextField: [Google_Protobuf_SourceContext] {
+  var sourceContextField: [Google_Protobuf_SourceContext] {
     get {return _storage._sourceContextField}
     set {_uniqueStorage()._sourceContextField = newValue}
   }
 
-  public var structField: [Google_Protobuf_Struct] {
+  var structField: [Google_Protobuf_Struct] {
     get {return _storage._structField}
     set {_uniqueStorage()._structField = newValue}
   }
 
-  public var timestampField: [Google_Protobuf_Timestamp] {
+  var timestampField: [Google_Protobuf_Timestamp] {
     get {return _storage._timestampField}
     set {_uniqueStorage()._timestampField = newValue}
   }
 
-  public var typeField: [Google_Protobuf_Type] {
+  var typeField: [Google_Protobuf_Type] {
     get {return _storage._typeField}
     set {_uniqueStorage()._typeField = newValue}
   }
 
   ///   These don't actually make a lot of sense, but they're not prohibited...
-  public var doubleField: [Google_Protobuf_DoubleValue] {
+  var doubleField: [Google_Protobuf_DoubleValue] {
     get {return _storage._doubleField}
     set {_uniqueStorage()._doubleField = newValue}
   }
 
-  public var floatField: [Google_Protobuf_FloatValue] {
+  var floatField: [Google_Protobuf_FloatValue] {
     get {return _storage._floatField}
     set {_uniqueStorage()._floatField = newValue}
   }
 
-  public var int64Field: [Google_Protobuf_Int64Value] {
+  var int64Field: [Google_Protobuf_Int64Value] {
     get {return _storage._int64Field}
     set {_uniqueStorage()._int64Field = newValue}
   }
 
-  public var uint64Field: [Google_Protobuf_UInt64Value] {
+  var uint64Field: [Google_Protobuf_UInt64Value] {
     get {return _storage._uint64Field}
     set {_uniqueStorage()._uint64Field = newValue}
   }
 
-  public var int32Field: [Google_Protobuf_Int32Value] {
+  var int32Field: [Google_Protobuf_Int32Value] {
     get {return _storage._int32Field}
     set {_uniqueStorage()._int32Field = newValue}
   }
 
-  public var uint32Field: [Google_Protobuf_UInt32Value] {
+  var uint32Field: [Google_Protobuf_UInt32Value] {
     get {return _storage._uint32Field}
     set {_uniqueStorage()._uint32Field = newValue}
   }
 
-  public var boolField: [Google_Protobuf_BoolValue] {
+  var boolField: [Google_Protobuf_BoolValue] {
     get {return _storage._boolField}
     set {_uniqueStorage()._boolField = newValue}
   }
 
-  public var stringField: [Google_Protobuf_StringValue] {
+  var stringField: [Google_Protobuf_StringValue] {
     get {return _storage._stringField}
     set {_uniqueStorage()._stringField = newValue}
   }
 
-  public var bytesField: [Google_Protobuf_BytesValue] {
+  var bytesField: [Google_Protobuf_BytesValue] {
     get {return _storage._bytesField}
     set {_uniqueStorage()._bytesField = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1068,7 +1068,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var anyField: Google_Protobuf_Any {
+  var anyField: Google_Protobuf_Any {
     get {
       if case .anyField(let v) = _storage._oneofField {
         return v
@@ -1080,7 +1080,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var apiField: Google_Protobuf_Api {
+  var apiField: Google_Protobuf_Api {
     get {
       if case .apiField(let v) = _storage._oneofField {
         return v
@@ -1092,7 +1092,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var durationField: Google_Protobuf_Duration {
+  var durationField: Google_Protobuf_Duration {
     get {
       if case .durationField(let v) = _storage._oneofField {
         return v
@@ -1104,7 +1104,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var emptyField: Google_Protobuf_Empty {
+  var emptyField: Google_Protobuf_Empty {
     get {
       if case .emptyField(let v) = _storage._oneofField {
         return v
@@ -1116,7 +1116,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var fieldMaskField: Google_Protobuf_FieldMask {
+  var fieldMaskField: Google_Protobuf_FieldMask {
     get {
       if case .fieldMaskField(let v) = _storage._oneofField {
         return v
@@ -1128,7 +1128,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var sourceContextField: Google_Protobuf_SourceContext {
+  var sourceContextField: Google_Protobuf_SourceContext {
     get {
       if case .sourceContextField(let v) = _storage._oneofField {
         return v
@@ -1140,7 +1140,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var structField: Google_Protobuf_Struct {
+  var structField: Google_Protobuf_Struct {
     get {
       if case .structField(let v) = _storage._oneofField {
         return v
@@ -1152,7 +1152,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var timestampField: Google_Protobuf_Timestamp {
+  var timestampField: Google_Protobuf_Timestamp {
     get {
       if case .timestampField(let v) = _storage._oneofField {
         return v
@@ -1164,7 +1164,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var typeField: Google_Protobuf_Type {
+  var typeField: Google_Protobuf_Type {
     get {
       if case .typeField(let v) = _storage._oneofField {
         return v
@@ -1176,7 +1176,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var doubleField: Google_Protobuf_DoubleValue {
+  var doubleField: Google_Protobuf_DoubleValue {
     get {
       if case .doubleField(let v) = _storage._oneofField {
         return v
@@ -1188,7 +1188,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var floatField: Google_Protobuf_FloatValue {
+  var floatField: Google_Protobuf_FloatValue {
     get {
       if case .floatField(let v) = _storage._oneofField {
         return v
@@ -1200,7 +1200,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var int64Field: Google_Protobuf_Int64Value {
+  var int64Field: Google_Protobuf_Int64Value {
     get {
       if case .int64Field(let v) = _storage._oneofField {
         return v
@@ -1212,7 +1212,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var uint64Field: Google_Protobuf_UInt64Value {
+  var uint64Field: Google_Protobuf_UInt64Value {
     get {
       if case .uint64Field(let v) = _storage._oneofField {
         return v
@@ -1224,7 +1224,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var int32Field: Google_Protobuf_Int32Value {
+  var int32Field: Google_Protobuf_Int32Value {
     get {
       if case .int32Field(let v) = _storage._oneofField {
         return v
@@ -1236,7 +1236,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var uint32Field: Google_Protobuf_UInt32Value {
+  var uint32Field: Google_Protobuf_UInt32Value {
     get {
       if case .uint32Field(let v) = _storage._oneofField {
         return v
@@ -1248,7 +1248,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var boolField: Google_Protobuf_BoolValue {
+  var boolField: Google_Protobuf_BoolValue {
     get {
       if case .boolField(let v) = _storage._oneofField {
         return v
@@ -1260,7 +1260,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var stringField: Google_Protobuf_StringValue {
+  var stringField: Google_Protobuf_StringValue {
     get {
       if case .stringField(let v) = _storage._oneofField {
         return v
@@ -1272,7 +1272,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var bytesField: Google_Protobuf_BytesValue {
+  var bytesField: Google_Protobuf_BytesValue {
     get {
       if case .bytesField(let v) = _storage._oneofField {
         return v
@@ -1291,7 +1291,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1514,97 +1514,97 @@ struct ProtobufUnittest_MapWellKnownTypes: ProtobufGeneratedMessage, ProtobufPro
   private var _storage = _StorageClass()
 
 
-  public var anyField: Dictionary<Int32,Google_Protobuf_Any> {
+  var anyField: Dictionary<Int32,Google_Protobuf_Any> {
     get {return _storage._anyField}
     set {_uniqueStorage()._anyField = newValue}
   }
 
-  public var apiField: Dictionary<Int32,Google_Protobuf_Api> {
+  var apiField: Dictionary<Int32,Google_Protobuf_Api> {
     get {return _storage._apiField}
     set {_uniqueStorage()._apiField = newValue}
   }
 
-  public var durationField: Dictionary<Int32,Google_Protobuf_Duration> {
+  var durationField: Dictionary<Int32,Google_Protobuf_Duration> {
     get {return _storage._durationField}
     set {_uniqueStorage()._durationField = newValue}
   }
 
-  public var emptyField: Dictionary<Int32,Google_Protobuf_Empty> {
+  var emptyField: Dictionary<Int32,Google_Protobuf_Empty> {
     get {return _storage._emptyField}
     set {_uniqueStorage()._emptyField = newValue}
   }
 
-  public var fieldMaskField: Dictionary<Int32,Google_Protobuf_FieldMask> {
+  var fieldMaskField: Dictionary<Int32,Google_Protobuf_FieldMask> {
     get {return _storage._fieldMaskField}
     set {_uniqueStorage()._fieldMaskField = newValue}
   }
 
-  public var sourceContextField: Dictionary<Int32,Google_Protobuf_SourceContext> {
+  var sourceContextField: Dictionary<Int32,Google_Protobuf_SourceContext> {
     get {return _storage._sourceContextField}
     set {_uniqueStorage()._sourceContextField = newValue}
   }
 
-  public var structField: Dictionary<Int32,Google_Protobuf_Struct> {
+  var structField: Dictionary<Int32,Google_Protobuf_Struct> {
     get {return _storage._structField}
     set {_uniqueStorage()._structField = newValue}
   }
 
-  public var timestampField: Dictionary<Int32,Google_Protobuf_Timestamp> {
+  var timestampField: Dictionary<Int32,Google_Protobuf_Timestamp> {
     get {return _storage._timestampField}
     set {_uniqueStorage()._timestampField = newValue}
   }
 
-  public var typeField: Dictionary<Int32,Google_Protobuf_Type> {
+  var typeField: Dictionary<Int32,Google_Protobuf_Type> {
     get {return _storage._typeField}
     set {_uniqueStorage()._typeField = newValue}
   }
 
-  public var doubleField: Dictionary<Int32,Google_Protobuf_DoubleValue> {
+  var doubleField: Dictionary<Int32,Google_Protobuf_DoubleValue> {
     get {return _storage._doubleField}
     set {_uniqueStorage()._doubleField = newValue}
   }
 
-  public var floatField: Dictionary<Int32,Google_Protobuf_FloatValue> {
+  var floatField: Dictionary<Int32,Google_Protobuf_FloatValue> {
     get {return _storage._floatField}
     set {_uniqueStorage()._floatField = newValue}
   }
 
-  public var int64Field: Dictionary<Int32,Google_Protobuf_Int64Value> {
+  var int64Field: Dictionary<Int32,Google_Protobuf_Int64Value> {
     get {return _storage._int64Field}
     set {_uniqueStorage()._int64Field = newValue}
   }
 
-  public var uint64Field: Dictionary<Int32,Google_Protobuf_UInt64Value> {
+  var uint64Field: Dictionary<Int32,Google_Protobuf_UInt64Value> {
     get {return _storage._uint64Field}
     set {_uniqueStorage()._uint64Field = newValue}
   }
 
-  public var int32Field: Dictionary<Int32,Google_Protobuf_Int32Value> {
+  var int32Field: Dictionary<Int32,Google_Protobuf_Int32Value> {
     get {return _storage._int32Field}
     set {_uniqueStorage()._int32Field = newValue}
   }
 
-  public var uint32Field: Dictionary<Int32,Google_Protobuf_UInt32Value> {
+  var uint32Field: Dictionary<Int32,Google_Protobuf_UInt32Value> {
     get {return _storage._uint32Field}
     set {_uniqueStorage()._uint32Field = newValue}
   }
 
-  public var boolField: Dictionary<Int32,Google_Protobuf_BoolValue> {
+  var boolField: Dictionary<Int32,Google_Protobuf_BoolValue> {
     get {return _storage._boolField}
     set {_uniqueStorage()._boolField = newValue}
   }
 
-  public var stringField: Dictionary<Int32,Google_Protobuf_StringValue> {
+  var stringField: Dictionary<Int32,Google_Protobuf_StringValue> {
     get {return _storage._stringField}
     set {_uniqueStorage()._stringField = newValue}
   }
 
-  public var bytesField: Dictionary<Int32,Google_Protobuf_BytesValue> {
+  var bytesField: Dictionary<Int32,Google_Protobuf_BytesValue> {
     get {return _storage._bytesField}
     set {_uniqueStorage()._bytesField = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/google/protobuf/wrappers.pb.swift
+++ b/Reference/google/protobuf/wrappers.pb.swift
@@ -60,9 +60,9 @@ struct Google_Protobuf_DoubleValue: ProtobufGeneratedMessage, ProtobufProto3Mess
 
 
   ///   The double value.
-  public var value: Double = 0
+  var value: Double = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -99,9 +99,9 @@ struct Google_Protobuf_FloatValue: ProtobufGeneratedMessage, ProtobufProto3Messa
 
 
   ///   The float value.
-  public var value: Float = 0
+  var value: Float = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -138,9 +138,9 @@ struct Google_Protobuf_Int64Value: ProtobufGeneratedMessage, ProtobufProto3Messa
 
 
   ///   The int64 value.
-  public var value: Int64 = 0
+  var value: Int64 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -177,9 +177,9 @@ struct Google_Protobuf_UInt64Value: ProtobufGeneratedMessage, ProtobufProto3Mess
 
 
   ///   The uint64 value.
-  public var value: UInt64 = 0
+  var value: UInt64 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -216,9 +216,9 @@ struct Google_Protobuf_Int32Value: ProtobufGeneratedMessage, ProtobufProto3Messa
 
 
   ///   The int32 value.
-  public var value: Int32 = 0
+  var value: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -255,9 +255,9 @@ struct Google_Protobuf_UInt32Value: ProtobufGeneratedMessage, ProtobufProto3Mess
 
 
   ///   The uint32 value.
-  public var value: UInt32 = 0
+  var value: UInt32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -294,9 +294,9 @@ struct Google_Protobuf_BoolValue: ProtobufGeneratedMessage, ProtobufProto3Messag
 
 
   ///   The bool value.
-  public var value: Bool = false
+  var value: Bool = false
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -333,9 +333,9 @@ struct Google_Protobuf_StringValue: ProtobufGeneratedMessage, ProtobufProto3Mess
 
 
   ///   The string value.
-  public var value: String = ""
+  var value: String = ""
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -372,9 +372,9 @@ struct Google_Protobuf_BytesValue: ProtobufGeneratedMessage, ProtobufProto3Messa
 
 
   ///   The bytes value.
-  public var value: Data = Data()
+  var value: Data = Data()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/test/option_apple_swift_prefix.pb.swift
+++ b/Reference/test/option_apple_swift_prefix.pb.swift
@@ -18,7 +18,7 @@ struct TestFoo: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/test/test_names.pb.swift
+++ b/Reference/test/test_names.pb.swift
@@ -26,13 +26,13 @@ struct Swift_Protobuf_Test_NamesTest: ProtobufGeneratedMessage, ProtobufProto3Me
   ]}
 
 
-  public var httpRequest: Int32 = 0
+  var httpRequest: Int32 = 0
 
-  public var url: Int32 = 0
+  var url: Int32 = 0
 
-  public var aBC: Int32 = 0
+  var aBC: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -77,11 +77,11 @@ struct Swift_Protobuf_Test_NamesTest2: ProtobufGeneratedMessage, ProtobufProto3M
   ]}
 
 
-  public var httprequest: Int32 = 0
+  var httprequest: Int32 = 0
 
-  public var url: Int32 = 0
+  var url: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -119,9 +119,9 @@ struct Swift_Protobuf_Test_NamesTest3: ProtobufGeneratedMessage, ProtobufProto3M
   ]}
 
 
-  public var url: Int32 = 0
+  var url: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -507,7 +507,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
@@ -515,11 +515,11 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     ///   Intentionally negative.
     case neg // = -1
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       case 2: self = .bar
@@ -529,7 +529,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -539,7 +539,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -549,7 +549,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -559,7 +559,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -570,7 +570,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -581,9 +581,9 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -613,7 +613,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -624,7 +624,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       return _bb = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -659,7 +659,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -670,7 +670,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -692,7 +692,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
   }
 
   ///   Singular
-  public var requiredInt32: Int32 {
+  var requiredInt32: Int32 {
     get {return _storage._requiredInt32 ?? 0}
     set {_uniqueStorage()._requiredInt32 = newValue}
   }
@@ -703,7 +703,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredInt32 = nil
   }
 
-  public var requiredInt64: Int64 {
+  var requiredInt64: Int64 {
     get {return _storage._requiredInt64 ?? 0}
     set {_uniqueStorage()._requiredInt64 = newValue}
   }
@@ -714,7 +714,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredInt64 = nil
   }
 
-  public var requiredUint32: UInt32 {
+  var requiredUint32: UInt32 {
     get {return _storage._requiredUint32 ?? 0}
     set {_uniqueStorage()._requiredUint32 = newValue}
   }
@@ -725,7 +725,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredUint32 = nil
   }
 
-  public var requiredUint64: UInt64 {
+  var requiredUint64: UInt64 {
     get {return _storage._requiredUint64 ?? 0}
     set {_uniqueStorage()._requiredUint64 = newValue}
   }
@@ -736,7 +736,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredUint64 = nil
   }
 
-  public var requiredSint32: Int32 {
+  var requiredSint32: Int32 {
     get {return _storage._requiredSint32 ?? 0}
     set {_uniqueStorage()._requiredSint32 = newValue}
   }
@@ -747,7 +747,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredSint32 = nil
   }
 
-  public var requiredSint64: Int64 {
+  var requiredSint64: Int64 {
     get {return _storage._requiredSint64 ?? 0}
     set {_uniqueStorage()._requiredSint64 = newValue}
   }
@@ -758,7 +758,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredSint64 = nil
   }
 
-  public var requiredFixed32: UInt32 {
+  var requiredFixed32: UInt32 {
     get {return _storage._requiredFixed32 ?? 0}
     set {_uniqueStorage()._requiredFixed32 = newValue}
   }
@@ -769,7 +769,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredFixed32 = nil
   }
 
-  public var requiredFixed64: UInt64 {
+  var requiredFixed64: UInt64 {
     get {return _storage._requiredFixed64 ?? 0}
     set {_uniqueStorage()._requiredFixed64 = newValue}
   }
@@ -780,7 +780,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredFixed64 = nil
   }
 
-  public var requiredSfixed32: Int32 {
+  var requiredSfixed32: Int32 {
     get {return _storage._requiredSfixed32 ?? 0}
     set {_uniqueStorage()._requiredSfixed32 = newValue}
   }
@@ -791,7 +791,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredSfixed32 = nil
   }
 
-  public var requiredSfixed64: Int64 {
+  var requiredSfixed64: Int64 {
     get {return _storage._requiredSfixed64 ?? 0}
     set {_uniqueStorage()._requiredSfixed64 = newValue}
   }
@@ -802,7 +802,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredSfixed64 = nil
   }
 
-  public var requiredFloat: Float {
+  var requiredFloat: Float {
     get {return _storage._requiredFloat ?? 0}
     set {_uniqueStorage()._requiredFloat = newValue}
   }
@@ -813,7 +813,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredFloat = nil
   }
 
-  public var requiredDouble: Double {
+  var requiredDouble: Double {
     get {return _storage._requiredDouble ?? 0}
     set {_uniqueStorage()._requiredDouble = newValue}
   }
@@ -824,7 +824,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredDouble = nil
   }
 
-  public var requiredBool: Bool {
+  var requiredBool: Bool {
     get {return _storage._requiredBool ?? false}
     set {_uniqueStorage()._requiredBool = newValue}
   }
@@ -835,7 +835,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredBool = nil
   }
 
-  public var requiredString: String {
+  var requiredString: String {
     get {return _storage._requiredString ?? ""}
     set {_uniqueStorage()._requiredString = newValue}
   }
@@ -846,7 +846,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredString = nil
   }
 
-  public var requiredBytes: Data {
+  var requiredBytes: Data {
     get {return _storage._requiredBytes ?? Data()}
     set {_uniqueStorage()._requiredBytes = newValue}
   }
@@ -857,7 +857,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredBytes = nil
   }
 
-  public var requiredGroup: ProtobufUnittest_TestAllRequiredTypes.RequiredGroup {
+  var requiredGroup: ProtobufUnittest_TestAllRequiredTypes.RequiredGroup {
     get {return _storage._requiredGroup ?? ProtobufUnittest_TestAllRequiredTypes.RequiredGroup()}
     set {_uniqueStorage()._requiredGroup = newValue}
   }
@@ -868,7 +868,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredGroup = nil
   }
 
-  public var requiredNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
+  var requiredNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
     get {return _storage._requiredNestedMessage ?? ProtobufUnittest_TestAllRequiredTypes.NestedMessage()}
     set {_uniqueStorage()._requiredNestedMessage = newValue}
   }
@@ -879,7 +879,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredNestedMessage = nil
   }
 
-  public var requiredForeignMessage: ProtobufUnittest_ForeignMessage {
+  var requiredForeignMessage: ProtobufUnittest_ForeignMessage {
     get {return _storage._requiredForeignMessage ?? ProtobufUnittest_ForeignMessage()}
     set {_uniqueStorage()._requiredForeignMessage = newValue}
   }
@@ -890,7 +890,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredForeignMessage = nil
   }
 
-  public var requiredImportMessage: ProtobufUnittestImport_ImportMessage {
+  var requiredImportMessage: ProtobufUnittestImport_ImportMessage {
     get {return _storage._requiredImportMessage ?? ProtobufUnittestImport_ImportMessage()}
     set {_uniqueStorage()._requiredImportMessage = newValue}
   }
@@ -901,7 +901,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredImportMessage = nil
   }
 
-  public var requiredNestedEnum: ProtobufUnittest_TestAllRequiredTypes.NestedEnum {
+  var requiredNestedEnum: ProtobufUnittest_TestAllRequiredTypes.NestedEnum {
     get {return _storage._requiredNestedEnum ?? ProtobufUnittest_TestAllRequiredTypes.NestedEnum.foo}
     set {_uniqueStorage()._requiredNestedEnum = newValue}
   }
@@ -912,7 +912,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredNestedEnum = nil
   }
 
-  public var requiredForeignEnum: ProtobufUnittest_ForeignEnum {
+  var requiredForeignEnum: ProtobufUnittest_ForeignEnum {
     get {return _storage._requiredForeignEnum ?? ProtobufUnittest_ForeignEnum.foreignFoo}
     set {_uniqueStorage()._requiredForeignEnum = newValue}
   }
@@ -923,7 +923,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredForeignEnum = nil
   }
 
-  public var requiredImportEnum: ProtobufUnittestImport_ImportEnum {
+  var requiredImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._requiredImportEnum ?? ProtobufUnittestImport_ImportEnum.importFoo}
     set {_uniqueStorage()._requiredImportEnum = newValue}
   }
@@ -934,7 +934,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredImportEnum = nil
   }
 
-  public var requiredStringPiece: String {
+  var requiredStringPiece: String {
     get {return _storage._requiredStringPiece ?? ""}
     set {_uniqueStorage()._requiredStringPiece = newValue}
   }
@@ -945,7 +945,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredStringPiece = nil
   }
 
-  public var requiredCord: String {
+  var requiredCord: String {
     get {return _storage._requiredCord ?? ""}
     set {_uniqueStorage()._requiredCord = newValue}
   }
@@ -957,7 +957,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
   }
 
   ///   Defined in unittest_import_public.proto
-  public var requiredPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
+  var requiredPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._requiredPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._requiredPublicImportMessage = newValue}
   }
@@ -968,7 +968,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredPublicImportMessage = nil
   }
 
-  public var requiredLazyMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
+  var requiredLazyMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
     get {return _storage._requiredLazyMessage ?? ProtobufUnittest_TestAllRequiredTypes.NestedMessage()}
     set {_uniqueStorage()._requiredLazyMessage = newValue}
   }
@@ -980,7 +980,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
   }
 
   ///   Singular with defaults
-  public var defaultInt32: Int32 {
+  var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
   }
@@ -991,7 +991,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultInt32 = nil
   }
 
-  public var defaultInt64: Int64 {
+  var defaultInt64: Int64 {
     get {return _storage._defaultInt64 ?? 42}
     set {_uniqueStorage()._defaultInt64 = newValue}
   }
@@ -1002,7 +1002,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultInt64 = nil
   }
 
-  public var defaultUint32: UInt32 {
+  var defaultUint32: UInt32 {
     get {return _storage._defaultUint32 ?? 43}
     set {_uniqueStorage()._defaultUint32 = newValue}
   }
@@ -1013,7 +1013,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultUint32 = nil
   }
 
-  public var defaultUint64: UInt64 {
+  var defaultUint64: UInt64 {
     get {return _storage._defaultUint64 ?? 44}
     set {_uniqueStorage()._defaultUint64 = newValue}
   }
@@ -1024,7 +1024,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultUint64 = nil
   }
 
-  public var defaultSint32: Int32 {
+  var defaultSint32: Int32 {
     get {return _storage._defaultSint32 ?? -45}
     set {_uniqueStorage()._defaultSint32 = newValue}
   }
@@ -1035,7 +1035,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultSint32 = nil
   }
 
-  public var defaultSint64: Int64 {
+  var defaultSint64: Int64 {
     get {return _storage._defaultSint64 ?? 46}
     set {_uniqueStorage()._defaultSint64 = newValue}
   }
@@ -1046,7 +1046,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultSint64 = nil
   }
 
-  public var defaultFixed32: UInt32 {
+  var defaultFixed32: UInt32 {
     get {return _storage._defaultFixed32 ?? 47}
     set {_uniqueStorage()._defaultFixed32 = newValue}
   }
@@ -1057,7 +1057,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultFixed32 = nil
   }
 
-  public var defaultFixed64: UInt64 {
+  var defaultFixed64: UInt64 {
     get {return _storage._defaultFixed64 ?? 48}
     set {_uniqueStorage()._defaultFixed64 = newValue}
   }
@@ -1068,7 +1068,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultFixed64 = nil
   }
 
-  public var defaultSfixed32: Int32 {
+  var defaultSfixed32: Int32 {
     get {return _storage._defaultSfixed32 ?? 49}
     set {_uniqueStorage()._defaultSfixed32 = newValue}
   }
@@ -1079,7 +1079,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultSfixed32 = nil
   }
 
-  public var defaultSfixed64: Int64 {
+  var defaultSfixed64: Int64 {
     get {return _storage._defaultSfixed64 ?? -50}
     set {_uniqueStorage()._defaultSfixed64 = newValue}
   }
@@ -1090,7 +1090,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultSfixed64 = nil
   }
 
-  public var defaultFloat: Float {
+  var defaultFloat: Float {
     get {return _storage._defaultFloat ?? 51.5}
     set {_uniqueStorage()._defaultFloat = newValue}
   }
@@ -1101,7 +1101,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultFloat = nil
   }
 
-  public var defaultDouble: Double {
+  var defaultDouble: Double {
     get {return _storage._defaultDouble ?? 52000}
     set {_uniqueStorage()._defaultDouble = newValue}
   }
@@ -1112,7 +1112,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultDouble = nil
   }
 
-  public var defaultBool: Bool {
+  var defaultBool: Bool {
     get {return _storage._defaultBool ?? true}
     set {_uniqueStorage()._defaultBool = newValue}
   }
@@ -1123,7 +1123,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultBool = nil
   }
 
-  public var defaultString: String {
+  var defaultString: String {
     get {return _storage._defaultString ?? "hello"}
     set {_uniqueStorage()._defaultString = newValue}
   }
@@ -1134,7 +1134,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultString = nil
   }
 
-  public var defaultBytes: Data {
+  var defaultBytes: Data {
     get {return _storage._defaultBytes ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {_uniqueStorage()._defaultBytes = newValue}
   }
@@ -1145,7 +1145,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultBytes = nil
   }
 
-  public var defaultNestedEnum: ProtobufUnittest_TestAllRequiredTypes.NestedEnum {
+  var defaultNestedEnum: ProtobufUnittest_TestAllRequiredTypes.NestedEnum {
     get {return _storage._defaultNestedEnum ?? ProtobufUnittest_TestAllRequiredTypes.NestedEnum.bar}
     set {_uniqueStorage()._defaultNestedEnum = newValue}
   }
@@ -1156,7 +1156,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultNestedEnum = nil
   }
 
-  public var defaultForeignEnum: ProtobufUnittest_ForeignEnum {
+  var defaultForeignEnum: ProtobufUnittest_ForeignEnum {
     get {return _storage._defaultForeignEnum ?? ProtobufUnittest_ForeignEnum.foreignBar}
     set {_uniqueStorage()._defaultForeignEnum = newValue}
   }
@@ -1167,7 +1167,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultForeignEnum = nil
   }
 
-  public var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
+  var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._defaultImportEnum ?? ProtobufUnittestImport_ImportEnum.importBar}
     set {_uniqueStorage()._defaultImportEnum = newValue}
   }
@@ -1178,7 +1178,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultImportEnum = nil
   }
 
-  public var defaultStringPiece: String {
+  var defaultStringPiece: String {
     get {return _storage._defaultStringPiece ?? "abc"}
     set {_uniqueStorage()._defaultStringPiece = newValue}
   }
@@ -1189,7 +1189,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultStringPiece = nil
   }
 
-  public var defaultCord: String {
+  var defaultCord: String {
     get {return _storage._defaultCord ?? "123"}
     set {_uniqueStorage()._defaultCord = newValue}
   }
@@ -1200,7 +1200,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultCord = nil
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1212,7 +1212,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public var oneofNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
+  var oneofNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1224,7 +1224,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1236,7 +1236,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1255,7 +1255,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1301,42 +1301,42 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   public var unknown = ProtobufUnknownStorage()
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       default: return nil
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -1344,7 +1344,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -1352,9 +1352,9 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1366,7 +1366,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
 
   ///   Singular
   private var _requiredInt32: Int32? = nil
-  public var requiredInt32: Int32 {
+  var requiredInt32: Int32 {
     get {return _requiredInt32 ?? 0}
     set {_requiredInt32 = newValue}
   }
@@ -1378,7 +1378,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   }
 
   private var _requiredFloat: Float? = nil
-  public var requiredFloat: Float {
+  var requiredFloat: Float {
     get {return _requiredFloat ?? 0}
     set {_requiredFloat = newValue}
   }
@@ -1390,7 +1390,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   }
 
   private var _requiredBool: Bool? = nil
-  public var requiredBool: Bool {
+  var requiredBool: Bool {
     get {return _requiredBool ?? false}
     set {_requiredBool = newValue}
   }
@@ -1402,7 +1402,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   }
 
   private var _requiredString: String? = nil
-  public var requiredString: String {
+  var requiredString: String {
     get {return _requiredString ?? ""}
     set {_requiredString = newValue}
   }
@@ -1414,7 +1414,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   }
 
   private var _requiredBytes: Data? = nil
-  public var requiredBytes: Data {
+  var requiredBytes: Data {
     get {return _requiredBytes ?? Data()}
     set {_requiredBytes = newValue}
   }
@@ -1426,7 +1426,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   }
 
   private var _requiredNestedEnum: ProtobufUnittest_TestSomeRequiredTypes.NestedEnum? = nil
-  public var requiredNestedEnum: ProtobufUnittest_TestSomeRequiredTypes.NestedEnum {
+  var requiredNestedEnum: ProtobufUnittest_TestSomeRequiredTypes.NestedEnum {
     get {return _requiredNestedEnum ?? ProtobufUnittest_TestSomeRequiredTypes.NestedEnum.foo}
     set {_requiredNestedEnum = newValue}
   }
@@ -1437,7 +1437,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
     return _requiredNestedEnum = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/unittest_swift_cycle.pb.swift
+++ b/Reference/unittest_swift_cycle.pb.swift
@@ -118,7 +118,7 @@ struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage, ProtobufProto2Messag
     set {_storage.unknown = newValue}
   }
 
-  public var aFoo: ProtobufUnittest_CycleFoo {
+  var aFoo: ProtobufUnittest_CycleFoo {
     get {return _storage._aFoo ?? ProtobufUnittest_CycleFoo()}
     set {_uniqueStorage()._aFoo = newValue}
   }
@@ -129,7 +129,7 @@ struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aFoo = nil
   }
 
-  public var aBar: ProtobufUnittest_CycleBar {
+  var aBar: ProtobufUnittest_CycleBar {
     get {return _storage._aBar ?? ProtobufUnittest_CycleBar()}
     set {_uniqueStorage()._aBar = newValue}
   }
@@ -140,7 +140,7 @@ struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBar = nil
   }
 
-  public var aBaz: ProtobufUnittest_CycleBaz {
+  var aBaz: ProtobufUnittest_CycleBaz {
     get {return _storage._aBaz ?? ProtobufUnittest_CycleBaz()}
     set {_uniqueStorage()._aBaz = newValue}
   }
@@ -151,7 +151,7 @@ struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBaz = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -244,7 +244,7 @@ struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage, ProtobufProto2Messag
     set {_storage.unknown = newValue}
   }
 
-  public var aBar: ProtobufUnittest_CycleBar {
+  var aBar: ProtobufUnittest_CycleBar {
     get {return _storage._aBar ?? ProtobufUnittest_CycleBar()}
     set {_uniqueStorage()._aBar = newValue}
   }
@@ -255,7 +255,7 @@ struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBar = nil
   }
 
-  public var aBaz: ProtobufUnittest_CycleBaz {
+  var aBaz: ProtobufUnittest_CycleBaz {
     get {return _storage._aBaz ?? ProtobufUnittest_CycleBaz()}
     set {_uniqueStorage()._aBaz = newValue}
   }
@@ -266,7 +266,7 @@ struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBaz = nil
   }
 
-  public var aFoo: ProtobufUnittest_CycleFoo {
+  var aFoo: ProtobufUnittest_CycleFoo {
     get {return _storage._aFoo ?? ProtobufUnittest_CycleFoo()}
     set {_uniqueStorage()._aFoo = newValue}
   }
@@ -277,7 +277,7 @@ struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aFoo = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -370,7 +370,7 @@ struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage, ProtobufProto2Messag
     set {_storage.unknown = newValue}
   }
 
-  public var aBaz: ProtobufUnittest_CycleBaz {
+  var aBaz: ProtobufUnittest_CycleBaz {
     get {return _storage._aBaz ?? ProtobufUnittest_CycleBaz()}
     set {_uniqueStorage()._aBaz = newValue}
   }
@@ -381,7 +381,7 @@ struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBaz = nil
   }
 
-  public var aFoo: ProtobufUnittest_CycleFoo {
+  var aFoo: ProtobufUnittest_CycleFoo {
     get {return _storage._aFoo ?? ProtobufUnittest_CycleFoo()}
     set {_uniqueStorage()._aFoo = newValue}
   }
@@ -392,7 +392,7 @@ struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aFoo = nil
   }
 
-  public var aBar: ProtobufUnittest_CycleBar {
+  var aBar: ProtobufUnittest_CycleBar {
     get {return _storage._aBar ?? ProtobufUnittest_CycleBar()}
     set {_uniqueStorage()._aBar = newValue}
   }
@@ -403,7 +403,7 @@ struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBar = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/unittest_swift_enum.pb.swift
+++ b/Reference/unittest_swift_enum.pb.swift
@@ -50,15 +50,15 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   enum EnumTest1: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case firstValue // = 1
     case secondValue // = 2
 
-    public init() {
+    init() {
       self = .firstValue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .firstValue
       case 2: self = .secondValue
@@ -66,7 +66,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "firstValue": self = .firstValue
       case "secondValue": self = .secondValue
@@ -74,7 +74,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ENUM_TEST_1_FIRST_VALUE": self = .firstValue
       case "ENUM_TEST_1_SECOND_VALUE": self = .secondValue
@@ -82,7 +82,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ENUM_TEST_1_FIRST_VALUE": self = .firstValue
       case "ENUM_TEST_1_SECOND_VALUE": self = .secondValue
@@ -90,7 +90,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .firstValue: return 1
@@ -99,7 +99,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .firstValue: return "\"ENUM_TEST_1_FIRST_VALUE\""
@@ -108,9 +108,9 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .firstValue: return ".firstValue"
@@ -122,15 +122,15 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   enum EnumTest2: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case enumTest2FirstValue // = 1
     case secondValue // = 2
 
-    public init() {
+    init() {
       self = .enumTest2FirstValue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .enumTest2FirstValue
       case 2: self = .secondValue
@@ -138,7 +138,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "enumTest2FirstValue": self = .enumTest2FirstValue
       case "secondValue": self = .secondValue
@@ -146,7 +146,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ENUM_TEST_2_FIRST_VALUE": self = .enumTest2FirstValue
       case "SECOND_VALUE": self = .secondValue
@@ -154,7 +154,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ENUM_TEST_2_FIRST_VALUE": self = .enumTest2FirstValue
       case "SECOND_VALUE": self = .secondValue
@@ -162,7 +162,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .enumTest2FirstValue: return 1
@@ -171,7 +171,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .enumTest2FirstValue: return "\"ENUM_TEST_2_FIRST_VALUE\""
@@ -180,9 +180,9 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .enumTest2FirstValue: return ".enumTest2FirstValue"
@@ -193,7 +193,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
 
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/unittest_swift_enum_optional_default.pb.swift
+++ b/Reference/unittest_swift_enum_optional_default.pb.swift
@@ -98,42 +98,42 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
     }
 
     enum Enum: ProtobufEnum {
-      public typealias RawValue = Int
+      typealias RawValue = Int
       case foo // = 0
 
-      public init() {
+      init() {
         self = .foo
       }
 
-      public init?(rawValue: Int) {
+      init?(rawValue: Int) {
         switch rawValue {
         case 0: self = .foo
         default: return nil
         }
       }
 
-      public init?(name: String) {
+      init?(name: String) {
         switch name {
         case "foo": self = .foo
         default: return nil
         }
       }
 
-      public init?(jsonName: String) {
+      init?(jsonName: String) {
         switch jsonName {
         case "FOO": self = .foo
         default: return nil
         }
       }
 
-      public init?(protoName: String) {
+      init?(protoName: String) {
         switch protoName {
         case "FOO": self = .foo
         default: return nil
         }
       }
 
-      public var rawValue: Int {
+      var rawValue: Int {
         get {
           switch self {
           case .foo: return 0
@@ -141,7 +141,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
         }
       }
 
-      public var json: String {
+      var json: String {
         get {
           switch self {
           case .foo: return "\"FOO\""
@@ -149,9 +149,9 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
         }
       }
 
-      public var hashValue: Int { return rawValue }
+      var hashValue: Int { return rawValue }
 
-      public var debugDescription: String {
+      var debugDescription: String {
         get {
           switch self {
           case .foo: return ".foo"
@@ -163,7 +163,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
 
     ///   The circular reference here forces the generator to
     ///   implement heap-backed storage.
-    public var message: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage {
+    var message: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage {
       get {return _storage._message ?? ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage()}
       set {_uniqueStorage()._message = newValue}
     }
@@ -174,7 +174,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
       return _storage._message = nil
     }
 
-    public var optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage.Enum {
+    var optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage.Enum {
       get {return _storage._optionalEnum ?? ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage.Enum.foo}
       set {_uniqueStorage()._optionalEnum = newValue}
     }
@@ -185,7 +185,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
       return _storage._optionalEnum = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -221,42 +221,42 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
     public var unknown = ProtobufUnknownStorage()
 
     enum Enum: ProtobufEnum {
-      public typealias RawValue = Int
+      typealias RawValue = Int
       case foo // = 0
 
-      public init() {
+      init() {
         self = .foo
       }
 
-      public init?(rawValue: Int) {
+      init?(rawValue: Int) {
         switch rawValue {
         case 0: self = .foo
         default: return nil
         }
       }
 
-      public init?(name: String) {
+      init?(name: String) {
         switch name {
         case "foo": self = .foo
         default: return nil
         }
       }
 
-      public init?(jsonName: String) {
+      init?(jsonName: String) {
         switch jsonName {
         case "FOO": self = .foo
         default: return nil
         }
       }
 
-      public init?(protoName: String) {
+      init?(protoName: String) {
         switch protoName {
         case "FOO": self = .foo
         default: return nil
         }
       }
 
-      public var rawValue: Int {
+      var rawValue: Int {
         get {
           switch self {
           case .foo: return 0
@@ -264,7 +264,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
         }
       }
 
-      public var json: String {
+      var json: String {
         get {
           switch self {
           case .foo: return "\"FOO\""
@@ -272,9 +272,9 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
         }
       }
 
-      public var hashValue: Int { return rawValue }
+      var hashValue: Int { return rawValue }
 
-      public var debugDescription: String {
+      var debugDescription: String {
         get {
           switch self {
           case .foo: return ".foo"
@@ -285,7 +285,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
     }
 
     private var _optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2.Enum? = nil
-    public var optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2.Enum {
+    var optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2.Enum {
       get {return _optionalEnum ?? ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2.Enum.foo}
       set {_optionalEnum = newValue}
     }
@@ -296,7 +296,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
       return _optionalEnum = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -319,7 +319,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -58,7 +58,7 @@ struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage, ProtobufProto2Mess
       public var unknown = ProtobufUnknownStorage()
 
       private var _a: Int32? = nil
-      public var a: Int32 {
+      var a: Int32 {
         get {return _a ?? 0}
         set {_a = newValue}
       }
@@ -69,7 +69,7 @@ struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage, ProtobufProto2Mess
         return _a = nil
       }
 
-      public init() {}
+      init() {}
 
       public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
         switch protoFieldNumber {
@@ -117,7 +117,7 @@ struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     }
@@ -132,7 +132,7 @@ struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -162,7 +162,7 @@ struct ProtobufUnittest_Extend_C: ProtobufGeneratedMessage, ProtobufProto2Messag
 
   ///        extensions 10 to 20;
   private var _c: Int64? = nil
-  public var c: Int64 {
+  var c: Int64 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -173,7 +173,7 @@ struct ProtobufUnittest_Extend_C: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -217,7 +217,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     public var unknown = ProtobufUnknownStorage()
 
     private var _oo: Int64? = nil
-    public var oo: Int64 {
+    var oo: Int64 {
       get {return _oo ?? 0}
       set {_oo = newValue}
     }
@@ -229,7 +229,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
 
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -240,7 +240,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
       return _bb = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -268,7 +268,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var myString: String {
+  var myString: String {
     get {return _storage._myString ?? ""}
     set {_uniqueStorage()._myString = newValue}
   }
@@ -279,7 +279,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     return _storage._myString = nil
   }
 
-  public var myInt: Int64 {
+  var myInt: Int64 {
     get {return _storage._myInt ?? 0}
     set {_uniqueStorage()._myInt = newValue}
   }
@@ -290,7 +290,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     return _storage._myInt = nil
   }
 
-  public var myFloat: Float {
+  var myFloat: Float {
     get {return _storage._myFloat ?? 0}
     set {_uniqueStorage()._myFloat = newValue}
   }
@@ -301,7 +301,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     return _storage._myFloat = nil
   }
 
-  public var oneofInt64: Int64 {
+  var oneofInt64: Int64 {
     get {
       if case .oneofInt64(let v) = _storage._options {
         return v
@@ -313,7 +313,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofBool: Bool {
+  var oneofBool: Bool {
     get {
       if case .oneofBool(let v) = _storage._options {
         return v
@@ -325,7 +325,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._options {
         return v
@@ -337,7 +337,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofInt32: Int32 {
+  var oneofInt32: Int32 {
     get {
       if case .oneofInt32(let v) = _storage._options {
         return v
@@ -349,7 +349,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage {
+  var optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Swift_Protobuf_TestFieldOrderings.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -367,7 +367,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -55,7 +55,7 @@ struct SwiftTestGroupExtensions: ProtobufGeneratedMessage, ProtobufProto2Message
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -66,7 +66,7 @@ struct SwiftTestGroupExtensions: ProtobufGeneratedMessage, ProtobufProto2Message
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -128,7 +128,7 @@ struct ExtensionGroup: ProtobufGeneratedMessage, ProtobufProto2Message {
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -139,7 +139,7 @@ struct ExtensionGroup: ProtobufGeneratedMessage, ProtobufProto2Message {
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -176,7 +176,7 @@ struct RepeatedExtensionGroup: ProtobufGeneratedMessage, ProtobufProto2Message {
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -187,7 +187,7 @@ struct RepeatedExtensionGroup: ProtobufGeneratedMessage, ProtobufProto2Message {
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -224,7 +224,7 @@ struct SwiftTestGroupUnextended: ProtobufGeneratedMessage, ProtobufProto2Message
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -235,7 +235,7 @@ struct SwiftTestGroupUnextended: ProtobufGeneratedMessage, ProtobufProto2Message
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -27,7 +27,7 @@ import SwiftProtobuf
 
 
 enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case a // = 0
   case string // = 1
   case int // = 2
@@ -238,11 +238,11 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
   case timeRecord // = 243
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .a
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .a
     case 1: self = .string
@@ -456,7 +456,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "a": self = .a
     case "string": self = .string
@@ -670,7 +670,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "A": self = .a
     case "String": self = .string
@@ -884,7 +884,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "A": self = .a
     case "String": self = .string
@@ -1098,7 +1098,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .a: return 0
@@ -1314,7 +1314,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .a: return "\"A\""
@@ -1530,9 +1530,9 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .a: return ".a"
@@ -1751,7 +1751,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
 }
 
 enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case aa // = 0
 
   ///   protoc no longer allows enum naming that would differ only in underscores.
@@ -1764,11 +1764,11 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
   case ____ // = 1065
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .aa
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .aa
     case 1065: self = .____
@@ -1776,7 +1776,7 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "aa": self = .aa
     case "____": self = .____
@@ -1784,7 +1784,7 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "AA": self = .aa
     case "__": self = .____
@@ -1792,7 +1792,7 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "AA": self = .aa
     case "__": self = .____
@@ -1800,7 +1800,7 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .aa: return 0
@@ -1810,7 +1810,7 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .aa: return "\"AA\""
@@ -1820,9 +1820,9 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .aa: return ".aa"
@@ -3745,1047 +3745,1047 @@ struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage, ProtobufProto3M
   private var _storage = _StorageClass()
 
 
-  public var string: Int32 {
+  var string: Int32 {
     get {return _storage._string}
     set {_uniqueStorage()._string = newValue}
   }
 
-  public var int: Int32 {
+  var int: Int32 {
     get {return _storage._int}
     set {_uniqueStorage()._int = newValue}
   }
 
-  public var double: Int32 {
+  var double: Int32 {
     get {return _storage._double}
     set {_uniqueStorage()._double = newValue}
   }
 
-  public var float: Int32 {
+  var float: Int32 {
     get {return _storage._float}
     set {_uniqueStorage()._float = newValue}
   }
 
-  public var uint: Int32 {
+  var uint: Int32 {
     get {return _storage._uint}
     set {_uniqueStorage()._uint = newValue}
   }
 
-  public var hashValue_p: Int32 {
+  var hashValue_p: Int32 {
     get {return _storage._hashValue_p}
     set {_uniqueStorage()._hashValue_p = newValue}
   }
 
-  public var description_p: Int32 {
+  var description_p: Int32 {
     get {return _storage._description_p}
     set {_uniqueStorage()._description_p = newValue}
   }
 
-  public var debugDescription_p: Int32 {
+  var debugDescription_p: Int32 {
     get {return _storage._debugDescription_p}
     set {_uniqueStorage()._debugDescription_p = newValue}
   }
 
-  public var swift: Int32 {
+  var swift: Int32 {
     get {return _storage._swift}
     set {_uniqueStorage()._swift = newValue}
   }
 
-  public var unrecognized: Int32 {
+  var unrecognized: Int32 {
     get {return _storage._unrecognized}
     set {_uniqueStorage()._unrecognized = newValue}
   }
 
-  public var class_p: Int32 {
+  var class_p: Int32 {
     get {return _storage._class_p}
     set {_uniqueStorage()._class_p = newValue}
   }
 
-  public var deinit_p: Int32 {
+  var deinit_p: Int32 {
     get {return _storage._deinit_p}
     set {_uniqueStorage()._deinit_p = newValue}
   }
 
-  public var enum_p: Int32 {
+  var enum_p: Int32 {
     get {return _storage._enum_p}
     set {_uniqueStorage()._enum_p = newValue}
   }
 
-  public var extension_p: Int32 {
+  var extension_p: Int32 {
     get {return _storage._extension_p}
     set {_uniqueStorage()._extension_p = newValue}
   }
 
-  public var func_p: Int32 {
+  var func_p: Int32 {
     get {return _storage._func_p}
     set {_uniqueStorage()._func_p = newValue}
   }
 
-  public var import_p: Int32 {
+  var import_p: Int32 {
     get {return _storage._import_p}
     set {_uniqueStorage()._import_p = newValue}
   }
 
-  public var init_p: Int32 {
+  var init_p: Int32 {
     get {return _storage._init_p}
     set {_uniqueStorage()._init_p = newValue}
   }
 
-  public var inout_p: Int32 {
+  var inout_p: Int32 {
     get {return _storage._inout_p}
     set {_uniqueStorage()._inout_p = newValue}
   }
 
-  public var internal_p: Int32 {
+  var internal_p: Int32 {
     get {return _storage._internal_p}
     set {_uniqueStorage()._internal_p = newValue}
   }
 
-  public var let_p: Int32 {
+  var let_p: Int32 {
     get {return _storage._let_p}
     set {_uniqueStorage()._let_p = newValue}
   }
 
-  public var operator_p: Int32 {
+  var operator_p: Int32 {
     get {return _storage._operator_p}
     set {_uniqueStorage()._operator_p = newValue}
   }
 
-  public var private_p: Int32 {
+  var private_p: Int32 {
     get {return _storage._private_p}
     set {_uniqueStorage()._private_p = newValue}
   }
 
-  public var protocol_p: Int32 {
+  var protocol_p: Int32 {
     get {return _storage._protocol_p}
     set {_uniqueStorage()._protocol_p = newValue}
   }
 
-  public var public_p: Int32 {
+  var public_p: Int32 {
     get {return _storage._public_p}
     set {_uniqueStorage()._public_p = newValue}
   }
 
-  public var static_p: Int32 {
+  var static_p: Int32 {
     get {return _storage._static_p}
     set {_uniqueStorage()._static_p = newValue}
   }
 
-  public var struct_p: Int32 {
+  var struct_p: Int32 {
     get {return _storage._struct_p}
     set {_uniqueStorage()._struct_p = newValue}
   }
 
-  public var subscript_p: Int32 {
+  var subscript_p: Int32 {
     get {return _storage._subscript_p}
     set {_uniqueStorage()._subscript_p = newValue}
   }
 
-  public var typealias_p: Int32 {
+  var typealias_p: Int32 {
     get {return _storage._typealias_p}
     set {_uniqueStorage()._typealias_p = newValue}
   }
 
-  public var var_p: Int32 {
+  var var_p: Int32 {
     get {return _storage._var_p}
     set {_uniqueStorage()._var_p = newValue}
   }
 
-  public var break_p: Int32 {
+  var break_p: Int32 {
     get {return _storage._break_p}
     set {_uniqueStorage()._break_p = newValue}
   }
 
-  public var case_p: Int32 {
+  var case_p: Int32 {
     get {return _storage._case_p}
     set {_uniqueStorage()._case_p = newValue}
   }
 
-  public var continue_p: Int32 {
+  var continue_p: Int32 {
     get {return _storage._continue_p}
     set {_uniqueStorage()._continue_p = newValue}
   }
 
-  public var default_p: Int32 {
+  var default_p: Int32 {
     get {return _storage._default_p}
     set {_uniqueStorage()._default_p = newValue}
   }
 
-  public var defer_p: Int32 {
+  var defer_p: Int32 {
     get {return _storage._defer_p}
     set {_uniqueStorage()._defer_p = newValue}
   }
 
-  public var do_p: Int32 {
+  var do_p: Int32 {
     get {return _storage._do_p}
     set {_uniqueStorage()._do_p = newValue}
   }
 
-  public var else_p: Int32 {
+  var else_p: Int32 {
     get {return _storage._else_p}
     set {_uniqueStorage()._else_p = newValue}
   }
 
-  public var fallthrough_p: Int32 {
+  var fallthrough_p: Int32 {
     get {return _storage._fallthrough_p}
     set {_uniqueStorage()._fallthrough_p = newValue}
   }
 
-  public var for_p: Int32 {
+  var for_p: Int32 {
     get {return _storage._for_p}
     set {_uniqueStorage()._for_p = newValue}
   }
 
-  public var guard_p: Int32 {
+  var guard_p: Int32 {
     get {return _storage._guard_p}
     set {_uniqueStorage()._guard_p = newValue}
   }
 
-  public var if_p: Int32 {
+  var if_p: Int32 {
     get {return _storage._if_p}
     set {_uniqueStorage()._if_p = newValue}
   }
 
-  public var in_p: Int32 {
+  var in_p: Int32 {
     get {return _storage._in_p}
     set {_uniqueStorage()._in_p = newValue}
   }
 
-  public var repeat_p: Int32 {
+  var repeat_p: Int32 {
     get {return _storage._repeat_p}
     set {_uniqueStorage()._repeat_p = newValue}
   }
 
-  public var return_p: Int32 {
+  var return_p: Int32 {
     get {return _storage._return_p}
     set {_uniqueStorage()._return_p = newValue}
   }
 
-  public var switch_p: Int32 {
+  var switch_p: Int32 {
     get {return _storage._switch_p}
     set {_uniqueStorage()._switch_p = newValue}
   }
 
-  public var where_p: Int32 {
+  var where_p: Int32 {
     get {return _storage._where_p}
     set {_uniqueStorage()._where_p = newValue}
   }
 
-  public var while_p: Int32 {
+  var while_p: Int32 {
     get {return _storage._while_p}
     set {_uniqueStorage()._while_p = newValue}
   }
 
-  public var as_p: Int32 {
+  var as_p: Int32 {
     get {return _storage._as_p}
     set {_uniqueStorage()._as_p = newValue}
   }
 
-  public var catch_p: Int32 {
+  var catch_p: Int32 {
     get {return _storage._catch_p}
     set {_uniqueStorage()._catch_p = newValue}
   }
 
-  public var dynamicType_p: Int32 {
+  var dynamicType_p: Int32 {
     get {return _storage._dynamicType_p}
     set {_uniqueStorage()._dynamicType_p = newValue}
   }
 
-  public var false_p: Int32 {
+  var false_p: Int32 {
     get {return _storage._false_p}
     set {_uniqueStorage()._false_p = newValue}
   }
 
-  public var is_p: Int32 {
+  var is_p: Int32 {
     get {return _storage._is_p}
     set {_uniqueStorage()._is_p = newValue}
   }
 
-  public var nil_p: Int32 {
+  var nil_p: Int32 {
     get {return _storage._nil_p}
     set {_uniqueStorage()._nil_p = newValue}
   }
 
-  public var rethrows_p: Int32 {
+  var rethrows_p: Int32 {
     get {return _storage._rethrows_p}
     set {_uniqueStorage()._rethrows_p = newValue}
   }
 
-  public var super_p: Int32 {
+  var super_p: Int32 {
     get {return _storage._super_p}
     set {_uniqueStorage()._super_p = newValue}
   }
 
-  public var self_p: Int32 {
+  var self_p: Int32 {
     get {return _storage._self_p}
     set {_uniqueStorage()._self_p = newValue}
   }
 
-  public var throw_p: Int32 {
+  var throw_p: Int32 {
     get {return _storage._throw_p}
     set {_uniqueStorage()._throw_p = newValue}
   }
 
-  public var throws_p: Int32 {
+  var throws_p: Int32 {
     get {return _storage._throws_p}
     set {_uniqueStorage()._throws_p = newValue}
   }
 
-  public var true_p: Int32 {
+  var true_p: Int32 {
     get {return _storage._true_p}
     set {_uniqueStorage()._true_p = newValue}
   }
 
-  public var try_p: Int32 {
+  var try_p: Int32 {
     get {return _storage._try_p}
     set {_uniqueStorage()._try_p = newValue}
   }
 
-  public var _Column__: Int32 {
+  var _Column__: Int32 {
     get {return _storage.__Column__}
     set {_uniqueStorage().__Column__ = newValue}
   }
 
-  public var _File__: Int32 {
+  var _File__: Int32 {
     get {return _storage.__File__}
     set {_uniqueStorage().__File__ = newValue}
   }
 
-  public var _Function__: Int32 {
+  var _Function__: Int32 {
     get {return _storage.__Function__}
     set {_uniqueStorage().__Function__ = newValue}
   }
 
-  public var _Line__: Int32 {
+  var _Line__: Int32 {
     get {return _storage.__Line__}
     set {_uniqueStorage().__Line__ = newValue}
   }
 
-  public var ___: Int32 {
+  var ___: Int32 {
     get {return _storage.____}
     set {_uniqueStorage().____ = newValue}
   }
 
-  public var associativity: Int32 {
+  var associativity: Int32 {
     get {return _storage._associativity}
     set {_uniqueStorage()._associativity = newValue}
   }
 
-  public var convenience: Int32 {
+  var convenience: Int32 {
     get {return _storage._convenience}
     set {_uniqueStorage()._convenience = newValue}
   }
 
-  public var dynamic: Int32 {
+  var dynamic: Int32 {
     get {return _storage._dynamic}
     set {_uniqueStorage()._dynamic = newValue}
   }
 
-  public var didSet: Int32 {
+  var didSet: Int32 {
     get {return _storage._didSet}
     set {_uniqueStorage()._didSet = newValue}
   }
 
-  public var final: Int32 {
+  var final: Int32 {
     get {return _storage._final}
     set {_uniqueStorage()._final = newValue}
   }
 
-  public var get: Int32 {
+  var get: Int32 {
     get {return _storage._get}
     set {_uniqueStorage()._get = newValue}
   }
 
-  public var infix: Int32 {
+  var infix: Int32 {
     get {return _storage._infix}
     set {_uniqueStorage()._infix = newValue}
   }
 
-  public var indirect: Int32 {
+  var indirect: Int32 {
     get {return _storage._indirect}
     set {_uniqueStorage()._indirect = newValue}
   }
 
-  public var lazy: Int32 {
+  var lazy: Int32 {
     get {return _storage._lazy}
     set {_uniqueStorage()._lazy = newValue}
   }
 
-  public var left: Int32 {
+  var left: Int32 {
     get {return _storage._left}
     set {_uniqueStorage()._left = newValue}
   }
 
-  public var mutating: Int32 {
+  var mutating: Int32 {
     get {return _storage._mutating}
     set {_uniqueStorage()._mutating = newValue}
   }
 
-  public var none: Int32 {
+  var none: Int32 {
     get {return _storage._none}
     set {_uniqueStorage()._none = newValue}
   }
 
-  public var nonmutating: Int32 {
+  var nonmutating: Int32 {
     get {return _storage._nonmutating}
     set {_uniqueStorage()._nonmutating = newValue}
   }
 
-  public var optional: Int32 {
+  var optional: Int32 {
     get {return _storage._optional}
     set {_uniqueStorage()._optional = newValue}
   }
 
-  public var override: Int32 {
+  var override: Int32 {
     get {return _storage._override}
     set {_uniqueStorage()._override = newValue}
   }
 
-  public var postfix: Int32 {
+  var postfix: Int32 {
     get {return _storage._postfix}
     set {_uniqueStorage()._postfix = newValue}
   }
 
-  public var precedence: Int32 {
+  var precedence: Int32 {
     get {return _storage._precedence}
     set {_uniqueStorage()._precedence = newValue}
   }
 
-  public var prefix: Int32 {
+  var prefix: Int32 {
     get {return _storage._prefix}
     set {_uniqueStorage()._prefix = newValue}
   }
 
-  public var required: Int32 {
+  var required: Int32 {
     get {return _storage._required}
     set {_uniqueStorage()._required = newValue}
   }
 
-  public var right: Int32 {
+  var right: Int32 {
     get {return _storage._right}
     set {_uniqueStorage()._right = newValue}
   }
 
-  public var set: Int32 {
+  var set: Int32 {
     get {return _storage._set}
     set {_uniqueStorage()._set = newValue}
   }
 
-  public var type: Int32 {
+  var type: Int32 {
     get {return _storage._type}
     set {_uniqueStorage()._type = newValue}
   }
 
-  public var unowned: Int32 {
+  var unowned: Int32 {
     get {return _storage._unowned}
     set {_uniqueStorage()._unowned = newValue}
   }
 
-  public var weak: Int32 {
+  var weak: Int32 {
     get {return _storage._weak}
     set {_uniqueStorage()._weak = newValue}
   }
 
-  public var willSet: Int32 {
+  var willSet: Int32 {
     get {return _storage._willSet}
     set {_uniqueStorage()._willSet = newValue}
   }
 
-  public var id: Int32 {
+  var id: Int32 {
     get {return _storage._id}
     set {_uniqueStorage()._id = newValue}
   }
 
-  public var cmd: Int32 {
+  var cmd: Int32 {
     get {return _storage._cmd}
     set {_uniqueStorage()._cmd = newValue}
   }
 
-  public var out: Int32 {
+  var out: Int32 {
     get {return _storage._out}
     set {_uniqueStorage()._out = newValue}
   }
 
-  public var bycopy: Int32 {
+  var bycopy: Int32 {
     get {return _storage._bycopy}
     set {_uniqueStorage()._bycopy = newValue}
   }
 
-  public var byref: Int32 {
+  var byref: Int32 {
     get {return _storage._byref}
     set {_uniqueStorage()._byref = newValue}
   }
 
-  public var oneway: Int32 {
+  var oneway: Int32 {
     get {return _storage._oneway}
     set {_uniqueStorage()._oneway = newValue}
   }
 
-  public var and: Int32 {
+  var and: Int32 {
     get {return _storage._and}
     set {_uniqueStorage()._and = newValue}
   }
 
-  public var andEq: Int32 {
+  var andEq: Int32 {
     get {return _storage._andEq}
     set {_uniqueStorage()._andEq = newValue}
   }
 
-  public var alignas: Int32 {
+  var alignas: Int32 {
     get {return _storage._alignas}
     set {_uniqueStorage()._alignas = newValue}
   }
 
-  public var alignof: Int32 {
+  var alignof: Int32 {
     get {return _storage._alignof}
     set {_uniqueStorage()._alignof = newValue}
   }
 
-  public var asm: Int32 {
+  var asm: Int32 {
     get {return _storage._asm}
     set {_uniqueStorage()._asm = newValue}
   }
 
-  public var auto: Int32 {
+  var auto: Int32 {
     get {return _storage._auto}
     set {_uniqueStorage()._auto = newValue}
   }
 
-  public var bitand: Int32 {
+  var bitand: Int32 {
     get {return _storage._bitand}
     set {_uniqueStorage()._bitand = newValue}
   }
 
-  public var bitor: Int32 {
+  var bitor: Int32 {
     get {return _storage._bitor}
     set {_uniqueStorage()._bitor = newValue}
   }
 
-  public var bool: Int32 {
+  var bool: Int32 {
     get {return _storage._bool}
     set {_uniqueStorage()._bool = newValue}
   }
 
-  public var char: Int32 {
+  var char: Int32 {
     get {return _storage._char}
     set {_uniqueStorage()._char = newValue}
   }
 
-  public var char16T: Int32 {
+  var char16T: Int32 {
     get {return _storage._char16T}
     set {_uniqueStorage()._char16T = newValue}
   }
 
-  public var char32T: Int32 {
+  var char32T: Int32 {
     get {return _storage._char32T}
     set {_uniqueStorage()._char32T = newValue}
   }
 
-  public var compl: Int32 {
+  var compl: Int32 {
     get {return _storage._compl}
     set {_uniqueStorage()._compl = newValue}
   }
 
-  public var const: Int32 {
+  var const: Int32 {
     get {return _storage._const}
     set {_uniqueStorage()._const = newValue}
   }
 
-  public var constexpr: Int32 {
+  var constexpr: Int32 {
     get {return _storage._constexpr}
     set {_uniqueStorage()._constexpr = newValue}
   }
 
-  public var constCast: Int32 {
+  var constCast: Int32 {
     get {return _storage._constCast}
     set {_uniqueStorage()._constCast = newValue}
   }
 
-  public var decltype: Int32 {
+  var decltype: Int32 {
     get {return _storage._decltype}
     set {_uniqueStorage()._decltype = newValue}
   }
 
-  public var delete: Int32 {
+  var delete: Int32 {
     get {return _storage._delete}
     set {_uniqueStorage()._delete = newValue}
   }
 
-  public var dynamicCast: Int32 {
+  var dynamicCast: Int32 {
     get {return _storage._dynamicCast}
     set {_uniqueStorage()._dynamicCast = newValue}
   }
 
-  public var explicit: Int32 {
+  var explicit: Int32 {
     get {return _storage._explicit}
     set {_uniqueStorage()._explicit = newValue}
   }
 
-  public var export: Int32 {
+  var export: Int32 {
     get {return _storage._export}
     set {_uniqueStorage()._export = newValue}
   }
 
-  public var extern: Int32 {
+  var extern: Int32 {
     get {return _storage._extern}
     set {_uniqueStorage()._extern = newValue}
   }
 
-  public var friend: Int32 {
+  var friend: Int32 {
     get {return _storage._friend}
     set {_uniqueStorage()._friend = newValue}
   }
 
-  public var goto: Int32 {
+  var goto: Int32 {
     get {return _storage._goto}
     set {_uniqueStorage()._goto = newValue}
   }
 
-  public var inline: Int32 {
+  var inline: Int32 {
     get {return _storage._inline}
     set {_uniqueStorage()._inline = newValue}
   }
 
-  public var long: Int32 {
+  var long: Int32 {
     get {return _storage._long}
     set {_uniqueStorage()._long = newValue}
   }
 
-  public var mutable: Int32 {
+  var mutable: Int32 {
     get {return _storage._mutable}
     set {_uniqueStorage()._mutable = newValue}
   }
 
-  public var namespace: Int32 {
+  var namespace: Int32 {
     get {return _storage._namespace}
     set {_uniqueStorage()._namespace = newValue}
   }
 
-  public var new: Int32 {
+  var new: Int32 {
     get {return _storage._new}
     set {_uniqueStorage()._new = newValue}
   }
 
-  public var noexcept: Int32 {
+  var noexcept: Int32 {
     get {return _storage._noexcept}
     set {_uniqueStorage()._noexcept = newValue}
   }
 
-  public var not: Int32 {
+  var not: Int32 {
     get {return _storage._not}
     set {_uniqueStorage()._not = newValue}
   }
 
-  public var notEq: Int32 {
+  var notEq: Int32 {
     get {return _storage._notEq}
     set {_uniqueStorage()._notEq = newValue}
   }
 
-  public var nullptr: Int32 {
+  var nullptr: Int32 {
     get {return _storage._nullptr}
     set {_uniqueStorage()._nullptr = newValue}
   }
 
-  public var or: Int32 {
+  var or: Int32 {
     get {return _storage._or}
     set {_uniqueStorage()._or = newValue}
   }
 
-  public var orEq: Int32 {
+  var orEq: Int32 {
     get {return _storage._orEq}
     set {_uniqueStorage()._orEq = newValue}
   }
 
-  public var protected: Int32 {
+  var protected: Int32 {
     get {return _storage._protected}
     set {_uniqueStorage()._protected = newValue}
   }
 
-  public var register: Int32 {
+  var register: Int32 {
     get {return _storage._register}
     set {_uniqueStorage()._register = newValue}
   }
 
-  public var reinterpretCast: Int32 {
+  var reinterpretCast: Int32 {
     get {return _storage._reinterpretCast}
     set {_uniqueStorage()._reinterpretCast = newValue}
   }
 
-  public var short: Int32 {
+  var short: Int32 {
     get {return _storage._short}
     set {_uniqueStorage()._short = newValue}
   }
 
-  public var signed: Int32 {
+  var signed: Int32 {
     get {return _storage._signed}
     set {_uniqueStorage()._signed = newValue}
   }
 
-  public var sizeof: Int32 {
+  var sizeof: Int32 {
     get {return _storage._sizeof}
     set {_uniqueStorage()._sizeof = newValue}
   }
 
-  public var staticAssert: Int32 {
+  var staticAssert: Int32 {
     get {return _storage._staticAssert}
     set {_uniqueStorage()._staticAssert = newValue}
   }
 
-  public var staticCast: Int32 {
+  var staticCast: Int32 {
     get {return _storage._staticCast}
     set {_uniqueStorage()._staticCast = newValue}
   }
 
-  public var template: Int32 {
+  var template: Int32 {
     get {return _storage._template}
     set {_uniqueStorage()._template = newValue}
   }
 
-  public var this: Int32 {
+  var this: Int32 {
     get {return _storage._this}
     set {_uniqueStorage()._this = newValue}
   }
 
-  public var threadLocal: Int32 {
+  var threadLocal: Int32 {
     get {return _storage._threadLocal}
     set {_uniqueStorage()._threadLocal = newValue}
   }
 
-  public var typedef: Int32 {
+  var typedef: Int32 {
     get {return _storage._typedef}
     set {_uniqueStorage()._typedef = newValue}
   }
 
-  public var typeid: Int32 {
+  var typeid: Int32 {
     get {return _storage._typeid}
     set {_uniqueStorage()._typeid = newValue}
   }
 
-  public var typename: Int32 {
+  var typename: Int32 {
     get {return _storage._typename}
     set {_uniqueStorage()._typename = newValue}
   }
 
-  public var union: Int32 {
+  var union: Int32 {
     get {return _storage._union}
     set {_uniqueStorage()._union = newValue}
   }
 
-  public var unsigned: Int32 {
+  var unsigned: Int32 {
     get {return _storage._unsigned}
     set {_uniqueStorage()._unsigned = newValue}
   }
 
-  public var using: Int32 {
+  var using: Int32 {
     get {return _storage._using}
     set {_uniqueStorage()._using = newValue}
   }
 
-  public var virtual: Int32 {
+  var virtual: Int32 {
     get {return _storage._virtual}
     set {_uniqueStorage()._virtual = newValue}
   }
 
-  public var void: Int32 {
+  var void: Int32 {
     get {return _storage._void}
     set {_uniqueStorage()._void = newValue}
   }
 
-  public var volatile: Int32 {
+  var volatile: Int32 {
     get {return _storage._volatile}
     set {_uniqueStorage()._volatile = newValue}
   }
 
-  public var wcharT: Int32 {
+  var wcharT: Int32 {
     get {return _storage._wcharT}
     set {_uniqueStorage()._wcharT = newValue}
   }
 
-  public var xor: Int32 {
+  var xor: Int32 {
     get {return _storage._xor}
     set {_uniqueStorage()._xor = newValue}
   }
 
-  public var xorEq: Int32 {
+  var xorEq: Int32 {
     get {return _storage._xorEq}
     set {_uniqueStorage()._xorEq = newValue}
   }
 
-  public var restrict: Int32 {
+  var restrict: Int32 {
     get {return _storage._restrict}
     set {_uniqueStorage()._restrict = newValue}
   }
 
-  public var category: Int32 {
+  var category: Int32 {
     get {return _storage._category}
     set {_uniqueStorage()._category = newValue}
   }
 
-  public var ivar: Int32 {
+  var ivar: Int32 {
     get {return _storage._ivar}
     set {_uniqueStorage()._ivar = newValue}
   }
 
-  public var method: Int32 {
+  var method: Int32 {
     get {return _storage._method}
     set {_uniqueStorage()._method = newValue}
   }
 
-  public var finalize: Int32 {
+  var finalize: Int32 {
     get {return _storage._finalize}
     set {_uniqueStorage()._finalize = newValue}
   }
 
-  public var hash: Int32 {
+  var hash: Int32 {
     get {return _storage._hash}
     set {_uniqueStorage()._hash = newValue}
   }
 
-  public var dealloc: Int32 {
+  var dealloc: Int32 {
     get {return _storage._dealloc}
     set {_uniqueStorage()._dealloc = newValue}
   }
 
-  public var superclass: Int32 {
+  var superclass: Int32 {
     get {return _storage._superclass}
     set {_uniqueStorage()._superclass = newValue}
   }
 
-  public var retain: Int32 {
+  var retain: Int32 {
     get {return _storage._retain}
     set {_uniqueStorage()._retain = newValue}
   }
 
-  public var release: Int32 {
+  var release: Int32 {
     get {return _storage._release}
     set {_uniqueStorage()._release = newValue}
   }
 
-  public var autorelease: Int32 {
+  var autorelease: Int32 {
     get {return _storage._autorelease}
     set {_uniqueStorage()._autorelease = newValue}
   }
 
-  public var retainCount: Int32 {
+  var retainCount: Int32 {
     get {return _storage._retainCount}
     set {_uniqueStorage()._retainCount = newValue}
   }
 
-  public var zone: Int32 {
+  var zone: Int32 {
     get {return _storage._zone}
     set {_uniqueStorage()._zone = newValue}
   }
 
-  public var isProxy: Int32 {
+  var isProxy: Int32 {
     get {return _storage._isProxy}
     set {_uniqueStorage()._isProxy = newValue}
   }
 
-  public var copy: Int32 {
+  var copy: Int32 {
     get {return _storage._copy}
     set {_uniqueStorage()._copy = newValue}
   }
 
-  public var mutableCopy: Int32 {
+  var mutableCopy: Int32 {
     get {return _storage._mutableCopy}
     set {_uniqueStorage()._mutableCopy = newValue}
   }
 
-  public var classForCoder: Int32 {
+  var classForCoder: Int32 {
     get {return _storage._classForCoder}
     set {_uniqueStorage()._classForCoder = newValue}
   }
 
-  public var clear: Int32 {
+  var clear: Int32 {
     get {return _storage._clear}
     set {_uniqueStorage()._clear = newValue}
   }
 
-  public var data: Int32 {
+  var data: Int32 {
     get {return _storage._data}
     set {_uniqueStorage()._data = newValue}
   }
 
-  public var delimitedData: Int32 {
+  var delimitedData: Int32 {
     get {return _storage._delimitedData}
     set {_uniqueStorage()._delimitedData = newValue}
   }
 
-  public var descriptor: Int32 {
+  var descriptor: Int32 {
     get {return _storage._descriptor}
     set {_uniqueStorage()._descriptor = newValue}
   }
 
-  public var extensionRegistry: Int32 {
+  var extensionRegistry: Int32 {
     get {return _storage._extensionRegistry}
     set {_uniqueStorage()._extensionRegistry = newValue}
   }
 
-  public var extensionsCurrentlySet: Int32 {
+  var extensionsCurrentlySet: Int32 {
     get {return _storage._extensionsCurrentlySet}
     set {_uniqueStorage()._extensionsCurrentlySet = newValue}
   }
 
-  public var isInitialized: Int32 {
+  var isInitialized: Int32 {
     get {return _storage._isInitialized}
     set {_uniqueStorage()._isInitialized = newValue}
   }
 
-  public var serializedSize: Int32 {
+  var serializedSize: Int32 {
     get {return _storage._serializedSize}
     set {_uniqueStorage()._serializedSize = newValue}
   }
 
-  public var sortedExtensionsInUse: Int32 {
+  var sortedExtensionsInUse: Int32 {
     get {return _storage._sortedExtensionsInUse}
     set {_uniqueStorage()._sortedExtensionsInUse = newValue}
   }
 
-  public var unknownFields: Int32 {
+  var unknownFields: Int32 {
     get {return _storage._unknownFields}
     set {_uniqueStorage()._unknownFields = newValue}
   }
 
-  public var fixed: Int32 {
+  var fixed: Int32 {
     get {return _storage._fixed}
     set {_uniqueStorage()._fixed = newValue}
   }
 
-  public var fract: Int32 {
+  var fract: Int32 {
     get {return _storage._fract}
     set {_uniqueStorage()._fract = newValue}
   }
 
-  public var size: Int32 {
+  var size: Int32 {
     get {return _storage._size}
     set {_uniqueStorage()._size = newValue}
   }
 
-  public var logicalAddress: Int32 {
+  var logicalAddress: Int32 {
     get {return _storage._logicalAddress}
     set {_uniqueStorage()._logicalAddress = newValue}
   }
 
-  public var physicalAddress: Int32 {
+  var physicalAddress: Int32 {
     get {return _storage._physicalAddress}
     set {_uniqueStorage()._physicalAddress = newValue}
   }
 
-  public var byteCount: Int32 {
+  var byteCount: Int32 {
     get {return _storage._byteCount}
     set {_uniqueStorage()._byteCount = newValue}
   }
 
-  public var byteOffset: Int32 {
+  var byteOffset: Int32 {
     get {return _storage._byteOffset}
     set {_uniqueStorage()._byteOffset = newValue}
   }
 
-  public var duration: Int32 {
+  var duration: Int32 {
     get {return _storage._duration}
     set {_uniqueStorage()._duration = newValue}
   }
 
-  public var absoluteTime: Int32 {
+  var absoluteTime: Int32 {
     get {return _storage._absoluteTime}
     set {_uniqueStorage()._absoluteTime = newValue}
   }
 
-  public var optionBits: Int32 {
+  var optionBits: Int32 {
     get {return _storage._optionBits}
     set {_uniqueStorage()._optionBits = newValue}
   }
 
-  public var itemCount: Int32 {
+  var itemCount: Int32 {
     get {return _storage._itemCount}
     set {_uniqueStorage()._itemCount = newValue}
   }
 
-  public var pbversion: Int32 {
+  var pbversion: Int32 {
     get {return _storage._pbversion}
     set {_uniqueStorage()._pbversion = newValue}
   }
 
-  public var scriptCode: Int32 {
+  var scriptCode: Int32 {
     get {return _storage._scriptCode}
     set {_uniqueStorage()._scriptCode = newValue}
   }
 
-  public var langCode: Int32 {
+  var langCode: Int32 {
     get {return _storage._langCode}
     set {_uniqueStorage()._langCode = newValue}
   }
 
-  public var regionCode: Int32 {
+  var regionCode: Int32 {
     get {return _storage._regionCode}
     set {_uniqueStorage()._regionCode = newValue}
   }
 
-  public var ostype: Int32 {
+  var ostype: Int32 {
     get {return _storage._ostype}
     set {_uniqueStorage()._ostype = newValue}
   }
 
-  public var processSerialNumber: Int32 {
+  var processSerialNumber: Int32 {
     get {return _storage._processSerialNumber}
     set {_uniqueStorage()._processSerialNumber = newValue}
   }
 
-  public var point: Int32 {
+  var point: Int32 {
     get {return _storage._point}
     set {_uniqueStorage()._point = newValue}
   }
 
-  public var rect: Int32 {
+  var rect: Int32 {
     get {return _storage._rect}
     set {_uniqueStorage()._rect = newValue}
   }
 
-  public var fixedPoint: Int32 {
+  var fixedPoint: Int32 {
     get {return _storage._fixedPoint}
     set {_uniqueStorage()._fixedPoint = newValue}
   }
 
-  public var fixedRect: Int32 {
+  var fixedRect: Int32 {
     get {return _storage._fixedRect}
     set {_uniqueStorage()._fixedRect = newValue}
   }
 
-  public var style: Int32 {
+  var style: Int32 {
     get {return _storage._style}
     set {_uniqueStorage()._style = newValue}
   }
 
-  public var styleParameter: Int32 {
+  var styleParameter: Int32 {
     get {return _storage._styleParameter}
     set {_uniqueStorage()._styleParameter = newValue}
   }
 
-  public var styleField: Int32 {
+  var styleField: Int32 {
     get {return _storage._styleField}
     set {_uniqueStorage()._styleField = newValue}
   }
 
-  public var timeScale: Int32 {
+  var timeScale: Int32 {
     get {return _storage._timeScale}
     set {_uniqueStorage()._timeScale = newValue}
   }
 
-  public var timeBase: Int32 {
+  var timeBase: Int32 {
     get {return _storage._timeBase}
     set {_uniqueStorage()._timeBase = newValue}
   }
 
-  public var timeRecord: Int32 {
+  var timeRecord: Int32 {
     get {return _storage._timeRecord}
     set {_uniqueStorage()._timeRecord = newValue}
   }
 
-  public var jsonShouldBeOverriden: Int32 {
+  var jsonShouldBeOverriden: Int32 {
     get {return _storage._jsonShouldBeOverriden}
     set {_uniqueStorage()._jsonShouldBeOverriden = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4827,9 +4827,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4862,9 +4862,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4897,9 +4897,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4932,9 +4932,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4967,9 +4967,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5002,9 +5002,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5037,9 +5037,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5072,9 +5072,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5107,9 +5107,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5142,9 +5142,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5177,9 +5177,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5212,9 +5212,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5247,9 +5247,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5282,9 +5282,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5317,9 +5317,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5352,9 +5352,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5387,9 +5387,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5422,9 +5422,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5457,9 +5457,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5492,9 +5492,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5527,9 +5527,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5562,9 +5562,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5597,9 +5597,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5632,9 +5632,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5667,9 +5667,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5702,9 +5702,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5737,9 +5737,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5772,9 +5772,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5807,9 +5807,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5842,9 +5842,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5877,9 +5877,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5912,9 +5912,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5947,9 +5947,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5982,9 +5982,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6017,9 +6017,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6052,9 +6052,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6087,9 +6087,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6122,9 +6122,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6157,9 +6157,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6192,9 +6192,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6227,9 +6227,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6262,9 +6262,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6297,9 +6297,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6332,9 +6332,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6367,9 +6367,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6402,9 +6402,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6437,9 +6437,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6472,9 +6472,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6507,9 +6507,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6542,9 +6542,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6577,9 +6577,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6612,9 +6612,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6647,9 +6647,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6682,9 +6682,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6717,9 +6717,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6752,9 +6752,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6787,9 +6787,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6822,9 +6822,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6857,9 +6857,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6892,9 +6892,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6927,9 +6927,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6962,9 +6962,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6997,9 +6997,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7032,9 +7032,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7067,9 +7067,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7102,9 +7102,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7137,9 +7137,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7172,9 +7172,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7207,9 +7207,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7242,9 +7242,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7277,9 +7277,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7312,9 +7312,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7347,9 +7347,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7382,9 +7382,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7417,9 +7417,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7452,9 +7452,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7487,9 +7487,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7522,9 +7522,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7557,9 +7557,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7592,9 +7592,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7627,9 +7627,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7662,9 +7662,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7697,9 +7697,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7732,9 +7732,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7767,9 +7767,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7802,9 +7802,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7837,9 +7837,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7872,9 +7872,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7907,9 +7907,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7942,9 +7942,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7977,9 +7977,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8012,9 +8012,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8047,9 +8047,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8082,9 +8082,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8117,9 +8117,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8152,9 +8152,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8187,9 +8187,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8222,9 +8222,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8257,9 +8257,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8292,9 +8292,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8327,9 +8327,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8362,9 +8362,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8397,9 +8397,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8432,9 +8432,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8467,9 +8467,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8502,9 +8502,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8537,9 +8537,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8572,9 +8572,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8607,9 +8607,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8642,9 +8642,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8677,9 +8677,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8712,9 +8712,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8747,9 +8747,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8782,9 +8782,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8817,9 +8817,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8852,9 +8852,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8887,9 +8887,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8922,9 +8922,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8957,9 +8957,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8992,9 +8992,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9027,9 +9027,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9062,9 +9062,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9097,9 +9097,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9132,9 +9132,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9167,9 +9167,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9202,9 +9202,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9237,9 +9237,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9272,9 +9272,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9307,9 +9307,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9342,9 +9342,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9377,9 +9377,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9412,9 +9412,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9447,9 +9447,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9482,9 +9482,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9517,9 +9517,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9552,9 +9552,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9587,9 +9587,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9622,9 +9622,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9657,9 +9657,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9692,9 +9692,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9727,9 +9727,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9762,9 +9762,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9797,9 +9797,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9832,9 +9832,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9867,9 +9867,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9902,9 +9902,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9937,9 +9937,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9972,9 +9972,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10007,9 +10007,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10042,9 +10042,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10077,9 +10077,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10112,9 +10112,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10147,9 +10147,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10182,9 +10182,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10217,9 +10217,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10252,9 +10252,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10287,9 +10287,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10322,9 +10322,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10357,9 +10357,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10392,9 +10392,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10427,9 +10427,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10462,9 +10462,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10497,9 +10497,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10532,9 +10532,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10567,9 +10567,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10602,9 +10602,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10637,9 +10637,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10672,9 +10672,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10707,9 +10707,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10742,9 +10742,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10777,9 +10777,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10812,9 +10812,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10847,9 +10847,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10882,9 +10882,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10917,9 +10917,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10952,9 +10952,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10987,9 +10987,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11022,9 +11022,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11057,9 +11057,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11092,9 +11092,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11127,9 +11127,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11162,9 +11162,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11197,9 +11197,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11232,9 +11232,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11267,9 +11267,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11302,9 +11302,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11337,9 +11337,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11372,9 +11372,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11407,9 +11407,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11442,9 +11442,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11477,9 +11477,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11512,9 +11512,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11547,9 +11547,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11582,9 +11582,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11617,9 +11617,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11652,9 +11652,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11687,9 +11687,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11722,9 +11722,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11757,9 +11757,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11792,9 +11792,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11827,9 +11827,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11862,9 +11862,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11897,9 +11897,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11932,9 +11932,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11967,9 +11967,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -12002,9 +12002,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -12037,9 +12037,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -12072,9 +12072,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -12107,9 +12107,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -12130,7 +12130,7 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -12152,43 +12152,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
 
 
   enum StringEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aString // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aString
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aString
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aString": self = .aString
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aString": self = .aString
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aString": self = .aString
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aString: return 0
@@ -12197,7 +12197,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aString: return "\"aString\""
@@ -12206,9 +12206,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aString: return ".aString"
@@ -12220,43 +12220,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ProtocolEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aProtocol // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aProtocol
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aProtocol
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aProtocol": self = .aProtocol
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aProtocol": self = .aProtocol
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aProtocol": self = .aProtocol
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aProtocol: return 0
@@ -12265,7 +12265,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aProtocol: return "\"aProtocol\""
@@ -12274,9 +12274,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aProtocol: return ".aProtocol"
@@ -12288,43 +12288,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum IntEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aInt // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aInt
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aInt
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aInt": self = .aInt
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aInt": self = .aInt
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aInt": self = .aInt
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aInt: return 0
@@ -12333,7 +12333,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aInt: return "\"aInt\""
@@ -12342,9 +12342,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aInt: return ".aInt"
@@ -12356,43 +12356,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum DoubleEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aDouble // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aDouble
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aDouble
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aDouble": self = .aDouble
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aDouble": self = .aDouble
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aDouble": self = .aDouble
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aDouble: return 0
@@ -12401,7 +12401,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aDouble: return "\"aDouble\""
@@ -12410,9 +12410,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aDouble: return ".aDouble"
@@ -12424,43 +12424,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum FloatEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aFloat // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aFloat
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aFloat
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aFloat": self = .aFloat
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aFloat": self = .aFloat
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aFloat": self = .aFloat
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aFloat: return 0
@@ -12469,7 +12469,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aFloat: return "\"aFloat\""
@@ -12478,9 +12478,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aFloat: return ".aFloat"
@@ -12492,43 +12492,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum UIntEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aUint // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aUint
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aUint
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aUint": self = .aUint
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aUInt": self = .aUint
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aUInt": self = .aUint
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aUint: return 0
@@ -12537,7 +12537,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aUint: return "\"aUInt\""
@@ -12546,9 +12546,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aUint: return ".aUint"
@@ -12560,43 +12560,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum hashValueEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ahashValue // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ahashValue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ahashValue
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ahashValue": self = .ahashValue
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ahashValue": self = .ahashValue
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ahashValue": self = .ahashValue
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ahashValue: return 0
@@ -12605,7 +12605,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ahashValue: return "\"ahashValue\""
@@ -12614,9 +12614,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ahashValue: return ".ahashValue"
@@ -12628,43 +12628,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum descriptionEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adescription // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adescription
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adescription
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adescription": self = .adescription
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adescription": self = .adescription
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adescription": self = .adescription
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adescription: return 0
@@ -12673,7 +12673,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adescription: return "\"adescription\""
@@ -12682,9 +12682,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adescription: return ".adescription"
@@ -12696,43 +12696,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum debugDescriptionEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adebugDescription // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adebugDescription
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adebugDescription
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adebugDescription": self = .adebugDescription
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adebugDescription": self = .adebugDescription
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adebugDescription": self = .adebugDescription
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adebugDescription: return 0
@@ -12741,7 +12741,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adebugDescription: return "\"adebugDescription\""
@@ -12750,9 +12750,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adebugDescription: return ".adebugDescription"
@@ -12764,43 +12764,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Swift: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aSwift // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aSwift
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aSwift
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aSwift": self = .aSwift
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aSwift": self = .aSwift
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aSwift": self = .aSwift
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aSwift: return 0
@@ -12809,7 +12809,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aSwift: return "\"aSwift\""
@@ -12818,9 +12818,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aSwift: return ".aSwift"
@@ -12832,43 +12832,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum UNRECOGNIZED: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aUnrecognized // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aUnrecognized
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aUnrecognized
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aUnrecognized": self = .aUnrecognized
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aUNRECOGNIZED": self = .aUnrecognized
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aUNRECOGNIZED": self = .aUnrecognized
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aUnrecognized: return 0
@@ -12877,7 +12877,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aUnrecognized: return "\"aUNRECOGNIZED\""
@@ -12886,9 +12886,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aUnrecognized: return ".aUnrecognized"
@@ -12900,43 +12900,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum classEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aclass // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aclass
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aclass
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aclass": self = .aclass
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aclass": self = .aclass
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aclass": self = .aclass
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aclass: return 0
@@ -12945,7 +12945,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aclass: return "\"aclass\""
@@ -12954,9 +12954,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aclass: return ".aclass"
@@ -12968,43 +12968,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum deinitEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adeinit // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adeinit
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adeinit
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adeinit": self = .adeinit
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adeinit": self = .adeinit
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adeinit": self = .adeinit
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adeinit: return 0
@@ -13013,7 +13013,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adeinit: return "\"adeinit\""
@@ -13022,9 +13022,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adeinit: return ".adeinit"
@@ -13036,43 +13036,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum enumEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aenum // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aenum
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aenum
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aenum": self = .aenum
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aenum": self = .aenum
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aenum": self = .aenum
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aenum: return 0
@@ -13081,7 +13081,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aenum: return "\"aenum\""
@@ -13090,9 +13090,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aenum: return ".aenum"
@@ -13104,43 +13104,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum extensionEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aextension // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aextension
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aextension
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aextension": self = .aextension
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aextension": self = .aextension
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aextension": self = .aextension
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aextension: return 0
@@ -13149,7 +13149,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aextension: return "\"aextension\""
@@ -13158,9 +13158,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aextension: return ".aextension"
@@ -13172,43 +13172,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum funcEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afunc // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afunc
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afunc
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afunc": self = .afunc
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afunc": self = .afunc
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afunc": self = .afunc
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afunc: return 0
@@ -13217,7 +13217,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afunc: return "\"afunc\""
@@ -13226,9 +13226,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afunc: return ".afunc"
@@ -13240,43 +13240,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum importEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aimport // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aimport
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aimport
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aimport": self = .aimport
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aimport": self = .aimport
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aimport": self = .aimport
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aimport: return 0
@@ -13285,7 +13285,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aimport: return "\"aimport\""
@@ -13294,9 +13294,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aimport: return ".aimport"
@@ -13308,43 +13308,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum initEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ainit // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ainit
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ainit
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ainit": self = .ainit
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ainit": self = .ainit
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ainit": self = .ainit
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ainit: return 0
@@ -13353,7 +13353,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ainit: return "\"ainit\""
@@ -13362,9 +13362,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ainit: return ".ainit"
@@ -13376,43 +13376,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum inoutEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ainout // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ainout
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ainout
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ainout": self = .ainout
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ainout": self = .ainout
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ainout": self = .ainout
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ainout: return 0
@@ -13421,7 +13421,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ainout: return "\"ainout\""
@@ -13430,9 +13430,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ainout: return ".ainout"
@@ -13444,43 +13444,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum internalEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ainternal // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ainternal
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ainternal
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ainternal": self = .ainternal
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ainternal": self = .ainternal
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ainternal": self = .ainternal
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ainternal: return 0
@@ -13489,7 +13489,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ainternal: return "\"ainternal\""
@@ -13498,9 +13498,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ainternal: return ".ainternal"
@@ -13512,43 +13512,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum letEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case alet // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .alet
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .alet
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "alet": self = .alet
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "alet": self = .alet
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "alet": self = .alet
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .alet: return 0
@@ -13557,7 +13557,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .alet: return "\"alet\""
@@ -13566,9 +13566,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .alet: return ".alet"
@@ -13580,43 +13580,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum operatorEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aoperator // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aoperator
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aoperator
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aoperator": self = .aoperator
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aoperator": self = .aoperator
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aoperator": self = .aoperator
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aoperator: return 0
@@ -13625,7 +13625,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aoperator: return "\"aoperator\""
@@ -13634,9 +13634,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aoperator: return ".aoperator"
@@ -13648,43 +13648,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum privateEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aprivate // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aprivate
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aprivate
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aprivate": self = .aprivate
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aprivate": self = .aprivate
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aprivate": self = .aprivate
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aprivate: return 0
@@ -13693,7 +13693,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aprivate: return "\"aprivate\""
@@ -13702,9 +13702,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aprivate: return ".aprivate"
@@ -13716,43 +13716,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum protocolEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aprotocol // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aprotocol
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aprotocol
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aprotocol": self = .aprotocol
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aprotocol": self = .aprotocol
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aprotocol": self = .aprotocol
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aprotocol: return 0
@@ -13761,7 +13761,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aprotocol: return "\"aprotocol\""
@@ -13770,9 +13770,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aprotocol: return ".aprotocol"
@@ -13784,43 +13784,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum publicEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case apublic // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .apublic
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .apublic
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "apublic": self = .apublic
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "apublic": self = .apublic
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "apublic": self = .apublic
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .apublic: return 0
@@ -13829,7 +13829,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .apublic: return "\"apublic\""
@@ -13838,9 +13838,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .apublic: return ".apublic"
@@ -13852,43 +13852,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum staticEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case astatic // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .astatic
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .astatic
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "astatic": self = .astatic
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "astatic": self = .astatic
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "astatic": self = .astatic
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .astatic: return 0
@@ -13897,7 +13897,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .astatic: return "\"astatic\""
@@ -13906,9 +13906,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .astatic: return ".astatic"
@@ -13920,43 +13920,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum structEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case astruct // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .astruct
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .astruct
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "astruct": self = .astruct
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "astruct": self = .astruct
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "astruct": self = .astruct
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .astruct: return 0
@@ -13965,7 +13965,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .astruct: return "\"astruct\""
@@ -13974,9 +13974,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .astruct: return ".astruct"
@@ -13988,43 +13988,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum subscriptEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asubscript // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asubscript
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asubscript
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asubscript": self = .asubscript
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asubscript": self = .asubscript
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asubscript": self = .asubscript
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asubscript: return 0
@@ -14033,7 +14033,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asubscript: return "\"asubscript\""
@@ -14042,9 +14042,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asubscript: return ".asubscript"
@@ -14056,43 +14056,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum typealiasEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atypealias // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atypealias
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atypealias
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atypealias": self = .atypealias
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atypealias": self = .atypealias
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atypealias": self = .atypealias
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atypealias: return 0
@@ -14101,7 +14101,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atypealias: return "\"atypealias\""
@@ -14110,9 +14110,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atypealias: return ".atypealias"
@@ -14124,43 +14124,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum varEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case avar // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .avar
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .avar
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "avar": self = .avar
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "avar": self = .avar
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "avar": self = .avar
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .avar: return 0
@@ -14169,7 +14169,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .avar: return "\"avar\""
@@ -14178,9 +14178,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .avar: return ".avar"
@@ -14192,43 +14192,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum breakEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abreak // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abreak
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abreak
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abreak": self = .abreak
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abreak": self = .abreak
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abreak": self = .abreak
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abreak: return 0
@@ -14237,7 +14237,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abreak: return "\"abreak\""
@@ -14246,9 +14246,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abreak: return ".abreak"
@@ -14260,43 +14260,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum caseEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case acase // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .acase
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .acase
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "acase": self = .acase
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "acase": self = .acase
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "acase": self = .acase
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .acase: return 0
@@ -14305,7 +14305,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .acase: return "\"acase\""
@@ -14314,9 +14314,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .acase: return ".acase"
@@ -14328,43 +14328,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum continueEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case acontinue // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .acontinue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .acontinue
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "acontinue": self = .acontinue
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "acontinue": self = .acontinue
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "acontinue": self = .acontinue
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .acontinue: return 0
@@ -14373,7 +14373,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .acontinue: return "\"acontinue\""
@@ -14382,9 +14382,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .acontinue: return ".acontinue"
@@ -14396,43 +14396,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum defaultEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adefault // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adefault
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adefault
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adefault": self = .adefault
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adefault": self = .adefault
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adefault": self = .adefault
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adefault: return 0
@@ -14441,7 +14441,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adefault: return "\"adefault\""
@@ -14450,9 +14450,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adefault: return ".adefault"
@@ -14464,43 +14464,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum deferEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adefer // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adefer
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adefer
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adefer": self = .adefer
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adefer": self = .adefer
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adefer": self = .adefer
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adefer: return 0
@@ -14509,7 +14509,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adefer: return "\"adefer\""
@@ -14518,9 +14518,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adefer: return ".adefer"
@@ -14532,43 +14532,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum doEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ado // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ado
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ado
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ado": self = .ado
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ado": self = .ado
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ado": self = .ado
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ado: return 0
@@ -14577,7 +14577,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ado: return "\"ado\""
@@ -14586,9 +14586,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ado: return ".ado"
@@ -14600,43 +14600,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum elseEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aelse // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aelse
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aelse
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aelse": self = .aelse
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aelse": self = .aelse
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aelse": self = .aelse
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aelse: return 0
@@ -14645,7 +14645,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aelse: return "\"aelse\""
@@ -14654,9 +14654,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aelse: return ".aelse"
@@ -14668,43 +14668,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum fallthroughEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afallthrough // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afallthrough
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afallthrough
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afallthrough": self = .afallthrough
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afallthrough": self = .afallthrough
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afallthrough": self = .afallthrough
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afallthrough: return 0
@@ -14713,7 +14713,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afallthrough: return "\"afallthrough\""
@@ -14722,9 +14722,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afallthrough: return ".afallthrough"
@@ -14736,43 +14736,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum forEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afor // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afor
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afor
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afor": self = .afor
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afor": self = .afor
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afor": self = .afor
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afor: return 0
@@ -14781,7 +14781,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afor: return "\"afor\""
@@ -14790,9 +14790,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afor: return ".afor"
@@ -14804,43 +14804,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum guardEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aguard // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aguard
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aguard
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aguard": self = .aguard
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aguard": self = .aguard
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aguard": self = .aguard
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aguard: return 0
@@ -14849,7 +14849,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aguard: return "\"aguard\""
@@ -14858,9 +14858,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aguard: return ".aguard"
@@ -14872,43 +14872,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ifEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aif // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aif
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aif
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aif": self = .aif
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aif": self = .aif
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aif": self = .aif
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aif: return 0
@@ -14917,7 +14917,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aif: return "\"aif\""
@@ -14926,9 +14926,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aif: return ".aif"
@@ -14940,43 +14940,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum inEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ain // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ain
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ain
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ain": self = .ain
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ain": self = .ain
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ain": self = .ain
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ain: return 0
@@ -14985,7 +14985,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ain: return "\"ain\""
@@ -14994,9 +14994,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ain: return ".ain"
@@ -15008,43 +15008,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum repeatEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case arepeat // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .arepeat
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .arepeat
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "arepeat": self = .arepeat
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "arepeat": self = .arepeat
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "arepeat": self = .arepeat
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .arepeat: return 0
@@ -15053,7 +15053,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .arepeat: return "\"arepeat\""
@@ -15062,9 +15062,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .arepeat: return ".arepeat"
@@ -15076,43 +15076,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum returnEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case areturn // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .areturn
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .areturn
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "areturn": self = .areturn
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "areturn": self = .areturn
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "areturn": self = .areturn
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .areturn: return 0
@@ -15121,7 +15121,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .areturn: return "\"areturn\""
@@ -15130,9 +15130,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .areturn: return ".areturn"
@@ -15144,43 +15144,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum switchEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aswitch // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aswitch
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aswitch
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aswitch": self = .aswitch
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aswitch": self = .aswitch
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aswitch": self = .aswitch
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aswitch: return 0
@@ -15189,7 +15189,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aswitch: return "\"aswitch\""
@@ -15198,9 +15198,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aswitch: return ".aswitch"
@@ -15212,43 +15212,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum whereEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case awhere // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .awhere
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .awhere
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "awhere": self = .awhere
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "awhere": self = .awhere
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "awhere": self = .awhere
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .awhere: return 0
@@ -15257,7 +15257,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .awhere: return "\"awhere\""
@@ -15266,9 +15266,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .awhere: return ".awhere"
@@ -15280,43 +15280,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum whileEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case awhile // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .awhile
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .awhile
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "awhile": self = .awhile
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "awhile": self = .awhile
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "awhile": self = .awhile
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .awhile: return 0
@@ -15325,7 +15325,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .awhile: return "\"awhile\""
@@ -15334,9 +15334,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .awhile: return ".awhile"
@@ -15348,43 +15348,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum asEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aas // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aas
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aas
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aas": self = .aas
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aas": self = .aas
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aas": self = .aas
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aas: return 0
@@ -15393,7 +15393,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aas: return "\"aas\""
@@ -15402,9 +15402,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aas: return ".aas"
@@ -15416,43 +15416,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum catchEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case acatch // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .acatch
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .acatch
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "acatch": self = .acatch
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "acatch": self = .acatch
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "acatch": self = .acatch
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .acatch: return 0
@@ -15461,7 +15461,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .acatch: return "\"acatch\""
@@ -15470,9 +15470,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .acatch: return ".acatch"
@@ -15484,43 +15484,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum dynamicTypeEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adynamicType // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adynamicType
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adynamicType
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adynamicType": self = .adynamicType
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adynamicType": self = .adynamicType
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adynamicType": self = .adynamicType
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adynamicType: return 0
@@ -15529,7 +15529,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adynamicType: return "\"adynamicType\""
@@ -15538,9 +15538,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adynamicType: return ".adynamicType"
@@ -15552,43 +15552,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum falseEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afalse // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afalse
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afalse
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afalse": self = .afalse
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afalse": self = .afalse
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afalse": self = .afalse
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afalse: return 0
@@ -15597,7 +15597,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afalse: return "\"afalse\""
@@ -15606,9 +15606,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afalse: return ".afalse"
@@ -15620,43 +15620,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum isEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ais // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ais
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ais
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ais": self = .ais
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ais": self = .ais
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ais": self = .ais
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ais: return 0
@@ -15665,7 +15665,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ais: return "\"ais\""
@@ -15674,9 +15674,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ais: return ".ais"
@@ -15688,43 +15688,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum nilEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anil // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anil
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anil
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anil": self = .anil
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anil": self = .anil
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anil": self = .anil
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anil: return 0
@@ -15733,7 +15733,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anil: return "\"anil\""
@@ -15742,9 +15742,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anil: return ".anil"
@@ -15756,43 +15756,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum rethrowsEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case arethrows // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .arethrows
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .arethrows
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "arethrows": self = .arethrows
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "arethrows": self = .arethrows
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "arethrows": self = .arethrows
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .arethrows: return 0
@@ -15801,7 +15801,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .arethrows: return "\"arethrows\""
@@ -15810,9 +15810,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .arethrows: return ".arethrows"
@@ -15824,43 +15824,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum superEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asuper // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asuper
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asuper
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asuper": self = .asuper
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asuper": self = .asuper
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asuper": self = .asuper
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asuper: return 0
@@ -15869,7 +15869,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asuper: return "\"asuper\""
@@ -15878,9 +15878,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asuper: return ".asuper"
@@ -15892,43 +15892,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum selfEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aself // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aself
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aself
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aself": self = .aself
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aself": self = .aself
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aself": self = .aself
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aself: return 0
@@ -15937,7 +15937,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aself: return "\"aself\""
@@ -15946,9 +15946,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aself: return ".aself"
@@ -15960,43 +15960,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum throwEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case athrow // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .athrow
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .athrow
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "athrow": self = .athrow
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "athrow": self = .athrow
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "athrow": self = .athrow
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .athrow: return 0
@@ -16005,7 +16005,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .athrow: return "\"athrow\""
@@ -16014,9 +16014,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .athrow: return ".athrow"
@@ -16028,43 +16028,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum throwsEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case athrows // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .athrows
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .athrows
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "athrows": self = .athrows
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "athrows": self = .athrows
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "athrows": self = .athrows
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .athrows: return 0
@@ -16073,7 +16073,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .athrows: return "\"athrows\""
@@ -16082,9 +16082,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .athrows: return ".athrows"
@@ -16096,43 +16096,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum trueEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atrue // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atrue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atrue
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atrue": self = .atrue
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atrue": self = .atrue
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atrue": self = .atrue
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atrue: return 0
@@ -16141,7 +16141,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atrue: return "\"atrue\""
@@ -16150,9 +16150,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atrue: return ".atrue"
@@ -16164,43 +16164,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum tryEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atry // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atry
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atry
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atry": self = .atry
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atry": self = .atry
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atry": self = .atry
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atry: return 0
@@ -16209,7 +16209,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atry: return "\"atry\""
@@ -16218,9 +16218,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atry: return ".atry"
@@ -16232,43 +16232,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum __COLUMN__Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a_Column__ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a_Column__
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a_Column__
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a_Column__": self = .a_Column__
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a__COLUMN__": self = .a_Column__
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a__COLUMN__": self = .a_Column__
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a_Column__: return 0
@@ -16277,7 +16277,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a_Column__: return "\"a__COLUMN__\""
@@ -16286,9 +16286,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a_Column__: return ".a_Column__"
@@ -16300,43 +16300,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum __FILE__Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a_File__ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a_File__
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a_File__
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a_File__": self = .a_File__
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a__FILE__": self = .a_File__
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a__FILE__": self = .a_File__
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a_File__: return 0
@@ -16345,7 +16345,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a_File__: return "\"a__FILE__\""
@@ -16354,9 +16354,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a_File__: return ".a_File__"
@@ -16368,43 +16368,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum __FUNCTION__Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a_Function__ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a_Function__
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a_Function__
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a_Function__": self = .a_Function__
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a__FUNCTION__": self = .a_Function__
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a__FUNCTION__": self = .a_Function__
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a_Function__: return 0
@@ -16413,7 +16413,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a_Function__: return "\"a__FUNCTION__\""
@@ -16422,9 +16422,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a_Function__: return ".a_Function__"
@@ -16436,43 +16436,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum __LINE__Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a_Line__ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a_Line__
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a_Line__
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a_Line__": self = .a_Line__
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a__LINE__": self = .a_Line__
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a__LINE__": self = .a_Line__
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a_Line__: return 0
@@ -16481,7 +16481,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a_Line__: return "\"a__LINE__\""
@@ -16490,9 +16490,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a_Line__: return ".a_Line__"
@@ -16504,43 +16504,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum _Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a_ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a_
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a_
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a_": self = .a_
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a_": self = .a_
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a_": self = .a_
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a_: return 0
@@ -16549,7 +16549,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a_: return "\"a_\""
@@ -16558,9 +16558,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a_: return ".a_"
@@ -16572,43 +16572,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum __Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a__ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a__
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a__
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a__": self = .a__
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a__": self = .a__
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a__": self = .a__
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a__: return 0
@@ -16617,7 +16617,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a__: return "\"a__\""
@@ -16626,9 +16626,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a__: return ".a__"
@@ -16640,43 +16640,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum associativity: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aassociativity // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aassociativity
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aassociativity
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aassociativity": self = .aassociativity
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aassociativity": self = .aassociativity
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aassociativity": self = .aassociativity
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aassociativity: return 0
@@ -16685,7 +16685,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aassociativity: return "\"aassociativity\""
@@ -16694,9 +16694,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aassociativity: return ".aassociativity"
@@ -16708,43 +16708,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum convenience: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aconvenience // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aconvenience
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aconvenience
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aconvenience": self = .aconvenience
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aconvenience": self = .aconvenience
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aconvenience": self = .aconvenience
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aconvenience: return 0
@@ -16753,7 +16753,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aconvenience: return "\"aconvenience\""
@@ -16762,9 +16762,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aconvenience: return ".aconvenience"
@@ -16776,43 +16776,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum dynamic: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adynamic // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adynamic
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adynamic
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adynamic": self = .adynamic
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adynamic": self = .adynamic
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adynamic": self = .adynamic
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adynamic: return 0
@@ -16821,7 +16821,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adynamic: return "\"adynamic\""
@@ -16830,9 +16830,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adynamic: return ".adynamic"
@@ -16844,43 +16844,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum didSet: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adidSet // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adidSet
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adidSet
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adidSet": self = .adidSet
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adidSet": self = .adidSet
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adidSet": self = .adidSet
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adidSet: return 0
@@ -16889,7 +16889,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adidSet: return "\"adidSet\""
@@ -16898,9 +16898,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adidSet: return ".adidSet"
@@ -16912,43 +16912,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum final: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afinal // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afinal
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afinal
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afinal": self = .afinal
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afinal": self = .afinal
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afinal": self = .afinal
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afinal: return 0
@@ -16957,7 +16957,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afinal: return "\"afinal\""
@@ -16966,9 +16966,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afinal: return ".afinal"
@@ -16980,43 +16980,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum get: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aget // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aget
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aget
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aget": self = .aget
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aget": self = .aget
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aget": self = .aget
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aget: return 0
@@ -17025,7 +17025,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aget: return "\"aget\""
@@ -17034,9 +17034,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aget: return ".aget"
@@ -17048,43 +17048,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum infix: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ainfix // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ainfix
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ainfix
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ainfix": self = .ainfix
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ainfix": self = .ainfix
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ainfix": self = .ainfix
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ainfix: return 0
@@ -17093,7 +17093,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ainfix: return "\"ainfix\""
@@ -17102,9 +17102,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ainfix: return ".ainfix"
@@ -17116,43 +17116,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum indirect: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aindirect // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aindirect
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aindirect
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aindirect": self = .aindirect
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aindirect": self = .aindirect
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aindirect": self = .aindirect
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aindirect: return 0
@@ -17161,7 +17161,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aindirect: return "\"aindirect\""
@@ -17170,9 +17170,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aindirect: return ".aindirect"
@@ -17184,43 +17184,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum lazy: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case alazy // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .alazy
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .alazy
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "alazy": self = .alazy
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "alazy": self = .alazy
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "alazy": self = .alazy
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .alazy: return 0
@@ -17229,7 +17229,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .alazy: return "\"alazy\""
@@ -17238,9 +17238,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .alazy: return ".alazy"
@@ -17252,43 +17252,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum left: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aleft // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aleft
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aleft
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aleft": self = .aleft
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aleft": self = .aleft
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aleft": self = .aleft
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aleft: return 0
@@ -17297,7 +17297,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aleft: return "\"aleft\""
@@ -17306,9 +17306,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aleft: return ".aleft"
@@ -17320,43 +17320,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum mutating: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case amutating // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .amutating
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .amutating
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "amutating": self = .amutating
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "amutating": self = .amutating
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "amutating": self = .amutating
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .amutating: return 0
@@ -17365,7 +17365,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .amutating: return "\"amutating\""
@@ -17374,9 +17374,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .amutating: return ".amutating"
@@ -17388,43 +17388,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum none: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anone // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anone
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anone
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anone": self = .anone
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anone": self = .anone
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anone": self = .anone
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anone: return 0
@@ -17433,7 +17433,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anone: return "\"anone\""
@@ -17442,9 +17442,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anone: return ".anone"
@@ -17456,43 +17456,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum nonmutating: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anonmutating // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anonmutating
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anonmutating
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anonmutating": self = .anonmutating
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anonmutating": self = .anonmutating
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anonmutating": self = .anonmutating
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anonmutating: return 0
@@ -17501,7 +17501,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anonmutating: return "\"anonmutating\""
@@ -17510,9 +17510,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anonmutating: return ".anonmutating"
@@ -17524,43 +17524,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum optional: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aoptional // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aoptional
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aoptional
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aoptional": self = .aoptional
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aoptional": self = .aoptional
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aoptional": self = .aoptional
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aoptional: return 0
@@ -17569,7 +17569,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aoptional: return "\"aoptional\""
@@ -17578,9 +17578,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aoptional: return ".aoptional"
@@ -17592,43 +17592,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum override: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aoverride // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aoverride
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aoverride
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aoverride": self = .aoverride
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aoverride": self = .aoverride
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aoverride": self = .aoverride
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aoverride: return 0
@@ -17637,7 +17637,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aoverride: return "\"aoverride\""
@@ -17646,9 +17646,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aoverride: return ".aoverride"
@@ -17660,43 +17660,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum postfix: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case apostfix // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .apostfix
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .apostfix
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "apostfix": self = .apostfix
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "apostfix": self = .apostfix
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "apostfix": self = .apostfix
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .apostfix: return 0
@@ -17705,7 +17705,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .apostfix: return "\"apostfix\""
@@ -17714,9 +17714,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .apostfix: return ".apostfix"
@@ -17728,43 +17728,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum precedence: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aprecedence // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aprecedence
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aprecedence
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aprecedence": self = .aprecedence
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aprecedence": self = .aprecedence
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aprecedence": self = .aprecedence
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aprecedence: return 0
@@ -17773,7 +17773,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aprecedence: return "\"aprecedence\""
@@ -17782,9 +17782,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aprecedence: return ".aprecedence"
@@ -17796,43 +17796,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum prefix: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aprefix // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aprefix
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aprefix
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aprefix": self = .aprefix
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aprefix": self = .aprefix
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aprefix": self = .aprefix
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aprefix: return 0
@@ -17841,7 +17841,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aprefix: return "\"aprefix\""
@@ -17850,9 +17850,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aprefix: return ".aprefix"
@@ -17864,43 +17864,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum required: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case arequired // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .arequired
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .arequired
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "arequired": self = .arequired
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "arequired": self = .arequired
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "arequired": self = .arequired
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .arequired: return 0
@@ -17909,7 +17909,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .arequired: return "\"arequired\""
@@ -17918,9 +17918,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .arequired: return ".arequired"
@@ -17932,43 +17932,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum right: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aright // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aright
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aright
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aright": self = .aright
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aright": self = .aright
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aright": self = .aright
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aright: return 0
@@ -17977,7 +17977,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aright: return "\"aright\""
@@ -17986,9 +17986,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aright: return ".aright"
@@ -18000,43 +18000,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum set: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aset // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aset
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aset
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aset": self = .aset
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aset": self = .aset
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aset": self = .aset
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aset: return 0
@@ -18045,7 +18045,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aset: return "\"aset\""
@@ -18054,9 +18054,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aset: return ".aset"
@@ -18068,43 +18068,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum TypeEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aType // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aType
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aType
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aType": self = .aType
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aType": self = .aType
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aType": self = .aType
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aType: return 0
@@ -18113,7 +18113,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aType: return "\"aType\""
@@ -18122,9 +18122,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aType: return ".aType"
@@ -18136,43 +18136,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum unowned: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aunowned // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aunowned
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aunowned
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aunowned": self = .aunowned
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aunowned": self = .aunowned
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aunowned": self = .aunowned
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aunowned: return 0
@@ -18181,7 +18181,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aunowned: return "\"aunowned\""
@@ -18190,9 +18190,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aunowned: return ".aunowned"
@@ -18204,43 +18204,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum weak: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aweak // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aweak
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aweak
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aweak": self = .aweak
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aweak": self = .aweak
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aweak": self = .aweak
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aweak: return 0
@@ -18249,7 +18249,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aweak: return "\"aweak\""
@@ -18258,9 +18258,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aweak: return ".aweak"
@@ -18272,43 +18272,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum willSet: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case awillSet // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .awillSet
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .awillSet
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "awillSet": self = .awillSet
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "awillSet": self = .awillSet
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "awillSet": self = .awillSet
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .awillSet: return 0
@@ -18317,7 +18317,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .awillSet: return "\"awillSet\""
@@ -18326,9 +18326,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .awillSet: return ".awillSet"
@@ -18340,43 +18340,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum id: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aid // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aid
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aid
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aid": self = .aid
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aid": self = .aid
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aid": self = .aid
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aid: return 0
@@ -18385,7 +18385,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aid: return "\"aid\""
@@ -18394,9 +18394,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aid: return ".aid"
@@ -18408,43 +18408,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum _cmd: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aCmd // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aCmd
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aCmd
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aCmd": self = .aCmd
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a_cmd": self = .aCmd
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a_cmd": self = .aCmd
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aCmd: return 0
@@ -18453,7 +18453,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aCmd: return "\"a_cmd\""
@@ -18462,9 +18462,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aCmd: return ".aCmd"
@@ -18476,43 +18476,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum out: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aout // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aout
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aout
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aout": self = .aout
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aout": self = .aout
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aout": self = .aout
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aout: return 0
@@ -18521,7 +18521,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aout: return "\"aout\""
@@ -18530,9 +18530,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aout: return ".aout"
@@ -18544,43 +18544,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum bycopy: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abycopy // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abycopy
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abycopy
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abycopy": self = .abycopy
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abycopy": self = .abycopy
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abycopy": self = .abycopy
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abycopy: return 0
@@ -18589,7 +18589,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abycopy: return "\"abycopy\""
@@ -18598,9 +18598,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abycopy: return ".abycopy"
@@ -18612,43 +18612,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum byref: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abyref // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abyref
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abyref
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abyref": self = .abyref
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abyref": self = .abyref
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abyref": self = .abyref
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abyref: return 0
@@ -18657,7 +18657,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abyref: return "\"abyref\""
@@ -18666,9 +18666,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abyref: return ".abyref"
@@ -18680,43 +18680,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum oneway: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aoneway // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aoneway
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aoneway
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aoneway": self = .aoneway
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aoneway": self = .aoneway
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aoneway": self = .aoneway
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aoneway: return 0
@@ -18725,7 +18725,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aoneway: return "\"aoneway\""
@@ -18734,9 +18734,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aoneway: return ".aoneway"
@@ -18748,43 +18748,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum and: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aand // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aand
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aand
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aand": self = .aand
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aand": self = .aand
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aand": self = .aand
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aand: return 0
@@ -18793,7 +18793,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aand: return "\"aand\""
@@ -18802,9 +18802,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aand: return ".aand"
@@ -18816,43 +18816,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum and_eq: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aandEq // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aandEq
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aandEq
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aandEq": self = .aandEq
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aand_eq": self = .aandEq
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aand_eq": self = .aandEq
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aandEq: return 0
@@ -18861,7 +18861,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aandEq: return "\"aand_eq\""
@@ -18870,9 +18870,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aandEq: return ".aandEq"
@@ -18884,43 +18884,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum alignas: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aalignas // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aalignas
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aalignas
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aalignas": self = .aalignas
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aalignas": self = .aalignas
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aalignas": self = .aalignas
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aalignas: return 0
@@ -18929,7 +18929,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aalignas: return "\"aalignas\""
@@ -18938,9 +18938,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aalignas: return ".aalignas"
@@ -18952,43 +18952,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum alignof: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aalignof // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aalignof
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aalignof
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aalignof": self = .aalignof
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aalignof": self = .aalignof
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aalignof": self = .aalignof
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aalignof: return 0
@@ -18997,7 +18997,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aalignof: return "\"aalignof\""
@@ -19006,9 +19006,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aalignof: return ".aalignof"
@@ -19020,43 +19020,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum asm: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aasm // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aasm
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aasm
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aasm": self = .aasm
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aasm": self = .aasm
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aasm": self = .aasm
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aasm: return 0
@@ -19065,7 +19065,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aasm: return "\"aasm\""
@@ -19074,9 +19074,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aasm: return ".aasm"
@@ -19088,43 +19088,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum auto: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aauto // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aauto
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aauto
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aauto": self = .aauto
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aauto": self = .aauto
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aauto": self = .aauto
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aauto: return 0
@@ -19133,7 +19133,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aauto: return "\"aauto\""
@@ -19142,9 +19142,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aauto: return ".aauto"
@@ -19156,43 +19156,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum bitand: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abitand // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abitand
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abitand
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abitand": self = .abitand
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abitand": self = .abitand
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abitand": self = .abitand
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abitand: return 0
@@ -19201,7 +19201,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abitand: return "\"abitand\""
@@ -19210,9 +19210,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abitand: return ".abitand"
@@ -19224,43 +19224,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum bitor: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abitor // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abitor
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abitor
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abitor": self = .abitor
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abitor": self = .abitor
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abitor": self = .abitor
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abitor: return 0
@@ -19269,7 +19269,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abitor: return "\"abitor\""
@@ -19278,9 +19278,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abitor: return ".abitor"
@@ -19292,43 +19292,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum bool: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abool // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abool
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abool
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abool": self = .abool
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abool": self = .abool
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abool": self = .abool
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abool: return 0
@@ -19337,7 +19337,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abool: return "\"abool\""
@@ -19346,9 +19346,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abool: return ".abool"
@@ -19360,43 +19360,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum char: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case achar // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .achar
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .achar
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "achar": self = .achar
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "achar": self = .achar
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "achar": self = .achar
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .achar: return 0
@@ -19405,7 +19405,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .achar: return "\"achar\""
@@ -19414,9 +19414,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .achar: return ".achar"
@@ -19428,43 +19428,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum char16_t: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case achar16T // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .achar16T
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .achar16T
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "achar16T": self = .achar16T
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "achar16_t": self = .achar16T
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "achar16_t": self = .achar16T
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .achar16T: return 0
@@ -19473,7 +19473,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .achar16T: return "\"achar16_t\""
@@ -19482,9 +19482,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .achar16T: return ".achar16T"
@@ -19496,43 +19496,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum char32_t: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case achar32T // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .achar32T
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .achar32T
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "achar32T": self = .achar32T
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "achar32_t": self = .achar32T
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "achar32_t": self = .achar32T
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .achar32T: return 0
@@ -19541,7 +19541,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .achar32T: return "\"achar32_t\""
@@ -19550,9 +19550,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .achar32T: return ".achar32T"
@@ -19564,43 +19564,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum compl: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case acompl // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .acompl
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .acompl
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "acompl": self = .acompl
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "acompl": self = .acompl
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "acompl": self = .acompl
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .acompl: return 0
@@ -19609,7 +19609,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .acompl: return "\"acompl\""
@@ -19618,9 +19618,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .acompl: return ".acompl"
@@ -19632,43 +19632,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum const: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aconst // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aconst
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aconst
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aconst": self = .aconst
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aconst": self = .aconst
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aconst": self = .aconst
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aconst: return 0
@@ -19677,7 +19677,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aconst: return "\"aconst\""
@@ -19686,9 +19686,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aconst: return ".aconst"
@@ -19700,43 +19700,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum constexpr: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aconstexpr // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aconstexpr
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aconstexpr
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aconstexpr": self = .aconstexpr
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aconstexpr": self = .aconstexpr
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aconstexpr": self = .aconstexpr
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aconstexpr: return 0
@@ -19745,7 +19745,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aconstexpr: return "\"aconstexpr\""
@@ -19754,9 +19754,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aconstexpr: return ".aconstexpr"
@@ -19768,43 +19768,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum const_cast: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aconstCast // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aconstCast
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aconstCast
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aconstCast": self = .aconstCast
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aconst_cast": self = .aconstCast
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aconst_cast": self = .aconstCast
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aconstCast: return 0
@@ -19813,7 +19813,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aconstCast: return "\"aconst_cast\""
@@ -19822,9 +19822,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aconstCast: return ".aconstCast"
@@ -19836,43 +19836,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum decltype: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adecltype // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adecltype
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adecltype
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adecltype": self = .adecltype
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adecltype": self = .adecltype
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adecltype": self = .adecltype
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adecltype: return 0
@@ -19881,7 +19881,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adecltype: return "\"adecltype\""
@@ -19890,9 +19890,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adecltype: return ".adecltype"
@@ -19904,43 +19904,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum delete: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adelete // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adelete
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adelete
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adelete": self = .adelete
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adelete": self = .adelete
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adelete": self = .adelete
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adelete: return 0
@@ -19949,7 +19949,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adelete: return "\"adelete\""
@@ -19958,9 +19958,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adelete: return ".adelete"
@@ -19972,43 +19972,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum dynamic_cast: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adynamicCast // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adynamicCast
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adynamicCast
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adynamicCast": self = .adynamicCast
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adynamic_cast": self = .adynamicCast
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adynamic_cast": self = .adynamicCast
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adynamicCast: return 0
@@ -20017,7 +20017,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adynamicCast: return "\"adynamic_cast\""
@@ -20026,9 +20026,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adynamicCast: return ".adynamicCast"
@@ -20040,43 +20040,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum explicit: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aexplicit // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aexplicit
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aexplicit
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aexplicit": self = .aexplicit
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aexplicit": self = .aexplicit
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aexplicit": self = .aexplicit
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aexplicit: return 0
@@ -20085,7 +20085,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aexplicit: return "\"aexplicit\""
@@ -20094,9 +20094,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aexplicit: return ".aexplicit"
@@ -20108,43 +20108,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum export: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aexport // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aexport
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aexport
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aexport": self = .aexport
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aexport": self = .aexport
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aexport": self = .aexport
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aexport: return 0
@@ -20153,7 +20153,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aexport: return "\"aexport\""
@@ -20162,9 +20162,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aexport: return ".aexport"
@@ -20176,43 +20176,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum extern: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aextern // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aextern
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aextern
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aextern": self = .aextern
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aextern": self = .aextern
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aextern": self = .aextern
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aextern: return 0
@@ -20221,7 +20221,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aextern: return "\"aextern\""
@@ -20230,9 +20230,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aextern: return ".aextern"
@@ -20244,43 +20244,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum friend: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afriend // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afriend
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afriend
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afriend": self = .afriend
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afriend": self = .afriend
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afriend": self = .afriend
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afriend: return 0
@@ -20289,7 +20289,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afriend: return "\"afriend\""
@@ -20298,9 +20298,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afriend: return ".afriend"
@@ -20312,43 +20312,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum goto: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case agoto // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .agoto
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .agoto
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "agoto": self = .agoto
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "agoto": self = .agoto
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "agoto": self = .agoto
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .agoto: return 0
@@ -20357,7 +20357,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .agoto: return "\"agoto\""
@@ -20366,9 +20366,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .agoto: return ".agoto"
@@ -20380,43 +20380,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum inline: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ainline // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ainline
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ainline
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ainline": self = .ainline
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ainline": self = .ainline
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ainline": self = .ainline
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ainline: return 0
@@ -20425,7 +20425,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ainline: return "\"ainline\""
@@ -20434,9 +20434,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ainline: return ".ainline"
@@ -20448,43 +20448,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum long: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case along // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .along
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .along
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "along": self = .along
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "along": self = .along
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "along": self = .along
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .along: return 0
@@ -20493,7 +20493,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .along: return "\"along\""
@@ -20502,9 +20502,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .along: return ".along"
@@ -20516,43 +20516,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum mutable: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case amutable // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .amutable
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .amutable
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "amutable": self = .amutable
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "amutable": self = .amutable
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "amutable": self = .amutable
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .amutable: return 0
@@ -20561,7 +20561,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .amutable: return "\"amutable\""
@@ -20570,9 +20570,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .amutable: return ".amutable"
@@ -20584,43 +20584,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum namespace: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anamespace // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anamespace
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anamespace
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anamespace": self = .anamespace
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anamespace": self = .anamespace
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anamespace": self = .anamespace
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anamespace: return 0
@@ -20629,7 +20629,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anamespace: return "\"anamespace\""
@@ -20638,9 +20638,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anamespace: return ".anamespace"
@@ -20652,43 +20652,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum new: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anew // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anew
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anew
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anew": self = .anew
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anew": self = .anew
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anew": self = .anew
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anew: return 0
@@ -20697,7 +20697,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anew: return "\"anew\""
@@ -20706,9 +20706,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anew: return ".anew"
@@ -20720,43 +20720,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum noexcept: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anoexcept // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anoexcept
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anoexcept
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anoexcept": self = .anoexcept
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anoexcept": self = .anoexcept
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anoexcept": self = .anoexcept
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anoexcept: return 0
@@ -20765,7 +20765,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anoexcept: return "\"anoexcept\""
@@ -20774,9 +20774,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anoexcept: return ".anoexcept"
@@ -20788,43 +20788,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum not: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anot // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anot
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anot
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anot": self = .anot
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anot": self = .anot
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anot": self = .anot
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anot: return 0
@@ -20833,7 +20833,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anot: return "\"anot\""
@@ -20842,9 +20842,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anot: return ".anot"
@@ -20856,43 +20856,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum not_eq: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anotEq // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anotEq
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anotEq
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anotEq": self = .anotEq
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anot_eq": self = .anotEq
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anot_eq": self = .anotEq
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anotEq: return 0
@@ -20901,7 +20901,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anotEq: return "\"anot_eq\""
@@ -20910,9 +20910,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anotEq: return ".anotEq"
@@ -20924,43 +20924,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum nullptr: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anullptr // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anullptr
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anullptr
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anullptr": self = .anullptr
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anullptr": self = .anullptr
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anullptr": self = .anullptr
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anullptr: return 0
@@ -20969,7 +20969,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anullptr: return "\"anullptr\""
@@ -20978,9 +20978,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anullptr: return ".anullptr"
@@ -20992,43 +20992,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum or: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aor // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aor
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aor
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aor": self = .aor
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aor": self = .aor
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aor": self = .aor
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aor: return 0
@@ -21037,7 +21037,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aor: return "\"aor\""
@@ -21046,9 +21046,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aor: return ".aor"
@@ -21060,43 +21060,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum or_eq: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aorEq // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aorEq
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aorEq
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aorEq": self = .aorEq
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aor_eq": self = .aorEq
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aor_eq": self = .aorEq
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aorEq: return 0
@@ -21105,7 +21105,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aorEq: return "\"aor_eq\""
@@ -21114,9 +21114,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aorEq: return ".aorEq"
@@ -21128,43 +21128,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum protected: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aprotected // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aprotected
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aprotected
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aprotected": self = .aprotected
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aprotected": self = .aprotected
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aprotected": self = .aprotected
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aprotected: return 0
@@ -21173,7 +21173,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aprotected: return "\"aprotected\""
@@ -21182,9 +21182,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aprotected: return ".aprotected"
@@ -21196,43 +21196,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum register: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aregister // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aregister
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aregister
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aregister": self = .aregister
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aregister": self = .aregister
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aregister": self = .aregister
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aregister: return 0
@@ -21241,7 +21241,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aregister: return "\"aregister\""
@@ -21250,9 +21250,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aregister: return ".aregister"
@@ -21264,43 +21264,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum reinterpret_cast: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case areinterpretCast // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .areinterpretCast
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .areinterpretCast
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "areinterpretCast": self = .areinterpretCast
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "areinterpret_cast": self = .areinterpretCast
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "areinterpret_cast": self = .areinterpretCast
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .areinterpretCast: return 0
@@ -21309,7 +21309,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .areinterpretCast: return "\"areinterpret_cast\""
@@ -21318,9 +21318,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .areinterpretCast: return ".areinterpretCast"
@@ -21332,43 +21332,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum short: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ashort // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ashort
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ashort
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ashort": self = .ashort
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ashort": self = .ashort
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ashort": self = .ashort
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ashort: return 0
@@ -21377,7 +21377,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ashort: return "\"ashort\""
@@ -21386,9 +21386,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ashort: return ".ashort"
@@ -21400,43 +21400,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum signed: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asigned // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asigned
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asigned
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asigned": self = .asigned
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asigned": self = .asigned
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asigned": self = .asigned
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asigned: return 0
@@ -21445,7 +21445,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asigned: return "\"asigned\""
@@ -21454,9 +21454,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asigned: return ".asigned"
@@ -21468,43 +21468,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum sizeof: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asizeof // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asizeof
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asizeof
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asizeof": self = .asizeof
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asizeof": self = .asizeof
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asizeof": self = .asizeof
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asizeof: return 0
@@ -21513,7 +21513,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asizeof: return "\"asizeof\""
@@ -21522,9 +21522,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asizeof: return ".asizeof"
@@ -21536,43 +21536,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum static_assert: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case astaticAssert // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .astaticAssert
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .astaticAssert
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "astaticAssert": self = .astaticAssert
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "astatic_assert": self = .astaticAssert
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "astatic_assert": self = .astaticAssert
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .astaticAssert: return 0
@@ -21581,7 +21581,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .astaticAssert: return "\"astatic_assert\""
@@ -21590,9 +21590,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .astaticAssert: return ".astaticAssert"
@@ -21604,43 +21604,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum static_cast: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case astaticCast // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .astaticCast
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .astaticCast
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "astaticCast": self = .astaticCast
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "astatic_cast": self = .astaticCast
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "astatic_cast": self = .astaticCast
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .astaticCast: return 0
@@ -21649,7 +21649,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .astaticCast: return "\"astatic_cast\""
@@ -21658,9 +21658,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .astaticCast: return ".astaticCast"
@@ -21672,43 +21672,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum template: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atemplate // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atemplate
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atemplate
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atemplate": self = .atemplate
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atemplate": self = .atemplate
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atemplate": self = .atemplate
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atemplate: return 0
@@ -21717,7 +21717,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atemplate: return "\"atemplate\""
@@ -21726,9 +21726,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atemplate: return ".atemplate"
@@ -21740,43 +21740,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum this: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case athis // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .athis
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .athis
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "athis": self = .athis
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "athis": self = .athis
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "athis": self = .athis
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .athis: return 0
@@ -21785,7 +21785,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .athis: return "\"athis\""
@@ -21794,9 +21794,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .athis: return ".athis"
@@ -21808,43 +21808,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum thread_local: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case athreadLocal // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .athreadLocal
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .athreadLocal
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "athreadLocal": self = .athreadLocal
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "athread_local": self = .athreadLocal
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "athread_local": self = .athreadLocal
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .athreadLocal: return 0
@@ -21853,7 +21853,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .athreadLocal: return "\"athread_local\""
@@ -21862,9 +21862,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .athreadLocal: return ".athreadLocal"
@@ -21876,43 +21876,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum typedef: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atypedef // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atypedef
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atypedef
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atypedef": self = .atypedef
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atypedef": self = .atypedef
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atypedef": self = .atypedef
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atypedef: return 0
@@ -21921,7 +21921,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atypedef: return "\"atypedef\""
@@ -21930,9 +21930,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atypedef: return ".atypedef"
@@ -21944,43 +21944,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum typeid: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atypeid // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atypeid
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atypeid
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atypeid": self = .atypeid
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atypeid": self = .atypeid
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atypeid": self = .atypeid
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atypeid: return 0
@@ -21989,7 +21989,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atypeid: return "\"atypeid\""
@@ -21998,9 +21998,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atypeid: return ".atypeid"
@@ -22012,43 +22012,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum typename: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atypename // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atypename
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atypename
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atypename": self = .atypename
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atypename": self = .atypename
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atypename": self = .atypename
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atypename: return 0
@@ -22057,7 +22057,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atypename: return "\"atypename\""
@@ -22066,9 +22066,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atypename: return ".atypename"
@@ -22080,43 +22080,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum union: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aunion // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aunion
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aunion
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aunion": self = .aunion
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aunion": self = .aunion
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aunion": self = .aunion
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aunion: return 0
@@ -22125,7 +22125,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aunion: return "\"aunion\""
@@ -22134,9 +22134,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aunion: return ".aunion"
@@ -22148,43 +22148,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum unsigned: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aunsigned // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aunsigned
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aunsigned
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aunsigned": self = .aunsigned
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aunsigned": self = .aunsigned
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aunsigned": self = .aunsigned
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aunsigned: return 0
@@ -22193,7 +22193,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aunsigned: return "\"aunsigned\""
@@ -22202,9 +22202,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aunsigned: return ".aunsigned"
@@ -22216,43 +22216,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum using: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ausing // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ausing
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ausing
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ausing": self = .ausing
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ausing": self = .ausing
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ausing": self = .ausing
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ausing: return 0
@@ -22261,7 +22261,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ausing: return "\"ausing\""
@@ -22270,9 +22270,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ausing: return ".ausing"
@@ -22284,43 +22284,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum virtual: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case avirtual // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .avirtual
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .avirtual
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "avirtual": self = .avirtual
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "avirtual": self = .avirtual
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "avirtual": self = .avirtual
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .avirtual: return 0
@@ -22329,7 +22329,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .avirtual: return "\"avirtual\""
@@ -22338,9 +22338,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .avirtual: return ".avirtual"
@@ -22352,43 +22352,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum void: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case avoid // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .avoid
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .avoid
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "avoid": self = .avoid
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "avoid": self = .avoid
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "avoid": self = .avoid
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .avoid: return 0
@@ -22397,7 +22397,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .avoid: return "\"avoid\""
@@ -22406,9 +22406,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .avoid: return ".avoid"
@@ -22420,43 +22420,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum volatile: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case avolatile // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .avolatile
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .avolatile
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "avolatile": self = .avolatile
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "avolatile": self = .avolatile
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "avolatile": self = .avolatile
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .avolatile: return 0
@@ -22465,7 +22465,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .avolatile: return "\"avolatile\""
@@ -22474,9 +22474,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .avolatile: return ".avolatile"
@@ -22488,43 +22488,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum wchar_t: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case awcharT // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .awcharT
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .awcharT
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "awcharT": self = .awcharT
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "awchar_t": self = .awcharT
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "awchar_t": self = .awcharT
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .awcharT: return 0
@@ -22533,7 +22533,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .awcharT: return "\"awchar_t\""
@@ -22542,9 +22542,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .awcharT: return ".awcharT"
@@ -22556,43 +22556,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum xor: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case axor // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .axor
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .axor
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "axor": self = .axor
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "axor": self = .axor
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "axor": self = .axor
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .axor: return 0
@@ -22601,7 +22601,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .axor: return "\"axor\""
@@ -22610,9 +22610,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .axor: return ".axor"
@@ -22624,43 +22624,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum xor_eq: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case axorEq // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .axorEq
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .axorEq
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "axorEq": self = .axorEq
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "axor_eq": self = .axorEq
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "axor_eq": self = .axorEq
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .axorEq: return 0
@@ -22669,7 +22669,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .axorEq: return "\"axor_eq\""
@@ -22678,9 +22678,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .axorEq: return ".axorEq"
@@ -22692,43 +22692,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum restrict: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case arestrict // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .arestrict
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .arestrict
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "arestrict": self = .arestrict
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "arestrict": self = .arestrict
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "arestrict": self = .arestrict
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .arestrict: return 0
@@ -22737,7 +22737,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .arestrict: return "\"arestrict\""
@@ -22746,9 +22746,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .arestrict: return ".arestrict"
@@ -22760,43 +22760,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Category: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aCategory // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aCategory
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aCategory
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aCategory": self = .aCategory
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aCategory": self = .aCategory
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aCategory": self = .aCategory
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aCategory: return 0
@@ -22805,7 +22805,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aCategory: return "\"aCategory\""
@@ -22814,9 +22814,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aCategory: return ".aCategory"
@@ -22828,43 +22828,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Ivar: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aIvar // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aIvar
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aIvar
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aIvar": self = .aIvar
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aIvar": self = .aIvar
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aIvar": self = .aIvar
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aIvar: return 0
@@ -22873,7 +22873,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aIvar: return "\"aIvar\""
@@ -22882,9 +22882,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aIvar: return ".aIvar"
@@ -22896,43 +22896,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Method: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aMethod // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aMethod
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aMethod
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aMethod": self = .aMethod
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aMethod": self = .aMethod
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aMethod": self = .aMethod
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aMethod: return 0
@@ -22941,7 +22941,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aMethod: return "\"aMethod\""
@@ -22950,9 +22950,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aMethod: return ".aMethod"
@@ -22964,43 +22964,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum finalize: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afinalize // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afinalize
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afinalize
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afinalize": self = .afinalize
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afinalize": self = .afinalize
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afinalize": self = .afinalize
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afinalize: return 0
@@ -23009,7 +23009,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afinalize: return "\"afinalize\""
@@ -23018,9 +23018,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afinalize: return ".afinalize"
@@ -23032,43 +23032,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum hash: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ahash // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ahash
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ahash
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ahash": self = .ahash
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ahash": self = .ahash
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ahash": self = .ahash
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ahash: return 0
@@ -23077,7 +23077,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ahash: return "\"ahash\""
@@ -23086,9 +23086,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ahash: return ".ahash"
@@ -23100,43 +23100,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum dealloc: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adealloc // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adealloc
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adealloc
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adealloc": self = .adealloc
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adealloc": self = .adealloc
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adealloc": self = .adealloc
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adealloc: return 0
@@ -23145,7 +23145,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adealloc: return "\"adealloc\""
@@ -23154,9 +23154,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adealloc: return ".adealloc"
@@ -23168,43 +23168,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum superclass: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asuperclass // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asuperclass
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asuperclass
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asuperclass": self = .asuperclass
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asuperclass": self = .asuperclass
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asuperclass": self = .asuperclass
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asuperclass: return 0
@@ -23213,7 +23213,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asuperclass: return "\"asuperclass\""
@@ -23222,9 +23222,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asuperclass: return ".asuperclass"
@@ -23236,43 +23236,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum retain: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aretain // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aretain
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aretain
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aretain": self = .aretain
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aretain": self = .aretain
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aretain": self = .aretain
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aretain: return 0
@@ -23281,7 +23281,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aretain: return "\"aretain\""
@@ -23290,9 +23290,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aretain: return ".aretain"
@@ -23304,43 +23304,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum release: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case arelease // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .arelease
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .arelease
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "arelease": self = .arelease
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "arelease": self = .arelease
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "arelease": self = .arelease
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .arelease: return 0
@@ -23349,7 +23349,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .arelease: return "\"arelease\""
@@ -23358,9 +23358,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .arelease: return ".arelease"
@@ -23372,43 +23372,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum autorelease: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aautorelease // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aautorelease
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aautorelease
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aautorelease": self = .aautorelease
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aautorelease": self = .aautorelease
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aautorelease": self = .aautorelease
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aautorelease: return 0
@@ -23417,7 +23417,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aautorelease: return "\"aautorelease\""
@@ -23426,9 +23426,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aautorelease: return ".aautorelease"
@@ -23440,43 +23440,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum retainCount: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aretainCount // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aretainCount
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aretainCount
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aretainCount": self = .aretainCount
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aretainCount": self = .aretainCount
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aretainCount": self = .aretainCount
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aretainCount: return 0
@@ -23485,7 +23485,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aretainCount: return "\"aretainCount\""
@@ -23494,9 +23494,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aretainCount: return ".aretainCount"
@@ -23508,43 +23508,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum zone: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case azone // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .azone
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .azone
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "azone": self = .azone
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "azone": self = .azone
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "azone": self = .azone
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .azone: return 0
@@ -23553,7 +23553,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .azone: return "\"azone\""
@@ -23562,9 +23562,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .azone: return ".azone"
@@ -23576,43 +23576,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum isProxy: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aisProxy // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aisProxy
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aisProxy
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aisProxy": self = .aisProxy
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aisProxy": self = .aisProxy
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aisProxy": self = .aisProxy
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aisProxy: return 0
@@ -23621,7 +23621,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aisProxy: return "\"aisProxy\""
@@ -23630,9 +23630,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aisProxy: return ".aisProxy"
@@ -23644,43 +23644,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum copy: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case acopy // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .acopy
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .acopy
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "acopy": self = .acopy
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "acopy": self = .acopy
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "acopy": self = .acopy
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .acopy: return 0
@@ -23689,7 +23689,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .acopy: return "\"acopy\""
@@ -23698,9 +23698,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .acopy: return ".acopy"
@@ -23712,43 +23712,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum mutableCopy: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case amutableCopy // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .amutableCopy
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .amutableCopy
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "amutableCopy": self = .amutableCopy
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "amutableCopy": self = .amutableCopy
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "amutableCopy": self = .amutableCopy
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .amutableCopy: return 0
@@ -23757,7 +23757,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .amutableCopy: return "\"amutableCopy\""
@@ -23766,9 +23766,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .amutableCopy: return ".amutableCopy"
@@ -23780,43 +23780,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum classForCoder: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aclassForCoder // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aclassForCoder
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aclassForCoder
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aclassForCoder": self = .aclassForCoder
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aclassForCoder": self = .aclassForCoder
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aclassForCoder": self = .aclassForCoder
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aclassForCoder: return 0
@@ -23825,7 +23825,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aclassForCoder: return "\"aclassForCoder\""
@@ -23834,9 +23834,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aclassForCoder: return ".aclassForCoder"
@@ -23848,43 +23848,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum clear: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aclear // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aclear
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aclear
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aclear": self = .aclear
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aclear": self = .aclear
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aclear": self = .aclear
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aclear: return 0
@@ -23893,7 +23893,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aclear: return "\"aclear\""
@@ -23902,9 +23902,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aclear: return ".aclear"
@@ -23916,43 +23916,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum data: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adata // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adata
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adata
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adata": self = .adata
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adata": self = .adata
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adata": self = .adata
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adata: return 0
@@ -23961,7 +23961,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adata: return "\"adata\""
@@ -23970,9 +23970,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adata: return ".adata"
@@ -23984,43 +23984,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum delimitedData: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adelimitedData // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adelimitedData
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adelimitedData
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adelimitedData": self = .adelimitedData
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adelimitedData": self = .adelimitedData
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adelimitedData": self = .adelimitedData
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adelimitedData: return 0
@@ -24029,7 +24029,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adelimitedData: return "\"adelimitedData\""
@@ -24038,9 +24038,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adelimitedData: return ".adelimitedData"
@@ -24052,43 +24052,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum descriptor: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adescriptor // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adescriptor
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adescriptor
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adescriptor": self = .adescriptor
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adescriptor": self = .adescriptor
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adescriptor": self = .adescriptor
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adescriptor: return 0
@@ -24097,7 +24097,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adescriptor: return "\"adescriptor\""
@@ -24106,9 +24106,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adescriptor: return ".adescriptor"
@@ -24120,43 +24120,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum extensionRegistry: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aextensionRegistry // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aextensionRegistry
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aextensionRegistry
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aextensionRegistry": self = .aextensionRegistry
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aextensionRegistry": self = .aextensionRegistry
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aextensionRegistry": self = .aextensionRegistry
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aextensionRegistry: return 0
@@ -24165,7 +24165,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aextensionRegistry: return "\"aextensionRegistry\""
@@ -24174,9 +24174,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aextensionRegistry: return ".aextensionRegistry"
@@ -24188,43 +24188,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum extensionsCurrentlySet: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aextensionsCurrentlySet // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aextensionsCurrentlySet
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aextensionsCurrentlySet
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aextensionsCurrentlySet": self = .aextensionsCurrentlySet
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aextensionsCurrentlySet": self = .aextensionsCurrentlySet
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aextensionsCurrentlySet": self = .aextensionsCurrentlySet
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aextensionsCurrentlySet: return 0
@@ -24233,7 +24233,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aextensionsCurrentlySet: return "\"aextensionsCurrentlySet\""
@@ -24242,9 +24242,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aextensionsCurrentlySet: return ".aextensionsCurrentlySet"
@@ -24256,43 +24256,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum isInitialized: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aisInitialized // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aisInitialized
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aisInitialized
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aisInitialized": self = .aisInitialized
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aisInitialized": self = .aisInitialized
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aisInitialized": self = .aisInitialized
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aisInitialized: return 0
@@ -24301,7 +24301,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aisInitialized: return "\"aisInitialized\""
@@ -24310,9 +24310,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aisInitialized: return ".aisInitialized"
@@ -24324,43 +24324,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum serializedSize: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aserializedSize // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aserializedSize
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aserializedSize
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aserializedSize": self = .aserializedSize
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aserializedSize": self = .aserializedSize
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aserializedSize": self = .aserializedSize
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aserializedSize: return 0
@@ -24369,7 +24369,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aserializedSize: return "\"aserializedSize\""
@@ -24378,9 +24378,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aserializedSize: return ".aserializedSize"
@@ -24392,43 +24392,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum sortedExtensionsInUse: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asortedExtensionsInUse // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asortedExtensionsInUse
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asortedExtensionsInUse
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asortedExtensionsInUse": self = .asortedExtensionsInUse
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asortedExtensionsInUse": self = .asortedExtensionsInUse
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asortedExtensionsInUse": self = .asortedExtensionsInUse
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asortedExtensionsInUse: return 0
@@ -24437,7 +24437,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asortedExtensionsInUse: return "\"asortedExtensionsInUse\""
@@ -24446,9 +24446,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asortedExtensionsInUse: return ".asortedExtensionsInUse"
@@ -24460,43 +24460,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum unknownFields: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aunknownFields // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aunknownFields
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aunknownFields
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aunknownFields": self = .aunknownFields
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aunknownFields": self = .aunknownFields
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aunknownFields": self = .aunknownFields
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aunknownFields: return 0
@@ -24505,7 +24505,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aunknownFields: return "\"aunknownFields\""
@@ -24514,9 +24514,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aunknownFields: return ".aunknownFields"
@@ -24528,43 +24528,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Fixed: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aFixed // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aFixed
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aFixed
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aFixed": self = .aFixed
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aFixed": self = .aFixed
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aFixed": self = .aFixed
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aFixed: return 0
@@ -24573,7 +24573,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aFixed: return "\"aFixed\""
@@ -24582,9 +24582,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aFixed: return ".aFixed"
@@ -24596,43 +24596,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Fract: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aFract // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aFract
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aFract
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aFract": self = .aFract
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aFract": self = .aFract
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aFract": self = .aFract
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aFract: return 0
@@ -24641,7 +24641,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aFract: return "\"aFract\""
@@ -24650,9 +24650,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aFract: return ".aFract"
@@ -24664,43 +24664,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Size: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aSize // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aSize
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aSize
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aSize": self = .aSize
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aSize": self = .aSize
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aSize": self = .aSize
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aSize: return 0
@@ -24709,7 +24709,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aSize: return "\"aSize\""
@@ -24718,9 +24718,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aSize: return ".aSize"
@@ -24732,43 +24732,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum LogicalAddress: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aLogicalAddress // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aLogicalAddress
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aLogicalAddress
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aLogicalAddress": self = .aLogicalAddress
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aLogicalAddress": self = .aLogicalAddress
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aLogicalAddress": self = .aLogicalAddress
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aLogicalAddress: return 0
@@ -24777,7 +24777,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aLogicalAddress: return "\"aLogicalAddress\""
@@ -24786,9 +24786,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aLogicalAddress: return ".aLogicalAddress"
@@ -24800,43 +24800,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum PhysicalAddress: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aPhysicalAddress // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aPhysicalAddress
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aPhysicalAddress
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aPhysicalAddress": self = .aPhysicalAddress
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aPhysicalAddress": self = .aPhysicalAddress
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aPhysicalAddress": self = .aPhysicalAddress
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aPhysicalAddress: return 0
@@ -24845,7 +24845,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aPhysicalAddress: return "\"aPhysicalAddress\""
@@ -24854,9 +24854,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aPhysicalAddress: return ".aPhysicalAddress"
@@ -24868,43 +24868,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ByteCount: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aByteCount // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aByteCount
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aByteCount
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aByteCount": self = .aByteCount
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aByteCount": self = .aByteCount
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aByteCount": self = .aByteCount
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aByteCount: return 0
@@ -24913,7 +24913,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aByteCount: return "\"aByteCount\""
@@ -24922,9 +24922,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aByteCount: return ".aByteCount"
@@ -24936,43 +24936,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ByteOffset: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aByteOffset // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aByteOffset
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aByteOffset
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aByteOffset": self = .aByteOffset
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aByteOffset": self = .aByteOffset
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aByteOffset": self = .aByteOffset
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aByteOffset: return 0
@@ -24981,7 +24981,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aByteOffset: return "\"aByteOffset\""
@@ -24990,9 +24990,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aByteOffset: return ".aByteOffset"
@@ -25004,43 +25004,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Duration: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aDuration // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aDuration
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aDuration
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aDuration": self = .aDuration
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aDuration": self = .aDuration
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aDuration": self = .aDuration
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aDuration: return 0
@@ -25049,7 +25049,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aDuration: return "\"aDuration\""
@@ -25058,9 +25058,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aDuration: return ".aDuration"
@@ -25072,43 +25072,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum AbsoluteTime: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aAbsoluteTime // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aAbsoluteTime
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aAbsoluteTime
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aAbsoluteTime": self = .aAbsoluteTime
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aAbsoluteTime": self = .aAbsoluteTime
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aAbsoluteTime": self = .aAbsoluteTime
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aAbsoluteTime: return 0
@@ -25117,7 +25117,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aAbsoluteTime: return "\"aAbsoluteTime\""
@@ -25126,9 +25126,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aAbsoluteTime: return ".aAbsoluteTime"
@@ -25140,43 +25140,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum OptionBits: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aOptionBits // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aOptionBits
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aOptionBits
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aOptionBits": self = .aOptionBits
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aOptionBits": self = .aOptionBits
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aOptionBits": self = .aOptionBits
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aOptionBits: return 0
@@ -25185,7 +25185,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aOptionBits: return "\"aOptionBits\""
@@ -25194,9 +25194,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aOptionBits: return ".aOptionBits"
@@ -25208,43 +25208,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ItemCount: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aItemCount // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aItemCount
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aItemCount
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aItemCount": self = .aItemCount
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aItemCount": self = .aItemCount
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aItemCount": self = .aItemCount
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aItemCount: return 0
@@ -25253,7 +25253,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aItemCount: return "\"aItemCount\""
@@ -25262,9 +25262,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aItemCount: return ".aItemCount"
@@ -25276,43 +25276,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum PBVersion: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aPbversion // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aPbversion
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aPbversion
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aPbversion": self = .aPbversion
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aPBVersion": self = .aPbversion
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aPBVersion": self = .aPbversion
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aPbversion: return 0
@@ -25321,7 +25321,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aPbversion: return "\"aPBVersion\""
@@ -25330,9 +25330,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aPbversion: return ".aPbversion"
@@ -25344,43 +25344,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ScriptCode: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aScriptCode // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aScriptCode
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aScriptCode
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aScriptCode": self = .aScriptCode
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aScriptCode": self = .aScriptCode
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aScriptCode": self = .aScriptCode
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aScriptCode: return 0
@@ -25389,7 +25389,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aScriptCode: return "\"aScriptCode\""
@@ -25398,9 +25398,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aScriptCode: return ".aScriptCode"
@@ -25412,43 +25412,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum LangCode: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aLangCode // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aLangCode
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aLangCode
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aLangCode": self = .aLangCode
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aLangCode": self = .aLangCode
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aLangCode": self = .aLangCode
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aLangCode: return 0
@@ -25457,7 +25457,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aLangCode: return "\"aLangCode\""
@@ -25466,9 +25466,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aLangCode: return ".aLangCode"
@@ -25480,43 +25480,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum RegionCode: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aRegionCode // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aRegionCode
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aRegionCode
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aRegionCode": self = .aRegionCode
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aRegionCode": self = .aRegionCode
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aRegionCode": self = .aRegionCode
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aRegionCode: return 0
@@ -25525,7 +25525,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aRegionCode: return "\"aRegionCode\""
@@ -25534,9 +25534,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aRegionCode: return ".aRegionCode"
@@ -25548,43 +25548,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum OSType: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aOstype // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aOstype
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aOstype
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aOstype": self = .aOstype
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aOSType": self = .aOstype
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aOSType": self = .aOstype
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aOstype: return 0
@@ -25593,7 +25593,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aOstype: return "\"aOSType\""
@@ -25602,9 +25602,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aOstype: return ".aOstype"
@@ -25616,43 +25616,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ProcessSerialNumber: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aProcessSerialNumber // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aProcessSerialNumber
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aProcessSerialNumber
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aProcessSerialNumber": self = .aProcessSerialNumber
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aProcessSerialNumber": self = .aProcessSerialNumber
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aProcessSerialNumber": self = .aProcessSerialNumber
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aProcessSerialNumber: return 0
@@ -25661,7 +25661,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aProcessSerialNumber: return "\"aProcessSerialNumber\""
@@ -25670,9 +25670,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aProcessSerialNumber: return ".aProcessSerialNumber"
@@ -25684,43 +25684,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Point: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aPoint // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aPoint
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aPoint
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aPoint": self = .aPoint
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aPoint": self = .aPoint
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aPoint": self = .aPoint
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aPoint: return 0
@@ -25729,7 +25729,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aPoint: return "\"aPoint\""
@@ -25738,9 +25738,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aPoint: return ".aPoint"
@@ -25752,43 +25752,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Rect: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aRect // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aRect
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aRect
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aRect": self = .aRect
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aRect": self = .aRect
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aRect": self = .aRect
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aRect: return 0
@@ -25797,7 +25797,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aRect: return "\"aRect\""
@@ -25806,9 +25806,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aRect: return ".aRect"
@@ -25820,43 +25820,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum FixedPoint: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aFixedPoint // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aFixedPoint
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aFixedPoint
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aFixedPoint": self = .aFixedPoint
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aFixedPoint": self = .aFixedPoint
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aFixedPoint": self = .aFixedPoint
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aFixedPoint: return 0
@@ -25865,7 +25865,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aFixedPoint: return "\"aFixedPoint\""
@@ -25874,9 +25874,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aFixedPoint: return ".aFixedPoint"
@@ -25888,43 +25888,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum FixedRect: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aFixedRect // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aFixedRect
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aFixedRect
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aFixedRect": self = .aFixedRect
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aFixedRect": self = .aFixedRect
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aFixedRect": self = .aFixedRect
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aFixedRect: return 0
@@ -25933,7 +25933,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aFixedRect: return "\"aFixedRect\""
@@ -25942,9 +25942,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aFixedRect: return ".aFixedRect"
@@ -25956,43 +25956,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Style: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aStyle // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aStyle
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aStyle
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aStyle": self = .aStyle
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aStyle": self = .aStyle
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aStyle": self = .aStyle
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aStyle: return 0
@@ -26001,7 +26001,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aStyle: return "\"aStyle\""
@@ -26010,9 +26010,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aStyle: return ".aStyle"
@@ -26024,43 +26024,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum StyleParameter: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aStyleParameter // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aStyleParameter
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aStyleParameter
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aStyleParameter": self = .aStyleParameter
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aStyleParameter": self = .aStyleParameter
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aStyleParameter": self = .aStyleParameter
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aStyleParameter: return 0
@@ -26069,7 +26069,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aStyleParameter: return "\"aStyleParameter\""
@@ -26078,9 +26078,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aStyleParameter: return ".aStyleParameter"
@@ -26092,43 +26092,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum StyleField: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aStyleField // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aStyleField
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aStyleField
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aStyleField": self = .aStyleField
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aStyleField": self = .aStyleField
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aStyleField": self = .aStyleField
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aStyleField: return 0
@@ -26137,7 +26137,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aStyleField: return "\"aStyleField\""
@@ -26146,9 +26146,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aStyleField: return ".aStyleField"
@@ -26160,43 +26160,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum TimeScale: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aTimeScale // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aTimeScale
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aTimeScale
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aTimeScale": self = .aTimeScale
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aTimeScale": self = .aTimeScale
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aTimeScale": self = .aTimeScale
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aTimeScale: return 0
@@ -26205,7 +26205,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aTimeScale: return "\"aTimeScale\""
@@ -26214,9 +26214,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aTimeScale: return ".aTimeScale"
@@ -26228,43 +26228,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum TimeBase: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aTimeBase // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aTimeBase
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aTimeBase
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aTimeBase": self = .aTimeBase
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aTimeBase": self = .aTimeBase
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aTimeBase": self = .aTimeBase
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aTimeBase: return 0
@@ -26273,7 +26273,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aTimeBase: return "\"aTimeBase\""
@@ -26282,9 +26282,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aTimeBase: return ".aTimeBase"
@@ -26296,43 +26296,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum TimeRecord: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aTimeRecord // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aTimeRecord
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aTimeRecord
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aTimeRecord": self = .aTimeRecord
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aTimeRecord": self = .aTimeRecord
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aTimeRecord": self = .aTimeRecord
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aTimeRecord: return 0
@@ -26341,7 +26341,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aTimeRecord: return "\"aTimeRecord\""
@@ -26350,9 +26350,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aTimeRecord: return ".aTimeRecord"
@@ -26363,7 +26363,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
 
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/unittest_swift_performance.pb.swift
+++ b/Reference/unittest_swift_performance.pb.swift
@@ -365,169 +365,169 @@ struct Swift_Performance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3M
 
 
   ///   One of every singular field type
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  public var repeatedRecursiveMessage: [Swift_Performance_TestAllTypes] {
+  var repeatedRecursiveMessage: [Swift_Performance_TestAllTypes] {
     get {return _storage._repeatedRecursiveMessage}
     set {_uniqueStorage()._repeatedRecursiveMessage = newValue}
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
   ///   Map
-  public var mapStringMessage: Dictionary<String,Swift_Performance_TestAllTypes> {
+  var mapStringMessage: Dictionary<String,Swift_Performance_TestAllTypes> {
     get {return _storage._mapStringMessage}
     set {_uniqueStorage()._mapStringMessage = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -36,7 +36,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
   public var unknown = ProtobufUnknownStorage()
 
   enum Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case double // = 1
     case json_ // = 2
     case `class` // = 3
@@ -44,11 +44,11 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
     case self_ // = 5
     case type // = 6
 
-    public init() {
+    init() {
       self = .double
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .double
       case 2: self = .json_
@@ -60,7 +60,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "double": self = .double
       case "json_": self = .json_
@@ -72,7 +72,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "DOUBLE": self = .double
       case "JSON": self = .json_
@@ -84,7 +84,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "DOUBLE": self = .double
       case "JSON": self = .json_
@@ -96,7 +96,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .double: return 1
@@ -109,7 +109,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .double: return "\"DOUBLE\""
@@ -122,9 +122,9 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .double: return ".double"
@@ -140,42 +140,42 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
   }
 
   enum ProtocolEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a // = 1
 
-    public init() {
+    init() {
       self = .a
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .a
       default: return nil
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a": self = .a
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a": self = .a
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a": self = .a
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a: return 1
@@ -183,7 +183,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a: return "\"a\""
@@ -191,9 +191,9 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a: return ".a"
@@ -212,7 +212,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
 
     public var unknown = ProtobufUnknownStorage()
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     }
@@ -236,7 +236,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
 
     public var unknown = ProtobufUnknownStorage()
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     }
@@ -260,7 +260,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
 
     public var unknown = ProtobufUnknownStorage()
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     }
@@ -275,7 +275,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -847,17 +847,17 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
   }
 
   enum Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case extra2 // = 20
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -867,7 +867,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -877,7 +877,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -887,7 +887,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -897,7 +897,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -908,7 +908,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -919,9 +919,9 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -948,7 +948,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -959,7 +959,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -996,7 +996,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1007,7 +1007,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1046,7 +1046,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 116}
       set {_a = newValue}
     }
@@ -1058,7 +1058,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
 
     private var _b: Int32? = nil
-    public var b: Int32 {
+    var b: Int32 {
       get {return _b ?? 0}
       set {_b = newValue}
     }
@@ -1069,7 +1069,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       return _b = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1097,7 +1097,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
@@ -1108,7 +1108,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalInt32 = nil
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64 ?? 0}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
@@ -1119,7 +1119,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalInt64 = nil
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32 ?? 0}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
@@ -1130,7 +1130,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalUint32 = nil
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64 ?? 0}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
@@ -1141,7 +1141,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalUint64 = nil
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32 ?? 0}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
@@ -1152,7 +1152,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalSint32 = nil
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64 ?? 0}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
@@ -1163,7 +1163,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalSint64 = nil
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32 ?? 0}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
@@ -1174,7 +1174,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalFixed32 = nil
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64 ?? 0}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
@@ -1185,7 +1185,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalFixed64 = nil
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32 ?? 0}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
@@ -1196,7 +1196,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalSfixed32 = nil
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64 ?? 0}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
@@ -1207,7 +1207,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalSfixed64 = nil
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat ?? 0}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
@@ -1218,7 +1218,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalFloat = nil
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble ?? 0}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
@@ -1229,7 +1229,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalDouble = nil
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool ?? false}
     set {_uniqueStorage()._optionalBool = newValue}
   }
@@ -1240,7 +1240,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalBool = nil
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString ?? ""}
     set {_uniqueStorage()._optionalString = newValue}
   }
@@ -1251,7 +1251,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalString = nil
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes ?? Data()}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -1262,7 +1262,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalBytes = nil
   }
 
-  public var optionalGroup: ProtobufUnittest_Message2.OptionalGroup {
+  var optionalGroup: ProtobufUnittest_Message2.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittest_Message2.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -1273,7 +1273,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalGroup = nil
   }
 
-  public var optionalMessage: ProtobufUnittest_Message2 {
+  var optionalMessage: ProtobufUnittest_Message2 {
     get {return _storage._optionalMessage ?? ProtobufUnittest_Message2()}
     set {_uniqueStorage()._optionalMessage = newValue}
   }
@@ -1284,7 +1284,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalMessage = nil
   }
 
-  public var optionalEnum: ProtobufUnittest_Message2.Enum {
+  var optionalEnum: ProtobufUnittest_Message2.Enum {
     get {return _storage._optionalEnum ?? ProtobufUnittest_Message2.Enum.foo}
     set {_uniqueStorage()._optionalEnum = newValue}
   }
@@ -1295,97 +1295,97 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalEnum = nil
   }
 
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedGroup: [ProtobufUnittest_Message2.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittest_Message2.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public var repeatedMessage: [ProtobufUnittest_Message2] {
+  var repeatedMessage: [ProtobufUnittest_Message2] {
     get {return _storage._repeatedMessage}
     set {_uniqueStorage()._repeatedMessage = newValue}
   }
 
-  public var repeatedEnum: [ProtobufUnittest_Message2.Enum] {
+  var repeatedEnum: [ProtobufUnittest_Message2.Enum] {
     get {return _storage._repeatedEnum}
     set {_uniqueStorage()._repeatedEnum = newValue}
   }
 
-  public var oneofInt32: Int32 {
+  var oneofInt32: Int32 {
     get {
       if case .oneofInt32(let v) = _storage._o {
         return v
@@ -1397,7 +1397,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofInt64: Int64 {
+  var oneofInt64: Int64 {
     get {
       if case .oneofInt64(let v) = _storage._o {
         return v
@@ -1409,7 +1409,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._o {
         return v
@@ -1421,7 +1421,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofUint64: UInt64 {
+  var oneofUint64: UInt64 {
     get {
       if case .oneofUint64(let v) = _storage._o {
         return v
@@ -1433,7 +1433,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofSint32: Int32 {
+  var oneofSint32: Int32 {
     get {
       if case .oneofSint32(let v) = _storage._o {
         return v
@@ -1445,7 +1445,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofSint64: Int64 {
+  var oneofSint64: Int64 {
     get {
       if case .oneofSint64(let v) = _storage._o {
         return v
@@ -1457,7 +1457,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofFixed32: UInt32 {
+  var oneofFixed32: UInt32 {
     get {
       if case .oneofFixed32(let v) = _storage._o {
         return v
@@ -1469,7 +1469,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofFixed64: UInt64 {
+  var oneofFixed64: UInt64 {
     get {
       if case .oneofFixed64(let v) = _storage._o {
         return v
@@ -1481,7 +1481,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofSfixed32: Int32 {
+  var oneofSfixed32: Int32 {
     get {
       if case .oneofSfixed32(let v) = _storage._o {
         return v
@@ -1493,7 +1493,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofSfixed64: Int64 {
+  var oneofSfixed64: Int64 {
     get {
       if case .oneofSfixed64(let v) = _storage._o {
         return v
@@ -1505,7 +1505,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofFloat: Float {
+  var oneofFloat: Float {
     get {
       if case .oneofFloat(let v) = _storage._o {
         return v
@@ -1517,7 +1517,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofDouble: Double {
+  var oneofDouble: Double {
     get {
       if case .oneofDouble(let v) = _storage._o {
         return v
@@ -1529,7 +1529,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofBool: Bool {
+  var oneofBool: Bool {
     get {
       if case .oneofBool(let v) = _storage._o {
         return v
@@ -1541,7 +1541,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._o {
         return v
@@ -1553,7 +1553,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._o {
         return v
@@ -1565,7 +1565,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofGroup: ProtobufUnittest_Message2.OneofGroup {
+  var oneofGroup: ProtobufUnittest_Message2.OneofGroup {
     get {
       if case .oneofGroup(let v) = _storage._o {
         return v
@@ -1577,7 +1577,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofMessage: ProtobufUnittest_Message2 {
+  var oneofMessage: ProtobufUnittest_Message2 {
     get {
       if case .oneofMessage(let v) = _storage._o {
         return v
@@ -1589,7 +1589,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofEnum: ProtobufUnittest_Message2.Enum {
+  var oneofEnum: ProtobufUnittest_Message2.Enum {
     get {
       if case .oneofEnum(let v) = _storage._o {
         return v
@@ -1602,97 +1602,97 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
   }
 
   ///   Some token map cases, too many combinations to list them all.
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapStringBytes: Dictionary<String,Data> {
+  var mapStringBytes: Dictionary<String,Data> {
     get {return _storage._mapStringBytes}
     set {_uniqueStorage()._mapStringBytes = newValue}
   }
 
-  public var mapStringMessage: Dictionary<String,ProtobufUnittest_Message2> {
+  var mapStringMessage: Dictionary<String,ProtobufUnittest_Message2> {
     get {return _storage._mapStringMessage}
     set {_uniqueStorage()._mapStringMessage = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_Message2.Enum> {
+  var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_Message2.Enum> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32Message: Dictionary<Int32,ProtobufUnittest_Message2> {
+  var mapInt32Message: Dictionary<Int32,ProtobufUnittest_Message2> {
     get {return _storage._mapInt32Message}
     set {_uniqueStorage()._mapInt32Message = newValue}
   }
@@ -1704,7 +1704,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -776,18 +776,18 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
   }
 
   enum Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case extra3 // = 30
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -797,7 +797,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -807,7 +807,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -817,7 +817,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -827,7 +827,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -839,7 +839,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -851,9 +851,9 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -867,83 +867,83 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
 
   }
 
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
   ///   No 'group' in proto3.
-  public var optionalMessage: ProtobufUnittest_Message3 {
+  var optionalMessage: ProtobufUnittest_Message3 {
     get {return _storage._optionalMessage ?? ProtobufUnittest_Message3()}
     set {_uniqueStorage()._optionalMessage = newValue}
   }
@@ -954,98 +954,98 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     return _storage._optionalMessage = nil
   }
 
-  public var optionalEnum: ProtobufUnittest_Message3.Enum {
+  var optionalEnum: ProtobufUnittest_Message3.Enum {
     get {return _storage._optionalEnum}
     set {_uniqueStorage()._optionalEnum = newValue}
   }
 
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
   ///   No 'group' in proto3.
-  public var repeatedMessage: [ProtobufUnittest_Message3] {
+  var repeatedMessage: [ProtobufUnittest_Message3] {
     get {return _storage._repeatedMessage}
     set {_uniqueStorage()._repeatedMessage = newValue}
   }
 
-  public var repeatedEnum: [ProtobufUnittest_Message3.Enum] {
+  var repeatedEnum: [ProtobufUnittest_Message3.Enum] {
     get {return _storage._repeatedEnum}
     set {_uniqueStorage()._repeatedEnum = newValue}
   }
 
-  public var oneofInt32: Int32 {
+  var oneofInt32: Int32 {
     get {
       if case .oneofInt32(let v) = _storage._o {
         return v
@@ -1057,7 +1057,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofInt64: Int64 {
+  var oneofInt64: Int64 {
     get {
       if case .oneofInt64(let v) = _storage._o {
         return v
@@ -1069,7 +1069,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._o {
         return v
@@ -1081,7 +1081,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofUint64: UInt64 {
+  var oneofUint64: UInt64 {
     get {
       if case .oneofUint64(let v) = _storage._o {
         return v
@@ -1093,7 +1093,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofSint32: Int32 {
+  var oneofSint32: Int32 {
     get {
       if case .oneofSint32(let v) = _storage._o {
         return v
@@ -1105,7 +1105,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofSint64: Int64 {
+  var oneofSint64: Int64 {
     get {
       if case .oneofSint64(let v) = _storage._o {
         return v
@@ -1117,7 +1117,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofFixed32: UInt32 {
+  var oneofFixed32: UInt32 {
     get {
       if case .oneofFixed32(let v) = _storage._o {
         return v
@@ -1129,7 +1129,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofFixed64: UInt64 {
+  var oneofFixed64: UInt64 {
     get {
       if case .oneofFixed64(let v) = _storage._o {
         return v
@@ -1141,7 +1141,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofSfixed32: Int32 {
+  var oneofSfixed32: Int32 {
     get {
       if case .oneofSfixed32(let v) = _storage._o {
         return v
@@ -1153,7 +1153,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofSfixed64: Int64 {
+  var oneofSfixed64: Int64 {
     get {
       if case .oneofSfixed64(let v) = _storage._o {
         return v
@@ -1165,7 +1165,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofFloat: Float {
+  var oneofFloat: Float {
     get {
       if case .oneofFloat(let v) = _storage._o {
         return v
@@ -1177,7 +1177,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofDouble: Double {
+  var oneofDouble: Double {
     get {
       if case .oneofDouble(let v) = _storage._o {
         return v
@@ -1189,7 +1189,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofBool: Bool {
+  var oneofBool: Bool {
     get {
       if case .oneofBool(let v) = _storage._o {
         return v
@@ -1201,7 +1201,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._o {
         return v
@@ -1213,7 +1213,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._o {
         return v
@@ -1226,7 +1226,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
   }
 
   ///   No 'group' in proto3.
-  public var oneofMessage: ProtobufUnittest_Message3 {
+  var oneofMessage: ProtobufUnittest_Message3 {
     get {
       if case .oneofMessage(let v) = _storage._o {
         return v
@@ -1238,7 +1238,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofEnum: ProtobufUnittest_Message3.Enum {
+  var oneofEnum: ProtobufUnittest_Message3.Enum {
     get {
       if case .oneofEnum(let v) = _storage._o {
         return v
@@ -1251,97 +1251,97 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
   }
 
   ///   Some token map cases, too many combinations to list them all.
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapStringBytes: Dictionary<String,Data> {
+  var mapStringBytes: Dictionary<String,Data> {
     get {return _storage._mapStringBytes}
     set {_uniqueStorage()._mapStringBytes = newValue}
   }
 
-  public var mapStringMessage: Dictionary<String,ProtobufUnittest_Message3> {
+  var mapStringMessage: Dictionary<String,ProtobufUnittest_Message3> {
     get {return _storage._mapStringMessage}
     set {_uniqueStorage()._mapStringMessage = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_Message3.Enum> {
+  var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_Message3.Enum> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32Message: Dictionary<Int32,ProtobufUnittest_Message3> {
+  var mapInt32Message: Dictionary<Int32,ProtobufUnittest_Message3> {
     get {return _storage._mapInt32Message}
     set {_uniqueStorage()._mapInt32Message = newValue}
   }
@@ -1353,7 +1353,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -49,7 +49,7 @@ struct ProtobufObjcUnittest_TestObjCStartupMessage: ProtobufGeneratedMessage, Pr
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -104,7 +104,7 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: ProtobufGeneratedMessage, Pro
     static let ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(protoFieldNumber: 3, protoFieldName: "nested_string_extension", jsonFieldName: "nestedStringExtension", swiftFieldName: "ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension", defaultValue: "")
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -164,7 +164,7 @@ class EnumGenerator {
         printer.print(comments)
         printer.print("\(generatorOptions.visibilitySourceSnippet)enum \(swiftRelativeName): ProtobufEnum {\n")
         printer.indent()
-        printer.print("public typealias RawValue = Int\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)typealias RawValue = Int\n")
 
         // Cases
         for c in enumCases {
@@ -176,7 +176,7 @@ class EnumGenerator {
 
         // Default init
         printer.print("\n")
-        printer.print("public init() {\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)init() {\n")
         printer.indent()
         printer.print("self = .\(defaultCase.swiftName)\n")
         printer.outdent()
@@ -184,7 +184,7 @@ class EnumGenerator {
 
         // rawValue init
         printer.print("\n")
-        printer.print("public init?(rawValue: Int) {\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)init?(rawValue: Int) {\n")
         printer.indent()
         printer.print("switch rawValue {\n")
         var uniqueCaseNumbers = Set<Int>()
@@ -203,7 +203,7 @@ class EnumGenerator {
 
         // Swift name init
         printer.print("\n")
-        printer.print("public init?(name: String) {\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)init?(name: String) {\n")
         printer.indent()
         printer.print("switch name {\n")
         for c in enumCases {
@@ -216,7 +216,7 @@ class EnumGenerator {
 
         // JSON name init
         printer.print("\n")
-        printer.print("public init?(jsonName: String) {\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)init?(jsonName: String) {\n")
         printer.indent()
         printer.print("switch jsonName {\n")
         for c in enumCases {
@@ -229,7 +229,7 @@ class EnumGenerator {
 
         // Proto name init
         printer.print("\n")
-        printer.print("public init?(protoName: String) {\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)init?(protoName: String) {\n")
         printer.indent()
         printer.print("switch protoName {\n")
         for c in enumCases {
@@ -242,7 +242,7 @@ class EnumGenerator {
 
         // rawValue property
         printer.print("\n")
-        printer.print("public var rawValue: Int {\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)var rawValue: Int {\n")
         printer.indent()
         printer.print("get {\n")
         printer.indent()
@@ -261,7 +261,7 @@ class EnumGenerator {
 
         // json property
         printer.print("\n")
-        printer.print("public var json: String {\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)var json: String {\n")
         printer.indent()
         printer.print("get {\n")
         printer.indent()
@@ -280,11 +280,11 @@ class EnumGenerator {
 
         // hashValue property
         printer.print("\n")
-        printer.print("public var hashValue: Int { return rawValue }\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)var hashValue: Int { return rawValue }\n")
 
         // debugDescription property
         printer.print("\n")
-        printer.print("public var debugDescription: String {\n")
+        printer.print("\(generatorOptions.visibilitySourceSnippet)var debugDescription: String {\n")
         printer.indent()
         printer.print("get {\n")
         printer.indent()

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -206,6 +206,7 @@ struct MessageFieldGenerator {
     let comments: String
     let isProto3: Bool
     let context: Context
+    let generatorOptions: GeneratorOptions
 
     init(descriptor: Google_Protobuf_FieldDescriptorProto,
         path: [Int32],
@@ -236,6 +237,7 @@ struct MessageFieldGenerator {
         self.comments = file.commentsFor(path: path)
         self.isProto3 = file.isProto3
         self.context = context
+        self.generatorOptions = file.generatorOptions
     }
 
     var isGroup: Bool {return descriptor.isGroup}
@@ -305,7 +307,7 @@ struct MessageFieldGenerator {
             p.print(comments)
         }
         if let oneof = oneof {
-            p.print("public var \(swiftName): \(swiftApiType) {\n")
+            p.print("\(generatorOptions.visibilitySourceSnippet)var \(swiftName): \(swiftApiType) {\n")
             p.indent()
             p.print("get {\n")
             p.indent()
@@ -326,14 +328,14 @@ struct MessageFieldGenerator {
             p.print("}\n")
         } else if !isRepeated && !isMap && !isProto3 {
             p.print("private var \(swiftStorageName): \(swiftStorageType) = \(swiftStorageDefaultValue)\n")
-            p.print("public var \(swiftName): \(swiftApiType) {\n")
+            p.print("\(generatorOptions.visibilitySourceSnippet)var \(swiftName): \(swiftApiType) {\n")
             p.indent()
             p.print("get {return \(swiftStorageName) ?? \(swiftDefaultValue)}\n")
             p.print("set {\(swiftStorageName) = newValue}\n")
             p.outdent()
             p.print("}\n")
         } else {
-            p.print("public var \(swiftName): \(swiftStorageType) = \(swiftStorageDefaultValue)\n")
+            p.print("\(generatorOptions.visibilitySourceSnippet)var \(swiftName): \(swiftStorageType) = \(swiftStorageDefaultValue)\n")
         }
     }
 
@@ -342,7 +344,7 @@ struct MessageFieldGenerator {
         if comments != "" {
             p.print(comments)
         }
-        p.print("public var \(swiftName): \(swiftApiType) {\n")
+        p.print("\(generatorOptions.visibilitySourceSnippet)var \(swiftName): \(swiftApiType) {\n")
         p.indent()
         if let oneof = oneof {
             p.print("get {\n")

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -523,7 +523,7 @@ class MessageGenerator {
 
         // Default init
         p.print("\n")
-        p.print("public init() {}\n")
+        p.print("\(generatorOptions.visibilitySourceSnippet)init() {}\n")
 
         // Field-addressable decoding
         p.print("\n")

--- a/Tests/SwiftProtobufTests/any_test.pb.swift
+++ b/Tests/SwiftProtobufTests/any_test.pb.swift
@@ -103,12 +103,12 @@ struct ProtobufUnittest_TestAny: ProtobufGeneratedMessage, ProtobufProto3Message
   private var _storage = _StorageClass()
 
 
-  public var int32Value: Int32 {
+  var int32Value: Int32 {
     get {return _storage._int32Value}
     set {_uniqueStorage()._int32Value = newValue}
   }
 
-  public var anyValue: Google_Protobuf_Any {
+  var anyValue: Google_Protobuf_Any {
     get {return _storage._anyValue ?? Google_Protobuf_Any()}
     set {_uniqueStorage()._anyValue = newValue}
   }
@@ -119,12 +119,12 @@ struct ProtobufUnittest_TestAny: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._anyValue = nil
   }
 
-  public var repeatedAnyValue: [Google_Protobuf_Any] {
+  var repeatedAnyValue: [Google_Protobuf_Any] {
     get {return _storage._repeatedAnyValue}
     set {_uniqueStorage()._repeatedAnyValue = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -60,17 +60,17 @@ import SwiftProtobuf
 //      iOS apps, where fork/stdin/stdout are not available.
 
 enum Conformance_WireFormat: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case unspecified // = 0
   case protobuf // = 1
   case json_ // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .unspecified
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .unspecified
     case 1: self = .protobuf
@@ -79,7 +79,7 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "unspecified": self = .unspecified
     case "protobuf": self = .protobuf
@@ -88,7 +88,7 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "UNSPECIFIED": self = .unspecified
     case "PROTOBUF": self = .protobuf
@@ -97,7 +97,7 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "UNSPECIFIED": self = .unspecified
     case "PROTOBUF": self = .protobuf
@@ -106,7 +106,7 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .unspecified: return 0
@@ -117,7 +117,7 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .unspecified: return "\"UNSPECIFIED\""
@@ -128,9 +128,9 @@ enum Conformance_WireFormat: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .unspecified: return ".unspecified"
@@ -144,17 +144,17 @@ enum Conformance_WireFormat: ProtobufEnum {
 }
 
 enum Conformance_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
   case foreignBaz // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foreignFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foreignFoo
     case 1: self = .foreignBar
@@ -163,7 +163,7 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignFoo": self = .foreignFoo
     case "foreignBar": self = .foreignBar
@@ -172,7 +172,7 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -181,7 +181,7 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -190,7 +190,7 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignFoo: return 0
@@ -201,7 +201,7 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignFoo: return "\"FOREIGN_FOO\""
@@ -212,9 +212,9 @@ enum Conformance_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignFoo: return ".foreignFoo"
@@ -295,7 +295,7 @@ struct Conformance_ConformanceRequest: ProtobufGeneratedMessage, ProtobufProto3M
     }
   }
 
-  public var protobufPayload: Data {
+  var protobufPayload: Data {
     get {
       if case .protobufPayload(let v) = payload {
         return v
@@ -309,7 +309,7 @@ struct Conformance_ConformanceRequest: ProtobufGeneratedMessage, ProtobufProto3M
 
   public var payload: Conformance_ConformanceRequest.OneOf_Payload = .None
 
-  public var jsonPayload: String {
+  var jsonPayload: String {
     get {
       if case .jsonPayload(let v) = payload {
         return v
@@ -322,9 +322,9 @@ struct Conformance_ConformanceRequest: ProtobufGeneratedMessage, ProtobufProto3M
   }
 
   ///   Which format should the testee serialize its message to?
-  public var requestedOutputFormat: Conformance_WireFormat = Conformance_WireFormat.unspecified
+  var requestedOutputFormat: Conformance_WireFormat = Conformance_WireFormat.unspecified
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -459,7 +459,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
   ///  
   ///   Setting this string does not necessarily mean the testee failed the
   ///   test.  Some of the test cases are intentionally invalid input.
-  public var parseError: String {
+  var parseError: String {
     get {
       if case .parseError(let v) = result {
         return v
@@ -476,7 +476,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
   ///   If the input was successfully parsed but errors occurred when
   ///   serializing it to the requested output format, set the error message in
   ///   this field.
-  public var serializeError: String {
+  var serializeError: String {
     get {
       if case .serializeError(let v) = result {
         return v
@@ -491,7 +491,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
   ///   This should be set if some other error occurred.  This will always
   ///   indicate that the test failed.  The string can provide more information
   ///   about the failure.
-  public var runtimeError: String {
+  var runtimeError: String {
     get {
       if case .runtimeError(let v) = result {
         return v
@@ -505,7 +505,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
 
   ///   If the input was successfully parsed and the requested output was
   ///   protobuf, serialize it to protobuf and set it in this field.
-  public var protobufPayload: Data {
+  var protobufPayload: Data {
     get {
       if case .protobufPayload(let v) = result {
         return v
@@ -519,7 +519,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
 
   ///   If the input was successfully parsed and the requested output was JSON,
   ///   serialize to JSON and set it in this field.
-  public var jsonPayload: String {
+  var jsonPayload: String {
     get {
       if case .jsonPayload(let v) = result {
         return v
@@ -533,7 +533,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
 
   ///   For when the testee skipped the test, likely because a certain feature
   ///   wasn't supported, like JSON input/output.
-  public var skipped: String {
+  var skipped: String {
     get {
       if case .skipped(let v) = result {
         return v
@@ -545,7 +545,7 @@ struct Conformance_ConformanceResponse: ProtobufGeneratedMessage, ProtobufProto3
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1619,7 +1619,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
@@ -1628,11 +1628,11 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     case neg // = -1
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -1642,7 +1642,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -1652,7 +1652,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1662,7 +1662,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1672,7 +1672,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -1684,7 +1684,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -1696,9 +1696,9 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1766,12 +1766,12 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     private var _storage = _StorageClass()
 
 
-    public var a: Int32 {
+    var a: Int32 {
       get {return _storage._a}
       set {_uniqueStorage()._a = newValue}
     }
 
-    public var corecursive: Conformance_TestAllTypes {
+    var corecursive: Conformance_TestAllTypes {
       get {return _storage._corecursive ?? Conformance_TestAllTypes()}
       set {_uniqueStorage()._corecursive = newValue}
     }
@@ -1782,7 +1782,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
       return _storage._corecursive = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1805,82 +1805,82 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  public var optionalNestedMessage: Conformance_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: Conformance_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Conformance_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -1891,7 +1891,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: Conformance_ForeignMessage {
+  var optionalForeignMessage: Conformance_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? Conformance_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -1902,27 +1902,27 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalNestedEnum: Conformance_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: Conformance_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
 
-  public var optionalForeignEnum: Conformance_ForeignEnum {
+  var optionalForeignEnum: Conformance_ForeignEnum {
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord}
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
-  public var recursiveMessage: Conformance_TestAllTypes {
+  var recursiveMessage: Conformance_TestAllTypes {
     get {return _storage._recursiveMessage ?? Conformance_TestAllTypes()}
     set {_uniqueStorage()._recursiveMessage = newValue}
   }
@@ -1934,208 +1934,208 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedNestedMessage: [Conformance_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [Conformance_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [Conformance_ForeignMessage] {
+  var repeatedForeignMessage: [Conformance_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [Conformance_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [Conformance_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [Conformance_ForeignEnum] {
+  var repeatedForeignEnum: [Conformance_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
   ///   Map
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapStringBytes: Dictionary<String,Data> {
+  var mapStringBytes: Dictionary<String,Data> {
     get {return _storage._mapStringBytes}
     set {_uniqueStorage()._mapStringBytes = newValue}
   }
 
-  public var mapStringNestedMessage: Dictionary<String,Conformance_TestAllTypes.NestedMessage> {
+  var mapStringNestedMessage: Dictionary<String,Conformance_TestAllTypes.NestedMessage> {
     get {return _storage._mapStringNestedMessage}
     set {_uniqueStorage()._mapStringNestedMessage = newValue}
   }
 
-  public var mapStringForeignMessage: Dictionary<String,Conformance_ForeignMessage> {
+  var mapStringForeignMessage: Dictionary<String,Conformance_ForeignMessage> {
     get {return _storage._mapStringForeignMessage}
     set {_uniqueStorage()._mapStringForeignMessage = newValue}
   }
 
-  public var mapStringNestedEnum: Dictionary<String,Conformance_TestAllTypes.NestedEnum> {
+  var mapStringNestedEnum: Dictionary<String,Conformance_TestAllTypes.NestedEnum> {
     get {return _storage._mapStringNestedEnum}
     set {_uniqueStorage()._mapStringNestedEnum = newValue}
   }
 
-  public var mapStringForeignEnum: Dictionary<String,Conformance_ForeignEnum> {
+  var mapStringForeignEnum: Dictionary<String,Conformance_ForeignEnum> {
     get {return _storage._mapStringForeignEnum}
     set {_uniqueStorage()._mapStringForeignEnum = newValue}
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -2147,7 +2147,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     }
   }
 
-  public var oneofNestedMessage: Conformance_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: Conformance_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -2159,7 +2159,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -2171,7 +2171,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -2184,7 +2184,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
   }
 
   ///   Well-known types
-  public var optionalBoolWrapper: Google_Protobuf_BoolValue {
+  var optionalBoolWrapper: Google_Protobuf_BoolValue {
     get {return _storage._optionalBoolWrapper ?? Google_Protobuf_BoolValue()}
     set {_uniqueStorage()._optionalBoolWrapper = newValue}
   }
@@ -2195,7 +2195,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalBoolWrapper = nil
   }
 
-  public var optionalInt32Wrapper: Google_Protobuf_Int32Value {
+  var optionalInt32Wrapper: Google_Protobuf_Int32Value {
     get {return _storage._optionalInt32Wrapper ?? Google_Protobuf_Int32Value()}
     set {_uniqueStorage()._optionalInt32Wrapper = newValue}
   }
@@ -2206,7 +2206,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalInt32Wrapper = nil
   }
 
-  public var optionalInt64Wrapper: Google_Protobuf_Int64Value {
+  var optionalInt64Wrapper: Google_Protobuf_Int64Value {
     get {return _storage._optionalInt64Wrapper ?? Google_Protobuf_Int64Value()}
     set {_uniqueStorage()._optionalInt64Wrapper = newValue}
   }
@@ -2217,7 +2217,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalInt64Wrapper = nil
   }
 
-  public var optionalUint32Wrapper: Google_Protobuf_UInt32Value {
+  var optionalUint32Wrapper: Google_Protobuf_UInt32Value {
     get {return _storage._optionalUint32Wrapper ?? Google_Protobuf_UInt32Value()}
     set {_uniqueStorage()._optionalUint32Wrapper = newValue}
   }
@@ -2228,7 +2228,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalUint32Wrapper = nil
   }
 
-  public var optionalUint64Wrapper: Google_Protobuf_UInt64Value {
+  var optionalUint64Wrapper: Google_Protobuf_UInt64Value {
     get {return _storage._optionalUint64Wrapper ?? Google_Protobuf_UInt64Value()}
     set {_uniqueStorage()._optionalUint64Wrapper = newValue}
   }
@@ -2239,7 +2239,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalUint64Wrapper = nil
   }
 
-  public var optionalFloatWrapper: Google_Protobuf_FloatValue {
+  var optionalFloatWrapper: Google_Protobuf_FloatValue {
     get {return _storage._optionalFloatWrapper ?? Google_Protobuf_FloatValue()}
     set {_uniqueStorage()._optionalFloatWrapper = newValue}
   }
@@ -2250,7 +2250,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalFloatWrapper = nil
   }
 
-  public var optionalDoubleWrapper: Google_Protobuf_DoubleValue {
+  var optionalDoubleWrapper: Google_Protobuf_DoubleValue {
     get {return _storage._optionalDoubleWrapper ?? Google_Protobuf_DoubleValue()}
     set {_uniqueStorage()._optionalDoubleWrapper = newValue}
   }
@@ -2261,7 +2261,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalDoubleWrapper = nil
   }
 
-  public var optionalStringWrapper: Google_Protobuf_StringValue {
+  var optionalStringWrapper: Google_Protobuf_StringValue {
     get {return _storage._optionalStringWrapper ?? Google_Protobuf_StringValue()}
     set {_uniqueStorage()._optionalStringWrapper = newValue}
   }
@@ -2272,7 +2272,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalStringWrapper = nil
   }
 
-  public var optionalBytesWrapper: Google_Protobuf_BytesValue {
+  var optionalBytesWrapper: Google_Protobuf_BytesValue {
     get {return _storage._optionalBytesWrapper ?? Google_Protobuf_BytesValue()}
     set {_uniqueStorage()._optionalBytesWrapper = newValue}
   }
@@ -2283,52 +2283,52 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalBytesWrapper = nil
   }
 
-  public var repeatedBoolWrapper: [Google_Protobuf_BoolValue] {
+  var repeatedBoolWrapper: [Google_Protobuf_BoolValue] {
     get {return _storage._repeatedBoolWrapper}
     set {_uniqueStorage()._repeatedBoolWrapper = newValue}
   }
 
-  public var repeatedInt32Wrapper: [Google_Protobuf_Int32Value] {
+  var repeatedInt32Wrapper: [Google_Protobuf_Int32Value] {
     get {return _storage._repeatedInt32Wrapper}
     set {_uniqueStorage()._repeatedInt32Wrapper = newValue}
   }
 
-  public var repeatedInt64Wrapper: [Google_Protobuf_Int64Value] {
+  var repeatedInt64Wrapper: [Google_Protobuf_Int64Value] {
     get {return _storage._repeatedInt64Wrapper}
     set {_uniqueStorage()._repeatedInt64Wrapper = newValue}
   }
 
-  public var repeatedUint32Wrapper: [Google_Protobuf_UInt32Value] {
+  var repeatedUint32Wrapper: [Google_Protobuf_UInt32Value] {
     get {return _storage._repeatedUint32Wrapper}
     set {_uniqueStorage()._repeatedUint32Wrapper = newValue}
   }
 
-  public var repeatedUint64Wrapper: [Google_Protobuf_UInt64Value] {
+  var repeatedUint64Wrapper: [Google_Protobuf_UInt64Value] {
     get {return _storage._repeatedUint64Wrapper}
     set {_uniqueStorage()._repeatedUint64Wrapper = newValue}
   }
 
-  public var repeatedFloatWrapper: [Google_Protobuf_FloatValue] {
+  var repeatedFloatWrapper: [Google_Protobuf_FloatValue] {
     get {return _storage._repeatedFloatWrapper}
     set {_uniqueStorage()._repeatedFloatWrapper = newValue}
   }
 
-  public var repeatedDoubleWrapper: [Google_Protobuf_DoubleValue] {
+  var repeatedDoubleWrapper: [Google_Protobuf_DoubleValue] {
     get {return _storage._repeatedDoubleWrapper}
     set {_uniqueStorage()._repeatedDoubleWrapper = newValue}
   }
 
-  public var repeatedStringWrapper: [Google_Protobuf_StringValue] {
+  var repeatedStringWrapper: [Google_Protobuf_StringValue] {
     get {return _storage._repeatedStringWrapper}
     set {_uniqueStorage()._repeatedStringWrapper = newValue}
   }
 
-  public var repeatedBytesWrapper: [Google_Protobuf_BytesValue] {
+  var repeatedBytesWrapper: [Google_Protobuf_BytesValue] {
     get {return _storage._repeatedBytesWrapper}
     set {_uniqueStorage()._repeatedBytesWrapper = newValue}
   }
 
-  public var optionalDuration: Google_Protobuf_Duration {
+  var optionalDuration: Google_Protobuf_Duration {
     get {return _storage._optionalDuration ?? Google_Protobuf_Duration()}
     set {_uniqueStorage()._optionalDuration = newValue}
   }
@@ -2339,7 +2339,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalDuration = nil
   }
 
-  public var optionalTimestamp: Google_Protobuf_Timestamp {
+  var optionalTimestamp: Google_Protobuf_Timestamp {
     get {return _storage._optionalTimestamp ?? Google_Protobuf_Timestamp()}
     set {_uniqueStorage()._optionalTimestamp = newValue}
   }
@@ -2350,7 +2350,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalTimestamp = nil
   }
 
-  public var optionalFieldMask: Google_Protobuf_FieldMask {
+  var optionalFieldMask: Google_Protobuf_FieldMask {
     get {return _storage._optionalFieldMask ?? Google_Protobuf_FieldMask()}
     set {_uniqueStorage()._optionalFieldMask = newValue}
   }
@@ -2361,7 +2361,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalFieldMask = nil
   }
 
-  public var optionalStruct: Google_Protobuf_Struct {
+  var optionalStruct: Google_Protobuf_Struct {
     get {return _storage._optionalStruct ?? Google_Protobuf_Struct()}
     set {_uniqueStorage()._optionalStruct = newValue}
   }
@@ -2372,7 +2372,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalStruct = nil
   }
 
-  public var optionalAny: Google_Protobuf_Any {
+  var optionalAny: Google_Protobuf_Any {
     get {return _storage._optionalAny ?? Google_Protobuf_Any()}
     set {_uniqueStorage()._optionalAny = newValue}
   }
@@ -2383,7 +2383,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalAny = nil
   }
 
-  public var optionalValue: Google_Protobuf_Value {
+  var optionalValue: Google_Protobuf_Value {
     get {return _storage._optionalValue ?? Google_Protobuf_Value()}
     set {_uniqueStorage()._optionalValue = newValue}
   }
@@ -2394,93 +2394,93 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._optionalValue = nil
   }
 
-  public var repeatedDuration: [Google_Protobuf_Duration] {
+  var repeatedDuration: [Google_Protobuf_Duration] {
     get {return _storage._repeatedDuration}
     set {_uniqueStorage()._repeatedDuration = newValue}
   }
 
-  public var repeatedTimestamp: [Google_Protobuf_Timestamp] {
+  var repeatedTimestamp: [Google_Protobuf_Timestamp] {
     get {return _storage._repeatedTimestamp}
     set {_uniqueStorage()._repeatedTimestamp = newValue}
   }
 
-  public var repeatedFieldmask: [Google_Protobuf_FieldMask] {
+  var repeatedFieldmask: [Google_Protobuf_FieldMask] {
     get {return _storage._repeatedFieldmask}
     set {_uniqueStorage()._repeatedFieldmask = newValue}
   }
 
-  public var repeatedStruct: [Google_Protobuf_Struct] {
+  var repeatedStruct: [Google_Protobuf_Struct] {
     get {return _storage._repeatedStruct}
     set {_uniqueStorage()._repeatedStruct = newValue}
   }
 
-  public var repeatedAny: [Google_Protobuf_Any] {
+  var repeatedAny: [Google_Protobuf_Any] {
     get {return _storage._repeatedAny}
     set {_uniqueStorage()._repeatedAny = newValue}
   }
 
-  public var repeatedValue: [Google_Protobuf_Value] {
+  var repeatedValue: [Google_Protobuf_Value] {
     get {return _storage._repeatedValue}
     set {_uniqueStorage()._repeatedValue = newValue}
   }
 
   ///   Test field-name-to-JSON-name convention.
-  public var fieldname1: Int32 {
+  var fieldname1: Int32 {
     get {return _storage._fieldname1}
     set {_uniqueStorage()._fieldname1 = newValue}
   }
 
-  public var fieldName2: Int32 {
+  var fieldName2: Int32 {
     get {return _storage._fieldName2}
     set {_uniqueStorage()._fieldName2 = newValue}
   }
 
-  public var fieldName3: Int32 {
+  var fieldName3: Int32 {
     get {return _storage._fieldName3}
     set {_uniqueStorage()._fieldName3 = newValue}
   }
 
-  public var field_Name4_: Int32 {
+  var field_Name4_: Int32 {
     get {return _storage._field_Name4_}
     set {_uniqueStorage()._field_Name4_ = newValue}
   }
 
-  public var field0Name5: Int32 {
+  var field0Name5: Int32 {
     get {return _storage._field0Name5}
     set {_uniqueStorage()._field0Name5 = newValue}
   }
 
-  public var field0Name6: Int32 {
+  var field0Name6: Int32 {
     get {return _storage._field0Name6}
     set {_uniqueStorage()._field0Name6 = newValue}
   }
 
-  public var fieldName7: Int32 {
+  var fieldName7: Int32 {
     get {return _storage._fieldName7}
     set {_uniqueStorage()._fieldName7 = newValue}
   }
 
-  public var fieldName8: Int32 {
+  var fieldName8: Int32 {
     get {return _storage._fieldName8}
     set {_uniqueStorage()._fieldName8 = newValue}
   }
 
-  public var fieldName9: Int32 {
+  var fieldName9: Int32 {
     get {return _storage._fieldName9}
     set {_uniqueStorage()._fieldName9 = newValue}
   }
 
-  public var fieldName10: Int32 {
+  var fieldName10: Int32 {
     get {return _storage._fieldName10}
     set {_uniqueStorage()._fieldName10 = newValue}
   }
 
-  public var fieldName11: Int32 {
+  var fieldName11: Int32 {
     get {return _storage._fieldName11}
     set {_uniqueStorage()._fieldName11 = newValue}
   }
 
-  public var fieldName12: Int32 {
+  var fieldName12: Int32 {
     get {return _storage._fieldName12}
     set {_uniqueStorage()._fieldName12 = newValue}
   }
@@ -2492,7 +2492,7 @@ struct Conformance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2526,9 +2526,9 @@ struct Conformance_ForeignMessage: ProtobufGeneratedMessage, ProtobufProto3Messa
   ]}
 
 
-  public var c: Int32 = 0
+  var c: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/descriptor.pb.swift
+++ b/Tests/SwiftProtobufTests/descriptor.pb.swift
@@ -63,9 +63,9 @@ struct Google_Protobuf_FileDescriptorSet: ProtobufGeneratedMessage, ProtobufProt
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var file: [Google_Protobuf_FileDescriptorProto] = []
+  var file: [Google_Protobuf_FileDescriptorProto] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -242,7 +242,7 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
   }
 
   ///   file name, relative to root of source tree
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -254,7 +254,7 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
   }
 
   ///   e.g. "foo", "foo.bar", etc.
-  public var package: String {
+  var package: String {
     get {return _storage._package ?? ""}
     set {_uniqueStorage()._package = newValue}
   }
@@ -266,46 +266,46 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
   }
 
   ///   Names of files imported by this file.
-  public var dependency: [String] {
+  var dependency: [String] {
     get {return _storage._dependency}
     set {_uniqueStorage()._dependency = newValue}
   }
 
   ///   Indexes of the public imported files in the dependency list above.
-  public var publicDependency: [Int32] {
+  var publicDependency: [Int32] {
     get {return _storage._publicDependency}
     set {_uniqueStorage()._publicDependency = newValue}
   }
 
   ///   Indexes of the weak imported files in the dependency list.
   ///   For Google-internal migration only. Do not use.
-  public var weakDependency: [Int32] {
+  var weakDependency: [Int32] {
     get {return _storage._weakDependency}
     set {_uniqueStorage()._weakDependency = newValue}
   }
 
   ///   All top-level definitions in this file.
-  public var messageType: [Google_Protobuf_DescriptorProto] {
+  var messageType: [Google_Protobuf_DescriptorProto] {
     get {return _storage._messageType}
     set {_uniqueStorage()._messageType = newValue}
   }
 
-  public var enumType: [Google_Protobuf_EnumDescriptorProto] {
+  var enumType: [Google_Protobuf_EnumDescriptorProto] {
     get {return _storage._enumType}
     set {_uniqueStorage()._enumType = newValue}
   }
 
-  public var service: [Google_Protobuf_ServiceDescriptorProto] {
+  var service: [Google_Protobuf_ServiceDescriptorProto] {
     get {return _storage._service}
     set {_uniqueStorage()._service = newValue}
   }
 
-  public var extension_p: [Google_Protobuf_FieldDescriptorProto] {
+  var extension_p: [Google_Protobuf_FieldDescriptorProto] {
     get {return _storage._extension_p}
     set {_uniqueStorage()._extension_p = newValue}
   }
 
-  public var options: Google_Protobuf_FileOptions {
+  var options: Google_Protobuf_FileOptions {
     get {return _storage._options ?? Google_Protobuf_FileOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -320,7 +320,7 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
   ///   You may safely remove this entire field without harming runtime
   ///   functionality of the descriptors -- the information is needed only by
   ///   development tools.
-  public var sourceCodeInfo: Google_Protobuf_SourceCodeInfo {
+  var sourceCodeInfo: Google_Protobuf_SourceCodeInfo {
     get {return _storage._sourceCodeInfo ?? Google_Protobuf_SourceCodeInfo()}
     set {_uniqueStorage()._sourceCodeInfo = newValue}
   }
@@ -333,7 +333,7 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
 
   ///   The syntax of the proto file.
   ///   The supported values are "proto2" and "proto3".
-  public var syntax: String {
+  var syntax: String {
     get {return _storage._syntax ?? ""}
     set {_uniqueStorage()._syntax = newValue}
   }
@@ -344,7 +344,7 @@ struct Google_Protobuf_FileDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
     return _storage._syntax = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -517,7 +517,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
     public var unknown = ProtobufUnknownStorage()
 
     private var _start: Int32? = nil
-    public var start: Int32 {
+    var start: Int32 {
       get {return _start ?? 0}
       set {_start = newValue}
     }
@@ -529,7 +529,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
     }
 
     private var _end: Int32? = nil
-    public var end: Int32 {
+    var end: Int32 {
       get {return _end ?? 0}
       set {_end = newValue}
     }
@@ -540,7 +540,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
       return _end = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -588,7 +588,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
 
     ///   Inclusive.
     private var _start: Int32? = nil
-    public var start: Int32 {
+    var start: Int32 {
       get {return _start ?? 0}
       set {_start = newValue}
     }
@@ -601,7 +601,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
 
     ///   Exclusive.
     private var _end: Int32? = nil
-    public var end: Int32 {
+    var end: Int32 {
       get {return _end ?? 0}
       set {_end = newValue}
     }
@@ -612,7 +612,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
       return _end = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -640,7 +640,7 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
     }
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -651,37 +651,37 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
     return _storage._name = nil
   }
 
-  public var field: [Google_Protobuf_FieldDescriptorProto] {
+  var field: [Google_Protobuf_FieldDescriptorProto] {
     get {return _storage._field}
     set {_uniqueStorage()._field = newValue}
   }
 
-  public var extension_p: [Google_Protobuf_FieldDescriptorProto] {
+  var extension_p: [Google_Protobuf_FieldDescriptorProto] {
     get {return _storage._extension_p}
     set {_uniqueStorage()._extension_p = newValue}
   }
 
-  public var nestedType: [Google_Protobuf_DescriptorProto] {
+  var nestedType: [Google_Protobuf_DescriptorProto] {
     get {return _storage._nestedType}
     set {_uniqueStorage()._nestedType = newValue}
   }
 
-  public var enumType: [Google_Protobuf_EnumDescriptorProto] {
+  var enumType: [Google_Protobuf_EnumDescriptorProto] {
     get {return _storage._enumType}
     set {_uniqueStorage()._enumType = newValue}
   }
 
-  public var extensionRange: [Google_Protobuf_DescriptorProto.ExtensionRange] {
+  var extensionRange: [Google_Protobuf_DescriptorProto.ExtensionRange] {
     get {return _storage._extensionRange}
     set {_uniqueStorage()._extensionRange = newValue}
   }
 
-  public var oneofDecl: [Google_Protobuf_OneofDescriptorProto] {
+  var oneofDecl: [Google_Protobuf_OneofDescriptorProto] {
     get {return _storage._oneofDecl}
     set {_uniqueStorage()._oneofDecl = newValue}
   }
 
-  public var options: Google_Protobuf_MessageOptions {
+  var options: Google_Protobuf_MessageOptions {
     get {return _storage._options ?? Google_Protobuf_MessageOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -692,19 +692,19 @@ struct Google_Protobuf_DescriptorProto: ProtobufGeneratedMessage, ProtobufProto2
     return _storage._options = nil
   }
 
-  public var reservedRange: [Google_Protobuf_DescriptorProto.ReservedRange] {
+  var reservedRange: [Google_Protobuf_DescriptorProto.ReservedRange] {
     get {return _storage._reservedRange}
     set {_uniqueStorage()._reservedRange = newValue}
   }
 
   ///   Reserved field names, which may not be used by fields in the same message.
   ///   A given name may only be reserved once.
-  public var reservedName: [String] {
+  var reservedName: [String] {
     get {return _storage._reservedName}
     set {_uniqueStorage()._reservedName = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -862,7 +862,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
   }
 
   enum TypeEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   0 is reserved for errors.
     ///   Order is weird for historical reasons.
@@ -901,11 +901,11 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     ///   Uses ZigZag encoding.
     case sint64 // = 18
 
-    public init() {
+    init() {
       self = .double
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .double
       case 2: self = .float
@@ -929,7 +929,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "double": self = .double
       case "float": self = .float
@@ -953,7 +953,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "TYPE_DOUBLE": self = .double
       case "TYPE_FLOAT": self = .float
@@ -977,7 +977,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "TYPE_DOUBLE": self = .double
       case "TYPE_FLOAT": self = .float
@@ -1001,7 +1001,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .double: return 1
@@ -1026,7 +1026,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .double: return "\"TYPE_DOUBLE\""
@@ -1051,9 +1051,9 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .double: return ".double"
@@ -1081,7 +1081,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
   }
 
   enum Label: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   0 is reserved for errors
     case `optional` // = 1
@@ -1090,11 +1090,11 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     ///   TODO(sanjay): Should we add LABEL_MAP?
     case repeated // = 3
 
-    public init() {
+    init() {
       self = .`optional`
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .`optional`
       case 2: self = .`required`
@@ -1103,7 +1103,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "optional": self = .`optional`
       case "required": self = .`required`
@@ -1112,7 +1112,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "LABEL_OPTIONAL": self = .`optional`
       case "LABEL_REQUIRED": self = .`required`
@@ -1121,7 +1121,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "LABEL_OPTIONAL": self = .`optional`
       case "LABEL_REQUIRED": self = .`required`
@@ -1130,7 +1130,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .`optional`: return 1
@@ -1140,7 +1140,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .`optional`: return "\"LABEL_OPTIONAL\""
@@ -1150,9 +1150,9 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .`optional`: return ".optional"
@@ -1164,7 +1164,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
 
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1175,7 +1175,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._name = nil
   }
 
-  public var number: Int32 {
+  var number: Int32 {
     get {return _storage._number ?? 0}
     set {_uniqueStorage()._number = newValue}
   }
@@ -1186,7 +1186,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._number = nil
   }
 
-  public var label: Google_Protobuf_FieldDescriptorProto.Label {
+  var label: Google_Protobuf_FieldDescriptorProto.Label {
     get {return _storage._label ?? Google_Protobuf_FieldDescriptorProto.Label.`optional`}
     set {_uniqueStorage()._label = newValue}
   }
@@ -1199,7 +1199,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
 
   ///   If type_name is set, this need not be set.  If both this and type_name
   ///   are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
-  public var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
+  var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
     get {return _storage._type ?? Google_Protobuf_FieldDescriptorProto.TypeEnum.double}
     set {_uniqueStorage()._type = newValue}
   }
@@ -1215,7 +1215,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
   ///   rules are used to find the type (i.e. first the nested types within this
   ///   message are searched, then within the parent, on up to the root
   ///   namespace).
-  public var typeName: String {
+  var typeName: String {
     get {return _storage._typeName ?? ""}
     set {_uniqueStorage()._typeName = newValue}
   }
@@ -1228,7 +1228,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
 
   ///   For extensions, this is the name of the type being extended.  It is
   ///   resolved in the same manner as type_name.
-  public var extendee: String {
+  var extendee: String {
     get {return _storage._extendee ?? ""}
     set {_uniqueStorage()._extendee = newValue}
   }
@@ -1244,7 +1244,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
   ///   For strings, contains the default text contents (not escaped in any way).
   ///   For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
   ///   TODO(kenton):  Base-64 encode?
-  public var defaultValue: String {
+  var defaultValue: String {
     get {return _storage._defaultValue ?? ""}
     set {_uniqueStorage()._defaultValue = newValue}
   }
@@ -1257,7 +1257,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
 
   ///   If set, gives the index of a oneof in the containing type's oneof_decl
   ///   list.  This field is a member of that oneof.
-  public var oneofIndex: Int32 {
+  var oneofIndex: Int32 {
     get {return _storage._oneofIndex ?? 0}
     set {_uniqueStorage()._oneofIndex = newValue}
   }
@@ -1272,7 +1272,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
   ///   user has set a "json_name" option on this field, that option's value
   ///   will be used. Otherwise, it's deduced from the field's name by converting
   ///   it to camelCase.
-  public var jsonName: String {
+  var jsonName: String {
     get {return _storage._jsonName ?? ""}
     set {_uniqueStorage()._jsonName = newValue}
   }
@@ -1283,7 +1283,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._jsonName = nil
   }
 
-  public var options: Google_Protobuf_FieldOptions {
+  var options: Google_Protobuf_FieldOptions {
     get {return _storage._options ?? Google_Protobuf_FieldOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1294,7 +1294,7 @@ struct Google_Protobuf_FieldDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._options = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1379,7 +1379,7 @@ struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     set {_storage.unknown = newValue}
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1390,7 +1390,7 @@ struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._name = nil
   }
 
-  public var options: Google_Protobuf_OneofOptions {
+  var options: Google_Protobuf_OneofOptions {
     get {return _storage._options ?? Google_Protobuf_OneofOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1401,7 +1401,7 @@ struct Google_Protobuf_OneofDescriptorProto: ProtobufGeneratedMessage, ProtobufP
     return _storage._options = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1495,7 +1495,7 @@ struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
     set {_storage.unknown = newValue}
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1506,12 +1506,12 @@ struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
     return _storage._name = nil
   }
 
-  public var value: [Google_Protobuf_EnumValueDescriptorProto] {
+  var value: [Google_Protobuf_EnumValueDescriptorProto] {
     get {return _storage._value}
     set {_uniqueStorage()._value = newValue}
   }
 
-  public var options: Google_Protobuf_EnumOptions {
+  var options: Google_Protobuf_EnumOptions {
     get {return _storage._options ?? Google_Protobuf_EnumOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1522,7 +1522,7 @@ struct Google_Protobuf_EnumDescriptorProto: ProtobufGeneratedMessage, ProtobufPr
     return _storage._options = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1616,7 +1616,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage, Proto
     set {_storage.unknown = newValue}
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1627,7 +1627,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage, Proto
     return _storage._name = nil
   }
 
-  public var number: Int32 {
+  var number: Int32 {
     get {return _storage._number ?? 0}
     set {_uniqueStorage()._number = newValue}
   }
@@ -1638,7 +1638,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage, Proto
     return _storage._number = nil
   }
 
-  public var options: Google_Protobuf_EnumValueOptions {
+  var options: Google_Protobuf_EnumValueOptions {
     get {return _storage._options ?? Google_Protobuf_EnumValueOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1649,7 +1649,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: ProtobufGeneratedMessage, Proto
     return _storage._options = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1743,7 +1743,7 @@ struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage, Protobu
     set {_storage.unknown = newValue}
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1754,12 +1754,12 @@ struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage, Protobu
     return _storage._name = nil
   }
 
-  public var method: [Google_Protobuf_MethodDescriptorProto] {
+  var method: [Google_Protobuf_MethodDescriptorProto] {
     get {return _storage._method}
     set {_uniqueStorage()._method = newValue}
   }
 
-  public var options: Google_Protobuf_ServiceOptions {
+  var options: Google_Protobuf_ServiceOptions {
     get {return _storage._options ?? Google_Protobuf_ServiceOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1770,7 +1770,7 @@ struct Google_Protobuf_ServiceDescriptorProto: ProtobufGeneratedMessage, Protobu
     return _storage._options = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1891,7 +1891,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
     set {_storage.unknown = newValue}
   }
 
-  public var name: String {
+  var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
   }
@@ -1904,7 +1904,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
 
   ///   Input and output type names.  These are resolved in the same way as
   ///   FieldDescriptorProto.type_name, but must refer to a message type.
-  public var inputType: String {
+  var inputType: String {
     get {return _storage._inputType ?? ""}
     set {_uniqueStorage()._inputType = newValue}
   }
@@ -1915,7 +1915,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
     return _storage._inputType = nil
   }
 
-  public var outputType: String {
+  var outputType: String {
     get {return _storage._outputType ?? ""}
     set {_uniqueStorage()._outputType = newValue}
   }
@@ -1926,7 +1926,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
     return _storage._outputType = nil
   }
 
-  public var options: Google_Protobuf_MethodOptions {
+  var options: Google_Protobuf_MethodOptions {
     get {return _storage._options ?? Google_Protobuf_MethodOptions()}
     set {_uniqueStorage()._options = newValue}
   }
@@ -1938,7 +1938,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
   }
 
   ///   Identifies if client streams multiple client messages
-  public var clientStreaming: Bool {
+  var clientStreaming: Bool {
     get {return _storage._clientStreaming ?? false}
     set {_uniqueStorage()._clientStreaming = newValue}
   }
@@ -1950,7 +1950,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
   }
 
   ///   Identifies if server streams multiple server messages
-  public var serverStreaming: Bool {
+  var serverStreaming: Bool {
     get {return _storage._serverStreaming ?? false}
     set {_uniqueStorage()._serverStreaming = newValue}
   }
@@ -1961,7 +1961,7 @@ struct Google_Protobuf_MethodDescriptorProto: ProtobufGeneratedMessage, Protobuf
     return _storage._serverStreaming = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2060,7 +2060,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
 
   ///   Generated classes can be optimized for speed or code size.
   enum OptimizeMode: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   Generate complete code for parsing, serialization,
     case speed // = 1
@@ -2071,11 +2071,11 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
     ///   Generate code using MessageLite and the lite runtime.
     case liteRuntime // = 3
 
-    public init() {
+    init() {
       self = .speed
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .speed
       case 2: self = .codeSize
@@ -2084,7 +2084,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "speed": self = .speed
       case "codeSize": self = .codeSize
@@ -2093,7 +2093,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "SPEED": self = .speed
       case "CODE_SIZE": self = .codeSize
@@ -2102,7 +2102,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "SPEED": self = .speed
       case "CODE_SIZE": self = .codeSize
@@ -2111,7 +2111,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .speed: return 1
@@ -2121,7 +2121,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .speed: return "\"SPEED\""
@@ -2131,9 +2131,9 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .speed: return ".speed"
@@ -2150,7 +2150,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   inappropriate because proto packages do not normally start with backwards
   ///   domain names.
   private var _javaPackage: String? = nil
-  public var javaPackage: String {
+  var javaPackage: String {
     get {return _javaPackage ?? ""}
     set {_javaPackage = newValue}
   }
@@ -2167,7 +2167,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   a .proto always translates to a single class, but you may want to
   ///   explicitly choose the class name).
   private var _javaOuterClassname: String? = nil
-  public var javaOuterClassname: String {
+  var javaOuterClassname: String {
     get {return _javaOuterClassname ?? ""}
     set {_javaOuterClassname = newValue}
   }
@@ -2185,7 +2185,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   generated to contain the file's getDescriptor() method as well as any
   ///   top-level extensions defined in the file.
   private var _javaMultipleFiles: Bool? = nil
-  public var javaMultipleFiles: Bool {
+  var javaMultipleFiles: Bool {
     get {return _javaMultipleFiles ?? false}
     set {_javaMultipleFiles = newValue}
   }
@@ -2209,7 +2209,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   than object identity. (Implementations should not assume that hashcodes
   ///   will be consistent across runtimes or versions of the protocol compiler.)
   private var _javaGenerateEqualsAndHash: Bool? = nil
-  public var javaGenerateEqualsAndHash: Bool {
+  var javaGenerateEqualsAndHash: Bool {
     get {return _javaGenerateEqualsAndHash ?? false}
     set {_javaGenerateEqualsAndHash = newValue}
   }
@@ -2227,7 +2227,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   However, an extension field still accepts non-UTF-8 byte sequences.
   ///   This option has no effect on when used with the lite runtime.
   private var _javaStringCheckUtf8: Bool? = nil
-  public var javaStringCheckUtf8: Bool {
+  var javaStringCheckUtf8: Bool {
     get {return _javaStringCheckUtf8 ?? false}
     set {_javaStringCheckUtf8 = newValue}
   }
@@ -2239,7 +2239,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   private var _optimizeFor: Google_Protobuf_FileOptions.OptimizeMode? = nil
-  public var optimizeFor: Google_Protobuf_FileOptions.OptimizeMode {
+  var optimizeFor: Google_Protobuf_FileOptions.OptimizeMode {
     get {return _optimizeFor ?? Google_Protobuf_FileOptions.OptimizeMode.speed}
     set {_optimizeFor = newValue}
   }
@@ -2256,7 +2256,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///     - Otherwise, the package statement in the .proto file, if present.
   ///     - Otherwise, the basename of the .proto file, without extension.
   private var _goPackage: String? = nil
-  public var goPackage: String {
+  var goPackage: String {
     get {return _goPackage ?? ""}
     set {_goPackage = newValue}
   }
@@ -2278,7 +2278,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   these default to false.  Old code which depends on generic services should
   ///   explicitly set them to true.
   private var _ccGenericServices: Bool? = nil
-  public var ccGenericServices: Bool {
+  var ccGenericServices: Bool {
     get {return _ccGenericServices ?? false}
     set {_ccGenericServices = newValue}
   }
@@ -2290,7 +2290,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   private var _javaGenericServices: Bool? = nil
-  public var javaGenericServices: Bool {
+  var javaGenericServices: Bool {
     get {return _javaGenericServices ?? false}
     set {_javaGenericServices = newValue}
   }
@@ -2302,7 +2302,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   private var _pyGenericServices: Bool? = nil
-  public var pyGenericServices: Bool {
+  var pyGenericServices: Bool {
     get {return _pyGenericServices ?? false}
     set {_pyGenericServices = newValue}
   }
@@ -2318,7 +2318,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   for everything in the file, or it will be completely ignored; in the very
   ///   least, this is a formalization for deprecating files.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -2332,7 +2332,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   Enables the use of arenas for the proto messages in this file. This applies
   ///   only to generated classes for C++.
   private var _ccEnableArenas: Bool? = nil
-  public var ccEnableArenas: Bool {
+  var ccEnableArenas: Bool {
     get {return _ccEnableArenas ?? false}
     set {_ccEnableArenas = newValue}
   }
@@ -2346,7 +2346,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   Sets the objective c class prefix which is prepended to all objective c
   ///   generated classes from this .proto. There is no default.
   private var _objcClassPrefix: String? = nil
-  public var objcClassPrefix: String {
+  var objcClassPrefix: String {
     get {return _objcClassPrefix ?? ""}
     set {_objcClassPrefix = newValue}
   }
@@ -2359,7 +2359,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
 
   ///   Namespace for generated classes; defaults to the package.
   private var _csharpNamespace: String? = nil
-  public var csharpNamespace: String {
+  var csharpNamespace: String {
     get {return _csharpNamespace ?? ""}
     set {_csharpNamespace = newValue}
   }
@@ -2373,7 +2373,7 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   Prefix prepended to all Swift generated top-level types.
   ///   Default is CamelCased package name.
   private var _swiftPrefix: String? = nil
-  public var swiftPrefix: String {
+  var swiftPrefix: String {
     get {return _swiftPrefix ?? ""}
     set {_swiftPrefix = newValue}
   }
@@ -2385,9 +2385,9 @@ struct Google_Protobuf_FileOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2550,7 +2550,7 @@ struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufProto2M
   ///   Because this is an option, the above two restrictions are not enforced by
   ///   the protocol compiler.
   private var _messageSetWireFormat: Bool? = nil
-  public var messageSetWireFormat: Bool {
+  var messageSetWireFormat: Bool {
     get {return _messageSetWireFormat ?? false}
     set {_messageSetWireFormat = newValue}
   }
@@ -2565,7 +2565,7 @@ struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufProto2M
   ///   conflict with a field of the same name.  This is meant to make migration
   ///   from proto1 easier; new code should avoid fields named "descriptor".
   private var _noStandardDescriptorAccessor: Bool? = nil
-  public var noStandardDescriptorAccessor: Bool {
+  var noStandardDescriptorAccessor: Bool {
     get {return _noStandardDescriptorAccessor ?? false}
     set {_noStandardDescriptorAccessor = newValue}
   }
@@ -2581,7 +2581,7 @@ struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufProto2M
   ///   for the message, or it will be completely ignored; in the very least,
   ///   this is a formalization for deprecating messages.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -2614,7 +2614,7 @@ struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufProto2M
   ///   instead. The option should only be implicitly set by the proto compiler
   ///   parser.
   private var _mapEntry: Bool? = nil
-  public var mapEntry: Bool {
+  var mapEntry: Bool {
     get {return _mapEntry ?? false}
     set {_mapEntry = newValue}
   }
@@ -2626,9 +2626,9 @@ struct Google_Protobuf_MessageOptions: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2722,18 +2722,18 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   public var unknown = ProtobufUnknownStorage()
 
   enum CType: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   Default mode.
     case string // = 0
     case cord // = 1
     case stringPiece // = 2
 
-    public init() {
+    init() {
       self = .string
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .string
       case 1: self = .cord
@@ -2742,7 +2742,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "string": self = .string
       case "cord": self = .cord
@@ -2751,7 +2751,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "STRING": self = .string
       case "CORD": self = .cord
@@ -2760,7 +2760,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "STRING": self = .string
       case "CORD": self = .cord
@@ -2769,7 +2769,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .string: return 0
@@ -2779,7 +2779,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .string: return "\"STRING\""
@@ -2789,9 +2789,9 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .string: return ".string"
@@ -2804,7 +2804,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   }
 
   enum JSType: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
 
     ///   Use the default type.
     case jsNormal // = 0
@@ -2815,11 +2815,11 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
     ///   Use JavaScript numbers.
     case jsNumber // = 2
 
-    public init() {
+    init() {
       self = .jsNormal
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .jsNormal
       case 1: self = .jsString
@@ -2828,7 +2828,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "jsNormal": self = .jsNormal
       case "jsString": self = .jsString
@@ -2837,7 +2837,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "JS_NORMAL": self = .jsNormal
       case "JS_STRING": self = .jsString
@@ -2846,7 +2846,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "JS_NORMAL": self = .jsNormal
       case "JS_STRING": self = .jsString
@@ -2855,7 +2855,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .jsNormal: return 0
@@ -2865,7 +2865,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .jsNormal: return "\"JS_NORMAL\""
@@ -2875,9 +2875,9 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .jsNormal: return ".jsNormal"
@@ -2894,7 +2894,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   ///   options below.  This option is not yet implemented in the open source
   ///   release -- sorry, we'll try to include it in a future version!
   private var _ctype: Google_Protobuf_FieldOptions.CType? = nil
-  public var ctype: Google_Protobuf_FieldOptions.CType {
+  var ctype: Google_Protobuf_FieldOptions.CType {
     get {return _ctype ?? Google_Protobuf_FieldOptions.CType.string}
     set {_ctype = newValue}
   }
@@ -2911,7 +2911,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   ///   a single length-delimited blob. In proto3, only explicit setting it to
   ///   false will avoid using packed encoding.
   private var _packed: Bool? = nil
-  public var packed: Bool {
+  var packed: Bool {
     get {return _packed ?? false}
     set {_packed = newValue}
   }
@@ -2932,7 +2932,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   ///   This option is an enum to permit additional types to be added,
   ///   e.g. goog.math.Integer.
   private var _jstype: Google_Protobuf_FieldOptions.JSType? = nil
-  public var jstype: Google_Protobuf_FieldOptions.JSType {
+  var jstype: Google_Protobuf_FieldOptions.JSType {
     get {return _jstype ?? Google_Protobuf_FieldOptions.JSType.jsNormal}
     set {_jstype = newValue}
   }
@@ -2972,7 +2972,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   ///   check its required fields, regardless of whether or not the message has
   ///   been parsed.
   private var _lazy: Bool? = nil
-  public var lazy: Bool {
+  var lazy: Bool {
     get {return _lazy ?? false}
     set {_lazy = newValue}
   }
@@ -2988,7 +2988,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   ///   for accessors, or it will be completely ignored; in the very least, this
   ///   is a formalization for deprecating fields.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -3001,7 +3001,7 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
 
   ///   For Google-internal migration only. Do not use.
   private var _weak: Bool? = nil
-  public var weak: Bool {
+  var weak: Bool {
     get {return _weak ?? false}
     set {_weak = newValue}
   }
@@ -3013,9 +3013,9 @@ struct Google_Protobuf_FieldOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3107,9 +3107,9 @@ struct Google_Protobuf_OneofOptions: ProtobufGeneratedMessage, ProtobufProto2Mes
   public var unknown = ProtobufUnknownStorage()
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3177,7 +3177,7 @@ struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   Set this option to true to allow mapping different tag names to the same
   ///   value.
   private var _allowAlias: Bool? = nil
-  public var allowAlias: Bool {
+  var allowAlias: Bool {
     get {return _allowAlias ?? false}
     set {_allowAlias = newValue}
   }
@@ -3193,7 +3193,7 @@ struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   ///   for the enum, or it will be completely ignored; in the very least, this
   ///   is a formalization for deprecating enums.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -3205,9 +3205,9 @@ struct Google_Protobuf_EnumOptions: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3285,7 +3285,7 @@ struct Google_Protobuf_EnumValueOptions: ProtobufGeneratedMessage, ProtobufProto
   ///   for the enum value, or it will be completely ignored; in the very least,
   ///   this is a formalization for deprecating enum values.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -3297,9 +3297,9 @@ struct Google_Protobuf_EnumValueOptions: ProtobufGeneratedMessage, ProtobufProto
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3377,7 +3377,7 @@ struct Google_Protobuf_ServiceOptions: ProtobufGeneratedMessage, ProtobufProto2M
   ///   for the service, or it will be completely ignored; in the very least,
   ///   this is a formalization for deprecating services.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -3389,9 +3389,9 @@ struct Google_Protobuf_ServiceOptions: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3469,7 +3469,7 @@ struct Google_Protobuf_MethodOptions: ProtobufGeneratedMessage, ProtobufProto2Me
   ///   for the method, or it will be completely ignored; in the very least,
   ///   this is a formalization for deprecating methods.
   private var _deprecated: Bool? = nil
-  public var deprecated: Bool {
+  var deprecated: Bool {
     get {return _deprecated ?? false}
     set {_deprecated = newValue}
   }
@@ -3481,9 +3481,9 @@ struct Google_Protobuf_MethodOptions: ProtobufGeneratedMessage, ProtobufProto2Me
   }
 
   ///   The parser stores options it doesn't recognize here. See above.
-  public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
+  var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3588,7 +3588,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
     public var unknown = ProtobufUnknownStorage()
 
     private var _namePart: String? = nil
-    public var namePart: String {
+    var namePart: String {
       get {return _namePart ?? ""}
       set {_namePart = newValue}
     }
@@ -3600,7 +3600,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
     }
 
     private var _isExtension: Bool? = nil
-    public var isExtension: Bool {
+    var isExtension: Bool {
       get {return _isExtension ?? false}
       set {_isExtension = newValue}
     }
@@ -3611,7 +3611,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
       return _isExtension = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -3635,12 +3635,12 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
     }
   }
 
-  public var name: [Google_Protobuf_UninterpretedOption.NamePart] = []
+  var name: [Google_Protobuf_UninterpretedOption.NamePart] = []
 
   ///   The value of the uninterpreted option, in whatever type the tokenizer
   ///   identified it as during parsing. Exactly one of these should be set.
   private var _identifierValue: String? = nil
-  public var identifierValue: String {
+  var identifierValue: String {
     get {return _identifierValue ?? ""}
     set {_identifierValue = newValue}
   }
@@ -3652,7 +3652,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _positiveIntValue: UInt64? = nil
-  public var positiveIntValue: UInt64 {
+  var positiveIntValue: UInt64 {
     get {return _positiveIntValue ?? 0}
     set {_positiveIntValue = newValue}
   }
@@ -3664,7 +3664,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _negativeIntValue: Int64? = nil
-  public var negativeIntValue: Int64 {
+  var negativeIntValue: Int64 {
     get {return _negativeIntValue ?? 0}
     set {_negativeIntValue = newValue}
   }
@@ -3676,7 +3676,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _doubleValue: Double? = nil
-  public var doubleValue: Double {
+  var doubleValue: Double {
     get {return _doubleValue ?? 0}
     set {_doubleValue = newValue}
   }
@@ -3688,7 +3688,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _stringValue: Data? = nil
-  public var stringValue: Data {
+  var stringValue: Data {
     get {return _stringValue ?? Data()}
     set {_stringValue = newValue}
   }
@@ -3700,7 +3700,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _aggregateValue: String? = nil
-  public var aggregateValue: String {
+  var aggregateValue: String {
     get {return _aggregateValue ?? ""}
     set {_aggregateValue = newValue}
   }
@@ -3711,7 +3711,7 @@ struct Google_Protobuf_UninterpretedOption: ProtobufGeneratedMessage, ProtobufPr
     return _aggregateValue = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3826,14 +3826,14 @@ struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage, ProtobufProto2M
     ///     [ 4, 3, 2, 7 ]
     ///   this path refers to the whole field declaration (from the beginning
     ///   of the label to the terminating semicolon).
-    public var path: [Int32] = []
+    var path: [Int32] = []
 
     ///   Always has exactly three or four elements: start line, start column,
     ///   end line (optional, otherwise assumed same as start line), end column.
     ///   These are packed into a single field for efficiency.  Note that line
     ///   and column numbers are zero-based -- typically you will want to add
     ///   1 to each before displaying to a user.
-    public var span: [Int32] = []
+    var span: [Int32] = []
 
     ///   If this SourceCodeInfo represents a complete declaration, these are any
     ///   comments appearing before and after the declaration which appear to be
@@ -3883,7 +3883,7 @@ struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage, ProtobufProto2M
     ///  
     ///     // ignored detached comments.
     private var _leadingComments: String? = nil
-    public var leadingComments: String {
+    var leadingComments: String {
       get {return _leadingComments ?? ""}
       set {_leadingComments = newValue}
     }
@@ -3895,7 +3895,7 @@ struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage, ProtobufProto2M
     }
 
     private var _trailingComments: String? = nil
-    public var trailingComments: String {
+    var trailingComments: String {
       get {return _trailingComments ?? ""}
       set {_trailingComments = newValue}
     }
@@ -3906,9 +3906,9 @@ struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage, ProtobufProto2M
       return _trailingComments = nil
     }
 
-    public var leadingDetachedComments: [String] = []
+    var leadingDetachedComments: [String] = []
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -3994,9 +3994,9 @@ struct Google_Protobuf_SourceCodeInfo: ProtobufGeneratedMessage, ProtobufProto2M
   ///   - Code which tries to interpret locations should probably be designed to
   ///     ignore those that it doesn't understand, as more types of locations could
   ///     be recorded in the future.
-  public var location: [Google_Protobuf_SourceCodeInfo.Location] = []
+  var location: [Google_Protobuf_SourceCodeInfo.Location] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -4056,11 +4056,11 @@ struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage, ProtobufProt
 
     ///   Identifies the element in the original source .proto file. This field
     ///   is formatted the same as SourceCodeInfo.Location.path.
-    public var path: [Int32] = []
+    var path: [Int32] = []
 
     ///   Identifies the filesystem path to the original source .proto.
     private var _sourceFile: String? = nil
-    public var sourceFile: String {
+    var sourceFile: String {
       get {return _sourceFile ?? ""}
       set {_sourceFile = newValue}
     }
@@ -4074,7 +4074,7 @@ struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage, ProtobufProt
     ///   Identifies the starting offset in bytes in the generated code
     ///   that relates to the identified object.
     private var _begin: Int32? = nil
-    public var begin: Int32 {
+    var begin: Int32 {
       get {return _begin ?? 0}
       set {_begin = newValue}
     }
@@ -4089,7 +4089,7 @@ struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage, ProtobufProt
     ///   relates to the identified offset. The end offset should be one past
     ///   the last relevant byte (so the length of the text = end - begin).
     private var _end: Int32? = nil
-    public var end: Int32 {
+    var end: Int32 {
       get {return _end ?? 0}
       set {_end = newValue}
     }
@@ -4100,7 +4100,7 @@ struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage, ProtobufProt
       return _end = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4140,9 +4140,9 @@ struct Google_Protobuf_GeneratedCodeInfo: ProtobufGeneratedMessage, ProtobufProt
 
   ///   An Annotation connects some span of text in generated code to an element
   ///   of its generating .proto file.
-  public var annotation: [Google_Protobuf_GeneratedCodeInfo.Annotation] = []
+  var annotation: [Google_Protobuf_GeneratedCodeInfo.Annotation] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/map_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest.pb.swift
@@ -41,17 +41,17 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittest_MapEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foo
     case 1: self = .bar
@@ -60,7 +60,7 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     case "bar": self = .bar
@@ -69,7 +69,7 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "MAP_ENUM_FOO": self = .foo
     case "MAP_ENUM_BAR": self = .bar
@@ -78,7 +78,7 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "MAP_ENUM_FOO": self = .foo
     case "MAP_ENUM_BAR": self = .bar
@@ -87,7 +87,7 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 0
@@ -98,7 +98,7 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"MAP_ENUM_FOO\""
@@ -109,9 +109,9 @@ enum ProtobufUnittest_MapEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -323,97 +323,97 @@ struct ProtobufUnittest_TestMap: ProtobufGeneratedMessage, ProtobufProto3Message
   private var _storage = _StorageClass()
 
 
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnum> {
+  var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnum> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessage> {
+  var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessage> {
     get {return _storage._mapInt32ForeignMessage}
     set {_uniqueStorage()._mapInt32ForeignMessage = newValue}
   }
 
-  public var mapStringForeignMessage: Dictionary<String,ProtobufUnittest_ForeignMessage> {
+  var mapStringForeignMessage: Dictionary<String,ProtobufUnittest_ForeignMessage> {
     get {return _storage._mapStringForeignMessage}
     set {_uniqueStorage()._mapStringForeignMessage = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -480,7 +480,7 @@ struct ProtobufUnittest_TestMapSubmessage: ProtobufGeneratedMessage, ProtobufPro
   private var _storage = _StorageClass()
 
 
-  public var testMap: ProtobufUnittest_TestMap {
+  var testMap: ProtobufUnittest_TestMap {
     get {return _storage._testMap ?? ProtobufUnittest_TestMap()}
     set {_uniqueStorage()._testMap = newValue}
   }
@@ -491,7 +491,7 @@ struct ProtobufUnittest_TestMapSubmessage: ProtobufGeneratedMessage, ProtobufPro
     return _storage._testMap = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -525,9 +525,9 @@ struct ProtobufUnittest_TestMessageMap: ProtobufGeneratedMessage, ProtobufProto3
   ]}
 
 
-  public var mapInt32Message: Dictionary<Int32,ProtobufUnittest_TestAllTypes> = [:]
+  var mapInt32Message: Dictionary<Int32,ProtobufUnittest_TestAllTypes> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -563,11 +563,11 @@ struct ProtobufUnittest_TestSameTypeMap: ProtobufGeneratedMessage, ProtobufProto
   ]}
 
 
-  public var map1: Dictionary<Int32,Int32> = [:]
+  var map1: Dictionary<Int32,Int32> = [:]
 
-  public var map2: Dictionary<Int32,Int32> = [:]
+  var map2: Dictionary<Int32,Int32> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -606,9 +606,9 @@ struct ProtobufUnittest_TestRequiredMessageMap: ProtobufGeneratedMessage, Protob
   ]}
 
 
-  public var mapField: Dictionary<Int32,ProtobufUnittest_TestRequired> = [:]
+  var mapField: Dictionary<Int32,ProtobufUnittest_TestRequired> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -827,97 +827,97 @@ struct ProtobufUnittest_TestArenaMap: ProtobufGeneratedMessage, ProtobufProto3Me
   private var _storage = _StorageClass()
 
 
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnum> {
+  var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_MapEnum> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessage> {
+  var mapInt32ForeignMessage: Dictionary<Int32,ProtobufUnittest_ForeignMessage> {
     get {return _storage._mapInt32ForeignMessage}
     set {_uniqueStorage()._mapInt32ForeignMessage = newValue}
   }
 
-  public var mapInt32ForeignMessageNoArena: Dictionary<Int32,ProtobufUnittestNoArena_ForeignMessage> {
+  var mapInt32ForeignMessageNoArena: Dictionary<Int32,ProtobufUnittestNoArena_ForeignMessage> {
     get {return _storage._mapInt32ForeignMessageNoArena}
     set {_uniqueStorage()._mapInt32ForeignMessageNoArena = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -954,43 +954,43 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessag
 
 
   enum TypeEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "TYPE_FOO": self = .foo
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "TYPE_FOO": self = .foo
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -999,7 +999,7 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessag
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"TYPE_FOO\""
@@ -1008,9 +1008,9 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessag
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1021,9 +1021,9 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: ProtobufGeneratedMessag
 
   }
 
-  public var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
+  var type: Dictionary<String,ProtobufUnittest_MessageContainingEnumCalledType> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1057,9 +1057,9 @@ struct ProtobufUnittest_MessageContainingMapCalledEntry: ProtobufGeneratedMessag
   ]}
 
 
-  public var entry: Dictionary<Int32,Int32> = [:]
+  var entry: Dictionary<Int32,Int32> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1092,9 +1092,9 @@ struct ProtobufUnittest_TestRecursiveMapMessage: ProtobufGeneratedMessage, Proto
   ]}
 
 
-  public var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
+  var a: Dictionary<String,ProtobufUnittest_TestRecursiveMapMessage> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/map_unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest_proto3.pb.swift
@@ -48,17 +48,17 @@ import SwiftProtobuf
 
 
 enum Proto3MapEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foo
     case 1: self = .bar
@@ -67,7 +67,7 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     case "bar": self = .bar
@@ -76,7 +76,7 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "MAP_ENUM_FOO": self = .foo
     case "MAP_ENUM_BAR": self = .bar
@@ -85,7 +85,7 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "MAP_ENUM_FOO": self = .foo
     case "MAP_ENUM_BAR": self = .bar
@@ -94,7 +94,7 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 0
@@ -105,7 +105,7 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"MAP_ENUM_FOO\""
@@ -116,9 +116,9 @@ enum Proto3MapEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -321,92 +321,92 @@ struct Proto3TestMap: ProtobufGeneratedMessage, ProtobufProto3Message {
   private var _storage = _StorageClass()
 
 
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,Proto3MapEnum> {
+  var mapInt32Enum: Dictionary<Int32,Proto3MapEnum> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32ForeignMessage: Dictionary<Int32,Proto3ForeignMessage> {
+  var mapInt32ForeignMessage: Dictionary<Int32,Proto3ForeignMessage> {
     get {return _storage._mapInt32ForeignMessage}
     set {_uniqueStorage()._mapInt32ForeignMessage = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -473,7 +473,7 @@ struct Proto3TestMapSubmessage: ProtobufGeneratedMessage, ProtobufProto3Message 
   private var _storage = _StorageClass()
 
 
-  public var testMap: Proto3TestMap {
+  var testMap: Proto3TestMap {
     get {return _storage._testMap ?? Proto3TestMap()}
     set {_uniqueStorage()._testMap = newValue}
   }
@@ -484,7 +484,7 @@ struct Proto3TestMapSubmessage: ProtobufGeneratedMessage, ProtobufProto3Message 
     return _storage._testMap = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -518,9 +518,9 @@ struct Proto3TestMessageMap: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var mapInt32Message: Dictionary<Int32,Proto3TestAllTypes> = [:]
+  var mapInt32Message: Dictionary<Int32,Proto3TestAllTypes> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -556,11 +556,11 @@ struct Proto3TestSameTypeMap: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var map1: Dictionary<Int32,Int32> = [:]
+  var map1: Dictionary<Int32,Int32> = [:]
 
-  public var map2: Dictionary<Int32,Int32> = [:]
+  var map2: Dictionary<Int32,Int32> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -626,37 +626,37 @@ struct Proto3TestArenaMap: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var mapInt32Int32: Dictionary<Int32,Int32> = [:]
+  var mapInt32Int32: Dictionary<Int32,Int32> = [:]
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> = [:]
+  var mapInt64Int64: Dictionary<Int64,Int64> = [:]
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> = [:]
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> = [:]
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> = [:]
+  var mapSint32Sint32: Dictionary<Int32,Int32> = [:]
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> = [:]
+  var mapSint64Sint64: Dictionary<Int64,Int64> = [:]
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> = [:]
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> = [:]
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> = [:]
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> = [:]
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> = [:]
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> = [:]
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> = [:]
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> = [:]
 
-  public var mapInt32Float: Dictionary<Int32,Float> = [:]
+  var mapInt32Float: Dictionary<Int32,Float> = [:]
 
-  public var mapInt32Double: Dictionary<Int32,Double> = [:]
+  var mapInt32Double: Dictionary<Int32,Double> = [:]
 
-  public var mapBoolBool: Dictionary<Bool,Bool> = [:]
+  var mapBoolBool: Dictionary<Bool,Bool> = [:]
 
-  public var mapInt32Enum: Dictionary<Int32,Proto3MapEnum> = [:]
+  var mapInt32Enum: Dictionary<Int32,Proto3MapEnum> = [:]
 
-  public var mapInt32ForeignMessage: Dictionary<Int32,Proto3ForeignMessage> = [:]
+  var mapInt32ForeignMessage: Dictionary<Int32,Proto3ForeignMessage> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -762,43 +762,43 @@ struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage, Protobuf
 
 
   enum TypeEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "TYPE_FOO": self = .foo
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "TYPE_FOO": self = .foo
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -807,7 +807,7 @@ struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"TYPE_FOO\""
@@ -816,9 +816,9 @@ struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -829,9 +829,9 @@ struct Proto3MessageContainingEnumCalledType: ProtobufGeneratedMessage, Protobuf
 
   }
 
-  public var type: Dictionary<Int32,Proto3MessageContainingEnumCalledType> = [:]
+  var type: Dictionary<Int32,Proto3MessageContainingEnumCalledType> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -865,9 +865,9 @@ struct Proto3MessageContainingMapCalledEntry: ProtobufGeneratedMessage, Protobuf
   ]}
 
 
-  public var entry: Dictionary<Int32,Int32> = [:]
+  var entry: Dictionary<Int32,Int32> = [:]
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -47,16 +47,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
 
-  public init() {
+  init() {
     self = .foreignFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 4: self = .foreignFoo
     case 5: self = .foreignBar
@@ -65,7 +65,7 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignFoo": self = .foreignFoo
     case "foreignBar": self = .foreignBar
@@ -74,7 +74,7 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -83,7 +83,7 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -92,7 +92,7 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignFoo: return 4
@@ -102,7 +102,7 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignFoo: return "\"FOREIGN_FOO\""
@@ -112,9 +112,9 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignFoo: return ".foreignFoo"
@@ -128,18 +128,18 @@ enum ProtobufUnittest_ForeignEnum: ProtobufEnum {
 
 ///   Test an enum that has multiple values with the same number.
 enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo1 // = 1
   case bar1 // = 2
   case baz // = 3
   case foo2 // = 1
   case bar2 // = 2
 
-  public init() {
+  init() {
     self = .foo1
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .foo1
     case 2: self = .bar1
@@ -148,7 +148,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo1": self = .foo1
     case "bar1": self = .bar1
@@ -159,7 +159,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOO1": self = .foo1
     case "BAR1": self = .bar1
@@ -170,7 +170,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOO1": self = .foo1
     case "BAR1": self = .bar1
@@ -181,7 +181,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo1: return 1
@@ -193,7 +193,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo1: return "\"FOO1\""
@@ -205,9 +205,9 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo1: return ".foo1"
@@ -223,7 +223,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: ProtobufEnum {
 
 ///   Test an enum with large, unordered values.
 enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case sparseA // = 123
   case sparseB // = 62374
   case sparseC // = 12589234
@@ -232,11 +232,11 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
   case sparseF // = 0
   case sparseG // = 2
 
-  public init() {
+  init() {
     self = .sparseA
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 123: self = .sparseA
     case 62374: self = .sparseB
@@ -249,7 +249,7 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "sparseA": self = .sparseA
     case "sparseB": self = .sparseB
@@ -262,7 +262,7 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "SPARSE_A": self = .sparseA
     case "SPARSE_B": self = .sparseB
@@ -275,7 +275,7 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "SPARSE_A": self = .sparseA
     case "SPARSE_B": self = .sparseB
@@ -288,7 +288,7 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .sparseA: return 123
@@ -302,7 +302,7 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .sparseA: return "\"SPARSE_A\""
@@ -316,9 +316,9 @@ enum ProtobufUnittest_TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .sparseA: return ".sparseA"
@@ -1106,7 +1106,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
@@ -1114,11 +1114,11 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     ///   Intentionally negative.
     case neg // = -1
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       case 2: self = .bar
@@ -1128,7 +1128,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -1138,7 +1138,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1148,7 +1148,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1158,7 +1158,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -1169,7 +1169,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -1180,9 +1180,9 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1212,7 +1212,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -1223,7 +1223,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       return _bb = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1260,7 +1260,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1271,7 +1271,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1308,7 +1308,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1319,7 +1319,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1343,7 +1343,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
@@ -1354,7 +1354,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalInt32 = nil
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64 ?? 0}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
@@ -1365,7 +1365,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalInt64 = nil
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32 ?? 0}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
@@ -1376,7 +1376,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalUint32 = nil
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64 ?? 0}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
@@ -1387,7 +1387,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalUint64 = nil
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32 ?? 0}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
@@ -1398,7 +1398,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalSint32 = nil
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64 ?? 0}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
@@ -1409,7 +1409,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalSint64 = nil
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32 ?? 0}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
@@ -1420,7 +1420,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalFixed32 = nil
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64 ?? 0}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
@@ -1431,7 +1431,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalFixed64 = nil
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32 ?? 0}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
@@ -1442,7 +1442,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalSfixed32 = nil
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64 ?? 0}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
@@ -1453,7 +1453,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalSfixed64 = nil
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat ?? 0}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
@@ -1464,7 +1464,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalFloat = nil
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble ?? 0}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
@@ -1475,7 +1475,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalDouble = nil
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool ?? false}
     set {_uniqueStorage()._optionalBool = newValue}
   }
@@ -1486,7 +1486,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalBool = nil
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString ?? ""}
     set {_uniqueStorage()._optionalString = newValue}
   }
@@ -1497,7 +1497,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalString = nil
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes ?? Data()}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -1508,7 +1508,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalBytes = nil
   }
 
-  public var optionalGroup: ProtobufUnittest_TestAllTypes.OptionalGroup {
+  var optionalGroup: ProtobufUnittest_TestAllTypes.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittest_TestAllTypes.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -1519,7 +1519,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalGroup = nil
   }
 
-  public var optionalNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -1530,7 +1530,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: ProtobufUnittest_ForeignMessage {
+  var optionalForeignMessage: ProtobufUnittest_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? ProtobufUnittest_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -1541,7 +1541,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
+  var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
     get {return _storage._optionalImportMessage ?? ProtobufUnittestImport_ImportMessage()}
     set {_uniqueStorage()._optionalImportMessage = newValue}
   }
@@ -1552,7 +1552,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalImportMessage = nil
   }
 
-  public var optionalNestedEnum: ProtobufUnittest_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum ?? ProtobufUnittest_TestAllTypes.NestedEnum.foo}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
@@ -1563,7 +1563,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalNestedEnum = nil
   }
 
-  public var optionalForeignEnum: ProtobufUnittest_ForeignEnum {
+  var optionalForeignEnum: ProtobufUnittest_ForeignEnum {
     get {return _storage._optionalForeignEnum ?? ProtobufUnittest_ForeignEnum.foreignFoo}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
@@ -1574,7 +1574,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalForeignEnum = nil
   }
 
-  public var optionalImportEnum: ProtobufUnittestImport_ImportEnum {
+  var optionalImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._optionalImportEnum ?? ProtobufUnittestImport_ImportEnum.importFoo}
     set {_uniqueStorage()._optionalImportEnum = newValue}
   }
@@ -1585,7 +1585,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalImportEnum = nil
   }
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece ?? ""}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
@@ -1596,7 +1596,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalStringPiece = nil
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord ?? ""}
     set {_uniqueStorage()._optionalCord = newValue}
   }
@@ -1608,7 +1608,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
   }
 
   ///   Defined in unittest_import_public.proto
-  public var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
+  var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
   }
@@ -1619,7 +1619,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._optionalPublicImportMessage = nil
   }
 
-  public var optionalLazyMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var optionalLazyMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalLazyMessage ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalLazyMessage = newValue}
   }
@@ -1631,133 +1631,133 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedGroup: [ProtobufUnittest_TestAllTypes.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittest_TestAllTypes.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public var repeatedNestedMessage: [ProtobufUnittest_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [ProtobufUnittest_ForeignMessage] {
+  var repeatedForeignMessage: [ProtobufUnittest_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
+  var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [ProtobufUnittest_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [ProtobufUnittest_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [ProtobufUnittest_ForeignEnum] {
+  var repeatedForeignEnum: [ProtobufUnittest_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedImportEnum: [ProtobufUnittestImport_ImportEnum] {
+  var repeatedImportEnum: [ProtobufUnittestImport_ImportEnum] {
     get {return _storage._repeatedImportEnum}
     set {_uniqueStorage()._repeatedImportEnum = newValue}
   }
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [ProtobufUnittest_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessage: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
   ///   Singular with defaults
-  public var defaultInt32: Int32 {
+  var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
   }
@@ -1768,7 +1768,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultInt32 = nil
   }
 
-  public var defaultInt64: Int64 {
+  var defaultInt64: Int64 {
     get {return _storage._defaultInt64 ?? 42}
     set {_uniqueStorage()._defaultInt64 = newValue}
   }
@@ -1779,7 +1779,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultInt64 = nil
   }
 
-  public var defaultUint32: UInt32 {
+  var defaultUint32: UInt32 {
     get {return _storage._defaultUint32 ?? 43}
     set {_uniqueStorage()._defaultUint32 = newValue}
   }
@@ -1790,7 +1790,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultUint32 = nil
   }
 
-  public var defaultUint64: UInt64 {
+  var defaultUint64: UInt64 {
     get {return _storage._defaultUint64 ?? 44}
     set {_uniqueStorage()._defaultUint64 = newValue}
   }
@@ -1801,7 +1801,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultUint64 = nil
   }
 
-  public var defaultSint32: Int32 {
+  var defaultSint32: Int32 {
     get {return _storage._defaultSint32 ?? -45}
     set {_uniqueStorage()._defaultSint32 = newValue}
   }
@@ -1812,7 +1812,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultSint32 = nil
   }
 
-  public var defaultSint64: Int64 {
+  var defaultSint64: Int64 {
     get {return _storage._defaultSint64 ?? 46}
     set {_uniqueStorage()._defaultSint64 = newValue}
   }
@@ -1823,7 +1823,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultSint64 = nil
   }
 
-  public var defaultFixed32: UInt32 {
+  var defaultFixed32: UInt32 {
     get {return _storage._defaultFixed32 ?? 47}
     set {_uniqueStorage()._defaultFixed32 = newValue}
   }
@@ -1834,7 +1834,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultFixed32 = nil
   }
 
-  public var defaultFixed64: UInt64 {
+  var defaultFixed64: UInt64 {
     get {return _storage._defaultFixed64 ?? 48}
     set {_uniqueStorage()._defaultFixed64 = newValue}
   }
@@ -1845,7 +1845,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultFixed64 = nil
   }
 
-  public var defaultSfixed32: Int32 {
+  var defaultSfixed32: Int32 {
     get {return _storage._defaultSfixed32 ?? 49}
     set {_uniqueStorage()._defaultSfixed32 = newValue}
   }
@@ -1856,7 +1856,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultSfixed32 = nil
   }
 
-  public var defaultSfixed64: Int64 {
+  var defaultSfixed64: Int64 {
     get {return _storage._defaultSfixed64 ?? -50}
     set {_uniqueStorage()._defaultSfixed64 = newValue}
   }
@@ -1867,7 +1867,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultSfixed64 = nil
   }
 
-  public var defaultFloat: Float {
+  var defaultFloat: Float {
     get {return _storage._defaultFloat ?? 51.5}
     set {_uniqueStorage()._defaultFloat = newValue}
   }
@@ -1878,7 +1878,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultFloat = nil
   }
 
-  public var defaultDouble: Double {
+  var defaultDouble: Double {
     get {return _storage._defaultDouble ?? 52000}
     set {_uniqueStorage()._defaultDouble = newValue}
   }
@@ -1889,7 +1889,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultDouble = nil
   }
 
-  public var defaultBool: Bool {
+  var defaultBool: Bool {
     get {return _storage._defaultBool ?? true}
     set {_uniqueStorage()._defaultBool = newValue}
   }
@@ -1900,7 +1900,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultBool = nil
   }
 
-  public var defaultString: String {
+  var defaultString: String {
     get {return _storage._defaultString ?? "hello"}
     set {_uniqueStorage()._defaultString = newValue}
   }
@@ -1911,7 +1911,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultString = nil
   }
 
-  public var defaultBytes: Data {
+  var defaultBytes: Data {
     get {return _storage._defaultBytes ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {_uniqueStorage()._defaultBytes = newValue}
   }
@@ -1922,7 +1922,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultBytes = nil
   }
 
-  public var defaultNestedEnum: ProtobufUnittest_TestAllTypes.NestedEnum {
+  var defaultNestedEnum: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return _storage._defaultNestedEnum ?? ProtobufUnittest_TestAllTypes.NestedEnum.bar}
     set {_uniqueStorage()._defaultNestedEnum = newValue}
   }
@@ -1933,7 +1933,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultNestedEnum = nil
   }
 
-  public var defaultForeignEnum: ProtobufUnittest_ForeignEnum {
+  var defaultForeignEnum: ProtobufUnittest_ForeignEnum {
     get {return _storage._defaultForeignEnum ?? ProtobufUnittest_ForeignEnum.foreignBar}
     set {_uniqueStorage()._defaultForeignEnum = newValue}
   }
@@ -1944,7 +1944,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultForeignEnum = nil
   }
 
-  public var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
+  var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._defaultImportEnum ?? ProtobufUnittestImport_ImportEnum.importBar}
     set {_uniqueStorage()._defaultImportEnum = newValue}
   }
@@ -1955,7 +1955,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultImportEnum = nil
   }
 
-  public var defaultStringPiece: String {
+  var defaultStringPiece: String {
     get {return _storage._defaultStringPiece ?? "abc"}
     set {_uniqueStorage()._defaultStringPiece = newValue}
   }
@@ -1966,7 +1966,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultStringPiece = nil
   }
 
-  public var defaultCord: String {
+  var defaultCord: String {
     get {return _storage._defaultCord ?? "123"}
     set {_uniqueStorage()._defaultCord = newValue}
   }
@@ -1977,7 +1977,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._defaultCord = nil
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1989,7 +1989,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     }
   }
 
-  public var oneofNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -2001,7 +2001,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -2013,7 +2013,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -2032,7 +2032,7 @@ struct ProtobufUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto2Me
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2126,7 +2126,7 @@ struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufPr
     set {_storage.unknown = newValue}
   }
 
-  public var child: ProtobufUnittest_NestedTestAllTypes {
+  var child: ProtobufUnittest_NestedTestAllTypes {
     get {return _storage._child ?? ProtobufUnittest_NestedTestAllTypes()}
     set {_uniqueStorage()._child = newValue}
   }
@@ -2137,7 +2137,7 @@ struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._child = nil
   }
 
-  public var payload: ProtobufUnittest_TestAllTypes {
+  var payload: ProtobufUnittest_TestAllTypes {
     get {return _storage._payload ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._payload = newValue}
   }
@@ -2148,12 +2148,12 @@ struct ProtobufUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._payload = nil
   }
 
-  public var repeatedChild: [ProtobufUnittest_NestedTestAllTypes] {
+  var repeatedChild: [ProtobufUnittest_NestedTestAllTypes] {
     get {return _storage._repeatedChild}
     set {_uniqueStorage()._repeatedChild = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2189,7 +2189,7 @@ struct ProtobufUnittest_TestDeprecatedFields: ProtobufGeneratedMessage, Protobuf
   public var unknown = ProtobufUnknownStorage()
 
   private var _deprecatedInt32: Int32? = nil
-  public var deprecatedInt32: Int32 {
+  var deprecatedInt32: Int32 {
     get {return _deprecatedInt32 ?? 0}
     set {_deprecatedInt32 = newValue}
   }
@@ -2200,7 +2200,7 @@ struct ProtobufUnittest_TestDeprecatedFields: ProtobufGeneratedMessage, Protobuf
     return _deprecatedInt32 = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2241,7 +2241,7 @@ struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage, ProtobufProto2
   public var unknown = ProtobufUnknownStorage()
 
   private var _c: Int32? = nil
-  public var c: Int32 {
+  var c: Int32 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -2253,7 +2253,7 @@ struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage, ProtobufProto2
   }
 
   private var _d: Int32? = nil
-  public var d: Int32 {
+  var d: Int32 {
     get {return _d ?? 0}
     set {_d = newValue}
   }
@@ -2264,7 +2264,7 @@ struct ProtobufUnittest_ForeignMessage: ProtobufGeneratedMessage, ProtobufProto2
     return _d = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2301,7 +2301,7 @@ struct ProtobufUnittest_TestReservedFields: ProtobufGeneratedMessage, ProtobufPr
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -2325,7 +2325,7 @@ struct ProtobufUnittest_TestAllExtensions: ProtobufGeneratedMessage, ProtobufPro
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -2380,7 +2380,7 @@ struct ProtobufUnittest_OptionalGroup_extension: ProtobufGeneratedMessage, Proto
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -2391,7 +2391,7 @@ struct ProtobufUnittest_OptionalGroup_extension: ProtobufGeneratedMessage, Proto
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2428,7 +2428,7 @@ struct ProtobufUnittest_RepeatedGroup_extension: ProtobufGeneratedMessage, Proto
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -2439,7 +2439,7 @@ struct ProtobufUnittest_RepeatedGroup_extension: ProtobufGeneratedMessage, Proto
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2482,7 +2482,7 @@ struct ProtobufUnittest_TestNestedExtension: ProtobufGeneratedMessage, ProtobufP
     static let ProtobufUnittest_TestAllExtensions_nestedStringExtension = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufString>, ProtobufUnittest_TestAllExtensions>(protoFieldNumber: 1003, protoFieldName: "nested_string_extension", jsonFieldName: "nestedStringExtension", swiftFieldName: "ProtobufUnittest_TestNestedExtension_nestedStringExtension", defaultValue: "")
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -2844,7 +2844,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     static let ProtobufUnittest_TestAllExtensions_multi = ProtobufGenericMessageExtension<ProtobufRepeatedMessageField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(protoFieldNumber: 1001, protoFieldName: "multi", jsonFieldName: "multi", swiftFieldName: "ProtobufUnittest_TestRequired_multi", defaultValue: [])
   }
 
-  public var a: Int32 {
+  var a: Int32 {
     get {return _storage._a ?? 0}
     set {_uniqueStorage()._a = newValue}
   }
@@ -2855,7 +2855,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._a = nil
   }
 
-  public var dummy2: Int32 {
+  var dummy2: Int32 {
     get {return _storage._dummy2 ?? 0}
     set {_uniqueStorage()._dummy2 = newValue}
   }
@@ -2866,7 +2866,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy2 = nil
   }
 
-  public var b: Int32 {
+  var b: Int32 {
     get {return _storage._b ?? 0}
     set {_uniqueStorage()._b = newValue}
   }
@@ -2879,7 +2879,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
 
   ///   Pad the field count to 32 so that we can test that IsInitialized()
   ///   properly checks multiple elements of has_bits_.
-  public var dummy4: Int32 {
+  var dummy4: Int32 {
     get {return _storage._dummy4 ?? 0}
     set {_uniqueStorage()._dummy4 = newValue}
   }
@@ -2890,7 +2890,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy4 = nil
   }
 
-  public var dummy5: Int32 {
+  var dummy5: Int32 {
     get {return _storage._dummy5 ?? 0}
     set {_uniqueStorage()._dummy5 = newValue}
   }
@@ -2901,7 +2901,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy5 = nil
   }
 
-  public var dummy6: Int32 {
+  var dummy6: Int32 {
     get {return _storage._dummy6 ?? 0}
     set {_uniqueStorage()._dummy6 = newValue}
   }
@@ -2912,7 +2912,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy6 = nil
   }
 
-  public var dummy7: Int32 {
+  var dummy7: Int32 {
     get {return _storage._dummy7 ?? 0}
     set {_uniqueStorage()._dummy7 = newValue}
   }
@@ -2923,7 +2923,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy7 = nil
   }
 
-  public var dummy8: Int32 {
+  var dummy8: Int32 {
     get {return _storage._dummy8 ?? 0}
     set {_uniqueStorage()._dummy8 = newValue}
   }
@@ -2934,7 +2934,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy8 = nil
   }
 
-  public var dummy9: Int32 {
+  var dummy9: Int32 {
     get {return _storage._dummy9 ?? 0}
     set {_uniqueStorage()._dummy9 = newValue}
   }
@@ -2945,7 +2945,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy9 = nil
   }
 
-  public var dummy10: Int32 {
+  var dummy10: Int32 {
     get {return _storage._dummy10 ?? 0}
     set {_uniqueStorage()._dummy10 = newValue}
   }
@@ -2956,7 +2956,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy10 = nil
   }
 
-  public var dummy11: Int32 {
+  var dummy11: Int32 {
     get {return _storage._dummy11 ?? 0}
     set {_uniqueStorage()._dummy11 = newValue}
   }
@@ -2967,7 +2967,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy11 = nil
   }
 
-  public var dummy12: Int32 {
+  var dummy12: Int32 {
     get {return _storage._dummy12 ?? 0}
     set {_uniqueStorage()._dummy12 = newValue}
   }
@@ -2978,7 +2978,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy12 = nil
   }
 
-  public var dummy13: Int32 {
+  var dummy13: Int32 {
     get {return _storage._dummy13 ?? 0}
     set {_uniqueStorage()._dummy13 = newValue}
   }
@@ -2989,7 +2989,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy13 = nil
   }
 
-  public var dummy14: Int32 {
+  var dummy14: Int32 {
     get {return _storage._dummy14 ?? 0}
     set {_uniqueStorage()._dummy14 = newValue}
   }
@@ -3000,7 +3000,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy14 = nil
   }
 
-  public var dummy15: Int32 {
+  var dummy15: Int32 {
     get {return _storage._dummy15 ?? 0}
     set {_uniqueStorage()._dummy15 = newValue}
   }
@@ -3011,7 +3011,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy15 = nil
   }
 
-  public var dummy16: Int32 {
+  var dummy16: Int32 {
     get {return _storage._dummy16 ?? 0}
     set {_uniqueStorage()._dummy16 = newValue}
   }
@@ -3022,7 +3022,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy16 = nil
   }
 
-  public var dummy17: Int32 {
+  var dummy17: Int32 {
     get {return _storage._dummy17 ?? 0}
     set {_uniqueStorage()._dummy17 = newValue}
   }
@@ -3033,7 +3033,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy17 = nil
   }
 
-  public var dummy18: Int32 {
+  var dummy18: Int32 {
     get {return _storage._dummy18 ?? 0}
     set {_uniqueStorage()._dummy18 = newValue}
   }
@@ -3044,7 +3044,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy18 = nil
   }
 
-  public var dummy19: Int32 {
+  var dummy19: Int32 {
     get {return _storage._dummy19 ?? 0}
     set {_uniqueStorage()._dummy19 = newValue}
   }
@@ -3055,7 +3055,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy19 = nil
   }
 
-  public var dummy20: Int32 {
+  var dummy20: Int32 {
     get {return _storage._dummy20 ?? 0}
     set {_uniqueStorage()._dummy20 = newValue}
   }
@@ -3066,7 +3066,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy20 = nil
   }
 
-  public var dummy21: Int32 {
+  var dummy21: Int32 {
     get {return _storage._dummy21 ?? 0}
     set {_uniqueStorage()._dummy21 = newValue}
   }
@@ -3077,7 +3077,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy21 = nil
   }
 
-  public var dummy22: Int32 {
+  var dummy22: Int32 {
     get {return _storage._dummy22 ?? 0}
     set {_uniqueStorage()._dummy22 = newValue}
   }
@@ -3088,7 +3088,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy22 = nil
   }
 
-  public var dummy23: Int32 {
+  var dummy23: Int32 {
     get {return _storage._dummy23 ?? 0}
     set {_uniqueStorage()._dummy23 = newValue}
   }
@@ -3099,7 +3099,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy23 = nil
   }
 
-  public var dummy24: Int32 {
+  var dummy24: Int32 {
     get {return _storage._dummy24 ?? 0}
     set {_uniqueStorage()._dummy24 = newValue}
   }
@@ -3110,7 +3110,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy24 = nil
   }
 
-  public var dummy25: Int32 {
+  var dummy25: Int32 {
     get {return _storage._dummy25 ?? 0}
     set {_uniqueStorage()._dummy25 = newValue}
   }
@@ -3121,7 +3121,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy25 = nil
   }
 
-  public var dummy26: Int32 {
+  var dummy26: Int32 {
     get {return _storage._dummy26 ?? 0}
     set {_uniqueStorage()._dummy26 = newValue}
   }
@@ -3132,7 +3132,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy26 = nil
   }
 
-  public var dummy27: Int32 {
+  var dummy27: Int32 {
     get {return _storage._dummy27 ?? 0}
     set {_uniqueStorage()._dummy27 = newValue}
   }
@@ -3143,7 +3143,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy27 = nil
   }
 
-  public var dummy28: Int32 {
+  var dummy28: Int32 {
     get {return _storage._dummy28 ?? 0}
     set {_uniqueStorage()._dummy28 = newValue}
   }
@@ -3154,7 +3154,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy28 = nil
   }
 
-  public var dummy29: Int32 {
+  var dummy29: Int32 {
     get {return _storage._dummy29 ?? 0}
     set {_uniqueStorage()._dummy29 = newValue}
   }
@@ -3165,7 +3165,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy29 = nil
   }
 
-  public var dummy30: Int32 {
+  var dummy30: Int32 {
     get {return _storage._dummy30 ?? 0}
     set {_uniqueStorage()._dummy30 = newValue}
   }
@@ -3176,7 +3176,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy30 = nil
   }
 
-  public var dummy31: Int32 {
+  var dummy31: Int32 {
     get {return _storage._dummy31 ?? 0}
     set {_uniqueStorage()._dummy31 = newValue}
   }
@@ -3187,7 +3187,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy31 = nil
   }
 
-  public var dummy32: Int32 {
+  var dummy32: Int32 {
     get {return _storage._dummy32 ?? 0}
     set {_uniqueStorage()._dummy32 = newValue}
   }
@@ -3198,7 +3198,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._dummy32 = nil
   }
 
-  public var c: Int32 {
+  var c: Int32 {
     get {return _storage._c ?? 0}
     set {_uniqueStorage()._c = newValue}
   }
@@ -3209,7 +3209,7 @@ struct ProtobufUnittest_TestRequired: ProtobufGeneratedMessage, ProtobufProto2Me
     return _storage._c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3302,7 +3302,7 @@ struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage, ProtobufP
     set {_storage.unknown = newValue}
   }
 
-  public var optionalMessage: ProtobufUnittest_TestRequired {
+  var optionalMessage: ProtobufUnittest_TestRequired {
     get {return _storage._optionalMessage ?? ProtobufUnittest_TestRequired()}
     set {_uniqueStorage()._optionalMessage = newValue}
   }
@@ -3313,12 +3313,12 @@ struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalMessage = nil
   }
 
-  public var repeatedMessage: [ProtobufUnittest_TestRequired] {
+  var repeatedMessage: [ProtobufUnittest_TestRequired] {
     get {return _storage._repeatedMessage}
     set {_uniqueStorage()._repeatedMessage = newValue}
   }
 
-  public var dummy: Int32 {
+  var dummy: Int32 {
     get {return _storage._dummy ?? 0}
     set {_uniqueStorage()._dummy = newValue}
   }
@@ -3329,7 +3329,7 @@ struct ProtobufUnittest_TestRequiredForeign: ProtobufGeneratedMessage, ProtobufP
     return _storage._dummy = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3405,7 +3405,7 @@ struct ProtobufUnittest_TestForeignNested: ProtobufGeneratedMessage, ProtobufPro
     set {_storage.unknown = newValue}
   }
 
-  public var foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage {
+  var foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return _storage._foreignNested ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._foreignNested = newValue}
   }
@@ -3416,7 +3416,7 @@ struct ProtobufUnittest_TestForeignNested: ProtobufGeneratedMessage, ProtobufPro
     return _storage._foreignNested = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3448,7 +3448,7 @@ struct ProtobufUnittest_TestEmptyMessage: ProtobufGeneratedMessage, ProtobufProt
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3474,7 +3474,7 @@ struct ProtobufUnittest_TestEmptyMessageWithExtensions: ProtobufGeneratedMessage
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -3524,7 +3524,7 @@ struct ProtobufUnittest_TestMultipleExtensionRanges: ProtobufGeneratedMessage, P
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (42 <= protoFieldNumber && protoFieldNumber < 43) || (4143 <= protoFieldNumber && protoFieldNumber < 4244) || (65536 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -3586,7 +3586,7 @@ struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessage, Prot
   ///   The largest possible tag number is 2^28 - 1, since the wire format uses
   ///   three bits to communicate wire type.
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -3598,7 +3598,7 @@ struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessage, Prot
   }
 
   private var _bb: Int32? = nil
-  public var bb: Int32 {
+  var bb: Int32 {
     get {return _bb ?? 0}
     set {_bb = newValue}
   }
@@ -3609,7 +3609,7 @@ struct ProtobufUnittest_TestReallyLargeTagNumber: ProtobufGeneratedMessage, Prot
     return _bb = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3699,7 +3699,7 @@ struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage, Protobuf
     set {_storage.unknown = newValue}
   }
 
-  public var a: ProtobufUnittest_TestRecursiveMessage {
+  var a: ProtobufUnittest_TestRecursiveMessage {
     get {return _storage._a ?? ProtobufUnittest_TestRecursiveMessage()}
     set {_uniqueStorage()._a = newValue}
   }
@@ -3710,7 +3710,7 @@ struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage, Protobuf
     return _storage._a = nil
   }
 
-  public var i: Int32 {
+  var i: Int32 {
     get {return _storage._i ?? 0}
     set {_uniqueStorage()._i = newValue}
   }
@@ -3721,7 +3721,7 @@ struct ProtobufUnittest_TestRecursiveMessage: ProtobufGeneratedMessage, Protobuf
     return _storage._i = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3797,7 +3797,7 @@ struct ProtobufUnittest_TestMutualRecursionA: ProtobufGeneratedMessage, Protobuf
     set {_storage.unknown = newValue}
   }
 
-  public var bb: ProtobufUnittest_TestMutualRecursionB {
+  var bb: ProtobufUnittest_TestMutualRecursionB {
     get {return _storage._bb ?? ProtobufUnittest_TestMutualRecursionB()}
     set {_uniqueStorage()._bb = newValue}
   }
@@ -3808,7 +3808,7 @@ struct ProtobufUnittest_TestMutualRecursionA: ProtobufGeneratedMessage, Protobuf
     return _storage._bb = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3892,7 +3892,7 @@ struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage, Protobuf
     set {_storage.unknown = newValue}
   }
 
-  public var a: ProtobufUnittest_TestMutualRecursionA {
+  var a: ProtobufUnittest_TestMutualRecursionA {
     get {return _storage._a ?? ProtobufUnittest_TestMutualRecursionA()}
     set {_uniqueStorage()._a = newValue}
   }
@@ -3903,7 +3903,7 @@ struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage, Protobuf
     return _storage._a = nil
   }
 
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
@@ -3914,7 +3914,7 @@ struct ProtobufUnittest_TestMutualRecursionB: ProtobufGeneratedMessage, Protobuf
     return _storage._optionalInt32 = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4025,7 +4025,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -4036,7 +4036,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4073,7 +4073,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -4084,7 +4084,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4108,7 +4108,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
   }
 
   ///   NO_PROTO1
-  public var a: Int32 {
+  var a: Int32 {
     get {return _storage._a ?? 0}
     set {_uniqueStorage()._a = newValue}
   }
@@ -4119,7 +4119,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
     return _storage._a = nil
   }
 
-  public var foo: ProtobufUnittest_TestDupFieldNumber.Foo {
+  var foo: ProtobufUnittest_TestDupFieldNumber.Foo {
     get {return _storage._foo ?? ProtobufUnittest_TestDupFieldNumber.Foo()}
     set {_uniqueStorage()._foo = newValue}
   }
@@ -4130,7 +4130,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
     return _storage._foo = nil
   }
 
-  public var bar: ProtobufUnittest_TestDupFieldNumber.Bar {
+  var bar: ProtobufUnittest_TestDupFieldNumber.Bar {
     get {return _storage._bar ?? ProtobufUnittest_TestDupFieldNumber.Bar()}
     set {_uniqueStorage()._bar = newValue}
   }
@@ -4141,7 +4141,7 @@ struct ProtobufUnittest_TestDupFieldNumber: ProtobufGeneratedMessage, ProtobufPr
     return _storage._bar = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4217,7 +4217,7 @@ struct ProtobufUnittest_TestEagerMessage: ProtobufGeneratedMessage, ProtobufProt
     set {_storage.unknown = newValue}
   }
 
-  public var subMessage: ProtobufUnittest_TestAllTypes {
+  var subMessage: ProtobufUnittest_TestAllTypes {
     get {return _storage._subMessage ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._subMessage = newValue}
   }
@@ -4228,7 +4228,7 @@ struct ProtobufUnittest_TestEagerMessage: ProtobufGeneratedMessage, ProtobufProt
     return _storage._subMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4303,7 +4303,7 @@ struct ProtobufUnittest_TestLazyMessage: ProtobufGeneratedMessage, ProtobufProto
     set {_storage.unknown = newValue}
   }
 
-  public var subMessage: ProtobufUnittest_TestAllTypes {
+  var subMessage: ProtobufUnittest_TestAllTypes {
     get {return _storage._subMessage ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._subMessage = newValue}
   }
@@ -4314,7 +4314,7 @@ struct ProtobufUnittest_TestLazyMessage: ProtobufGeneratedMessage, ProtobufProto
     return _storage._subMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4405,11 +4405,11 @@ struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessage, Prot
 
     public var unknown = ProtobufUnknownStorage()
 
-    public var nestedmessageRepeatedInt32: [Int32] = []
+    var nestedmessageRepeatedInt32: [Int32] = []
 
-    public var nestedmessageRepeatedForeignmessage: [ProtobufUnittest_ForeignMessage] = []
+    var nestedmessageRepeatedForeignmessage: [ProtobufUnittest_ForeignMessage] = []
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4437,7 +4437,7 @@ struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessage, Prot
     }
   }
 
-  public var optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage {
+  var optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage {
     get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestNestedMessageHasBits.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -4448,7 +4448,7 @@ struct ProtobufUnittest_TestNestedMessageHasBits: ProtobufGeneratedMessage, Prot
     return _storage._optionalNestedMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4624,7 +4624,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     set {_storage.unknown = newValue}
   }
 
-  public var primitiveField: Int32 {
+  var primitiveField: Int32 {
     get {return _storage._primitiveField ?? 0}
     set {_uniqueStorage()._primitiveField = newValue}
   }
@@ -4635,7 +4635,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._primitiveField = nil
   }
 
-  public var stringField: String {
+  var stringField: String {
     get {return _storage._stringField ?? ""}
     set {_uniqueStorage()._stringField = newValue}
   }
@@ -4646,7 +4646,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._stringField = nil
   }
 
-  public var enumField: ProtobufUnittest_ForeignEnum {
+  var enumField: ProtobufUnittest_ForeignEnum {
     get {return _storage._enumField ?? ProtobufUnittest_ForeignEnum.foreignFoo}
     set {_uniqueStorage()._enumField = newValue}
   }
@@ -4657,7 +4657,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._enumField = nil
   }
 
-  public var messageField: ProtobufUnittest_ForeignMessage {
+  var messageField: ProtobufUnittest_ForeignMessage {
     get {return _storage._messageField ?? ProtobufUnittest_ForeignMessage()}
     set {_uniqueStorage()._messageField = newValue}
   }
@@ -4668,7 +4668,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._messageField = nil
   }
 
-  public var stringPieceField: String {
+  var stringPieceField: String {
     get {return _storage._stringPieceField ?? ""}
     set {_uniqueStorage()._stringPieceField = newValue}
   }
@@ -4679,7 +4679,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._stringPieceField = nil
   }
 
-  public var cordField: String {
+  var cordField: String {
     get {return _storage._cordField ?? ""}
     set {_uniqueStorage()._cordField = newValue}
   }
@@ -4690,37 +4690,37 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: ProtobufGeneratedMessage, Proto
     return _storage._cordField = nil
   }
 
-  public var repeatedPrimitiveField: [Int32] {
+  var repeatedPrimitiveField: [Int32] {
     get {return _storage._repeatedPrimitiveField}
     set {_uniqueStorage()._repeatedPrimitiveField = newValue}
   }
 
-  public var repeatedStringField: [String] {
+  var repeatedStringField: [String] {
     get {return _storage._repeatedStringField}
     set {_uniqueStorage()._repeatedStringField = newValue}
   }
 
-  public var repeatedEnumField: [ProtobufUnittest_ForeignEnum] {
+  var repeatedEnumField: [ProtobufUnittest_ForeignEnum] {
     get {return _storage._repeatedEnumField}
     set {_uniqueStorage()._repeatedEnumField = newValue}
   }
 
-  public var repeatedMessageField: [ProtobufUnittest_ForeignMessage] {
+  var repeatedMessageField: [ProtobufUnittest_ForeignMessage] {
     get {return _storage._repeatedMessageField}
     set {_uniqueStorage()._repeatedMessageField = newValue}
   }
 
-  public var repeatedStringPieceField: [String] {
+  var repeatedStringPieceField: [String] {
     get {return _storage._repeatedStringPieceField}
     set {_uniqueStorage()._repeatedStringPieceField = newValue}
   }
 
-  public var repeatedCordField: [String] {
+  var repeatedCordField: [String] {
     get {return _storage._repeatedCordField}
     set {_uniqueStorage()._repeatedCordField = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4847,7 +4847,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     public var unknown = ProtobufUnknownStorage()
 
     private var _oo: Int64? = nil
-    public var oo: Int64 {
+    var oo: Int64 {
       get {return _oo ?? 0}
       set {_oo = newValue}
     }
@@ -4862,7 +4862,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -4873,7 +4873,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
       return _bb = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4901,7 +4901,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     }
   }
 
-  public var myString: String {
+  var myString: String {
     get {return _storage._myString ?? ""}
     set {_uniqueStorage()._myString = newValue}
   }
@@ -4912,7 +4912,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     return _storage._myString = nil
   }
 
-  public var myInt: Int64 {
+  var myInt: Int64 {
     get {return _storage._myInt ?? 0}
     set {_uniqueStorage()._myInt = newValue}
   }
@@ -4923,7 +4923,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     return _storage._myInt = nil
   }
 
-  public var myFloat: Float {
+  var myFloat: Float {
     get {return _storage._myFloat ?? 0}
     set {_uniqueStorage()._myFloat = newValue}
   }
@@ -4934,7 +4934,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     return _storage._myFloat = nil
   }
 
-  public var optionalNestedMessage: ProtobufUnittest_TestFieldOrderings.NestedMessage {
+  var optionalNestedMessage: ProtobufUnittest_TestFieldOrderings.NestedMessage {
     get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestFieldOrderings.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -4945,7 +4945,7 @@ struct ProtobufUnittest_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufPr
     return _storage._optionalNestedMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -5270,7 +5270,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     set {_storage.unknown = newValue}
   }
 
-  public var escapedBytes: Data {
+  var escapedBytes: Data {
     get {return _storage._escapedBytes ?? Data(bytes: [0, 1, 7, 8, 12, 10, 13, 9, 11, 92, 39, 34, 254])}
     set {_uniqueStorage()._escapedBytes = newValue}
   }
@@ -5281,7 +5281,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._escapedBytes = nil
   }
 
-  public var largeUint32: UInt32 {
+  var largeUint32: UInt32 {
     get {return _storage._largeUint32 ?? 4294967295}
     set {_uniqueStorage()._largeUint32 = newValue}
   }
@@ -5292,7 +5292,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._largeUint32 = nil
   }
 
-  public var largeUint64: UInt64 {
+  var largeUint64: UInt64 {
     get {return _storage._largeUint64 ?? 18446744073709551615}
     set {_uniqueStorage()._largeUint64 = newValue}
   }
@@ -5303,7 +5303,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._largeUint64 = nil
   }
 
-  public var smallInt32: Int32 {
+  var smallInt32: Int32 {
     get {return _storage._smallInt32 ?? -2147483647}
     set {_uniqueStorage()._smallInt32 = newValue}
   }
@@ -5314,7 +5314,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._smallInt32 = nil
   }
 
-  public var smallInt64: Int64 {
+  var smallInt64: Int64 {
     get {return _storage._smallInt64 ?? -9223372036854775807}
     set {_uniqueStorage()._smallInt64 = newValue}
   }
@@ -5325,7 +5325,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._smallInt64 = nil
   }
 
-  public var reallySmallInt32: Int32 {
+  var reallySmallInt32: Int32 {
     get {return _storage._reallySmallInt32 ?? -2147483648}
     set {_uniqueStorage()._reallySmallInt32 = newValue}
   }
@@ -5336,7 +5336,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._reallySmallInt32 = nil
   }
 
-  public var reallySmallInt64: Int64 {
+  var reallySmallInt64: Int64 {
     get {return _storage._reallySmallInt64 ?? -9223372036854775808}
     set {_uniqueStorage()._reallySmallInt64 = newValue}
   }
@@ -5350,7 +5350,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   ///   The default value here is UTF-8 for "\u1234".  (We could also just type
   ///   the UTF-8 text directly into this text file rather than escape it, but
   ///   lots of people use editors that would be confused by this.)
-  public var utf8String: String {
+  var utf8String: String {
     get {return _storage._utf8String ?? "ሴ"}
     set {_uniqueStorage()._utf8String = newValue}
   }
@@ -5362,7 +5362,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   }
 
   ///   Tests for single-precision floating-point values.
-  public var zeroFloat: Float {
+  var zeroFloat: Float {
     get {return _storage._zeroFloat ?? 0}
     set {_uniqueStorage()._zeroFloat = newValue}
   }
@@ -5373,7 +5373,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._zeroFloat = nil
   }
 
-  public var oneFloat: Float {
+  var oneFloat: Float {
     get {return _storage._oneFloat ?? 1}
     set {_uniqueStorage()._oneFloat = newValue}
   }
@@ -5384,7 +5384,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._oneFloat = nil
   }
 
-  public var smallFloat: Float {
+  var smallFloat: Float {
     get {return _storage._smallFloat ?? 1.5}
     set {_uniqueStorage()._smallFloat = newValue}
   }
@@ -5395,7 +5395,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._smallFloat = nil
   }
 
-  public var negativeOneFloat: Float {
+  var negativeOneFloat: Float {
     get {return _storage._negativeOneFloat ?? -1}
     set {_uniqueStorage()._negativeOneFloat = newValue}
   }
@@ -5406,7 +5406,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._negativeOneFloat = nil
   }
 
-  public var negativeFloat: Float {
+  var negativeFloat: Float {
     get {return _storage._negativeFloat ?? -1.5}
     set {_uniqueStorage()._negativeFloat = newValue}
   }
@@ -5418,7 +5418,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   }
 
   ///   Using exponents
-  public var largeFloat: Float {
+  var largeFloat: Float {
     get {return _storage._largeFloat ?? 2e+08}
     set {_uniqueStorage()._largeFloat = newValue}
   }
@@ -5429,7 +5429,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._largeFloat = nil
   }
 
-  public var smallNegativeFloat: Float {
+  var smallNegativeFloat: Float {
     get {return _storage._smallNegativeFloat ?? -8e-28}
     set {_uniqueStorage()._smallNegativeFloat = newValue}
   }
@@ -5441,7 +5441,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   }
 
   ///   Text for nonfinite floating-point values.
-  public var infDouble: Double {
+  var infDouble: Double {
     get {return _storage._infDouble ?? Double.infinity}
     set {_uniqueStorage()._infDouble = newValue}
   }
@@ -5452,7 +5452,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._infDouble = nil
   }
 
-  public var negInfDouble: Double {
+  var negInfDouble: Double {
     get {return _storage._negInfDouble ?? -Double.infinity}
     set {_uniqueStorage()._negInfDouble = newValue}
   }
@@ -5463,7 +5463,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._negInfDouble = nil
   }
 
-  public var nanDouble: Double {
+  var nanDouble: Double {
     get {return _storage._nanDouble ?? Double.nan}
     set {_uniqueStorage()._nanDouble = newValue}
   }
@@ -5474,7 +5474,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._nanDouble = nil
   }
 
-  public var infFloat: Float {
+  var infFloat: Float {
     get {return _storage._infFloat ?? Float.infinity}
     set {_uniqueStorage()._infFloat = newValue}
   }
@@ -5485,7 +5485,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._infFloat = nil
   }
 
-  public var negInfFloat: Float {
+  var negInfFloat: Float {
     get {return _storage._negInfFloat ?? -Float.infinity}
     set {_uniqueStorage()._negInfFloat = newValue}
   }
@@ -5496,7 +5496,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._negInfFloat = nil
   }
 
-  public var nanFloat: Float {
+  var nanFloat: Float {
     get {return _storage._nanFloat ?? Float.nan}
     set {_uniqueStorage()._nanFloat = newValue}
   }
@@ -5512,7 +5512,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   ///   escaped for other languages.
   ///   Note that in .proto file, "\?" is a valid way to escape ? in string
   ///   literals.
-  public var cppTrigraph: String {
+  var cppTrigraph: String {
     get {return _storage._cppTrigraph ?? "? ? ?? ?? ??? ??/ ??-"}
     set {_uniqueStorage()._cppTrigraph = newValue}
   }
@@ -5524,7 +5524,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
   }
 
   ///   String defaults containing the character '\000'
-  public var stringWithZero: String {
+  var stringWithZero: String {
     get {return _storage._stringWithZero ?? "hel\0lo"}
     set {_uniqueStorage()._stringWithZero = newValue}
   }
@@ -5535,7 +5535,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._stringWithZero = nil
   }
 
-  public var bytesWithZero: Data {
+  var bytesWithZero: Data {
     get {return _storage._bytesWithZero ?? Data(bytes: [119, 111, 114, 0, 108, 100])}
     set {_uniqueStorage()._bytesWithZero = newValue}
   }
@@ -5546,7 +5546,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._bytesWithZero = nil
   }
 
-  public var stringPieceWithZero: String {
+  var stringPieceWithZero: String {
     get {return _storage._stringPieceWithZero ?? "ab\0c"}
     set {_uniqueStorage()._stringPieceWithZero = newValue}
   }
@@ -5557,7 +5557,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._stringPieceWithZero = nil
   }
 
-  public var cordWithZero: String {
+  var cordWithZero: String {
     get {return _storage._cordWithZero ?? "12\03"}
     set {_uniqueStorage()._cordWithZero = newValue}
   }
@@ -5568,7 +5568,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._cordWithZero = nil
   }
 
-  public var replacementString: String {
+  var replacementString: String {
     get {return _storage._replacementString ?? "${unknown}"}
     set {_uniqueStorage()._replacementString = newValue}
   }
@@ -5579,7 +5579,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: ProtobufGeneratedMessage, Prot
     return _storage._replacementString = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -5615,7 +5615,7 @@ struct ProtobufUnittest_SparseEnumMessage: ProtobufGeneratedMessage, ProtobufPro
   public var unknown = ProtobufUnknownStorage()
 
   private var _sparseEnum: ProtobufUnittest_TestSparseEnum? = nil
-  public var sparseEnum: ProtobufUnittest_TestSparseEnum {
+  var sparseEnum: ProtobufUnittest_TestSparseEnum {
     get {return _sparseEnum ?? ProtobufUnittest_TestSparseEnum.sparseA}
     set {_sparseEnum = newValue}
   }
@@ -5626,7 +5626,7 @@ struct ProtobufUnittest_SparseEnumMessage: ProtobufGeneratedMessage, ProtobufPro
     return _sparseEnum = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5664,7 +5664,7 @@ struct ProtobufUnittest_OneString: ProtobufGeneratedMessage, ProtobufProto2Messa
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: String? = nil
-  public var data: String {
+  var data: String {
     get {return _data ?? ""}
     set {_data = newValue}
   }
@@ -5675,7 +5675,7 @@ struct ProtobufUnittest_OneString: ProtobufGeneratedMessage, ProtobufProto2Messa
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5711,9 +5711,9 @@ struct ProtobufUnittest_MoreString: ProtobufGeneratedMessage, ProtobufProto2Mess
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var data: [String] = []
+  var data: [String] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5750,7 +5750,7 @@ struct ProtobufUnittest_OneBytes: ProtobufGeneratedMessage, ProtobufProto2Messag
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: Data? = nil
-  public var data: Data {
+  var data: Data {
     get {return _data ?? Data()}
     set {_data = newValue}
   }
@@ -5761,7 +5761,7 @@ struct ProtobufUnittest_OneBytes: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5797,9 +5797,9 @@ struct ProtobufUnittest_MoreBytes: ProtobufGeneratedMessage, ProtobufProto2Messa
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var data: [Data] = []
+  var data: [Data] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5837,7 +5837,7 @@ struct ProtobufUnittest_Int32Message: ProtobufGeneratedMessage, ProtobufProto2Me
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: Int32? = nil
-  public var data: Int32 {
+  var data: Int32 {
     get {return _data ?? 0}
     set {_data = newValue}
   }
@@ -5848,7 +5848,7 @@ struct ProtobufUnittest_Int32Message: ProtobufGeneratedMessage, ProtobufProto2Me
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5885,7 +5885,7 @@ struct ProtobufUnittest_Uint32Message: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: UInt32? = nil
-  public var data: UInt32 {
+  var data: UInt32 {
     get {return _data ?? 0}
     set {_data = newValue}
   }
@@ -5896,7 +5896,7 @@ struct ProtobufUnittest_Uint32Message: ProtobufGeneratedMessage, ProtobufProto2M
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5933,7 +5933,7 @@ struct ProtobufUnittest_Int64Message: ProtobufGeneratedMessage, ProtobufProto2Me
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: Int64? = nil
-  public var data: Int64 {
+  var data: Int64 {
     get {return _data ?? 0}
     set {_data = newValue}
   }
@@ -5944,7 +5944,7 @@ struct ProtobufUnittest_Int64Message: ProtobufGeneratedMessage, ProtobufProto2Me
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -5981,7 +5981,7 @@ struct ProtobufUnittest_Uint64Message: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: UInt64? = nil
-  public var data: UInt64 {
+  var data: UInt64 {
     get {return _data ?? 0}
     set {_data = newValue}
   }
@@ -5992,7 +5992,7 @@ struct ProtobufUnittest_Uint64Message: ProtobufGeneratedMessage, ProtobufProto2M
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -6029,7 +6029,7 @@ struct ProtobufUnittest_BoolMessage: ProtobufGeneratedMessage, ProtobufProto2Mes
   public var unknown = ProtobufUnknownStorage()
 
   private var _data: Bool? = nil
-  public var data: Bool {
+  var data: Bool {
     get {return _data ?? false}
     set {_data = newValue}
   }
@@ -6040,7 +6040,7 @@ struct ProtobufUnittest_BoolMessage: ProtobufGeneratedMessage, ProtobufProto2Mes
     return _data = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -6210,7 +6210,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -6222,7 +6222,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
 
     private var _b: String? = nil
-    public var b: String {
+    var b: String {
       get {return _b ?? ""}
       set {_b = newValue}
     }
@@ -6233,7 +6233,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
       return _b = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6261,7 +6261,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
   }
 
-  public var fooInt: Int32 {
+  var fooInt: Int32 {
     get {
       if case .fooInt(let v) = _storage._foo {
         return v
@@ -6273,7 +6273,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
   }
 
-  public var fooString: String {
+  var fooString: String {
     get {
       if case .fooString(let v) = _storage._foo {
         return v
@@ -6285,7 +6285,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
   }
 
-  public var fooMessage: ProtobufUnittest_TestAllTypes {
+  var fooMessage: ProtobufUnittest_TestAllTypes {
     get {
       if case .fooMessage(let v) = _storage._foo {
         return v
@@ -6297,7 +6297,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
   }
 
-  public var fooGroup: ProtobufUnittest_TestOneof.FooGroup {
+  var fooGroup: ProtobufUnittest_TestOneof.FooGroup {
     get {
       if case .fooGroup(let v) = _storage._foo {
         return v
@@ -6316,7 +6316,7 @@ struct ProtobufUnittest_TestOneof: ProtobufGeneratedMessage, ProtobufProto2Messa
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -6434,7 +6434,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -6446,7 +6446,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     }
 
     private var _b: String? = nil
-    public var b: String {
+    var b: String {
       get {return _b ?? ""}
       set {_b = newValue}
     }
@@ -6457,7 +6457,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
       return _b = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6485,7 +6485,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     }
   }
 
-  public var fooInt: Int32 {
+  var fooInt: Int32 {
     get {return _storage._fooInt ?? 0}
     set {_uniqueStorage()._fooInt = newValue}
   }
@@ -6496,7 +6496,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     return _storage._fooInt = nil
   }
 
-  public var fooString: String {
+  var fooString: String {
     get {return _storage._fooString ?? ""}
     set {_uniqueStorage()._fooString = newValue}
   }
@@ -6507,7 +6507,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     return _storage._fooString = nil
   }
 
-  public var fooMessage: ProtobufUnittest_TestAllTypes {
+  var fooMessage: ProtobufUnittest_TestAllTypes {
     get {return _storage._fooMessage ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._fooMessage = newValue}
   }
@@ -6518,7 +6518,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     return _storage._fooMessage = nil
   }
 
-  public var fooGroup: ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup {
+  var fooGroup: ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup {
     get {return _storage._fooGroup ?? ProtobufUnittest_TestOneofBackwardsCompatible.FooGroup()}
     set {_uniqueStorage()._fooGroup = newValue}
   }
@@ -6529,7 +6529,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: ProtobufGeneratedMessage, 
     return _storage._fooGroup = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -6877,16 +6877,16 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       case 2: self = .bar
@@ -6895,7 +6895,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -6904,7 +6904,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -6913,7 +6913,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -6922,7 +6922,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -6932,7 +6932,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -6942,9 +6942,9 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -6972,7 +6972,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -6984,7 +6984,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
 
     private var _b: String? = nil
-    public var b: String {
+    var b: String {
       get {return _b ?? ""}
       set {_b = newValue}
     }
@@ -6995,7 +6995,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       return _b = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7039,7 +7039,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     public var unknown = ProtobufUnknownStorage()
 
     private var _quxInt: Int64? = nil
-    public var quxInt: Int64 {
+    var quxInt: Int64 {
       get {return _quxInt ?? 0}
       set {_quxInt = newValue}
     }
@@ -7050,9 +7050,9 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
       return _quxInt = nil
     }
 
-    public var corgeInt: [Int32] = []
+    var corgeInt: [Int32] = []
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7080,7 +7080,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooInt: Int32 {
+  var fooInt: Int32 {
     get {
       if case .fooInt(let v) = _storage._foo {
         return v
@@ -7092,7 +7092,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooString: String {
+  var fooString: String {
     get {
       if case .fooString(let v) = _storage._foo {
         return v
@@ -7104,7 +7104,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooCord: String {
+  var fooCord: String {
     get {
       if case .fooCord(let v) = _storage._foo {
         return v
@@ -7116,7 +7116,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooStringPiece: String {
+  var fooStringPiece: String {
     get {
       if case .fooStringPiece(let v) = _storage._foo {
         return v
@@ -7128,7 +7128,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooBytes: Data {
+  var fooBytes: Data {
     get {
       if case .fooBytes(let v) = _storage._foo {
         return v
@@ -7140,7 +7140,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooEnum: ProtobufUnittest_TestOneof2.NestedEnum {
+  var fooEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
       if case .fooEnum(let v) = _storage._foo {
         return v
@@ -7152,7 +7152,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooMessage: ProtobufUnittest_TestOneof2.NestedMessage {
+  var fooMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
       if case .fooMessage(let v) = _storage._foo {
         return v
@@ -7164,7 +7164,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooGroup: ProtobufUnittest_TestOneof2.FooGroup {
+  var fooGroup: ProtobufUnittest_TestOneof2.FooGroup {
     get {
       if case .fooGroup(let v) = _storage._foo {
         return v
@@ -7176,7 +7176,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var fooLazyMessage: ProtobufUnittest_TestOneof2.NestedMessage {
+  var fooLazyMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
       if case .fooLazyMessage(let v) = _storage._foo {
         return v
@@ -7188,7 +7188,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barInt: Int32 {
+  var barInt: Int32 {
     get {
       if case .barInt(let v) = _storage._bar {
         return v
@@ -7200,7 +7200,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barString: String {
+  var barString: String {
     get {
       if case .barString(let v) = _storage._bar {
         return v
@@ -7212,7 +7212,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barCord: String {
+  var barCord: String {
     get {
       if case .barCord(let v) = _storage._bar {
         return v
@@ -7224,7 +7224,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barStringPiece: String {
+  var barStringPiece: String {
     get {
       if case .barStringPiece(let v) = _storage._bar {
         return v
@@ -7236,7 +7236,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barBytes: Data {
+  var barBytes: Data {
     get {
       if case .barBytes(let v) = _storage._bar {
         return v
@@ -7248,7 +7248,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var barEnum: ProtobufUnittest_TestOneof2.NestedEnum {
+  var barEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
       if case .barEnum(let v) = _storage._bar {
         return v
@@ -7260,7 +7260,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public var bazInt: Int32 {
+  var bazInt: Int32 {
     get {return _storage._bazInt ?? 0}
     set {_uniqueStorage()._bazInt = newValue}
   }
@@ -7271,7 +7271,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     return _storage._bazInt = nil
   }
 
-  public var bazString: String {
+  var bazString: String {
     get {return _storage._bazString ?? "BAZ"}
     set {_uniqueStorage()._bazString = newValue}
   }
@@ -7296,7 +7296,7 @@ struct ProtobufUnittest_TestOneof2: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -7449,7 +7449,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
     public var unknown = ProtobufUnknownStorage()
 
     private var _requiredDouble: Double? = nil
-    public var requiredDouble: Double {
+    var requiredDouble: Double {
       get {return _requiredDouble ?? 0}
       set {_requiredDouble = newValue}
     }
@@ -7460,7 +7460,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
       return _requiredDouble = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7481,7 +7481,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
     }
   }
 
-  public var fooInt: Int32 {
+  var fooInt: Int32 {
     get {
       if case .fooInt(let v) = _storage._foo {
         return v
@@ -7493,7 +7493,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
     }
   }
 
-  public var fooString: String {
+  var fooString: String {
     get {
       if case .fooString(let v) = _storage._foo {
         return v
@@ -7505,7 +7505,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
     }
   }
 
-  public var fooMessage: ProtobufUnittest_TestRequiredOneof.NestedMessage {
+  var fooMessage: ProtobufUnittest_TestRequiredOneof.NestedMessage {
     get {
       if case .fooMessage(let v) = _storage._foo {
         return v
@@ -7524,7 +7524,7 @@ struct ProtobufUnittest_TestRequiredOneof: ProtobufGeneratedMessage, ProtobufPro
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -7587,35 +7587,35 @@ struct ProtobufUnittest_TestPackedTypes: ProtobufGeneratedMessage, ProtobufProto
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var packedInt32: [Int32] = []
+  var packedInt32: [Int32] = []
 
-  public var packedInt64: [Int64] = []
+  var packedInt64: [Int64] = []
 
-  public var packedUint32: [UInt32] = []
+  var packedUint32: [UInt32] = []
 
-  public var packedUint64: [UInt64] = []
+  var packedUint64: [UInt64] = []
 
-  public var packedSint32: [Int32] = []
+  var packedSint32: [Int32] = []
 
-  public var packedSint64: [Int64] = []
+  var packedSint64: [Int64] = []
 
-  public var packedFixed32: [UInt32] = []
+  var packedFixed32: [UInt32] = []
 
-  public var packedFixed64: [UInt64] = []
+  var packedFixed64: [UInt64] = []
 
-  public var packedSfixed32: [Int32] = []
+  var packedSfixed32: [Int32] = []
 
-  public var packedSfixed64: [Int64] = []
+  var packedSfixed64: [Int64] = []
 
-  public var packedFloat: [Float] = []
+  var packedFloat: [Float] = []
 
-  public var packedDouble: [Double] = []
+  var packedDouble: [Double] = []
 
-  public var packedBool: [Bool] = []
+  var packedBool: [Bool] = []
 
-  public var packedEnum: [ProtobufUnittest_ForeignEnum] = []
+  var packedEnum: [ProtobufUnittest_ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -7744,35 +7744,35 @@ struct ProtobufUnittest_TestUnpackedTypes: ProtobufGeneratedMessage, ProtobufPro
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var unpackedInt32: [Int32] = []
+  var unpackedInt32: [Int32] = []
 
-  public var unpackedInt64: [Int64] = []
+  var unpackedInt64: [Int64] = []
 
-  public var unpackedUint32: [UInt32] = []
+  var unpackedUint32: [UInt32] = []
 
-  public var unpackedUint64: [UInt64] = []
+  var unpackedUint64: [UInt64] = []
 
-  public var unpackedSint32: [Int32] = []
+  var unpackedSint32: [Int32] = []
 
-  public var unpackedSint64: [Int64] = []
+  var unpackedSint64: [Int64] = []
 
-  public var unpackedFixed32: [UInt32] = []
+  var unpackedFixed32: [UInt32] = []
 
-  public var unpackedFixed64: [UInt64] = []
+  var unpackedFixed64: [UInt64] = []
 
-  public var unpackedSfixed32: [Int32] = []
+  var unpackedSfixed32: [Int32] = []
 
-  public var unpackedSfixed64: [Int64] = []
+  var unpackedSfixed64: [Int64] = []
 
-  public var unpackedFloat: [Float] = []
+  var unpackedFloat: [Float] = []
 
-  public var unpackedDouble: [Double] = []
+  var unpackedDouble: [Double] = []
 
-  public var unpackedBool: [Bool] = []
+  var unpackedBool: [Bool] = []
 
-  public var unpackedEnum: [ProtobufUnittest_ForeignEnum] = []
+  var unpackedEnum: [ProtobufUnittest_ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -7869,7 +7869,7 @@ struct ProtobufUnittest_TestPackedExtensions: ProtobufGeneratedMessage, Protobuf
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -7919,7 +7919,7 @@ struct ProtobufUnittest_TestUnpackedExtensions: ProtobufGeneratedMessage, Protob
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -8071,16 +8071,16 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
   }
 
   enum DynamicEnumType: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case dynamicFoo // = 2200
     case dynamicBar // = 2201
     case dynamicBaz // = 2202
 
-    public init() {
+    init() {
       self = .dynamicFoo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 2200: self = .dynamicFoo
       case 2201: self = .dynamicBar
@@ -8089,7 +8089,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "dynamicFoo": self = .dynamicFoo
       case "dynamicBar": self = .dynamicBar
@@ -8098,7 +8098,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "DYNAMIC_FOO": self = .dynamicFoo
       case "DYNAMIC_BAR": self = .dynamicBar
@@ -8107,7 +8107,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "DYNAMIC_FOO": self = .dynamicFoo
       case "DYNAMIC_BAR": self = .dynamicBar
@@ -8116,7 +8116,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .dynamicFoo: return 2200
@@ -8126,7 +8126,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .dynamicFoo: return "\"DYNAMIC_FOO\""
@@ -8136,9 +8136,9 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .dynamicFoo: return ".dynamicFoo"
@@ -8164,7 +8164,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     public var unknown = ProtobufUnknownStorage()
 
     private var _dynamicField: Int32? = nil
-    public var dynamicField: Int32 {
+    var dynamicField: Int32 {
       get {return _dynamicField ?? 0}
       set {_dynamicField = newValue}
     }
@@ -8175,7 +8175,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
       return _dynamicField = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8198,7 +8198,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     }
   }
 
-  public var scalarExtension: UInt32 {
+  var scalarExtension: UInt32 {
     get {return _storage._scalarExtension ?? 0}
     set {_uniqueStorage()._scalarExtension = newValue}
   }
@@ -8209,7 +8209,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     return _storage._scalarExtension = nil
   }
 
-  public var enumExtension: ProtobufUnittest_ForeignEnum {
+  var enumExtension: ProtobufUnittest_ForeignEnum {
     get {return _storage._enumExtension ?? ProtobufUnittest_ForeignEnum.foreignFoo}
     set {_uniqueStorage()._enumExtension = newValue}
   }
@@ -8220,7 +8220,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     return _storage._enumExtension = nil
   }
 
-  public var dynamicEnumExtension: ProtobufUnittest_TestDynamicExtensions.DynamicEnumType {
+  var dynamicEnumExtension: ProtobufUnittest_TestDynamicExtensions.DynamicEnumType {
     get {return _storage._dynamicEnumExtension ?? ProtobufUnittest_TestDynamicExtensions.DynamicEnumType.dynamicFoo}
     set {_uniqueStorage()._dynamicEnumExtension = newValue}
   }
@@ -8231,7 +8231,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     return _storage._dynamicEnumExtension = nil
   }
 
-  public var messageExtension: ProtobufUnittest_ForeignMessage {
+  var messageExtension: ProtobufUnittest_ForeignMessage {
     get {return _storage._messageExtension ?? ProtobufUnittest_ForeignMessage()}
     set {_uniqueStorage()._messageExtension = newValue}
   }
@@ -8242,7 +8242,7 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     return _storage._messageExtension = nil
   }
 
-  public var dynamicMessageExtension: ProtobufUnittest_TestDynamicExtensions.DynamicMessageType {
+  var dynamicMessageExtension: ProtobufUnittest_TestDynamicExtensions.DynamicMessageType {
     get {return _storage._dynamicMessageExtension ?? ProtobufUnittest_TestDynamicExtensions.DynamicMessageType()}
     set {_uniqueStorage()._dynamicMessageExtension = newValue}
   }
@@ -8253,17 +8253,17 @@ struct ProtobufUnittest_TestDynamicExtensions: ProtobufGeneratedMessage, Protobu
     return _storage._dynamicMessageExtension = nil
   }
 
-  public var repeatedExtension: [String] {
+  var repeatedExtension: [String] {
     get {return _storage._repeatedExtension}
     set {_uniqueStorage()._repeatedExtension = newValue}
   }
 
-  public var packedExtension: [Int32] {
+  var packedExtension: [Int32] {
     get {return _storage._packedExtension}
     set {_uniqueStorage()._packedExtension = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -8311,22 +8311,22 @@ struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMe
   ///   Parsing repeated fixed size values used to fail. This message needs to be
   ///   used in order to get a tag of the right size; all of the repeated fields
   ///   in TestAllTypes didn't trigger the check.
-  public var repeatedFixed32: [UInt32] = []
+  var repeatedFixed32: [UInt32] = []
 
   ///   Check for a varint type, just for good measure.
-  public var repeatedInt32: [Int32] = []
+  var repeatedInt32: [Int32] = []
 
   ///   These have two-byte tags.
-  public var repeatedFixed64: [UInt64] = []
+  var repeatedFixed64: [UInt64] = []
 
-  public var repeatedInt64: [Int64] = []
+  var repeatedInt64: [Int64] = []
 
   ///   Three byte tags.
-  public var repeatedFloat: [Float] = []
+  var repeatedFloat: [Float] = []
 
-  public var repeatedUint64: [UInt64] = []
+  var repeatedUint64: [UInt64] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -8554,7 +8554,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
         set {_storage.unknown = newValue}
       }
 
-      public var field1: ProtobufUnittest_TestAllTypes {
+      var field1: ProtobufUnittest_TestAllTypes {
         get {return _storage._field1 ?? ProtobufUnittest_TestAllTypes()}
         set {_uniqueStorage()._field1 = newValue}
       }
@@ -8565,7 +8565,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
         return _storage._field1 = nil
       }
 
-      public init() {}
+      init() {}
 
       public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
         try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -8640,7 +8640,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
         set {_storage.unknown = newValue}
       }
 
-      public var field1: ProtobufUnittest_TestAllTypes {
+      var field1: ProtobufUnittest_TestAllTypes {
         get {return _storage._field1 ?? ProtobufUnittest_TestAllTypes()}
         set {_uniqueStorage()._field1 = newValue}
       }
@@ -8651,7 +8651,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
         return _storage._field1 = nil
       }
 
-      public init() {}
+      init() {}
 
       public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
         try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -8673,21 +8673,21 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var field1: [ProtobufUnittest_TestAllTypes] = []
+    var field1: [ProtobufUnittest_TestAllTypes] = []
 
-    public var field2: [ProtobufUnittest_TestAllTypes] = []
+    var field2: [ProtobufUnittest_TestAllTypes] = []
 
-    public var field3: [ProtobufUnittest_TestAllTypes] = []
+    var field3: [ProtobufUnittest_TestAllTypes] = []
 
-    public var group1: [ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1] = []
+    var group1: [ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1] = []
 
-    public var group2: [ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2] = []
+    var group2: [ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2] = []
 
-    public var ext1: [ProtobufUnittest_TestAllTypes] = []
+    var ext1: [ProtobufUnittest_TestAllTypes] = []
 
-    public var ext2: [ProtobufUnittest_TestAllTypes] = []
+    var ext2: [ProtobufUnittest_TestAllTypes] = []
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8793,7 +8793,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
       set {_storage.unknown = newValue}
     }
 
-    public var optionalGroupAllTypes: ProtobufUnittest_TestAllTypes {
+    var optionalGroupAllTypes: ProtobufUnittest_TestAllTypes {
       get {return _storage._optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
       set {_uniqueStorage()._optionalGroupAllTypes = newValue}
     }
@@ -8804,7 +8804,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
       return _storage._optionalGroupAllTypes = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -8879,7 +8879,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
       set {_storage.unknown = newValue}
     }
 
-    public var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes {
+    var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes {
       get {return _storage._repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypes()}
       set {_uniqueStorage()._repeatedGroupAllTypes = newValue}
     }
@@ -8890,7 +8890,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
       return _storage._repeatedGroupAllTypes = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -8919,7 +8919,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
     static let ProtobufUnittest_TestParsingMerge_repeatedExt = ProtobufGenericMessageExtension<ProtobufRepeatedMessageField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(protoFieldNumber: 1001, protoFieldName: "repeated_ext", jsonFieldName: "repeatedExt", swiftFieldName: "ProtobufUnittest_TestParsingMerge_repeatedExt", defaultValue: [])
   }
 
-  public var requiredAllTypes: ProtobufUnittest_TestAllTypes {
+  var requiredAllTypes: ProtobufUnittest_TestAllTypes {
     get {return _storage._requiredAllTypes ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._requiredAllTypes = newValue}
   }
@@ -8930,7 +8930,7 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
     return _storage._requiredAllTypes = nil
   }
 
-  public var optionalAllTypes: ProtobufUnittest_TestAllTypes {
+  var optionalAllTypes: ProtobufUnittest_TestAllTypes {
     get {return _storage._optionalAllTypes ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._optionalAllTypes = newValue}
   }
@@ -8941,12 +8941,12 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalAllTypes = nil
   }
 
-  public var repeatedAllTypes: [ProtobufUnittest_TestAllTypes] {
+  var repeatedAllTypes: [ProtobufUnittest_TestAllTypes] {
     get {return _storage._repeatedAllTypes}
     set {_uniqueStorage()._repeatedAllTypes = newValue}
   }
 
-  public var optionalGroup: ProtobufUnittest_TestParsingMerge.OptionalGroup {
+  var optionalGroup: ProtobufUnittest_TestParsingMerge.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittest_TestParsingMerge.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -8957,12 +8957,12 @@ struct ProtobufUnittest_TestParsingMerge: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalGroup = nil
   }
 
-  public var repeatedGroup: [ProtobufUnittest_TestParsingMerge.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittest_TestParsingMerge.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -9015,7 +9015,7 @@ struct ProtobufUnittest_TestCommentInjectionMessage: ProtobufGeneratedMessage, P
 
   ///   */ <- This should not close the generated doc comment
   private var _a: String? = nil
-  public var a: String {
+  var a: String {
     get {return _a ?? "*/ <- Neither should this."}
     set {_a = newValue}
   }
@@ -9026,7 +9026,7 @@ struct ProtobufUnittest_TestCommentInjectionMessage: ProtobufGeneratedMessage, P
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -9059,7 +9059,7 @@ struct ProtobufUnittest_FooRequest: ProtobufGeneratedMessage, ProtobufProto2Mess
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -9083,7 +9083,7 @@ struct ProtobufUnittest_FooResponse: ProtobufGeneratedMessage, ProtobufProto2Mes
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -9107,7 +9107,7 @@ struct ProtobufUnittest_FooClientMessage: ProtobufGeneratedMessage, ProtobufProt
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -9131,7 +9131,7 @@ struct ProtobufUnittest_FooServerMessage: ProtobufGeneratedMessage, ProtobufProt
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -9155,7 +9155,7 @@ struct ProtobufUnittest_BarRequest: ProtobufGeneratedMessage, ProtobufProto2Mess
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -9179,7 +9179,7 @@ struct ProtobufUnittest_BarResponse: ProtobufGeneratedMessage, ProtobufProto2Mes
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Tests/SwiftProtobufTests/unittest_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_arena.pb.swift
@@ -54,7 +54,7 @@ struct Proto2ArenaUnittest_NestedMessage: ProtobufGeneratedMessage, ProtobufProt
   public var unknown = ProtobufUnknownStorage()
 
   private var _d: Int32? = nil
-  public var d: Int32 {
+  var d: Int32 {
     get {return _d ?? 0}
     set {_d = newValue}
   }
@@ -65,7 +65,7 @@ struct Proto2ArenaUnittest_NestedMessage: ProtobufGeneratedMessage, ProtobufProt
     return _d = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -103,11 +103,11 @@ struct Proto2ArenaUnittest_ArenaMessage: ProtobufGeneratedMessage, ProtobufProto
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var repeatedNestedMessage: [Proto2ArenaUnittest_NestedMessage] = []
+  var repeatedNestedMessage: [Proto2ArenaUnittest_NestedMessage] = []
 
-  public var repeatedImportNoArenaMessage: [Proto2ArenaUnittest_ImportNoArenaNestedMessage] = []
+  var repeatedImportNoArenaMessage: [Proto2ArenaUnittest_ImportNoArenaNestedMessage] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -47,15 +47,15 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case val1 // = 1
   case val2 // = 2
 
-  public init() {
+  init() {
     self = .val1
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .val1
     case 2: self = .val2
@@ -63,7 +63,7 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "val1": self = .val1
     case "val2": self = .val2
@@ -71,7 +71,7 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "METHODOPT1_VAL1": self = .val1
     case "METHODOPT1_VAL2": self = .val2
@@ -79,7 +79,7 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "METHODOPT1_VAL1": self = .val1
     case "METHODOPT1_VAL2": self = .val2
@@ -87,7 +87,7 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .val1: return 1
@@ -96,7 +96,7 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .val1: return "\"METHODOPT1_VAL1\""
@@ -105,9 +105,9 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .val1: return ".val1"
@@ -119,42 +119,42 @@ enum ProtobufUnittest_MethodOpt1: ProtobufEnum {
 }
 
 enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case value // = 1
 
-  public init() {
+  init() {
     self = .value
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .value
     default: return nil
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "value": self = .value
     default: return nil
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "VALUE": self = .value
     default: return nil
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "VALUE": self = .value
     default: return nil
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .value: return 1
@@ -162,7 +162,7 @@ enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .value: return "\"VALUE\""
@@ -170,9 +170,9 @@ enum ProtobufUnittest_AggregateEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .value: return ".value"
@@ -240,15 +240,15 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
   }
 
   enum AnEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case val1 // = 1
     case val2 // = 2
 
-    public init() {
+    init() {
       self = .val1
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .val1
       case 2: self = .val2
@@ -256,7 +256,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "val1": self = .val1
       case "val2": self = .val2
@@ -264,7 +264,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ANENUM_VAL1": self = .val1
       case "ANENUM_VAL2": self = .val2
@@ -272,7 +272,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ANENUM_VAL1": self = .val1
       case "ANENUM_VAL2": self = .val2
@@ -280,7 +280,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .val1: return 1
@@ -289,7 +289,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .val1: return "\"ANENUM_VAL1\""
@@ -298,9 +298,9 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .val1: return ".val1"
@@ -312,7 +312,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
   }
 
   private var _field1: String? = nil
-  public var field1: String {
+  var field1: String {
     get {return _field1 ?? ""}
     set {_field1 = newValue}
   }
@@ -323,7 +323,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
     return _field1 = nil
   }
 
-  public var oneofField: Int32 {
+  var oneofField: Int32 {
     get {
       if case .oneofField(let v) = anOneof {
         return v
@@ -337,7 +337,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: ProtobufGeneratedMessage, 
 
   public var anOneof: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof = .None
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -374,7 +374,7 @@ struct ProtobufUnittest_CustomOptionFooRequest: ProtobufGeneratedMessage, Protob
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -398,7 +398,7 @@ struct ProtobufUnittest_CustomOptionFooResponse: ProtobufGeneratedMessage, Proto
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -422,7 +422,7 @@ struct ProtobufUnittest_CustomOptionFooClientMessage: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -446,7 +446,7 @@ struct ProtobufUnittest_CustomOptionFooServerMessage: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -473,15 +473,15 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
   public var unknown = ProtobufUnknownStorage()
 
   enum TestEnumType: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case testOptionEnumType1 // = 22
     case testOptionEnumType2 // = -23
 
-    public init() {
+    init() {
       self = .testOptionEnumType1
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 22: self = .testOptionEnumType1
       case -23: self = .testOptionEnumType2
@@ -489,7 +489,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "testOptionEnumType1": self = .testOptionEnumType1
       case "testOptionEnumType2": self = .testOptionEnumType2
@@ -497,7 +497,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "TEST_OPTION_ENUM_TYPE1": self = .testOptionEnumType1
       case "TEST_OPTION_ENUM_TYPE2": self = .testOptionEnumType2
@@ -505,7 +505,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "TEST_OPTION_ENUM_TYPE1": self = .testOptionEnumType1
       case "TEST_OPTION_ENUM_TYPE2": self = .testOptionEnumType2
@@ -513,7 +513,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .testOptionEnumType1: return 22
@@ -522,7 +522,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .testOptionEnumType1: return "\"TEST_OPTION_ENUM_TYPE1\""
@@ -531,9 +531,9 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .testOptionEnumType1: return ".testOptionEnumType1"
@@ -544,7 +544,7 @@ struct ProtobufUnittest_DummyMessageContainingEnum: ProtobufGeneratedMessage, Pr
 
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -568,7 +568,7 @@ struct ProtobufUnittest_DummyMessageInvalidAsOptionType: ProtobufGeneratedMessag
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -592,7 +592,7 @@ struct ProtobufUnittest_CustomOptionMinIntegerValues: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -616,7 +616,7 @@ struct ProtobufUnittest_CustomOptionMaxIntegerValues: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -640,7 +640,7 @@ struct ProtobufUnittest_CustomOptionOtherValues: ProtobufGeneratedMessage, Proto
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -664,7 +664,7 @@ struct ProtobufUnittest_SettingRealsFromPositiveInts: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -688,7 +688,7 @@ struct ProtobufUnittest_SettingRealsFromNegativeInts: ProtobufGeneratedMessage, 
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -726,7 +726,7 @@ struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufPr
   public var unknown = ProtobufUnknownStorage()
 
   private var _foo: Int32? = nil
-  public var foo: Int32 {
+  var foo: Int32 {
     get {return _foo ?? 0}
     set {_foo = newValue}
   }
@@ -738,7 +738,7 @@ struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _foo2: Int32? = nil
-  public var foo2: Int32 {
+  var foo2: Int32 {
     get {return _foo2 ?? 0}
     set {_foo2 = newValue}
   }
@@ -750,7 +750,7 @@ struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufPr
   }
 
   private var _foo3: Int32? = nil
-  public var foo3: Int32 {
+  var foo3: Int32 {
     get {return _foo3 ?? 0}
     set {_foo3 = newValue}
   }
@@ -761,9 +761,9 @@ struct ProtobufUnittest_ComplexOptionType1: ProtobufGeneratedMessage, ProtobufPr
     return _foo3 = nil
   }
 
-  public var foo4: [Int32] = []
+  var foo4: [Int32] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -931,7 +931,7 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
     }
 
     private var _waldo: Int32? = nil
-    public var waldo: Int32 {
+    var waldo: Int32 {
       get {return _waldo ?? 0}
       set {_waldo = newValue}
     }
@@ -942,7 +942,7 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
       return _waldo = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -965,7 +965,7 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
     }
   }
 
-  public var bar: ProtobufUnittest_ComplexOptionType1 {
+  var bar: ProtobufUnittest_ComplexOptionType1 {
     get {return _storage._bar ?? ProtobufUnittest_ComplexOptionType1()}
     set {_uniqueStorage()._bar = newValue}
   }
@@ -976,7 +976,7 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
     return _storage._bar = nil
   }
 
-  public var baz: Int32 {
+  var baz: Int32 {
     get {return _storage._baz ?? 0}
     set {_uniqueStorage()._baz = newValue}
   }
@@ -987,7 +987,7 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
     return _storage._baz = nil
   }
 
-  public var fred: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
+  var fred: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
     get {return _storage._fred ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
     set {_uniqueStorage()._fred = newValue}
   }
@@ -998,12 +998,12 @@ struct ProtobufUnittest_ComplexOptionType2: ProtobufGeneratedMessage, ProtobufPr
     return _storage._fred = nil
   }
 
-  public var barney: [ProtobufUnittest_ComplexOptionType2.ComplexOptionType4] {
+  var barney: [ProtobufUnittest_ComplexOptionType2.ComplexOptionType4] {
     get {return _storage._barney}
     set {_uniqueStorage()._barney = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1117,7 +1117,7 @@ struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage, ProtobufPr
     public var unknown = ProtobufUnknownStorage()
 
     private var _plugh: Int32? = nil
-    public var plugh: Int32 {
+    var plugh: Int32 {
       get {return _plugh ?? 0}
       set {_plugh = newValue}
     }
@@ -1128,7 +1128,7 @@ struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage, ProtobufPr
       return _plugh = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1151,7 +1151,7 @@ struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage, ProtobufPr
     }
   }
 
-  public var qux: Int32 {
+  var qux: Int32 {
     get {return _storage._qux ?? 0}
     set {_uniqueStorage()._qux = newValue}
   }
@@ -1162,7 +1162,7 @@ struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage, ProtobufPr
     return _storage._qux = nil
   }
 
-  public var complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5 {
+  var complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5 {
     get {return _storage._complexOptionType5 ?? ProtobufUnittest_ComplexOptionType3.ComplexOptionType5()}
     set {_uniqueStorage()._complexOptionType5 = newValue}
   }
@@ -1173,7 +1173,7 @@ struct ProtobufUnittest_ComplexOptionType3: ProtobufGeneratedMessage, ProtobufPr
     return _storage._complexOptionType5 = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1209,7 +1209,7 @@ struct ProtobufUnittest_ComplexOpt6: ProtobufGeneratedMessage, ProtobufProto2Mes
   public var unknown = ProtobufUnknownStorage()
 
   private var _xyzzy: Int32? = nil
-  public var xyzzy: Int32 {
+  var xyzzy: Int32 {
     get {return _xyzzy ?? 0}
     set {_xyzzy = newValue}
   }
@@ -1220,7 +1220,7 @@ struct ProtobufUnittest_ComplexOpt6: ProtobufGeneratedMessage, ProtobufProto2Mes
     return _xyzzy = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1253,7 +1253,7 @@ struct ProtobufUnittest_VariousComplexOptions: ProtobufGeneratedMessage, Protobu
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -1281,7 +1281,7 @@ struct ProtobufUnittest_AggregateMessageSet: ProtobufGeneratedMessage, ProtobufP
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (4 <= protoFieldNumber && protoFieldNumber < 2147483647) {
@@ -1341,7 +1341,7 @@ struct ProtobufUnittest_AggregateMessageSetElement: ProtobufGeneratedMessage, Pr
   }
 
   private var _s: String? = nil
-  public var s: String {
+  var s: String {
     get {return _s ?? ""}
     set {_s = newValue}
   }
@@ -1352,7 +1352,7 @@ struct ProtobufUnittest_AggregateMessageSetElement: ProtobufGeneratedMessage, Pr
     return _s = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1470,7 +1470,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
     static let Google_Protobuf_FileOptions_nested = ProtobufGenericMessageExtension<ProtobufOptionalMessageField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(protoFieldNumber: 15476903, protoFieldName: "nested", jsonFieldName: "nested", swiftFieldName: "ProtobufUnittest_Aggregate_nested", defaultValue: ProtobufUnittest_Aggregate())
   }
 
-  public var i: Int32 {
+  var i: Int32 {
     get {return _storage._i ?? 0}
     set {_uniqueStorage()._i = newValue}
   }
@@ -1481,7 +1481,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
     return _storage._i = nil
   }
 
-  public var s: String {
+  var s: String {
     get {return _storage._s ?? ""}
     set {_uniqueStorage()._s = newValue}
   }
@@ -1493,7 +1493,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
   }
 
   ///   A nested object
-  public var sub: ProtobufUnittest_Aggregate {
+  var sub: ProtobufUnittest_Aggregate {
     get {return _storage._sub ?? ProtobufUnittest_Aggregate()}
     set {_uniqueStorage()._sub = newValue}
   }
@@ -1505,7 +1505,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
   }
 
   ///   To test the parsing of extensions inside aggregate values
-  public var file: Google_Protobuf_FileOptions {
+  var file: Google_Protobuf_FileOptions {
     get {return _storage._file ?? Google_Protobuf_FileOptions()}
     set {_uniqueStorage()._file = newValue}
   }
@@ -1517,7 +1517,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
   }
 
   ///   An embedded message set
-  public var mset: ProtobufUnittest_AggregateMessageSet {
+  var mset: ProtobufUnittest_AggregateMessageSet {
     get {return _storage._mset ?? ProtobufUnittest_AggregateMessageSet()}
     set {_uniqueStorage()._mset = newValue}
   }
@@ -1528,7 +1528,7 @@ struct ProtobufUnittest_Aggregate: ProtobufGeneratedMessage, ProtobufProto2Messa
     return _storage._mset = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1564,7 +1564,7 @@ struct ProtobufUnittest_AggregateMessage: ProtobufGeneratedMessage, ProtobufProt
   public var unknown = ProtobufUnknownStorage()
 
   private var _fieldname: Int32? = nil
-  public var fieldname: Int32 {
+  var fieldname: Int32 {
     get {return _fieldname ?? 0}
     set {_fieldname = newValue}
   }
@@ -1575,7 +1575,7 @@ struct ProtobufUnittest_AggregateMessage: ProtobufGeneratedMessage, ProtobufProt
     return _fieldname = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1609,42 +1609,42 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
   public var unknown = ProtobufUnknownStorage()
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case value // = 1
 
-    public init() {
+    init() {
       self = .value
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .value
       default: return nil
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "value": self = .value
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "NESTED_ENUM_VALUE": self = .value
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "NESTED_ENUM_VALUE": self = .value
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .value: return 1
@@ -1652,7 +1652,7 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .value: return "\"NESTED_ENUM_VALUE\""
@@ -1660,9 +1660,9 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .value: return ".value"
@@ -1686,7 +1686,7 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
     public var unknown = ProtobufUnknownStorage()
 
     private var _nestedField: Int32? = nil
-    public var nestedField: Int32 {
+    var nestedField: Int32 {
       get {return _nestedField ?? 0}
       set {_nestedField = newValue}
     }
@@ -1697,7 +1697,7 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
       return _nestedField = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1725,7 +1725,7 @@ struct ProtobufUnittest_NestedOptionType: ProtobufGeneratedMessage, ProtobufProt
     static let Google_Protobuf_FileOptions_nestedExtension = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufInt32>, Google_Protobuf_FileOptions>(protoFieldNumber: 7912573, protoFieldName: "nested_extension", jsonFieldName: "nestedExtension", swiftFieldName: "ProtobufUnittest_NestedOptionType_nestedExtension", defaultValue: 0)
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -1756,42 +1756,42 @@ struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   enum TestEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case oldValue // = 0
 
-    public init() {
+    init() {
       self = .oldValue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .oldValue
       default: return nil
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "oldValue": self = .oldValue
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "OLD_VALUE": self = .oldValue
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "OLD_VALUE": self = .oldValue
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .oldValue: return 0
@@ -1799,7 +1799,7 @@ struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .oldValue: return "\"OLD_VALUE\""
@@ -1807,9 +1807,9 @@ struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .oldValue: return ".oldValue"
@@ -1820,7 +1820,7 @@ struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   private var _value: ProtobufUnittest_OldOptionType.TestEnum? = nil
-  public var value: ProtobufUnittest_OldOptionType.TestEnum {
+  var value: ProtobufUnittest_OldOptionType.TestEnum {
     get {return _value ?? ProtobufUnittest_OldOptionType.TestEnum.oldValue}
     set {_value = newValue}
   }
@@ -1831,7 +1831,7 @@ struct ProtobufUnittest_OldOptionType: ProtobufGeneratedMessage, ProtobufProto2M
     return _value = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1867,15 +1867,15 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   enum TestEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case oldValue // = 0
     case newValue // = 1
 
-    public init() {
+    init() {
       self = .oldValue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .oldValue
       case 1: self = .newValue
@@ -1883,7 +1883,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "oldValue": self = .oldValue
       case "newValue": self = .newValue
@@ -1891,7 +1891,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "OLD_VALUE": self = .oldValue
       case "NEW_VALUE": self = .newValue
@@ -1899,7 +1899,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "OLD_VALUE": self = .oldValue
       case "NEW_VALUE": self = .newValue
@@ -1907,7 +1907,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .oldValue: return 0
@@ -1916,7 +1916,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .oldValue: return "\"OLD_VALUE\""
@@ -1925,9 +1925,9 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .oldValue: return ".oldValue"
@@ -1939,7 +1939,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   private var _value: ProtobufUnittest_NewOptionType.TestEnum? = nil
-  public var value: ProtobufUnittest_NewOptionType.TestEnum {
+  var value: ProtobufUnittest_NewOptionType.TestEnum {
     get {return _value ?? ProtobufUnittest_NewOptionType.TestEnum.oldValue}
     set {_value = newValue}
   }
@@ -1950,7 +1950,7 @@ struct ProtobufUnittest_NewOptionType: ProtobufGeneratedMessage, ProtobufProto2M
     return _value = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1981,7 +1981,7 @@ struct ProtobufUnittest_TestMessageWithRequiredEnumOption: ProtobufGeneratedMess
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Tests/SwiftProtobufTests/unittest_drop_unknown_fields.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_drop_unknown_fields.pb.swift
@@ -55,17 +55,17 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
 
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -74,7 +74,7 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -83,7 +83,7 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -92,7 +92,7 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -101,7 +101,7 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -112,7 +112,7 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -123,9 +123,9 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -138,11 +138,11 @@ struct UnittestDropUnknownFields_Foo: ProtobufGeneratedMessage, ProtobufProto3Me
 
   }
 
-  public var int32Value: Int32 = 0
+  var int32Value: Int32 = 0
 
-  public var enumValue: UnittestDropUnknownFields_Foo.NestedEnum = UnittestDropUnknownFields_Foo.NestedEnum.foo
+  var enumValue: UnittestDropUnknownFields_Foo.NestedEnum = UnittestDropUnknownFields_Foo.NestedEnum.foo
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -185,18 +185,18 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
 
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case qux // = 3
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -206,7 +206,7 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -216,7 +216,7 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -226,7 +226,7 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -236,7 +236,7 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -248,7 +248,7 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -260,9 +260,9 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -276,13 +276,13 @@ struct UnittestDropUnknownFields_FooWithExtraFields: ProtobufGeneratedMessage, P
 
   }
 
-  public var int32Value: Int32 = 0
+  var int32Value: Int32 = 0
 
-  public var enumValue: UnittestDropUnknownFields_FooWithExtraFields.NestedEnum = UnittestDropUnknownFields_FooWithExtraFields.NestedEnum.foo
+  var enumValue: UnittestDropUnknownFields_FooWithExtraFields.NestedEnum = UnittestDropUnknownFields_FooWithExtraFields.NestedEnum.foo
 
-  public var extraInt32Value: Int32 = 0
+  var extraInt32Value: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_embed_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_embed_optimize_for.pb.swift
@@ -110,7 +110,7 @@ struct ProtobufUnittest_TestEmbedOptimizedForSize: ProtobufGeneratedMessage, Pro
 
   ///   Test that embedding a message which has optimize_for = CODE_SIZE into
   ///   one optimized for speed works.
-  public var optionalMessage: ProtobufUnittest_TestOptimizedForSize {
+  var optionalMessage: ProtobufUnittest_TestOptimizedForSize {
     get {return _storage._optionalMessage ?? ProtobufUnittest_TestOptimizedForSize()}
     set {_uniqueStorage()._optionalMessage = newValue}
   }
@@ -121,12 +121,12 @@ struct ProtobufUnittest_TestEmbedOptimizedForSize: ProtobufGeneratedMessage, Pro
     return _storage._optionalMessage = nil
   }
 
-  public var repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] {
+  var repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] {
     get {return _storage._repeatedMessage}
     set {_uniqueStorage()._repeatedMessage = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/unittest_import.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import.pb.swift
@@ -47,16 +47,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case importFoo // = 7
   case importBar // = 8
   case importBaz // = 9
 
-  public init() {
+  init() {
     self = .importFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 7: self = .importFoo
     case 8: self = .importBar
@@ -65,7 +65,7 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "importFoo": self = .importFoo
     case "importBar": self = .importBar
@@ -74,7 +74,7 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "IMPORT_FOO": self = .importFoo
     case "IMPORT_BAR": self = .importBar
@@ -83,7 +83,7 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "IMPORT_FOO": self = .importFoo
     case "IMPORT_BAR": self = .importBar
@@ -92,7 +92,7 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .importFoo: return 7
@@ -102,7 +102,7 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .importFoo: return "\"IMPORT_FOO\""
@@ -112,9 +112,9 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .importFoo: return ".importFoo"
@@ -128,16 +128,16 @@ enum ProtobufUnittestImport_ImportEnum: ProtobufEnum {
 
 ///   To use an enum in a map, it must has the first value as 0.
 enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case unknown // = 0
   case foo // = 1
   case bar // = 2
 
-  public init() {
+  init() {
     self = .unknown
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .unknown
     case 1: self = .foo
@@ -146,7 +146,7 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "unknown": self = .unknown
     case "foo": self = .foo
@@ -155,7 +155,7 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "UNKNOWN": self = .unknown
     case "FOO": self = .foo
@@ -164,7 +164,7 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "UNKNOWN": self = .unknown
     case "FOO": self = .foo
@@ -173,7 +173,7 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .unknown: return 0
@@ -183,7 +183,7 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .unknown: return "\"UNKNOWN\""
@@ -193,9 +193,9 @@ enum ProtobufUnittestImport_ImportEnumForMap: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .unknown: return ".unknown"
@@ -221,7 +221,7 @@ struct ProtobufUnittestImport_ImportMessage: ProtobufGeneratedMessage, ProtobufP
   public var unknown = ProtobufUnknownStorage()
 
   private var _d: Int32? = nil
-  public var d: Int32 {
+  var d: Int32 {
     get {return _d ?? 0}
     set {_d = newValue}
   }
@@ -232,7 +232,7 @@ struct ProtobufUnittestImport_ImportMessage: ProtobufGeneratedMessage, ProtobufP
     return _d = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_import_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_lite.pb.swift
@@ -45,16 +45,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case importLiteFoo // = 7
   case importLiteBar // = 8
   case importLiteBaz // = 9
 
-  public init() {
+  init() {
     self = .importLiteFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 7: self = .importLiteFoo
     case 8: self = .importLiteBar
@@ -63,7 +63,7 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "importLiteFoo": self = .importLiteFoo
     case "importLiteBar": self = .importLiteBar
@@ -72,7 +72,7 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "IMPORT_LITE_FOO": self = .importLiteFoo
     case "IMPORT_LITE_BAR": self = .importLiteBar
@@ -81,7 +81,7 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "IMPORT_LITE_FOO": self = .importLiteFoo
     case "IMPORT_LITE_BAR": self = .importLiteBar
@@ -90,7 +90,7 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .importLiteFoo: return 7
@@ -100,7 +100,7 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .importLiteFoo: return "\"IMPORT_LITE_FOO\""
@@ -110,9 +110,9 @@ enum ProtobufUnittestImport_ImportEnumLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .importLiteFoo: return ".importLiteFoo"
@@ -138,7 +138,7 @@ struct ProtobufUnittestImport_ImportMessageLite: ProtobufGeneratedMessage, Proto
   public var unknown = ProtobufUnknownStorage()
 
   private var _d: Int32? = nil
-  public var d: Int32 {
+  var d: Int32 {
     get {return _d ?? 0}
     set {_d = newValue}
   }
@@ -149,7 +149,7 @@ struct ProtobufUnittestImport_ImportMessageLite: ProtobufGeneratedMessage, Proto
     return _d = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_import_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_proto3.pb.swift
@@ -47,18 +47,18 @@ import SwiftProtobuf
 
 
 enum Proto3ImportEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case importEnumUnspecified // = 0
   case importFoo // = 7
   case importBar // = 8
   case importBaz // = 9
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .importEnumUnspecified
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .importEnumUnspecified
     case 7: self = .importFoo
@@ -68,7 +68,7 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "importEnumUnspecified": self = .importEnumUnspecified
     case "importFoo": self = .importFoo
@@ -78,7 +78,7 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "IMPORT_ENUM_UNSPECIFIED": self = .importEnumUnspecified
     case "IMPORT_FOO": self = .importFoo
@@ -88,7 +88,7 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "IMPORT_ENUM_UNSPECIFIED": self = .importEnumUnspecified
     case "IMPORT_FOO": self = .importFoo
@@ -98,7 +98,7 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .importEnumUnspecified: return 0
@@ -110,7 +110,7 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .importEnumUnspecified: return "\"IMPORT_ENUM_UNSPECIFIED\""
@@ -122,9 +122,9 @@ enum Proto3ImportEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .importEnumUnspecified: return ".importEnumUnspecified"
@@ -150,9 +150,9 @@ struct Proto3ImportMessage: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var d: Int32 = 0
+  var d: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_import_public.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_public.pb.swift
@@ -56,7 +56,7 @@ struct ProtobufUnittestImport_PublicImportMessage: ProtobufGeneratedMessage, Pro
   public var unknown = ProtobufUnknownStorage()
 
   private var _e: Int32? = nil
-  public var e: Int32 {
+  var e: Int32 {
     get {return _e ?? 0}
     set {_e = newValue}
   }
@@ -67,7 +67,7 @@ struct ProtobufUnittestImport_PublicImportMessage: ProtobufGeneratedMessage, Pro
     return _e = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_import_public_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_public_lite.pb.swift
@@ -56,7 +56,7 @@ struct ProtobufUnittestImport_PublicImportMessageLite: ProtobufGeneratedMessage,
   public var unknown = ProtobufUnknownStorage()
 
   private var _e: Int32? = nil
-  public var e: Int32 {
+  var e: Int32 {
     get {return _e ?? 0}
     set {_e = newValue}
   }
@@ -67,7 +67,7 @@ struct ProtobufUnittestImport_PublicImportMessageLite: ProtobufGeneratedMessage,
     return _e = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_import_public_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_public_proto3.pb.swift
@@ -54,9 +54,9 @@ struct Proto3PublicImportMessage: ProtobufGeneratedMessage, ProtobufProto3Messag
   ]}
 
 
-  public var e: Int32 = 0
+  var e: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -45,16 +45,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignLiteFoo // = 4
   case foreignLiteBar // = 5
   case foreignLiteBaz // = 6
 
-  public init() {
+  init() {
     self = .foreignLiteFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 4: self = .foreignLiteFoo
     case 5: self = .foreignLiteBar
@@ -63,7 +63,7 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignLiteFoo": self = .foreignLiteFoo
     case "foreignLiteBar": self = .foreignLiteBar
@@ -72,7 +72,7 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_LITE_FOO": self = .foreignLiteFoo
     case "FOREIGN_LITE_BAR": self = .foreignLiteBar
@@ -81,7 +81,7 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_LITE_FOO": self = .foreignLiteFoo
     case "FOREIGN_LITE_BAR": self = .foreignLiteBar
@@ -90,7 +90,7 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignLiteFoo: return 4
@@ -100,7 +100,7 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignLiteFoo: return "\"FOREIGN_LITE_FOO\""
@@ -110,9 +110,9 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignLiteFoo: return ".foreignLiteFoo"
@@ -125,42 +125,42 @@ enum ProtobufUnittest_ForeignEnumLite: ProtobufEnum {
 }
 
 enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case v1First // = 1
 
-  public init() {
+  init() {
     self = .v1First
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .v1First
     default: return nil
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "v1First": self = .v1First
     default: return nil
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "V1_FIRST": self = .v1First
     default: return nil
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "V1_FIRST": self = .v1First
     default: return nil
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .v1First: return 1
@@ -168,7 +168,7 @@ enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .v1First: return "\"V1_FIRST\""
@@ -176,9 +176,9 @@ enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .v1First: return ".v1First"
@@ -189,15 +189,15 @@ enum ProtobufUnittest_V1EnumLite: ProtobufEnum {
 }
 
 enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case v2First // = 1
   case v2Second // = 2
 
-  public init() {
+  init() {
     self = .v2First
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .v2First
     case 2: self = .v2Second
@@ -205,7 +205,7 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "v2First": self = .v2First
     case "v2Second": self = .v2Second
@@ -213,7 +213,7 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "V2_FIRST": self = .v2First
     case "V2_SECOND": self = .v2Second
@@ -221,7 +221,7 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "V2_FIRST": self = .v2First
     case "V2_SECOND": self = .v2Second
@@ -229,7 +229,7 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .v2First: return 1
@@ -238,7 +238,7 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .v2First: return "\"V2_FIRST\""
@@ -247,9 +247,9 @@ enum ProtobufUnittest_V2EnumLite: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .v2First: return ".v2First"
@@ -1044,16 +1044,16 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       case 2: self = .bar
@@ -1062,7 +1062,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -1071,7 +1071,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1080,7 +1080,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -1089,7 +1089,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -1099,7 +1099,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -1109,9 +1109,9 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1139,7 +1139,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     public var unknown = ProtobufUnknownStorage()
 
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -1151,7 +1151,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
 
     private var _cc: Int64? = nil
-    public var cc: Int64 {
+    var cc: Int64 {
       get {return _cc ?? 0}
       set {_cc = newValue}
     }
@@ -1162,7 +1162,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       return _cc = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1204,7 +1204,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1215,7 +1215,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1252,7 +1252,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1263,7 +1263,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1287,7 +1287,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
@@ -1298,7 +1298,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalInt32 = nil
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64 ?? 0}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
@@ -1309,7 +1309,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalInt64 = nil
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32 ?? 0}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
@@ -1320,7 +1320,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalUint32 = nil
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64 ?? 0}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
@@ -1331,7 +1331,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalUint64 = nil
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32 ?? 0}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
@@ -1342,7 +1342,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalSint32 = nil
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64 ?? 0}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
@@ -1353,7 +1353,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalSint64 = nil
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32 ?? 0}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
@@ -1364,7 +1364,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalFixed32 = nil
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64 ?? 0}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
@@ -1375,7 +1375,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalFixed64 = nil
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32 ?? 0}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
@@ -1386,7 +1386,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalSfixed32 = nil
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64 ?? 0}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
@@ -1397,7 +1397,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalSfixed64 = nil
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat ?? 0}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
@@ -1408,7 +1408,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalFloat = nil
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble ?? 0}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
@@ -1419,7 +1419,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalDouble = nil
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool ?? false}
     set {_uniqueStorage()._optionalBool = newValue}
   }
@@ -1430,7 +1430,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalBool = nil
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString ?? ""}
     set {_uniqueStorage()._optionalString = newValue}
   }
@@ -1441,7 +1441,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalString = nil
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes ?? Data()}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -1452,7 +1452,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalBytes = nil
   }
 
-  public var optionalGroup: ProtobufUnittest_TestAllTypesLite.OptionalGroup {
+  var optionalGroup: ProtobufUnittest_TestAllTypesLite.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittest_TestAllTypesLite.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -1463,7 +1463,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalGroup = nil
   }
 
-  public var optionalNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var optionalNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return _storage._optionalNestedMessage ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -1474,7 +1474,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: ProtobufUnittest_ForeignMessageLite {
+  var optionalForeignMessage: ProtobufUnittest_ForeignMessageLite {
     get {return _storage._optionalForeignMessage ?? ProtobufUnittest_ForeignMessageLite()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -1485,7 +1485,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalImportMessage: ProtobufUnittestImport_ImportMessageLite {
+  var optionalImportMessage: ProtobufUnittestImport_ImportMessageLite {
     get {return _storage._optionalImportMessage ?? ProtobufUnittestImport_ImportMessageLite()}
     set {_uniqueStorage()._optionalImportMessage = newValue}
   }
@@ -1496,7 +1496,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalImportMessage = nil
   }
 
-  public var optionalNestedEnum: ProtobufUnittest_TestAllTypesLite.NestedEnum {
+  var optionalNestedEnum: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return _storage._optionalNestedEnum ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.foo}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
@@ -1507,7 +1507,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalNestedEnum = nil
   }
 
-  public var optionalForeignEnum: ProtobufUnittest_ForeignEnumLite {
+  var optionalForeignEnum: ProtobufUnittest_ForeignEnumLite {
     get {return _storage._optionalForeignEnum ?? ProtobufUnittest_ForeignEnumLite.foreignLiteFoo}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
@@ -1518,7 +1518,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalForeignEnum = nil
   }
 
-  public var optionalImportEnum: ProtobufUnittestImport_ImportEnumLite {
+  var optionalImportEnum: ProtobufUnittestImport_ImportEnumLite {
     get {return _storage._optionalImportEnum ?? ProtobufUnittestImport_ImportEnumLite.importLiteFoo}
     set {_uniqueStorage()._optionalImportEnum = newValue}
   }
@@ -1529,7 +1529,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalImportEnum = nil
   }
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece ?? ""}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
@@ -1540,7 +1540,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalStringPiece = nil
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord ?? ""}
     set {_uniqueStorage()._optionalCord = newValue}
   }
@@ -1552,7 +1552,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
   }
 
   ///   Defined in unittest_import_public.proto
-  public var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessageLite {
+  var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessageLite {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessageLite()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
   }
@@ -1563,7 +1563,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._optionalPublicImportMessage = nil
   }
 
-  public var optionalLazyMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var optionalLazyMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return _storage._optionalLazyMessage ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {_uniqueStorage()._optionalLazyMessage = newValue}
   }
@@ -1575,133 +1575,133 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedGroup: [ProtobufUnittest_TestAllTypesLite.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittest_TestAllTypesLite.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public var repeatedNestedMessage: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
+  var repeatedNestedMessage: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [ProtobufUnittest_ForeignMessageLite] {
+  var repeatedForeignMessage: [ProtobufUnittest_ForeignMessageLite] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [ProtobufUnittestImport_ImportMessageLite] {
+  var repeatedImportMessage: [ProtobufUnittestImport_ImportMessageLite] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
+  var repeatedNestedEnum: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [ProtobufUnittest_ForeignEnumLite] {
+  var repeatedForeignEnum: [ProtobufUnittest_ForeignEnumLite] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedImportEnum: [ProtobufUnittestImport_ImportEnumLite] {
+  var repeatedImportEnum: [ProtobufUnittestImport_ImportEnumLite] {
     get {return _storage._repeatedImportEnum}
     set {_uniqueStorage()._repeatedImportEnum = newValue}
   }
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
+  var repeatedLazyMessage: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
   ///   Singular with defaults
-  public var defaultInt32: Int32 {
+  var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
   }
@@ -1712,7 +1712,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultInt32 = nil
   }
 
-  public var defaultInt64: Int64 {
+  var defaultInt64: Int64 {
     get {return _storage._defaultInt64 ?? 42}
     set {_uniqueStorage()._defaultInt64 = newValue}
   }
@@ -1723,7 +1723,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultInt64 = nil
   }
 
-  public var defaultUint32: UInt32 {
+  var defaultUint32: UInt32 {
     get {return _storage._defaultUint32 ?? 43}
     set {_uniqueStorage()._defaultUint32 = newValue}
   }
@@ -1734,7 +1734,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultUint32 = nil
   }
 
-  public var defaultUint64: UInt64 {
+  var defaultUint64: UInt64 {
     get {return _storage._defaultUint64 ?? 44}
     set {_uniqueStorage()._defaultUint64 = newValue}
   }
@@ -1745,7 +1745,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultUint64 = nil
   }
 
-  public var defaultSint32: Int32 {
+  var defaultSint32: Int32 {
     get {return _storage._defaultSint32 ?? -45}
     set {_uniqueStorage()._defaultSint32 = newValue}
   }
@@ -1756,7 +1756,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultSint32 = nil
   }
 
-  public var defaultSint64: Int64 {
+  var defaultSint64: Int64 {
     get {return _storage._defaultSint64 ?? 46}
     set {_uniqueStorage()._defaultSint64 = newValue}
   }
@@ -1767,7 +1767,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultSint64 = nil
   }
 
-  public var defaultFixed32: UInt32 {
+  var defaultFixed32: UInt32 {
     get {return _storage._defaultFixed32 ?? 47}
     set {_uniqueStorage()._defaultFixed32 = newValue}
   }
@@ -1778,7 +1778,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultFixed32 = nil
   }
 
-  public var defaultFixed64: UInt64 {
+  var defaultFixed64: UInt64 {
     get {return _storage._defaultFixed64 ?? 48}
     set {_uniqueStorage()._defaultFixed64 = newValue}
   }
@@ -1789,7 +1789,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultFixed64 = nil
   }
 
-  public var defaultSfixed32: Int32 {
+  var defaultSfixed32: Int32 {
     get {return _storage._defaultSfixed32 ?? 49}
     set {_uniqueStorage()._defaultSfixed32 = newValue}
   }
@@ -1800,7 +1800,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultSfixed32 = nil
   }
 
-  public var defaultSfixed64: Int64 {
+  var defaultSfixed64: Int64 {
     get {return _storage._defaultSfixed64 ?? -50}
     set {_uniqueStorage()._defaultSfixed64 = newValue}
   }
@@ -1811,7 +1811,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultSfixed64 = nil
   }
 
-  public var defaultFloat: Float {
+  var defaultFloat: Float {
     get {return _storage._defaultFloat ?? 51.5}
     set {_uniqueStorage()._defaultFloat = newValue}
   }
@@ -1822,7 +1822,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultFloat = nil
   }
 
-  public var defaultDouble: Double {
+  var defaultDouble: Double {
     get {return _storage._defaultDouble ?? 52000}
     set {_uniqueStorage()._defaultDouble = newValue}
   }
@@ -1833,7 +1833,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultDouble = nil
   }
 
-  public var defaultBool: Bool {
+  var defaultBool: Bool {
     get {return _storage._defaultBool ?? true}
     set {_uniqueStorage()._defaultBool = newValue}
   }
@@ -1844,7 +1844,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultBool = nil
   }
 
-  public var defaultString: String {
+  var defaultString: String {
     get {return _storage._defaultString ?? "hello"}
     set {_uniqueStorage()._defaultString = newValue}
   }
@@ -1855,7 +1855,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultString = nil
   }
 
-  public var defaultBytes: Data {
+  var defaultBytes: Data {
     get {return _storage._defaultBytes ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {_uniqueStorage()._defaultBytes = newValue}
   }
@@ -1866,7 +1866,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultBytes = nil
   }
 
-  public var defaultNestedEnum: ProtobufUnittest_TestAllTypesLite.NestedEnum {
+  var defaultNestedEnum: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return _storage._defaultNestedEnum ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.bar}
     set {_uniqueStorage()._defaultNestedEnum = newValue}
   }
@@ -1877,7 +1877,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultNestedEnum = nil
   }
 
-  public var defaultForeignEnum: ProtobufUnittest_ForeignEnumLite {
+  var defaultForeignEnum: ProtobufUnittest_ForeignEnumLite {
     get {return _storage._defaultForeignEnum ?? ProtobufUnittest_ForeignEnumLite.foreignLiteBar}
     set {_uniqueStorage()._defaultForeignEnum = newValue}
   }
@@ -1888,7 +1888,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultForeignEnum = nil
   }
 
-  public var defaultImportEnum: ProtobufUnittestImport_ImportEnumLite {
+  var defaultImportEnum: ProtobufUnittestImport_ImportEnumLite {
     get {return _storage._defaultImportEnum ?? ProtobufUnittestImport_ImportEnumLite.importLiteBar}
     set {_uniqueStorage()._defaultImportEnum = newValue}
   }
@@ -1899,7 +1899,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultImportEnum = nil
   }
 
-  public var defaultStringPiece: String {
+  var defaultStringPiece: String {
     get {return _storage._defaultStringPiece ?? "abc"}
     set {_uniqueStorage()._defaultStringPiece = newValue}
   }
@@ -1910,7 +1910,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultStringPiece = nil
   }
 
-  public var defaultCord: String {
+  var defaultCord: String {
     get {return _storage._defaultCord ?? "123"}
     set {_uniqueStorage()._defaultCord = newValue}
   }
@@ -1921,7 +1921,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     return _storage._defaultCord = nil
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1933,7 +1933,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var oneofNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1945,7 +1945,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1957,7 +1957,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1969,7 +1969,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofLazyNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
+  var oneofLazyNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
       if case .oneofLazyNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1988,7 +1988,7 @@ struct ProtobufUnittest_TestAllTypesLite: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2024,7 +2024,7 @@ struct ProtobufUnittest_ForeignMessageLite: ProtobufGeneratedMessage, ProtobufPr
   public var unknown = ProtobufUnknownStorage()
 
   private var _c: Int32? = nil
-  public var c: Int32 {
+  var c: Int32 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -2035,7 +2035,7 @@ struct ProtobufUnittest_ForeignMessageLite: ProtobufGeneratedMessage, ProtobufPr
     return _c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2097,35 +2097,35 @@ struct ProtobufUnittest_TestPackedTypesLite: ProtobufGeneratedMessage, ProtobufP
 
   public var unknown = ProtobufUnknownStorage()
 
-  public var packedInt32: [Int32] = []
+  var packedInt32: [Int32] = []
 
-  public var packedInt64: [Int64] = []
+  var packedInt64: [Int64] = []
 
-  public var packedUint32: [UInt32] = []
+  var packedUint32: [UInt32] = []
 
-  public var packedUint64: [UInt64] = []
+  var packedUint64: [UInt64] = []
 
-  public var packedSint32: [Int32] = []
+  var packedSint32: [Int32] = []
 
-  public var packedSint64: [Int64] = []
+  var packedSint64: [Int64] = []
 
-  public var packedFixed32: [UInt32] = []
+  var packedFixed32: [UInt32] = []
 
-  public var packedFixed64: [UInt64] = []
+  var packedFixed64: [UInt64] = []
 
-  public var packedSfixed32: [Int32] = []
+  var packedSfixed32: [Int32] = []
 
-  public var packedSfixed64: [Int64] = []
+  var packedSfixed64: [Int64] = []
 
-  public var packedFloat: [Float] = []
+  var packedFloat: [Float] = []
 
-  public var packedDouble: [Double] = []
+  var packedDouble: [Double] = []
 
-  public var packedBool: [Bool] = []
+  var packedBool: [Bool] = []
 
-  public var packedEnum: [ProtobufUnittest_ForeignEnumLite] = []
+  var packedEnum: [ProtobufUnittest_ForeignEnumLite] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2222,7 +2222,7 @@ struct ProtobufUnittest_TestAllExtensionsLite: ProtobufGeneratedMessage, Protobu
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -2277,7 +2277,7 @@ struct ProtobufUnittest_OptionalGroup_extension_lite: ProtobufGeneratedMessage, 
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -2288,7 +2288,7 @@ struct ProtobufUnittest_OptionalGroup_extension_lite: ProtobufGeneratedMessage, 
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2325,7 +2325,7 @@ struct ProtobufUnittest_RepeatedGroup_extension_lite: ProtobufGeneratedMessage, 
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -2336,7 +2336,7 @@ struct ProtobufUnittest_RepeatedGroup_extension_lite: ProtobufGeneratedMessage, 
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2368,7 +2368,7 @@ struct ProtobufUnittest_TestPackedExtensionsLite: ProtobufGeneratedMessage, Prot
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -2423,7 +2423,7 @@ struct ProtobufUnittest_TestNestedExtensionLite: ProtobufGeneratedMessage, Proto
     static let ProtobufUnittest_TestAllExtensionsLite_nestedExtension = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(protoFieldNumber: 12345, protoFieldName: "nested_extension", jsonFieldName: "nestedExtension", swiftFieldName: "ProtobufUnittest_TestNestedExtensionLite_nestedExtension", defaultValue: 0)
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -2454,7 +2454,7 @@ struct ProtobufUnittest_TestDeprecatedLite: ProtobufGeneratedMessage, ProtobufPr
   public var unknown = ProtobufUnknownStorage()
 
   private var _deprecatedField: Int32? = nil
-  public var deprecatedField: Int32 {
+  var deprecatedField: Int32 {
     get {return _deprecatedField ?? 0}
     set {_deprecatedField = newValue}
   }
@@ -2465,7 +2465,7 @@ struct ProtobufUnittest_TestDeprecatedLite: ProtobufGeneratedMessage, ProtobufPr
     return _deprecatedField = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2662,7 +2662,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
         set {_storage.unknown = newValue}
       }
 
-      public var field1: ProtobufUnittest_TestAllTypesLite {
+      var field1: ProtobufUnittest_TestAllTypesLite {
         get {return _storage._field1 ?? ProtobufUnittest_TestAllTypesLite()}
         set {_uniqueStorage()._field1 = newValue}
       }
@@ -2673,7 +2673,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
         return _storage._field1 = nil
       }
 
-      public init() {}
+      init() {}
 
       public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
         try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2748,7 +2748,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
         set {_storage.unknown = newValue}
       }
 
-      public var field1: ProtobufUnittest_TestAllTypesLite {
+      var field1: ProtobufUnittest_TestAllTypesLite {
         get {return _storage._field1 ?? ProtobufUnittest_TestAllTypesLite()}
         set {_uniqueStorage()._field1 = newValue}
       }
@@ -2759,7 +2759,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
         return _storage._field1 = nil
       }
 
-      public init() {}
+      init() {}
 
       public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
         try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2781,21 +2781,21 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var field1: [ProtobufUnittest_TestAllTypesLite] = []
+    var field1: [ProtobufUnittest_TestAllTypesLite] = []
 
-    public var field2: [ProtobufUnittest_TestAllTypesLite] = []
+    var field2: [ProtobufUnittest_TestAllTypesLite] = []
 
-    public var field3: [ProtobufUnittest_TestAllTypesLite] = []
+    var field3: [ProtobufUnittest_TestAllTypesLite] = []
 
-    public var group1: [ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1] = []
+    var group1: [ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1] = []
 
-    public var group2: [ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2] = []
+    var group2: [ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2] = []
 
-    public var ext1: [ProtobufUnittest_TestAllTypesLite] = []
+    var ext1: [ProtobufUnittest_TestAllTypesLite] = []
 
-    public var ext2: [ProtobufUnittest_TestAllTypesLite] = []
+    var ext2: [ProtobufUnittest_TestAllTypesLite] = []
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -2901,7 +2901,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
       set {_storage.unknown = newValue}
     }
 
-    public var optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
+    var optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
       get {return _storage._optionalGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
       set {_uniqueStorage()._optionalGroupAllTypes = newValue}
     }
@@ -2912,7 +2912,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
       return _storage._optionalGroupAllTypes = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2987,7 +2987,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
       set {_storage.unknown = newValue}
     }
 
-    public var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
+    var repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite {
       get {return _storage._repeatedGroupAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
       set {_uniqueStorage()._repeatedGroupAllTypes = newValue}
     }
@@ -2998,7 +2998,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
       return _storage._repeatedGroupAllTypes = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3027,7 +3027,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
     static let ProtobufUnittest_TestParsingMergeLite_repeatedExt = ProtobufGenericMessageExtension<ProtobufRepeatedMessageField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(protoFieldNumber: 1001, protoFieldName: "repeated_ext", jsonFieldName: "repeatedExt", swiftFieldName: "ProtobufUnittest_TestParsingMergeLite_repeatedExt", defaultValue: [])
   }
 
-  public var requiredAllTypes: ProtobufUnittest_TestAllTypesLite {
+  var requiredAllTypes: ProtobufUnittest_TestAllTypesLite {
     get {return _storage._requiredAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
     set {_uniqueStorage()._requiredAllTypes = newValue}
   }
@@ -3038,7 +3038,7 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredAllTypes = nil
   }
 
-  public var optionalAllTypes: ProtobufUnittest_TestAllTypesLite {
+  var optionalAllTypes: ProtobufUnittest_TestAllTypesLite {
     get {return _storage._optionalAllTypes ?? ProtobufUnittest_TestAllTypesLite()}
     set {_uniqueStorage()._optionalAllTypes = newValue}
   }
@@ -3049,12 +3049,12 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
     return _storage._optionalAllTypes = nil
   }
 
-  public var repeatedAllTypes: [ProtobufUnittest_TestAllTypesLite] {
+  var repeatedAllTypes: [ProtobufUnittest_TestAllTypesLite] {
     get {return _storage._repeatedAllTypes}
     set {_uniqueStorage()._repeatedAllTypes = newValue}
   }
 
-  public var optionalGroup: ProtobufUnittest_TestParsingMergeLite.OptionalGroup {
+  var optionalGroup: ProtobufUnittest_TestParsingMergeLite.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittest_TestParsingMergeLite.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -3065,12 +3065,12 @@ struct ProtobufUnittest_TestParsingMergeLite: ProtobufGeneratedMessage, Protobuf
     return _storage._optionalGroup = nil
   }
 
-  public var repeatedGroup: [ProtobufUnittest_TestParsingMergeLite.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittest_TestParsingMergeLite.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -3118,7 +3118,7 @@ struct ProtobufUnittest_TestEmptyMessageLite: ProtobufGeneratedMessage, Protobuf
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3144,7 +3144,7 @@ struct ProtobufUnittest_TestEmptyMessageWithExtensionsLite: ProtobufGeneratedMes
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -3201,7 +3201,7 @@ struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   private var _intField: Int32? = nil
-  public var intField: Int32 {
+  var intField: Int32 {
     get {return _intField ?? 0}
     set {_intField = newValue}
   }
@@ -3213,7 +3213,7 @@ struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   private var _enumField: ProtobufUnittest_V1EnumLite? = nil
-  public var enumField: ProtobufUnittest_V1EnumLite {
+  var enumField: ProtobufUnittest_V1EnumLite {
     get {return _enumField ?? ProtobufUnittest_V1EnumLite.v1First}
     set {_enumField = newValue}
   }
@@ -3224,7 +3224,7 @@ struct ProtobufUnittest_V1MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
     return _enumField = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3266,7 +3266,7 @@ struct ProtobufUnittest_V2MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   private var _intField: Int32? = nil
-  public var intField: Int32 {
+  var intField: Int32 {
     get {return _intField ?? 0}
     set {_intField = newValue}
   }
@@ -3278,7 +3278,7 @@ struct ProtobufUnittest_V2MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   private var _enumField: ProtobufUnittest_V2EnumLite? = nil
-  public var enumField: ProtobufUnittest_V2EnumLite {
+  var enumField: ProtobufUnittest_V2EnumLite {
     get {return _enumField ?? ProtobufUnittest_V2EnumLite.v2First}
     set {_enumField = newValue}
   }
@@ -3289,7 +3289,7 @@ struct ProtobufUnittest_V2MessageLite: ProtobufGeneratedMessage, ProtobufProto2M
     return _enumField = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_lite_imports_nonlite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite_imports_nonlite.pb.swift
@@ -97,7 +97,7 @@ struct ProtobufUnittest_TestLiteImportsNonlite: ProtobufGeneratedMessage, Protob
     set {_storage.unknown = newValue}
   }
 
-  public var message: ProtobufUnittest_TestAllTypes {
+  var message: ProtobufUnittest_TestAllTypes {
     get {return _storage._message ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._message = newValue}
   }
@@ -108,7 +108,7 @@ struct ProtobufUnittest_TestLiteImportsNonlite: ProtobufGeneratedMessage, Protob
     return _storage._message = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -100,7 +100,7 @@ struct ProtobufUnittest_TestMessageSetContainer: ProtobufGeneratedMessage, Proto
     set {_storage.unknown = newValue}
   }
 
-  public var messageSet: Proto2WireformatUnittest_TestMessageSet {
+  var messageSet: Proto2WireformatUnittest_TestMessageSet {
     get {return _storage._messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
     set {_uniqueStorage()._messageSet = newValue}
   }
@@ -111,7 +111,7 @@ struct ProtobufUnittest_TestMessageSetContainer: ProtobufGeneratedMessage, Proto
     return _storage._messageSet = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -152,7 +152,7 @@ struct ProtobufUnittest_TestMessageSetExtension1: ProtobufGeneratedMessage, Prot
   }
 
   private var _i: Int32? = nil
-  public var i: Int32 {
+  var i: Int32 {
     get {return _i ?? 0}
     set {_i = newValue}
   }
@@ -163,7 +163,7 @@ struct ProtobufUnittest_TestMessageSetExtension1: ProtobufGeneratedMessage, Prot
     return _i = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -205,7 +205,7 @@ struct ProtobufUnittest_TestMessageSetExtension2: ProtobufGeneratedMessage, Prot
   }
 
   private var _str: String? = nil
-  public var str: String {
+  var str: String {
     get {return _str ?? ""}
     set {_str = newValue}
   }
@@ -216,7 +216,7 @@ struct ProtobufUnittest_TestMessageSetExtension2: ProtobufGeneratedMessage, Prot
     return _str = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -280,7 +280,7 @@ struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage, ProtobufProto2M
     public var unknown = ProtobufUnknownStorage()
 
     private var _typeId: Int32? = nil
-    public var typeId: Int32 {
+    var typeId: Int32 {
       get {return _typeId ?? 0}
       set {_typeId = newValue}
     }
@@ -292,7 +292,7 @@ struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage, ProtobufProto2M
     }
 
     private var _message: Data? = nil
-    public var message: Data {
+    var message: Data {
       get {return _message ?? Data()}
       set {_message = newValue}
     }
@@ -303,7 +303,7 @@ struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage, ProtobufProto2M
       return _message = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -327,9 +327,9 @@ struct ProtobufUnittest_RawMessageSet: ProtobufGeneratedMessage, ProtobufProto2M
     }
   }
 
-  public var item: [ProtobufUnittest_RawMessageSet.Item] = []
+  var item: [ProtobufUnittest_RawMessageSet.Item] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
@@ -56,7 +56,7 @@ struct Proto2WireformatUnittest_TestMessageSet: ProtobufGeneratedMessage, Protob
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (4 <= protoFieldNumber && protoFieldNumber < 2147483647) {
@@ -150,7 +150,7 @@ struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer: ProtobufGener
     set {_storage.unknown = newValue}
   }
 
-  public var messageSet: Proto2WireformatUnittest_TestMessageSet {
+  var messageSet: Proto2WireformatUnittest_TestMessageSet {
     get {return _storage._messageSet ?? Proto2WireformatUnittest_TestMessageSet()}
     set {_uniqueStorage()._messageSet = newValue}
   }
@@ -161,7 +161,7 @@ struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer: ProtobufGener
     return _storage._messageSet = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -49,16 +49,16 @@ import SwiftProtobuf
 
 
 enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
 
-  public init() {
+  init() {
     self = .foreignFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 4: self = .foreignFoo
     case 5: self = .foreignBar
@@ -67,7 +67,7 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignFoo": self = .foreignFoo
     case "foreignBar": self = .foreignBar
@@ -76,7 +76,7 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -85,7 +85,7 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -94,7 +94,7 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignFoo: return 4
@@ -104,7 +104,7 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignFoo: return "\"FOREIGN_FOO\""
@@ -114,9 +114,9 @@ enum ProtobufUnittestNoArena_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignFoo: return ".foreignFoo"
@@ -913,7 +913,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
@@ -921,11 +921,11 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     ///   Intentionally negative.
     case neg // = -1
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       case 2: self = .bar
@@ -935,7 +935,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -945,7 +945,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -955,7 +955,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -965,7 +965,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -976,7 +976,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -987,9 +987,9 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1019,7 +1019,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -1030,7 +1030,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       return _bb = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1067,7 +1067,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1078,7 +1078,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1115,7 +1115,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1126,7 +1126,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1150,7 +1150,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
@@ -1161,7 +1161,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalInt32 = nil
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64 ?? 0}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
@@ -1172,7 +1172,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalInt64 = nil
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32 ?? 0}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
@@ -1183,7 +1183,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalUint32 = nil
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64 ?? 0}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
@@ -1194,7 +1194,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalUint64 = nil
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32 ?? 0}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
@@ -1205,7 +1205,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalSint32 = nil
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64 ?? 0}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
@@ -1216,7 +1216,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalSint64 = nil
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32 ?? 0}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
@@ -1227,7 +1227,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalFixed32 = nil
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64 ?? 0}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
@@ -1238,7 +1238,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalFixed64 = nil
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32 ?? 0}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
@@ -1249,7 +1249,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalSfixed32 = nil
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64 ?? 0}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
@@ -1260,7 +1260,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalSfixed64 = nil
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat ?? 0}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
@@ -1271,7 +1271,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalFloat = nil
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble ?? 0}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
@@ -1282,7 +1282,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalDouble = nil
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool ?? false}
     set {_uniqueStorage()._optionalBool = newValue}
   }
@@ -1293,7 +1293,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalBool = nil
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString ?? ""}
     set {_uniqueStorage()._optionalString = newValue}
   }
@@ -1304,7 +1304,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalString = nil
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes ?? Data()}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -1315,7 +1315,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalBytes = nil
   }
 
-  public var optionalGroup: ProtobufUnittestNoArena_TestAllTypes.OptionalGroup {
+  var optionalGroup: ProtobufUnittestNoArena_TestAllTypes.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittestNoArena_TestAllTypes.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -1326,7 +1326,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalGroup = nil
   }
 
-  public var optionalNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? ProtobufUnittestNoArena_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -1337,7 +1337,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: ProtobufUnittestNoArena_ForeignMessage {
+  var optionalForeignMessage: ProtobufUnittestNoArena_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? ProtobufUnittestNoArena_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -1348,7 +1348,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
+  var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
     get {return _storage._optionalImportMessage ?? ProtobufUnittestImport_ImportMessage()}
     set {_uniqueStorage()._optionalImportMessage = newValue}
   }
@@ -1359,7 +1359,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalImportMessage = nil
   }
 
-  public var optionalNestedEnum: ProtobufUnittestNoArena_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: ProtobufUnittestNoArena_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum ?? ProtobufUnittestNoArena_TestAllTypes.NestedEnum.foo}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
@@ -1370,7 +1370,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalNestedEnum = nil
   }
 
-  public var optionalForeignEnum: ProtobufUnittestNoArena_ForeignEnum {
+  var optionalForeignEnum: ProtobufUnittestNoArena_ForeignEnum {
     get {return _storage._optionalForeignEnum ?? ProtobufUnittestNoArena_ForeignEnum.foreignFoo}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
@@ -1381,7 +1381,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalForeignEnum = nil
   }
 
-  public var optionalImportEnum: ProtobufUnittestImport_ImportEnum {
+  var optionalImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._optionalImportEnum ?? ProtobufUnittestImport_ImportEnum.importFoo}
     set {_uniqueStorage()._optionalImportEnum = newValue}
   }
@@ -1392,7 +1392,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalImportEnum = nil
   }
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece ?? ""}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
@@ -1403,7 +1403,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalStringPiece = nil
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord ?? ""}
     set {_uniqueStorage()._optionalCord = newValue}
   }
@@ -1415,7 +1415,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   ///   Defined in unittest_import_public.proto
-  public var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
+  var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
   }
@@ -1426,7 +1426,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._optionalPublicImportMessage = nil
   }
 
-  public var optionalMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
+  var optionalMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {return _storage._optionalMessage ?? ProtobufUnittestNoArena_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalMessage = newValue}
   }
@@ -1438,133 +1438,133 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedGroup: [ProtobufUnittestNoArena_TestAllTypes.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittestNoArena_TestAllTypes.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public var repeatedNestedMessage: [ProtobufUnittestNoArena_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [ProtobufUnittestNoArena_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [ProtobufUnittestNoArena_ForeignMessage] {
+  var repeatedForeignMessage: [ProtobufUnittestNoArena_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
+  var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [ProtobufUnittestNoArena_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [ProtobufUnittestNoArena_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [ProtobufUnittestNoArena_ForeignEnum] {
+  var repeatedForeignEnum: [ProtobufUnittestNoArena_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedImportEnum: [ProtobufUnittestImport_ImportEnum] {
+  var repeatedImportEnum: [ProtobufUnittestImport_ImportEnum] {
     get {return _storage._repeatedImportEnum}
     set {_uniqueStorage()._repeatedImportEnum = newValue}
   }
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [ProtobufUnittestNoArena_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessage: [ProtobufUnittestNoArena_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
   ///   Singular with defaults
-  public var defaultInt32: Int32 {
+  var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
   }
@@ -1575,7 +1575,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultInt32 = nil
   }
 
-  public var defaultInt64: Int64 {
+  var defaultInt64: Int64 {
     get {return _storage._defaultInt64 ?? 42}
     set {_uniqueStorage()._defaultInt64 = newValue}
   }
@@ -1586,7 +1586,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultInt64 = nil
   }
 
-  public var defaultUint32: UInt32 {
+  var defaultUint32: UInt32 {
     get {return _storage._defaultUint32 ?? 43}
     set {_uniqueStorage()._defaultUint32 = newValue}
   }
@@ -1597,7 +1597,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultUint32 = nil
   }
 
-  public var defaultUint64: UInt64 {
+  var defaultUint64: UInt64 {
     get {return _storage._defaultUint64 ?? 44}
     set {_uniqueStorage()._defaultUint64 = newValue}
   }
@@ -1608,7 +1608,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultUint64 = nil
   }
 
-  public var defaultSint32: Int32 {
+  var defaultSint32: Int32 {
     get {return _storage._defaultSint32 ?? -45}
     set {_uniqueStorage()._defaultSint32 = newValue}
   }
@@ -1619,7 +1619,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultSint32 = nil
   }
 
-  public var defaultSint64: Int64 {
+  var defaultSint64: Int64 {
     get {return _storage._defaultSint64 ?? 46}
     set {_uniqueStorage()._defaultSint64 = newValue}
   }
@@ -1630,7 +1630,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultSint64 = nil
   }
 
-  public var defaultFixed32: UInt32 {
+  var defaultFixed32: UInt32 {
     get {return _storage._defaultFixed32 ?? 47}
     set {_uniqueStorage()._defaultFixed32 = newValue}
   }
@@ -1641,7 +1641,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultFixed32 = nil
   }
 
-  public var defaultFixed64: UInt64 {
+  var defaultFixed64: UInt64 {
     get {return _storage._defaultFixed64 ?? 48}
     set {_uniqueStorage()._defaultFixed64 = newValue}
   }
@@ -1652,7 +1652,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultFixed64 = nil
   }
 
-  public var defaultSfixed32: Int32 {
+  var defaultSfixed32: Int32 {
     get {return _storage._defaultSfixed32 ?? 49}
     set {_uniqueStorage()._defaultSfixed32 = newValue}
   }
@@ -1663,7 +1663,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultSfixed32 = nil
   }
 
-  public var defaultSfixed64: Int64 {
+  var defaultSfixed64: Int64 {
     get {return _storage._defaultSfixed64 ?? -50}
     set {_uniqueStorage()._defaultSfixed64 = newValue}
   }
@@ -1674,7 +1674,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultSfixed64 = nil
   }
 
-  public var defaultFloat: Float {
+  var defaultFloat: Float {
     get {return _storage._defaultFloat ?? 51.5}
     set {_uniqueStorage()._defaultFloat = newValue}
   }
@@ -1685,7 +1685,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultFloat = nil
   }
 
-  public var defaultDouble: Double {
+  var defaultDouble: Double {
     get {return _storage._defaultDouble ?? 52000}
     set {_uniqueStorage()._defaultDouble = newValue}
   }
@@ -1696,7 +1696,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultDouble = nil
   }
 
-  public var defaultBool: Bool {
+  var defaultBool: Bool {
     get {return _storage._defaultBool ?? true}
     set {_uniqueStorage()._defaultBool = newValue}
   }
@@ -1707,7 +1707,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultBool = nil
   }
 
-  public var defaultString: String {
+  var defaultString: String {
     get {return _storage._defaultString ?? "hello"}
     set {_uniqueStorage()._defaultString = newValue}
   }
@@ -1718,7 +1718,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultString = nil
   }
 
-  public var defaultBytes: Data {
+  var defaultBytes: Data {
     get {return _storage._defaultBytes ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {_uniqueStorage()._defaultBytes = newValue}
   }
@@ -1729,7 +1729,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultBytes = nil
   }
 
-  public var defaultNestedEnum: ProtobufUnittestNoArena_TestAllTypes.NestedEnum {
+  var defaultNestedEnum: ProtobufUnittestNoArena_TestAllTypes.NestedEnum {
     get {return _storage._defaultNestedEnum ?? ProtobufUnittestNoArena_TestAllTypes.NestedEnum.bar}
     set {_uniqueStorage()._defaultNestedEnum = newValue}
   }
@@ -1740,7 +1740,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultNestedEnum = nil
   }
 
-  public var defaultForeignEnum: ProtobufUnittestNoArena_ForeignEnum {
+  var defaultForeignEnum: ProtobufUnittestNoArena_ForeignEnum {
     get {return _storage._defaultForeignEnum ?? ProtobufUnittestNoArena_ForeignEnum.foreignBar}
     set {_uniqueStorage()._defaultForeignEnum = newValue}
   }
@@ -1751,7 +1751,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultForeignEnum = nil
   }
 
-  public var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
+  var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._defaultImportEnum ?? ProtobufUnittestImport_ImportEnum.importBar}
     set {_uniqueStorage()._defaultImportEnum = newValue}
   }
@@ -1762,7 +1762,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultImportEnum = nil
   }
 
-  public var defaultStringPiece: String {
+  var defaultStringPiece: String {
     get {return _storage._defaultStringPiece ?? "abc"}
     set {_uniqueStorage()._defaultStringPiece = newValue}
   }
@@ -1773,7 +1773,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultStringPiece = nil
   }
 
-  public var defaultCord: String {
+  var defaultCord: String {
     get {return _storage._defaultCord ?? "123"}
     set {_uniqueStorage()._defaultCord = newValue}
   }
@@ -1784,7 +1784,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     return _storage._defaultCord = nil
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1796,7 +1796,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var oneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1808,7 +1808,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1820,7 +1820,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1832,7 +1832,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var lazyOneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
+  var lazyOneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
       if case .lazyOneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1851,7 +1851,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1889,7 +1889,7 @@ struct ProtobufUnittestNoArena_ForeignMessage: ProtobufGeneratedMessage, Protobu
   public var unknown = ProtobufUnknownStorage()
 
   private var _c: Int32? = nil
-  public var c: Int32 {
+  var c: Int32 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -1900,7 +1900,7 @@ struct ProtobufUnittestNoArena_ForeignMessage: ProtobufGeneratedMessage, Protobu
     return _c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1976,7 +1976,7 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage: ProtobufGeneratedMessage, Pro
     set {_storage.unknown = newValue}
   }
 
-  public var arenaMessage: Proto2ArenaUnittest_ArenaMessage {
+  var arenaMessage: Proto2ArenaUnittest_ArenaMessage {
     get {return _storage._arenaMessage ?? Proto2ArenaUnittest_ArenaMessage()}
     set {_uniqueStorage()._arenaMessage = newValue}
   }
@@ -1987,7 +1987,7 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage: ProtobufGeneratedMessage, Pro
     return _storage._arenaMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/unittest_no_arena_import.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena_import.pb.swift
@@ -54,7 +54,7 @@ struct Proto2ArenaUnittest_ImportNoArenaNestedMessage: ProtobufGeneratedMessage,
   public var unknown = ProtobufUnknownStorage()
 
   private var _d: Int32? = nil
-  public var d: Int32 {
+  var d: Int32 {
     get {return _d ?? 0}
     set {_d = newValue}
   }
@@ -65,7 +65,7 @@ struct Proto2ArenaUnittest_ImportNoArenaNestedMessage: ProtobufGeneratedMessage,
     return _d = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_no_arena_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena_lite.pb.swift
@@ -54,7 +54,7 @@ struct ProtobufUnittestNoArena_ForeignMessageLite: ProtobufGeneratedMessage, Pro
   public var unknown = ProtobufUnknownStorage()
 
   private var _c: Int32? = nil
-  public var c: Int32 {
+  var c: Int32 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -65,7 +65,7 @@ struct ProtobufUnittestNoArena_ForeignMessageLite: ProtobufGeneratedMessage, Pro
     return _c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -43,17 +43,17 @@ import SwiftProtobuf
 
 
 enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
   case foreignBaz // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foreignFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foreignFoo
     case 1: self = .foreignBar
@@ -62,7 +62,7 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignFoo": self = .foreignFoo
     case "foreignBar": self = .foreignBar
@@ -71,7 +71,7 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -80,7 +80,7 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_FOO": self = .foreignFoo
     case "FOREIGN_BAR": self = .foreignBar
@@ -89,7 +89,7 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignFoo: return 0
@@ -100,7 +100,7 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignFoo: return "\"FOREIGN_FOO\""
@@ -111,9 +111,9 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignFoo: return ".foreignFoo"
@@ -659,17 +659,17 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -678,7 +678,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -687,7 +687,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -696,7 +696,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -705,7 +705,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -716,7 +716,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -727,9 +727,9 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -754,9 +754,9 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     ]}
 
 
-    public var bb: Int32 = 0
+    var bb: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -780,82 +780,82 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
   ///   Singular
   ///   TODO: remove 'optional' labels as soon as CL 69188077 is LGTM'd to make
   ///   'optional' optional.
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  public var optionalNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -866,7 +866,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: Proto2NofieldpresenceUnittest_ForeignMessage {
+  var optionalForeignMessage: Proto2NofieldpresenceUnittest_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? Proto2NofieldpresenceUnittest_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -877,7 +877,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalProto2Message: ProtobufUnittest_TestAllTypes {
+  var optionalProto2Message: ProtobufUnittest_TestAllTypes {
     get {return _storage._optionalProto2Message ?? ProtobufUnittest_TestAllTypes()}
     set {_uniqueStorage()._optionalProto2Message = newValue}
   }
@@ -888,7 +888,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     return _storage._optionalProto2Message = nil
   }
 
-  public var optionalNestedEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
@@ -896,22 +896,22 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
   ///   N.B.: proto2-enum-type fields not allowed, because their default values
   ///   might not be zero.
   ///  optional protobuf_unittest.ForeignEnum          optional_proto2_enum     = 23;
-  public var optionalForeignEnum: Proto2NofieldpresenceUnittest_ForeignEnum {
+  var optionalForeignEnum: Proto2NofieldpresenceUnittest_ForeignEnum {
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord}
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
-  public var optionalLazyMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
+  var optionalLazyMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalLazyMessage ?? Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalLazyMessage = newValue}
   }
@@ -923,122 +923,122 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedNestedMessage: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [Proto2NofieldpresenceUnittest_ForeignMessage] {
+  var repeatedForeignMessage: [Proto2NofieldpresenceUnittest_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedProto2Message: [ProtobufUnittest_TestAllTypes] {
+  var repeatedProto2Message: [ProtobufUnittest_TestAllTypes] {
     get {return _storage._repeatedProto2Message}
     set {_uniqueStorage()._repeatedProto2Message = newValue}
   }
 
-  public var repeatedNestedEnum: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [Proto2NofieldpresenceUnittest_ForeignEnum] {
+  var repeatedForeignEnum: [Proto2NofieldpresenceUnittest_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessage: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1050,7 +1050,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     }
   }
 
-  public var oneofNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1062,7 +1062,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1074,7 +1074,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     }
   }
 
-  public var oneofEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
+  var oneofEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
     get {
       if case .oneofEnum(let v) = _storage._oneofField {
         return v
@@ -1093,7 +1093,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: ProtobufGeneratedMessage, Pro
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1160,7 +1160,7 @@ struct Proto2NofieldpresenceUnittest_TestProto2Required: ProtobufGeneratedMessag
   private var _storage = _StorageClass()
 
 
-  public var proto2: ProtobufUnittest_TestRequired {
+  var proto2: ProtobufUnittest_TestRequired {
     get {return _storage._proto2 ?? ProtobufUnittest_TestRequired()}
     set {_uniqueStorage()._proto2 = newValue}
   }
@@ -1171,7 +1171,7 @@ struct Proto2NofieldpresenceUnittest_TestProto2Required: ProtobufGeneratedMessag
     return _storage._proto2 = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1207,9 +1207,9 @@ struct Proto2NofieldpresenceUnittest_ForeignMessage: ProtobufGeneratedMessage, P
   ]}
 
 
-  public var c: Int32 = 0
+  var c: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -43,42 +43,42 @@ import SwiftProtobuf
 
 
 enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 1
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 1: self = .foo
     default: return nil
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     default: return nil
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOO": self = .foo
     default: return nil
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOO": self = .foo
     default: return nil
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 1
@@ -86,7 +86,7 @@ enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"FOO\""
@@ -94,9 +94,9 @@ enum Google_Protobuf_NoGenericServicesTest_TestEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -122,7 +122,7 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: ProtobufGeneratedMessa
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -133,7 +133,7 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: ProtobufGeneratedMessa
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -181,7 +181,7 @@ struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, Protobuf
     static let ProtobufUnittest_TestOptimizedForSize_testExtension2 = ProtobufGenericMessageExtension<ProtobufOptionalMessageField<ProtobufUnittest_TestRequiredOptimizedForSize>, ProtobufUnittest_TestOptimizedForSize>(protoFieldNumber: 1235, protoFieldName: "test_extension2", jsonFieldName: "testExtension2", swiftFieldName: "ProtobufUnittest_TestOptimizedForSize_testExtension2", defaultValue: ProtobufUnittest_TestRequiredOptimizedForSize())
   }
 
-  public var i: Int32 {
+  var i: Int32 {
     get {return _storage._i ?? 0}
     set {_uniqueStorage()._i = newValue}
   }
@@ -192,7 +192,7 @@ struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, Protobuf
     return _storage._i = nil
   }
 
-  public var msg: ProtobufUnittest_ForeignMessage {
+  var msg: ProtobufUnittest_ForeignMessage {
     get {return _storage._msg ?? ProtobufUnittest_ForeignMessage()}
     set {_uniqueStorage()._msg = newValue}
   }
@@ -203,7 +203,7 @@ struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, Protobuf
     return _storage._msg = nil
   }
 
-  public var integerField: Int32 {
+  var integerField: Int32 {
     get {
       if case .integerField(let v) = _storage._foo {
         return v
@@ -215,7 +215,7 @@ struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public var stringField: String {
+  var stringField: String {
     get {
       if case .stringField(let v) = _storage._foo {
         return v
@@ -234,7 +234,7 @@ struct ProtobufUnittest_TestOptimizedForSize: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -286,7 +286,7 @@ struct ProtobufUnittest_TestRequiredOptimizedForSize: ProtobufGeneratedMessage, 
   public var unknown = ProtobufUnknownStorage()
 
   private var _x: Int32? = nil
-  public var x: Int32 {
+  var x: Int32 {
     get {return _x ?? 0}
     set {_x = newValue}
   }
@@ -297,7 +297,7 @@ struct ProtobufUnittest_TestRequiredOptimizedForSize: ProtobufGeneratedMessage, 
     return _x = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -371,7 +371,7 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: ProtobufGeneratedMessage, 
     set {_storage.unknown = newValue}
   }
 
-  public var o: ProtobufUnittest_TestRequiredOptimizedForSize {
+  var o: ProtobufUnittest_TestRequiredOptimizedForSize {
     get {return _storage._o ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
     set {_uniqueStorage()._o = newValue}
   }
@@ -382,7 +382,7 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: ProtobufGeneratedMessage, 
     return _storage._o = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -41,17 +41,17 @@ import SwiftProtobuf
 
 
 enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foo
     case 1: self = .bar
@@ -60,7 +60,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     case "bar": self = .bar
@@ -69,7 +69,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOO": self = .foo
     case "BAR": self = .bar
@@ -78,7 +78,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOO": self = .foo
     case "BAR": self = .bar
@@ -87,7 +87,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 0
@@ -98,7 +98,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"FOO\""
@@ -109,9 +109,9 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -125,18 +125,18 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
 }
 
 enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case eFoo // = 0
   case eBar // = 1
   case eBaz // = 2
   case eExtra // = 3
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .eFoo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .eFoo
     case 1: self = .eBar
@@ -146,7 +146,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "eFoo": self = .eFoo
     case "eBar": self = .eBar
@@ -156,7 +156,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "E_FOO": self = .eFoo
     case "E_BAR": self = .eBar
@@ -166,7 +166,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "E_FOO": self = .eFoo
     case "E_BAR": self = .eBar
@@ -176,7 +176,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .eFoo: return 0
@@ -188,7 +188,7 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .eFoo: return "\"E_FOO\""
@@ -200,9 +200,9 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .eFoo: return ".eFoo"
@@ -285,16 +285,16 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
     }
   }
 
-  public var e: Proto3PreserveUnknownEnumUnittest_MyEnum = Proto3PreserveUnknownEnumUnittest_MyEnum.foo
+  var e: Proto3PreserveUnknownEnumUnittest_MyEnum = Proto3PreserveUnknownEnumUnittest_MyEnum.foo
 
-  public var repeatedE: [Proto3PreserveUnknownEnumUnittest_MyEnum] = []
+  var repeatedE: [Proto3PreserveUnknownEnumUnittest_MyEnum] = []
 
-  public var repeatedPackedE: [Proto3PreserveUnknownEnumUnittest_MyEnum] = []
+  var repeatedPackedE: [Proto3PreserveUnknownEnumUnittest_MyEnum] = []
 
   ///   not packed
-  public var repeatedPackedUnexpectedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
+  var repeatedPackedUnexpectedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
 
-  public var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnum {
+  var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
       if case .oneofE1(let v) = o {
         return v
@@ -308,7 +308,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
 
   public var o: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O = .None
 
-  public var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnum {
+  var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
       if case .oneofE2(let v) = o {
         return v
@@ -320,7 +320,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -428,15 +428,15 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGeneratedMe
     }
   }
 
-  public var e: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
+  var e: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
 
-  public var repeatedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
+  var repeatedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
 
-  public var repeatedPackedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
+  var repeatedPackedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
 
-  public var repeatedPackedUnexpectedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
+  var repeatedPackedUnexpectedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
 
-  public var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
+  var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
       if case .oneofE1(let v) = o {
         return v
@@ -450,7 +450,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGeneratedMe
 
   public var o: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O = .None
 
-  public var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
+  var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
       if case .oneofE2(let v) = o {
         return v
@@ -462,7 +462,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: ProtobufGeneratedMe
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -41,16 +41,16 @@ import SwiftProtobuf
 
 
 enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
 
-  public init() {
+  init() {
     self = .foo
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foo
     case 1: self = .bar
@@ -59,7 +59,7 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foo": self = .foo
     case "bar": self = .bar
@@ -68,7 +68,7 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOO": self = .foo
     case "BAR": self = .bar
@@ -77,7 +77,7 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOO": self = .foo
     case "BAR": self = .bar
@@ -86,7 +86,7 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foo: return 0
@@ -96,7 +96,7 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foo: return "\"FOO\""
@@ -106,9 +106,9 @@ enum Proto2PreserveUnknownEnumUnittest_MyEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foo: return ".foo"
@@ -195,7 +195,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
   }
 
   private var _e: Proto2PreserveUnknownEnumUnittest_MyEnum? = nil
-  public var e: Proto2PreserveUnknownEnumUnittest_MyEnum {
+  var e: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {return _e ?? Proto2PreserveUnknownEnumUnittest_MyEnum.foo}
     set {_e = newValue}
   }
@@ -206,14 +206,14 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
     return _e = nil
   }
 
-  public var repeatedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
+  var repeatedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
 
-  public var repeatedPackedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
+  var repeatedPackedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
 
   ///   not packed
-  public var repeatedPackedUnexpectedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
+  var repeatedPackedUnexpectedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
 
-  public var oneofE1: Proto2PreserveUnknownEnumUnittest_MyEnum {
+  var oneofE1: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
       if case .oneofE1(let v) = o {
         return v
@@ -227,7 +227,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
 
   public var o: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O = .None
 
-  public var oneofE2: Proto2PreserveUnknownEnumUnittest_MyEnum {
+  var oneofE2: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
       if case .oneofE2(let v) = o {
         return v
@@ -239,7 +239,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: ProtobufGeneratedMessage, Pr
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -47,18 +47,18 @@ import SwiftProtobuf
 
 
 enum Proto3ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignUnspecified // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foreignUnspecified
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foreignUnspecified
     case 4: self = .foreignFoo
@@ -68,7 +68,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignUnspecified": self = .foreignUnspecified
     case "foreignFoo": self = .foreignFoo
@@ -78,7 +78,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_UNSPECIFIED": self = .foreignUnspecified
     case "FOREIGN_FOO": self = .foreignFoo
@@ -88,7 +88,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_UNSPECIFIED": self = .foreignUnspecified
     case "FOREIGN_FOO": self = .foreignFoo
@@ -98,7 +98,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignUnspecified: return 0
@@ -110,7 +110,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignUnspecified: return "\"FOREIGN_UNSPECIFIED\""
@@ -122,9 +122,9 @@ enum Proto3ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignUnspecified: return ".foreignUnspecified"
@@ -140,7 +140,7 @@ enum Proto3ForeignEnum: ProtobufEnum {
 
 ///   Test an enum that has multiple values with the same number.
 enum Proto3TestEnumWithDupValue: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case testEnumWithDupValueUnspecified // = 0
   case foo1 // = 1
   case bar1 // = 2
@@ -149,11 +149,11 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
   case bar2 // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .testEnumWithDupValueUnspecified
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .testEnumWithDupValueUnspecified
     case 1: self = .foo1
@@ -163,7 +163,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "testEnumWithDupValueUnspecified": self = .testEnumWithDupValueUnspecified
     case "foo1": self = .foo1
@@ -175,7 +175,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED": self = .testEnumWithDupValueUnspecified
     case "FOO1": self = .foo1
@@ -187,7 +187,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED": self = .testEnumWithDupValueUnspecified
     case "FOO1": self = .foo1
@@ -199,7 +199,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .testEnumWithDupValueUnspecified: return 0
@@ -213,7 +213,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .testEnumWithDupValueUnspecified: return "\"TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED\""
@@ -227,9 +227,9 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .testEnumWithDupValueUnspecified: return ".testEnumWithDupValueUnspecified"
@@ -247,7 +247,7 @@ enum Proto3TestEnumWithDupValue: ProtobufEnum {
 
 ///   Test an enum with large, unordered values.
 enum Proto3TestSparseEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case testSparseEnumUnspecified // = 0
   case sparseA // = 123
   case sparseB // = 62374
@@ -260,11 +260,11 @@ enum Proto3TestSparseEnum: ProtobufEnum {
   case sparseG // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .testSparseEnumUnspecified
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .testSparseEnumUnspecified
     case 123: self = .sparseA
@@ -277,7 +277,7 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "testSparseEnumUnspecified": self = .testSparseEnumUnspecified
     case "sparseA": self = .sparseA
@@ -290,7 +290,7 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "TEST_SPARSE_ENUM_UNSPECIFIED": self = .testSparseEnumUnspecified
     case "SPARSE_A": self = .sparseA
@@ -303,7 +303,7 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "TEST_SPARSE_ENUM_UNSPECIFIED": self = .testSparseEnumUnspecified
     case "SPARSE_A": self = .sparseA
@@ -316,7 +316,7 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .testSparseEnumUnspecified: return 0
@@ -331,7 +331,7 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .testSparseEnumUnspecified: return "\"TEST_SPARSE_ENUM_UNSPECIFIED\""
@@ -346,9 +346,9 @@ enum Proto3TestSparseEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .testSparseEnumUnspecified: return ".testSparseEnumUnspecified"
@@ -880,7 +880,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case nestedEnumUnspecified // = 0
     case foo // = 1
     case bar // = 2
@@ -890,11 +890,11 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     case neg // = -1
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .nestedEnumUnspecified
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .nestedEnumUnspecified
       case 1: self = .foo
@@ -905,7 +905,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "nestedEnumUnspecified": self = .nestedEnumUnspecified
       case "foo": self = .foo
@@ -916,7 +916,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "NESTED_ENUM_UNSPECIFIED": self = .nestedEnumUnspecified
       case "FOO": self = .foo
@@ -927,7 +927,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "NESTED_ENUM_UNSPECIFIED": self = .nestedEnumUnspecified
       case "FOO": self = .foo
@@ -938,7 +938,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .nestedEnumUnspecified: return 0
@@ -951,7 +951,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .nestedEnumUnspecified: return "\"NESTED_ENUM_UNSPECIFIED\""
@@ -964,9 +964,9 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .nestedEnumUnspecified: return ".nestedEnumUnspecified"
@@ -996,9 +996,9 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     ///   The field name "b" fails to compile in proto1 because it conflicts with
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
-    public var bb: Int32 = 0
+    var bb: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1020,82 +1020,82 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Singular
-  public var singleInt32: Int32 {
+  var singleInt32: Int32 {
     get {return _storage._singleInt32}
     set {_uniqueStorage()._singleInt32 = newValue}
   }
 
-  public var singleInt64: Int64 {
+  var singleInt64: Int64 {
     get {return _storage._singleInt64}
     set {_uniqueStorage()._singleInt64 = newValue}
   }
 
-  public var singleUint32: UInt32 {
+  var singleUint32: UInt32 {
     get {return _storage._singleUint32}
     set {_uniqueStorage()._singleUint32 = newValue}
   }
 
-  public var singleUint64: UInt64 {
+  var singleUint64: UInt64 {
     get {return _storage._singleUint64}
     set {_uniqueStorage()._singleUint64 = newValue}
   }
 
-  public var singleSint32: Int32 {
+  var singleSint32: Int32 {
     get {return _storage._singleSint32}
     set {_uniqueStorage()._singleSint32 = newValue}
   }
 
-  public var singleSint64: Int64 {
+  var singleSint64: Int64 {
     get {return _storage._singleSint64}
     set {_uniqueStorage()._singleSint64 = newValue}
   }
 
-  public var singleFixed32: UInt32 {
+  var singleFixed32: UInt32 {
     get {return _storage._singleFixed32}
     set {_uniqueStorage()._singleFixed32 = newValue}
   }
 
-  public var singleFixed64: UInt64 {
+  var singleFixed64: UInt64 {
     get {return _storage._singleFixed64}
     set {_uniqueStorage()._singleFixed64 = newValue}
   }
 
-  public var singleSfixed32: Int32 {
+  var singleSfixed32: Int32 {
     get {return _storage._singleSfixed32}
     set {_uniqueStorage()._singleSfixed32 = newValue}
   }
 
-  public var singleSfixed64: Int64 {
+  var singleSfixed64: Int64 {
     get {return _storage._singleSfixed64}
     set {_uniqueStorage()._singleSfixed64 = newValue}
   }
 
-  public var singleFloat: Float {
+  var singleFloat: Float {
     get {return _storage._singleFloat}
     set {_uniqueStorage()._singleFloat = newValue}
   }
 
-  public var singleDouble: Double {
+  var singleDouble: Double {
     get {return _storage._singleDouble}
     set {_uniqueStorage()._singleDouble = newValue}
   }
 
-  public var singleBool: Bool {
+  var singleBool: Bool {
     get {return _storage._singleBool}
     set {_uniqueStorage()._singleBool = newValue}
   }
 
-  public var singleString: String {
+  var singleString: String {
     get {return _storage._singleString}
     set {_uniqueStorage()._singleString = newValue}
   }
 
-  public var singleBytes: Data {
+  var singleBytes: Data {
     get {return _storage._singleBytes}
     set {_uniqueStorage()._singleBytes = newValue}
   }
 
-  public var singleNestedMessage: Proto3TestAllTypes.NestedMessage {
+  var singleNestedMessage: Proto3TestAllTypes.NestedMessage {
     get {return _storage._singleNestedMessage ?? Proto3TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._singleNestedMessage = newValue}
   }
@@ -1106,7 +1106,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     return _storage._singleNestedMessage = nil
   }
 
-  public var singleForeignMessage: Proto3ForeignMessage {
+  var singleForeignMessage: Proto3ForeignMessage {
     get {return _storage._singleForeignMessage ?? Proto3ForeignMessage()}
     set {_uniqueStorage()._singleForeignMessage = newValue}
   }
@@ -1117,7 +1117,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     return _storage._singleForeignMessage = nil
   }
 
-  public var singleImportMessage: Proto3ImportMessage {
+  var singleImportMessage: Proto3ImportMessage {
     get {return _storage._singleImportMessage ?? Proto3ImportMessage()}
     set {_uniqueStorage()._singleImportMessage = newValue}
   }
@@ -1128,23 +1128,23 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     return _storage._singleImportMessage = nil
   }
 
-  public var singleNestedEnum: Proto3TestAllTypes.NestedEnum {
+  var singleNestedEnum: Proto3TestAllTypes.NestedEnum {
     get {return _storage._singleNestedEnum}
     set {_uniqueStorage()._singleNestedEnum = newValue}
   }
 
-  public var singleForeignEnum: Proto3ForeignEnum {
+  var singleForeignEnum: Proto3ForeignEnum {
     get {return _storage._singleForeignEnum}
     set {_uniqueStorage()._singleForeignEnum = newValue}
   }
 
-  public var singleImportEnum: Proto3ImportEnum {
+  var singleImportEnum: Proto3ImportEnum {
     get {return _storage._singleImportEnum}
     set {_uniqueStorage()._singleImportEnum = newValue}
   }
 
   ///   Defined in unittest_import_public.proto
-  public var singlePublicImportMessage: Proto3PublicImportMessage {
+  var singlePublicImportMessage: Proto3PublicImportMessage {
     get {return _storage._singlePublicImportMessage ?? Proto3PublicImportMessage()}
     set {_uniqueStorage()._singlePublicImportMessage = newValue}
   }
@@ -1156,118 +1156,118 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedNestedMessage: [Proto3TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [Proto3TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [Proto3ForeignMessage] {
+  var repeatedForeignMessage: [Proto3ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [Proto3ImportMessage] {
+  var repeatedImportMessage: [Proto3ImportMessage] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [Proto3TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [Proto3TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [Proto3ForeignEnum] {
+  var repeatedForeignEnum: [Proto3ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
 
-  public var repeatedImportEnum: [Proto3ImportEnum] {
+  var repeatedImportEnum: [Proto3ImportEnum] {
     get {return _storage._repeatedImportEnum}
     set {_uniqueStorage()._repeatedImportEnum = newValue}
   }
 
   ///   Defined in unittest_import_public.proto
-  public var repeatedPublicImportMessage: [Proto3PublicImportMessage] {
+  var repeatedPublicImportMessage: [Proto3PublicImportMessage] {
     get {return _storage._repeatedPublicImportMessage}
     set {_uniqueStorage()._repeatedPublicImportMessage = newValue}
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1279,7 +1279,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var oneofNestedMessage: Proto3TestAllTypes.NestedMessage {
+  var oneofNestedMessage: Proto3TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1291,7 +1291,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1303,7 +1303,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1322,7 +1322,7 @@ struct Proto3TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1408,7 +1408,7 @@ struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
   private var _storage = _StorageClass()
 
 
-  public var child: Proto3NestedTestAllTypes {
+  var child: Proto3NestedTestAllTypes {
     get {return _storage._child ?? Proto3NestedTestAllTypes()}
     set {_uniqueStorage()._child = newValue}
   }
@@ -1419,7 +1419,7 @@ struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._child = nil
   }
 
-  public var payload: Proto3TestAllTypes {
+  var payload: Proto3TestAllTypes {
     get {return _storage._payload ?? Proto3TestAllTypes()}
     set {_uniqueStorage()._payload = newValue}
   }
@@ -1430,12 +1430,12 @@ struct Proto3NestedTestAllTypes: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._payload = nil
   }
 
-  public var repeatedChild: [Proto3NestedTestAllTypes] {
+  var repeatedChild: [Proto3NestedTestAllTypes] {
     get {return _storage._repeatedChild}
     set {_uniqueStorage()._repeatedChild = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1469,9 +1469,9 @@ struct Proto3TestDeprecatedFields: ProtobufGeneratedMessage, ProtobufProto3Messa
   ]}
 
 
-  public var deprecatedInt32: Int32 = 0
+  var deprecatedInt32: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1506,9 +1506,9 @@ struct Proto3ForeignMessage: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var c: Int32 = 0
+  var c: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1537,7 +1537,7 @@ struct Proto3TestReservedFields: ProtobufGeneratedMessage, ProtobufProto3Message
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -1596,7 +1596,7 @@ struct Proto3TestForeignNested: ProtobufGeneratedMessage, ProtobufProto3Message 
   private var _storage = _StorageClass()
 
 
-  public var foreignNested: Proto3TestAllTypes.NestedMessage {
+  var foreignNested: Proto3TestAllTypes.NestedMessage {
     get {return _storage._foreignNested ?? Proto3TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._foreignNested = newValue}
   }
@@ -1607,7 +1607,7 @@ struct Proto3TestForeignNested: ProtobufGeneratedMessage, ProtobufProto3Message 
     return _storage._foreignNested = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1646,11 +1646,11 @@ struct Proto3TestReallyLargeTagNumber: ProtobufGeneratedMessage, ProtobufProto3M
 
   ///   The largest possible tag number is 2^28 - 1, since the wire format uses
   ///   three bits to communicate wire type.
-  public var a: Int32 = 0
+  var a: Int32 = 0
 
-  public var bb: Int32 = 0
+  var bb: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1730,7 +1730,7 @@ struct Proto3TestRecursiveMessage: ProtobufGeneratedMessage, ProtobufProto3Messa
   private var _storage = _StorageClass()
 
 
-  public var a: Proto3TestRecursiveMessage {
+  var a: Proto3TestRecursiveMessage {
     get {return _storage._a ?? Proto3TestRecursiveMessage()}
     set {_uniqueStorage()._a = newValue}
   }
@@ -1741,12 +1741,12 @@ struct Proto3TestRecursiveMessage: ProtobufGeneratedMessage, ProtobufProto3Messa
     return _storage._a = nil
   }
 
-  public var i: Int32 {
+  var i: Int32 {
     get {return _storage._i}
     set {_uniqueStorage()._i = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1814,7 +1814,7 @@ struct Proto3TestMutualRecursionA: ProtobufGeneratedMessage, ProtobufProto3Messa
   private var _storage = _StorageClass()
 
 
-  public var bb: Proto3TestMutualRecursionB {
+  var bb: Proto3TestMutualRecursionB {
     get {return _storage._bb ?? Proto3TestMutualRecursionB()}
     set {_uniqueStorage()._bb = newValue}
   }
@@ -1825,7 +1825,7 @@ struct Proto3TestMutualRecursionA: ProtobufGeneratedMessage, ProtobufProto3Messa
     return _storage._bb = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1901,7 +1901,7 @@ struct Proto3TestMutualRecursionB: ProtobufGeneratedMessage, ProtobufProto3Messa
   private var _storage = _StorageClass()
 
 
-  public var a: Proto3TestMutualRecursionA {
+  var a: Proto3TestMutualRecursionA {
     get {return _storage._a ?? Proto3TestMutualRecursionA()}
     set {_uniqueStorage()._a = newValue}
   }
@@ -1912,12 +1912,12 @@ struct Proto3TestMutualRecursionB: ProtobufGeneratedMessage, ProtobufProto3Messa
     return _storage._a = nil
   }
 
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2049,22 +2049,22 @@ struct Proto3TestCamelCaseFieldNames: ProtobufGeneratedMessage, ProtobufProto3Me
   private var _storage = _StorageClass()
 
 
-  public var primitiveField: Int32 {
+  var primitiveField: Int32 {
     get {return _storage._primitiveField}
     set {_uniqueStorage()._primitiveField = newValue}
   }
 
-  public var stringField: String {
+  var stringField: String {
     get {return _storage._stringField}
     set {_uniqueStorage()._stringField = newValue}
   }
 
-  public var enumField: Proto3ForeignEnum {
+  var enumField: Proto3ForeignEnum {
     get {return _storage._enumField}
     set {_uniqueStorage()._enumField = newValue}
   }
 
-  public var messageField: Proto3ForeignMessage {
+  var messageField: Proto3ForeignMessage {
     get {return _storage._messageField ?? Proto3ForeignMessage()}
     set {_uniqueStorage()._messageField = newValue}
   }
@@ -2075,27 +2075,27 @@ struct Proto3TestCamelCaseFieldNames: ProtobufGeneratedMessage, ProtobufProto3Me
     return _storage._messageField = nil
   }
 
-  public var repeatedPrimitiveField: [Int32] {
+  var repeatedPrimitiveField: [Int32] {
     get {return _storage._repeatedPrimitiveField}
     set {_uniqueStorage()._repeatedPrimitiveField = newValue}
   }
 
-  public var repeatedStringField: [String] {
+  var repeatedStringField: [String] {
     get {return _storage._repeatedStringField}
     set {_uniqueStorage()._repeatedStringField = newValue}
   }
 
-  public var repeatedEnumField: [Proto3ForeignEnum] {
+  var repeatedEnumField: [Proto3ForeignEnum] {
     get {return _storage._repeatedEnumField}
     set {_uniqueStorage()._repeatedEnumField = newValue}
   }
 
-  public var repeatedMessageField: [Proto3ForeignMessage] {
+  var repeatedMessageField: [Proto3ForeignMessage] {
     get {return _storage._repeatedMessageField}
     set {_uniqueStorage()._repeatedMessageField = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2205,14 +2205,14 @@ struct Proto3TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProto3Message
     ]}
 
 
-    public var oo: Int64 = 0
+    var oo: Int64 = 0
 
     ///   The field name "b" fails to compile in proto1 because it conflicts with
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
-    public var bb: Int32 = 0
+    var bb: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -2238,22 +2238,22 @@ struct Proto3TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProto3Message
     }
   }
 
-  public var myString: String {
+  var myString: String {
     get {return _storage._myString}
     set {_uniqueStorage()._myString = newValue}
   }
 
-  public var myInt: Int64 {
+  var myInt: Int64 {
     get {return _storage._myInt}
     set {_uniqueStorage()._myInt = newValue}
   }
 
-  public var myFloat: Float {
+  var myFloat: Float {
     get {return _storage._myFloat}
     set {_uniqueStorage()._myFloat = newValue}
   }
 
-  public var singleNestedMessage: Proto3TestFieldOrderings.NestedMessage {
+  var singleNestedMessage: Proto3TestFieldOrderings.NestedMessage {
     get {return _storage._singleNestedMessage ?? Proto3TestFieldOrderings.NestedMessage()}
     set {_uniqueStorage()._singleNestedMessage = newValue}
   }
@@ -2264,7 +2264,7 @@ struct Proto3TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProto3Message
     return _storage._singleNestedMessage = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2298,9 +2298,9 @@ struct Proto3SparseEnumMessage: ProtobufGeneratedMessage, ProtobufProto3Message 
   ]}
 
 
-  public var sparseEnum: Proto3TestSparseEnum = Proto3TestSparseEnum.testSparseEnumUnspecified
+  var sparseEnum: Proto3TestSparseEnum = Proto3TestSparseEnum.testSparseEnumUnspecified
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2334,9 +2334,9 @@ struct Proto3OneString: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: String = ""
+  var data: String = ""
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2369,9 +2369,9 @@ struct Proto3MoreString: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: [String] = []
+  var data: [String] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2404,9 +2404,9 @@ struct Proto3OneBytes: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: Data = Data()
+  var data: Data = Data()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2439,9 +2439,9 @@ struct Proto3MoreBytes: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: Data = Data()
+  var data: Data = Data()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2475,9 +2475,9 @@ struct Proto3Int32Message: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: Int32 = 0
+  var data: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2510,9 +2510,9 @@ struct Proto3Uint32Message: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: UInt32 = 0
+  var data: UInt32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2545,9 +2545,9 @@ struct Proto3Int64Message: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: Int64 = 0
+  var data: Int64 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2580,9 +2580,9 @@ struct Proto3Uint64Message: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: UInt64 = 0
+  var data: UInt64 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2615,9 +2615,9 @@ struct Proto3BoolMessage: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var data: Bool = false
+  var data: Bool = false
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -2744,7 +2744,7 @@ struct Proto3TestOneof: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var fooInt: Int32 {
+  var fooInt: Int32 {
     get {
       if case .fooInt(let v) = _storage._foo {
         return v
@@ -2756,7 +2756,7 @@ struct Proto3TestOneof: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var fooString: String {
+  var fooString: String {
     get {
       if case .fooString(let v) = _storage._foo {
         return v
@@ -2768,7 +2768,7 @@ struct Proto3TestOneof: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public var fooMessage: Proto3TestAllTypes {
+  var fooMessage: Proto3TestAllTypes {
     get {
       if case .fooMessage(let v) = _storage._foo {
         return v
@@ -2787,7 +2787,7 @@ struct Proto3TestOneof: ProtobufGeneratedMessage, ProtobufProto3Message {
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -2849,35 +2849,35 @@ struct Proto3TestPackedTypes: ProtobufGeneratedMessage, ProtobufProto3Message {
   ]}
 
 
-  public var packedInt32: [Int32] = []
+  var packedInt32: [Int32] = []
 
-  public var packedInt64: [Int64] = []
+  var packedInt64: [Int64] = []
 
-  public var packedUint32: [UInt32] = []
+  var packedUint32: [UInt32] = []
 
-  public var packedUint64: [UInt64] = []
+  var packedUint64: [UInt64] = []
 
-  public var packedSint32: [Int32] = []
+  var packedSint32: [Int32] = []
 
-  public var packedSint64: [Int64] = []
+  var packedSint64: [Int64] = []
 
-  public var packedFixed32: [UInt32] = []
+  var packedFixed32: [UInt32] = []
 
-  public var packedFixed64: [UInt64] = []
+  var packedFixed64: [UInt64] = []
 
-  public var packedSfixed32: [Int32] = []
+  var packedSfixed32: [Int32] = []
 
-  public var packedSfixed64: [Int64] = []
+  var packedSfixed64: [Int64] = []
 
-  public var packedFloat: [Float] = []
+  var packedFloat: [Float] = []
 
-  public var packedDouble: [Double] = []
+  var packedDouble: [Double] = []
 
-  public var packedBool: [Bool] = []
+  var packedBool: [Bool] = []
 
-  public var packedEnum: [Proto3ForeignEnum] = []
+  var packedEnum: [Proto3ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3003,35 +3003,35 @@ struct Proto3TestUnpackedTypes: ProtobufGeneratedMessage, ProtobufProto3Message 
   ]}
 
 
-  public var unpackedInt32: [Int32] = []
+  var unpackedInt32: [Int32] = []
 
-  public var unpackedInt64: [Int64] = []
+  var unpackedInt64: [Int64] = []
 
-  public var unpackedUint32: [UInt32] = []
+  var unpackedUint32: [UInt32] = []
 
-  public var unpackedUint64: [UInt64] = []
+  var unpackedUint64: [UInt64] = []
 
-  public var unpackedSint32: [Int32] = []
+  var unpackedSint32: [Int32] = []
 
-  public var unpackedSint64: [Int64] = []
+  var unpackedSint64: [Int64] = []
 
-  public var unpackedFixed32: [UInt32] = []
+  var unpackedFixed32: [UInt32] = []
 
-  public var unpackedFixed64: [UInt64] = []
+  var unpackedFixed64: [UInt64] = []
 
-  public var unpackedSfixed32: [Int32] = []
+  var unpackedSfixed32: [Int32] = []
 
-  public var unpackedSfixed64: [Int64] = []
+  var unpackedSfixed64: [Int64] = []
 
-  public var unpackedFloat: [Float] = []
+  var unpackedFloat: [Float] = []
 
-  public var unpackedDouble: [Double] = []
+  var unpackedDouble: [Double] = []
 
-  public var unpackedBool: [Bool] = []
+  var unpackedBool: [Bool] = []
 
-  public var unpackedEnum: [Proto3ForeignEnum] = []
+  var unpackedEnum: [Proto3ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3142,22 +3142,22 @@ struct Proto3TestRepeatedScalarDifferentTagSizes: ProtobufGeneratedMessage, Prot
   ///   Parsing repeated fixed size values used to fail. This message needs to be
   ///   used in order to get a tag of the right size; all of the repeated fields
   ///   in TestAllTypes didn't trigger the check.
-  public var repeatedFixed32: [UInt32] = []
+  var repeatedFixed32: [UInt32] = []
 
   ///   Check for a varint type, just for good measure.
-  public var repeatedInt32: [Int32] = []
+  var repeatedInt32: [Int32] = []
 
   ///   These have two-byte tags.
-  public var repeatedFixed64: [UInt64] = []
+  var repeatedFixed64: [UInt64] = []
 
-  public var repeatedInt64: [Int64] = []
+  var repeatedInt64: [Int64] = []
 
   ///   Three byte tags.
-  public var repeatedFloat: [Float] = []
+  var repeatedFloat: [Float] = []
 
-  public var repeatedUint64: [UInt64] = []
+  var repeatedUint64: [UInt64] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3216,9 +3216,9 @@ struct Proto3TestCommentInjectionMessage: ProtobufGeneratedMessage, ProtobufProt
 
 
   ///   */ <- This should not close the generated doc comment
-  public var a: String = ""
+  var a: String = ""
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -3248,7 +3248,7 @@ struct Proto3FooRequest: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3269,7 +3269,7 @@ struct Proto3FooResponse: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3290,7 +3290,7 @@ struct Proto3FooClientMessage: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3311,7 +3311,7 @@ struct Proto3FooServerMessage: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3332,7 +3332,7 @@ struct Proto3BarRequest: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -3353,7 +3353,7 @@ struct Proto3BarResponse: ProtobufGeneratedMessage, ProtobufProto3Message {
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -41,18 +41,18 @@ import SwiftProtobuf
 
 
 enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .foreignZero
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .foreignZero
     case 4: self = .foreignFoo
@@ -62,7 +62,7 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "foreignZero": self = .foreignZero
     case "foreignFoo": self = .foreignFoo
@@ -72,7 +72,7 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "FOREIGN_ZERO": self = .foreignZero
     case "FOREIGN_FOO": self = .foreignFoo
@@ -82,7 +82,7 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "FOREIGN_ZERO": self = .foreignZero
     case "FOREIGN_FOO": self = .foreignFoo
@@ -92,7 +92,7 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .foreignZero: return 0
@@ -104,7 +104,7 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .foreignZero: return "\"FOREIGN_ZERO\""
@@ -116,9 +116,9 @@ enum Proto3ArenaUnittest_ForeignEnum: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .foreignZero: return ".foreignZero"
@@ -674,7 +674,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case zero // = 0
     case foo // = 1
     case bar // = 2
@@ -684,11 +684,11 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     case neg // = -1
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .zero
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .zero
       case 1: self = .foo
@@ -699,7 +699,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "zero": self = .zero
       case "foo": self = .foo
@@ -710,7 +710,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ZERO": self = .zero
       case "FOO": self = .foo
@@ -721,7 +721,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ZERO": self = .zero
       case "FOO": self = .foo
@@ -732,7 +732,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .zero: return 0
@@ -745,7 +745,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .zero: return "\"ZERO\""
@@ -758,9 +758,9 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .zero: return ".zero"
@@ -790,9 +790,9 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     ///   The field name "b" fails to compile in proto1 because it conflicts with
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
-    public var bb: Int32 = 0
+    var bb: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -814,77 +814,77 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   }
 
   ///   Singular
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -894,7 +894,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   //    optional int32 a = 17;
   //  }
 
-  public var optionalNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
+  var optionalNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Proto3ArenaUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -905,7 +905,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     return _storage._optionalNestedMessage = nil
   }
 
-  public var optionalForeignMessage: Proto3ArenaUnittest_ForeignMessage {
+  var optionalForeignMessage: Proto3ArenaUnittest_ForeignMessage {
     get {return _storage._optionalForeignMessage ?? Proto3ArenaUnittest_ForeignMessage()}
     set {_uniqueStorage()._optionalForeignMessage = newValue}
   }
@@ -916,7 +916,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     return _storage._optionalForeignMessage = nil
   }
 
-  public var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
+  var optionalImportMessage: ProtobufUnittestImport_ImportMessage {
     get {return _storage._optionalImportMessage ?? ProtobufUnittestImport_ImportMessage()}
     set {_uniqueStorage()._optionalImportMessage = newValue}
   }
@@ -927,12 +927,12 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     return _storage._optionalImportMessage = nil
   }
 
-  public var optionalNestedEnum: Proto3ArenaUnittest_TestAllTypes.NestedEnum {
+  var optionalNestedEnum: Proto3ArenaUnittest_TestAllTypes.NestedEnum {
     get {return _storage._optionalNestedEnum}
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
 
-  public var optionalForeignEnum: Proto3ArenaUnittest_ForeignEnum {
+  var optionalForeignEnum: Proto3ArenaUnittest_ForeignEnum {
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
@@ -942,18 +942,18 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   // 
   //  optional protobuf_unittest_import.ImportEnum    optional_import_enum  = 23;
 
-  public var optionalStringPiece: String {
+  var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
 
-  public var optionalCord: String {
+  var optionalCord: String {
     get {return _storage._optionalCord}
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
   ///   Defined in unittest_import_public.proto
-  public var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
+  var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
   }
@@ -964,7 +964,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     return _storage._optionalPublicImportMessage = nil
   }
 
-  public var optionalLazyMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
+  var optionalLazyMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalLazyMessage ?? Proto3ArenaUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalLazyMessage = newValue}
   }
@@ -976,77 +976,77 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
@@ -1056,27 +1056,27 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   //    optional int32 a = 47;
   //  }
 
-  public var repeatedNestedMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] {
+  var repeatedNestedMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
   }
 
-  public var repeatedForeignMessage: [Proto3ArenaUnittest_ForeignMessage] {
+  var repeatedForeignMessage: [Proto3ArenaUnittest_ForeignMessage] {
     get {return _storage._repeatedForeignMessage}
     set {_uniqueStorage()._repeatedForeignMessage = newValue}
   }
 
-  public var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
+  var repeatedImportMessage: [ProtobufUnittestImport_ImportMessage] {
     get {return _storage._repeatedImportMessage}
     set {_uniqueStorage()._repeatedImportMessage = newValue}
   }
 
-  public var repeatedNestedEnum: [Proto3ArenaUnittest_TestAllTypes.NestedEnum] {
+  var repeatedNestedEnum: [Proto3ArenaUnittest_TestAllTypes.NestedEnum] {
     get {return _storage._repeatedNestedEnum}
     set {_uniqueStorage()._repeatedNestedEnum = newValue}
   }
 
-  public var repeatedForeignEnum: [Proto3ArenaUnittest_ForeignEnum] {
+  var repeatedForeignEnum: [Proto3ArenaUnittest_ForeignEnum] {
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
@@ -1086,22 +1086,22 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
   // 
   //  repeated protobuf_unittest_import.ImportEnum    repeated_import_enum  = 53;
 
-  public var repeatedStringPiece: [String] {
+  var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
     set {_uniqueStorage()._repeatedStringPiece = newValue}
   }
 
-  public var repeatedCord: [String] {
+  var repeatedCord: [String] {
     get {return _storage._repeatedCord}
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  public var repeatedLazyMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] {
+  var repeatedLazyMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedLazyMessage}
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1113,7 +1113,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     }
   }
 
-  public var oneofNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
+  var oneofNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1125,7 +1125,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1137,7 +1137,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1156,7 +1156,7 @@ struct Proto3ArenaUnittest_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1218,35 +1218,35 @@ struct Proto3ArenaUnittest_TestPackedTypes: ProtobufGeneratedMessage, ProtobufPr
   ]}
 
 
-  public var packedInt32: [Int32] = []
+  var packedInt32: [Int32] = []
 
-  public var packedInt64: [Int64] = []
+  var packedInt64: [Int64] = []
 
-  public var packedUint32: [UInt32] = []
+  var packedUint32: [UInt32] = []
 
-  public var packedUint64: [UInt64] = []
+  var packedUint64: [UInt64] = []
 
-  public var packedSint32: [Int32] = []
+  var packedSint32: [Int32] = []
 
-  public var packedSint64: [Int64] = []
+  var packedSint64: [Int64] = []
 
-  public var packedFixed32: [UInt32] = []
+  var packedFixed32: [UInt32] = []
 
-  public var packedFixed64: [UInt64] = []
+  var packedFixed64: [UInt64] = []
 
-  public var packedSfixed32: [Int32] = []
+  var packedSfixed32: [Int32] = []
 
-  public var packedSfixed64: [Int64] = []
+  var packedSfixed64: [Int64] = []
 
-  public var packedFloat: [Float] = []
+  var packedFloat: [Float] = []
 
-  public var packedDouble: [Double] = []
+  var packedDouble: [Double] = []
 
-  public var packedBool: [Bool] = []
+  var packedBool: [Bool] = []
 
-  public var packedEnum: [Proto3ArenaUnittest_ForeignEnum] = []
+  var packedEnum: [Proto3ArenaUnittest_ForeignEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1371,35 +1371,35 @@ struct Proto3ArenaUnittest_TestUnpackedTypes: ProtobufGeneratedMessage, Protobuf
   ]}
 
 
-  public var repeatedInt32: [Int32] = []
+  var repeatedInt32: [Int32] = []
 
-  public var repeatedInt64: [Int64] = []
+  var repeatedInt64: [Int64] = []
 
-  public var repeatedUint32: [UInt32] = []
+  var repeatedUint32: [UInt32] = []
 
-  public var repeatedUint64: [UInt64] = []
+  var repeatedUint64: [UInt64] = []
 
-  public var repeatedSint32: [Int32] = []
+  var repeatedSint32: [Int32] = []
 
-  public var repeatedSint64: [Int64] = []
+  var repeatedSint64: [Int64] = []
 
-  public var repeatedFixed32: [UInt32] = []
+  var repeatedFixed32: [UInt32] = []
 
-  public var repeatedFixed64: [UInt64] = []
+  var repeatedFixed64: [UInt64] = []
 
-  public var repeatedSfixed32: [Int32] = []
+  var repeatedSfixed32: [Int32] = []
 
-  public var repeatedSfixed64: [Int64] = []
+  var repeatedSfixed64: [Int64] = []
 
-  public var repeatedFloat: [Float] = []
+  var repeatedFloat: [Float] = []
 
-  public var repeatedDouble: [Double] = []
+  var repeatedDouble: [Double] = []
 
-  public var repeatedBool: [Bool] = []
+  var repeatedBool: [Bool] = []
 
-  public var repeatedNestedEnum: [Proto3ArenaUnittest_TestAllTypes.NestedEnum] = []
+  var repeatedNestedEnum: [Proto3ArenaUnittest_TestAllTypes.NestedEnum] = []
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1540,7 +1540,7 @@ struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Protobu
   private var _storage = _StorageClass()
 
 
-  public var child: Proto3ArenaUnittest_NestedTestAllTypes {
+  var child: Proto3ArenaUnittest_NestedTestAllTypes {
     get {return _storage._child ?? Proto3ArenaUnittest_NestedTestAllTypes()}
     set {_uniqueStorage()._child = newValue}
   }
@@ -1551,7 +1551,7 @@ struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Protobu
     return _storage._child = nil
   }
 
-  public var payload: Proto3ArenaUnittest_TestAllTypes {
+  var payload: Proto3ArenaUnittest_TestAllTypes {
     get {return _storage._payload ?? Proto3ArenaUnittest_TestAllTypes()}
     set {_uniqueStorage()._payload = newValue}
   }
@@ -1562,7 +1562,7 @@ struct Proto3ArenaUnittest_NestedTestAllTypes: ProtobufGeneratedMessage, Protobu
     return _storage._payload = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1598,9 +1598,9 @@ struct Proto3ArenaUnittest_ForeignMessage: ProtobufGeneratedMessage, ProtobufPro
   ]}
 
 
-  public var c: Int32 = 0
+  var c: Int32 = 0
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -1630,7 +1630,7 @@ struct Proto3ArenaUnittest_TestEmptyMessage: ProtobufGeneratedMessage, ProtobufP
   public var protoFieldNames: [String: Int] {return [:]}
 
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -507,7 +507,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
   }
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
@@ -515,11 +515,11 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     ///   Intentionally negative.
     case neg // = -1
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       case 2: self = .bar
@@ -529,7 +529,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -539,7 +539,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -549,7 +549,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -559,7 +559,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -570,7 +570,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -581,9 +581,9 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -613,7 +613,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     ///   a local variable named "b" in one of the generated methods.  Doh.
     ///   This file needs to compile in proto1 to test backwards-compatibility.
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -624,7 +624,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       return _bb = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -659,7 +659,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -670,7 +670,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -692,7 +692,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
   }
 
   ///   Singular
-  public var requiredInt32: Int32 {
+  var requiredInt32: Int32 {
     get {return _storage._requiredInt32 ?? 0}
     set {_uniqueStorage()._requiredInt32 = newValue}
   }
@@ -703,7 +703,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredInt32 = nil
   }
 
-  public var requiredInt64: Int64 {
+  var requiredInt64: Int64 {
     get {return _storage._requiredInt64 ?? 0}
     set {_uniqueStorage()._requiredInt64 = newValue}
   }
@@ -714,7 +714,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredInt64 = nil
   }
 
-  public var requiredUint32: UInt32 {
+  var requiredUint32: UInt32 {
     get {return _storage._requiredUint32 ?? 0}
     set {_uniqueStorage()._requiredUint32 = newValue}
   }
@@ -725,7 +725,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredUint32 = nil
   }
 
-  public var requiredUint64: UInt64 {
+  var requiredUint64: UInt64 {
     get {return _storage._requiredUint64 ?? 0}
     set {_uniqueStorage()._requiredUint64 = newValue}
   }
@@ -736,7 +736,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredUint64 = nil
   }
 
-  public var requiredSint32: Int32 {
+  var requiredSint32: Int32 {
     get {return _storage._requiredSint32 ?? 0}
     set {_uniqueStorage()._requiredSint32 = newValue}
   }
@@ -747,7 +747,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredSint32 = nil
   }
 
-  public var requiredSint64: Int64 {
+  var requiredSint64: Int64 {
     get {return _storage._requiredSint64 ?? 0}
     set {_uniqueStorage()._requiredSint64 = newValue}
   }
@@ -758,7 +758,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredSint64 = nil
   }
 
-  public var requiredFixed32: UInt32 {
+  var requiredFixed32: UInt32 {
     get {return _storage._requiredFixed32 ?? 0}
     set {_uniqueStorage()._requiredFixed32 = newValue}
   }
@@ -769,7 +769,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredFixed32 = nil
   }
 
-  public var requiredFixed64: UInt64 {
+  var requiredFixed64: UInt64 {
     get {return _storage._requiredFixed64 ?? 0}
     set {_uniqueStorage()._requiredFixed64 = newValue}
   }
@@ -780,7 +780,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredFixed64 = nil
   }
 
-  public var requiredSfixed32: Int32 {
+  var requiredSfixed32: Int32 {
     get {return _storage._requiredSfixed32 ?? 0}
     set {_uniqueStorage()._requiredSfixed32 = newValue}
   }
@@ -791,7 +791,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredSfixed32 = nil
   }
 
-  public var requiredSfixed64: Int64 {
+  var requiredSfixed64: Int64 {
     get {return _storage._requiredSfixed64 ?? 0}
     set {_uniqueStorage()._requiredSfixed64 = newValue}
   }
@@ -802,7 +802,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredSfixed64 = nil
   }
 
-  public var requiredFloat: Float {
+  var requiredFloat: Float {
     get {return _storage._requiredFloat ?? 0}
     set {_uniqueStorage()._requiredFloat = newValue}
   }
@@ -813,7 +813,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredFloat = nil
   }
 
-  public var requiredDouble: Double {
+  var requiredDouble: Double {
     get {return _storage._requiredDouble ?? 0}
     set {_uniqueStorage()._requiredDouble = newValue}
   }
@@ -824,7 +824,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredDouble = nil
   }
 
-  public var requiredBool: Bool {
+  var requiredBool: Bool {
     get {return _storage._requiredBool ?? false}
     set {_uniqueStorage()._requiredBool = newValue}
   }
@@ -835,7 +835,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredBool = nil
   }
 
-  public var requiredString: String {
+  var requiredString: String {
     get {return _storage._requiredString ?? ""}
     set {_uniqueStorage()._requiredString = newValue}
   }
@@ -846,7 +846,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredString = nil
   }
 
-  public var requiredBytes: Data {
+  var requiredBytes: Data {
     get {return _storage._requiredBytes ?? Data()}
     set {_uniqueStorage()._requiredBytes = newValue}
   }
@@ -857,7 +857,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredBytes = nil
   }
 
-  public var requiredGroup: ProtobufUnittest_TestAllRequiredTypes.RequiredGroup {
+  var requiredGroup: ProtobufUnittest_TestAllRequiredTypes.RequiredGroup {
     get {return _storage._requiredGroup ?? ProtobufUnittest_TestAllRequiredTypes.RequiredGroup()}
     set {_uniqueStorage()._requiredGroup = newValue}
   }
@@ -868,7 +868,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredGroup = nil
   }
 
-  public var requiredNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
+  var requiredNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
     get {return _storage._requiredNestedMessage ?? ProtobufUnittest_TestAllRequiredTypes.NestedMessage()}
     set {_uniqueStorage()._requiredNestedMessage = newValue}
   }
@@ -879,7 +879,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredNestedMessage = nil
   }
 
-  public var requiredForeignMessage: ProtobufUnittest_ForeignMessage {
+  var requiredForeignMessage: ProtobufUnittest_ForeignMessage {
     get {return _storage._requiredForeignMessage ?? ProtobufUnittest_ForeignMessage()}
     set {_uniqueStorage()._requiredForeignMessage = newValue}
   }
@@ -890,7 +890,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredForeignMessage = nil
   }
 
-  public var requiredImportMessage: ProtobufUnittestImport_ImportMessage {
+  var requiredImportMessage: ProtobufUnittestImport_ImportMessage {
     get {return _storage._requiredImportMessage ?? ProtobufUnittestImport_ImportMessage()}
     set {_uniqueStorage()._requiredImportMessage = newValue}
   }
@@ -901,7 +901,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredImportMessage = nil
   }
 
-  public var requiredNestedEnum: ProtobufUnittest_TestAllRequiredTypes.NestedEnum {
+  var requiredNestedEnum: ProtobufUnittest_TestAllRequiredTypes.NestedEnum {
     get {return _storage._requiredNestedEnum ?? ProtobufUnittest_TestAllRequiredTypes.NestedEnum.foo}
     set {_uniqueStorage()._requiredNestedEnum = newValue}
   }
@@ -912,7 +912,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredNestedEnum = nil
   }
 
-  public var requiredForeignEnum: ProtobufUnittest_ForeignEnum {
+  var requiredForeignEnum: ProtobufUnittest_ForeignEnum {
     get {return _storage._requiredForeignEnum ?? ProtobufUnittest_ForeignEnum.foreignFoo}
     set {_uniqueStorage()._requiredForeignEnum = newValue}
   }
@@ -923,7 +923,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredForeignEnum = nil
   }
 
-  public var requiredImportEnum: ProtobufUnittestImport_ImportEnum {
+  var requiredImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._requiredImportEnum ?? ProtobufUnittestImport_ImportEnum.importFoo}
     set {_uniqueStorage()._requiredImportEnum = newValue}
   }
@@ -934,7 +934,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredImportEnum = nil
   }
 
-  public var requiredStringPiece: String {
+  var requiredStringPiece: String {
     get {return _storage._requiredStringPiece ?? ""}
     set {_uniqueStorage()._requiredStringPiece = newValue}
   }
@@ -945,7 +945,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredStringPiece = nil
   }
 
-  public var requiredCord: String {
+  var requiredCord: String {
     get {return _storage._requiredCord ?? ""}
     set {_uniqueStorage()._requiredCord = newValue}
   }
@@ -957,7 +957,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
   }
 
   ///   Defined in unittest_import_public.proto
-  public var requiredPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
+  var requiredPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._requiredPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._requiredPublicImportMessage = newValue}
   }
@@ -968,7 +968,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._requiredPublicImportMessage = nil
   }
 
-  public var requiredLazyMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
+  var requiredLazyMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
     get {return _storage._requiredLazyMessage ?? ProtobufUnittest_TestAllRequiredTypes.NestedMessage()}
     set {_uniqueStorage()._requiredLazyMessage = newValue}
   }
@@ -980,7 +980,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
   }
 
   ///   Singular with defaults
-  public var defaultInt32: Int32 {
+  var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
   }
@@ -991,7 +991,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultInt32 = nil
   }
 
-  public var defaultInt64: Int64 {
+  var defaultInt64: Int64 {
     get {return _storage._defaultInt64 ?? 42}
     set {_uniqueStorage()._defaultInt64 = newValue}
   }
@@ -1002,7 +1002,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultInt64 = nil
   }
 
-  public var defaultUint32: UInt32 {
+  var defaultUint32: UInt32 {
     get {return _storage._defaultUint32 ?? 43}
     set {_uniqueStorage()._defaultUint32 = newValue}
   }
@@ -1013,7 +1013,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultUint32 = nil
   }
 
-  public var defaultUint64: UInt64 {
+  var defaultUint64: UInt64 {
     get {return _storage._defaultUint64 ?? 44}
     set {_uniqueStorage()._defaultUint64 = newValue}
   }
@@ -1024,7 +1024,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultUint64 = nil
   }
 
-  public var defaultSint32: Int32 {
+  var defaultSint32: Int32 {
     get {return _storage._defaultSint32 ?? -45}
     set {_uniqueStorage()._defaultSint32 = newValue}
   }
@@ -1035,7 +1035,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultSint32 = nil
   }
 
-  public var defaultSint64: Int64 {
+  var defaultSint64: Int64 {
     get {return _storage._defaultSint64 ?? 46}
     set {_uniqueStorage()._defaultSint64 = newValue}
   }
@@ -1046,7 +1046,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultSint64 = nil
   }
 
-  public var defaultFixed32: UInt32 {
+  var defaultFixed32: UInt32 {
     get {return _storage._defaultFixed32 ?? 47}
     set {_uniqueStorage()._defaultFixed32 = newValue}
   }
@@ -1057,7 +1057,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultFixed32 = nil
   }
 
-  public var defaultFixed64: UInt64 {
+  var defaultFixed64: UInt64 {
     get {return _storage._defaultFixed64 ?? 48}
     set {_uniqueStorage()._defaultFixed64 = newValue}
   }
@@ -1068,7 +1068,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultFixed64 = nil
   }
 
-  public var defaultSfixed32: Int32 {
+  var defaultSfixed32: Int32 {
     get {return _storage._defaultSfixed32 ?? 49}
     set {_uniqueStorage()._defaultSfixed32 = newValue}
   }
@@ -1079,7 +1079,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultSfixed32 = nil
   }
 
-  public var defaultSfixed64: Int64 {
+  var defaultSfixed64: Int64 {
     get {return _storage._defaultSfixed64 ?? -50}
     set {_uniqueStorage()._defaultSfixed64 = newValue}
   }
@@ -1090,7 +1090,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultSfixed64 = nil
   }
 
-  public var defaultFloat: Float {
+  var defaultFloat: Float {
     get {return _storage._defaultFloat ?? 51.5}
     set {_uniqueStorage()._defaultFloat = newValue}
   }
@@ -1101,7 +1101,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultFloat = nil
   }
 
-  public var defaultDouble: Double {
+  var defaultDouble: Double {
     get {return _storage._defaultDouble ?? 52000}
     set {_uniqueStorage()._defaultDouble = newValue}
   }
@@ -1112,7 +1112,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultDouble = nil
   }
 
-  public var defaultBool: Bool {
+  var defaultBool: Bool {
     get {return _storage._defaultBool ?? true}
     set {_uniqueStorage()._defaultBool = newValue}
   }
@@ -1123,7 +1123,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultBool = nil
   }
 
-  public var defaultString: String {
+  var defaultString: String {
     get {return _storage._defaultString ?? "hello"}
     set {_uniqueStorage()._defaultString = newValue}
   }
@@ -1134,7 +1134,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultString = nil
   }
 
-  public var defaultBytes: Data {
+  var defaultBytes: Data {
     get {return _storage._defaultBytes ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {_uniqueStorage()._defaultBytes = newValue}
   }
@@ -1145,7 +1145,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultBytes = nil
   }
 
-  public var defaultNestedEnum: ProtobufUnittest_TestAllRequiredTypes.NestedEnum {
+  var defaultNestedEnum: ProtobufUnittest_TestAllRequiredTypes.NestedEnum {
     get {return _storage._defaultNestedEnum ?? ProtobufUnittest_TestAllRequiredTypes.NestedEnum.bar}
     set {_uniqueStorage()._defaultNestedEnum = newValue}
   }
@@ -1156,7 +1156,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultNestedEnum = nil
   }
 
-  public var defaultForeignEnum: ProtobufUnittest_ForeignEnum {
+  var defaultForeignEnum: ProtobufUnittest_ForeignEnum {
     get {return _storage._defaultForeignEnum ?? ProtobufUnittest_ForeignEnum.foreignBar}
     set {_uniqueStorage()._defaultForeignEnum = newValue}
   }
@@ -1167,7 +1167,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultForeignEnum = nil
   }
 
-  public var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
+  var defaultImportEnum: ProtobufUnittestImport_ImportEnum {
     get {return _storage._defaultImportEnum ?? ProtobufUnittestImport_ImportEnum.importBar}
     set {_uniqueStorage()._defaultImportEnum = newValue}
   }
@@ -1178,7 +1178,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultImportEnum = nil
   }
 
-  public var defaultStringPiece: String {
+  var defaultStringPiece: String {
     get {return _storage._defaultStringPiece ?? "abc"}
     set {_uniqueStorage()._defaultStringPiece = newValue}
   }
@@ -1189,7 +1189,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultStringPiece = nil
   }
 
-  public var defaultCord: String {
+  var defaultCord: String {
     get {return _storage._defaultCord ?? "123"}
     set {_uniqueStorage()._defaultCord = newValue}
   }
@@ -1200,7 +1200,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     return _storage._defaultCord = nil
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._oneofField {
         return v
@@ -1212,7 +1212,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public var oneofNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
+  var oneofNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
     get {
       if case .oneofNestedMessage(let v) = _storage._oneofField {
         return v
@@ -1224,7 +1224,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._oneofField {
         return v
@@ -1236,7 +1236,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._oneofField {
         return v
@@ -1255,7 +1255,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: ProtobufGeneratedMessage, Protobuf
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1301,42 +1301,42 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   public var unknown = ProtobufUnknownStorage()
 
   enum NestedEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 1
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .foo
       default: return nil
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 1
@@ -1344,7 +1344,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -1352,9 +1352,9 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -1366,7 +1366,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
 
   ///   Singular
   private var _requiredInt32: Int32? = nil
-  public var requiredInt32: Int32 {
+  var requiredInt32: Int32 {
     get {return _requiredInt32 ?? 0}
     set {_requiredInt32 = newValue}
   }
@@ -1378,7 +1378,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   }
 
   private var _requiredFloat: Float? = nil
-  public var requiredFloat: Float {
+  var requiredFloat: Float {
     get {return _requiredFloat ?? 0}
     set {_requiredFloat = newValue}
   }
@@ -1390,7 +1390,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   }
 
   private var _requiredBool: Bool? = nil
-  public var requiredBool: Bool {
+  var requiredBool: Bool {
     get {return _requiredBool ?? false}
     set {_requiredBool = newValue}
   }
@@ -1402,7 +1402,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   }
 
   private var _requiredString: String? = nil
-  public var requiredString: String {
+  var requiredString: String {
     get {return _requiredString ?? ""}
     set {_requiredString = newValue}
   }
@@ -1414,7 +1414,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   }
 
   private var _requiredBytes: Data? = nil
-  public var requiredBytes: Data {
+  var requiredBytes: Data {
     get {return _requiredBytes ?? Data()}
     set {_requiredBytes = newValue}
   }
@@ -1426,7 +1426,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
   }
 
   private var _requiredNestedEnum: ProtobufUnittest_TestSomeRequiredTypes.NestedEnum? = nil
-  public var requiredNestedEnum: ProtobufUnittest_TestSomeRequiredTypes.NestedEnum {
+  var requiredNestedEnum: ProtobufUnittest_TestSomeRequiredTypes.NestedEnum {
     get {return _requiredNestedEnum ?? ProtobufUnittest_TestSomeRequiredTypes.NestedEnum.foo}
     set {_requiredNestedEnum = newValue}
   }
@@ -1437,7 +1437,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: ProtobufGeneratedMessage, Protobu
     return _requiredNestedEnum = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
@@ -118,7 +118,7 @@ struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage, ProtobufProto2Messag
     set {_storage.unknown = newValue}
   }
 
-  public var aFoo: ProtobufUnittest_CycleFoo {
+  var aFoo: ProtobufUnittest_CycleFoo {
     get {return _storage._aFoo ?? ProtobufUnittest_CycleFoo()}
     set {_uniqueStorage()._aFoo = newValue}
   }
@@ -129,7 +129,7 @@ struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aFoo = nil
   }
 
-  public var aBar: ProtobufUnittest_CycleBar {
+  var aBar: ProtobufUnittest_CycleBar {
     get {return _storage._aBar ?? ProtobufUnittest_CycleBar()}
     set {_uniqueStorage()._aBar = newValue}
   }
@@ -140,7 +140,7 @@ struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBar = nil
   }
 
-  public var aBaz: ProtobufUnittest_CycleBaz {
+  var aBaz: ProtobufUnittest_CycleBaz {
     get {return _storage._aBaz ?? ProtobufUnittest_CycleBaz()}
     set {_uniqueStorage()._aBaz = newValue}
   }
@@ -151,7 +151,7 @@ struct ProtobufUnittest_CycleFoo: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBaz = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -244,7 +244,7 @@ struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage, ProtobufProto2Messag
     set {_storage.unknown = newValue}
   }
 
-  public var aBar: ProtobufUnittest_CycleBar {
+  var aBar: ProtobufUnittest_CycleBar {
     get {return _storage._aBar ?? ProtobufUnittest_CycleBar()}
     set {_uniqueStorage()._aBar = newValue}
   }
@@ -255,7 +255,7 @@ struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBar = nil
   }
 
-  public var aBaz: ProtobufUnittest_CycleBaz {
+  var aBaz: ProtobufUnittest_CycleBaz {
     get {return _storage._aBaz ?? ProtobufUnittest_CycleBaz()}
     set {_uniqueStorage()._aBaz = newValue}
   }
@@ -266,7 +266,7 @@ struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBaz = nil
   }
 
-  public var aFoo: ProtobufUnittest_CycleFoo {
+  var aFoo: ProtobufUnittest_CycleFoo {
     get {return _storage._aFoo ?? ProtobufUnittest_CycleFoo()}
     set {_uniqueStorage()._aFoo = newValue}
   }
@@ -277,7 +277,7 @@ struct ProtobufUnittest_CycleBar: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aFoo = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -370,7 +370,7 @@ struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage, ProtobufProto2Messag
     set {_storage.unknown = newValue}
   }
 
-  public var aBaz: ProtobufUnittest_CycleBaz {
+  var aBaz: ProtobufUnittest_CycleBaz {
     get {return _storage._aBaz ?? ProtobufUnittest_CycleBaz()}
     set {_uniqueStorage()._aBaz = newValue}
   }
@@ -381,7 +381,7 @@ struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBaz = nil
   }
 
-  public var aFoo: ProtobufUnittest_CycleFoo {
+  var aFoo: ProtobufUnittest_CycleFoo {
     get {return _storage._aFoo ?? ProtobufUnittest_CycleFoo()}
     set {_uniqueStorage()._aFoo = newValue}
   }
@@ -392,7 +392,7 @@ struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aFoo = nil
   }
 
-  public var aBar: ProtobufUnittest_CycleBar {
+  var aBar: ProtobufUnittest_CycleBar {
     get {return _storage._aBar ?? ProtobufUnittest_CycleBar()}
     set {_uniqueStorage()._aBar = newValue}
   }
@@ -403,7 +403,7 @@ struct ProtobufUnittest_CycleBaz: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._aBar = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
@@ -50,15 +50,15 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
   public var unknown = ProtobufUnknownStorage()
 
   enum EnumTest1: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case firstValue // = 1
     case secondValue // = 2
 
-    public init() {
+    init() {
       self = .firstValue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .firstValue
       case 2: self = .secondValue
@@ -66,7 +66,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "firstValue": self = .firstValue
       case "secondValue": self = .secondValue
@@ -74,7 +74,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ENUM_TEST_1_FIRST_VALUE": self = .firstValue
       case "ENUM_TEST_1_SECOND_VALUE": self = .secondValue
@@ -82,7 +82,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ENUM_TEST_1_FIRST_VALUE": self = .firstValue
       case "ENUM_TEST_1_SECOND_VALUE": self = .secondValue
@@ -90,7 +90,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .firstValue: return 1
@@ -99,7 +99,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .firstValue: return "\"ENUM_TEST_1_FIRST_VALUE\""
@@ -108,9 +108,9 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .firstValue: return ".firstValue"
@@ -122,15 +122,15 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
   }
 
   enum EnumTest2: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case enumTest2FirstValue // = 1
     case secondValue // = 2
 
-    public init() {
+    init() {
       self = .enumTest2FirstValue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .enumTest2FirstValue
       case 2: self = .secondValue
@@ -138,7 +138,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "enumTest2FirstValue": self = .enumTest2FirstValue
       case "secondValue": self = .secondValue
@@ -146,7 +146,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ENUM_TEST_2_FIRST_VALUE": self = .enumTest2FirstValue
       case "SECOND_VALUE": self = .secondValue
@@ -154,7 +154,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ENUM_TEST_2_FIRST_VALUE": self = .enumTest2FirstValue
       case "SECOND_VALUE": self = .secondValue
@@ -162,7 +162,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .enumTest2FirstValue: return 1
@@ -171,7 +171,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .enumTest2FirstValue: return "\"ENUM_TEST_2_FIRST_VALUE\""
@@ -180,9 +180,9 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .enumTest2FirstValue: return ".enumTest2FirstValue"
@@ -193,7 +193,7 @@ struct ProtobufUnittest_SwiftEnumTest: ProtobufGeneratedMessage, ProtobufProto2M
 
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
@@ -98,42 +98,42 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
     }
 
     enum Enum: ProtobufEnum {
-      public typealias RawValue = Int
+      typealias RawValue = Int
       case foo // = 0
 
-      public init() {
+      init() {
         self = .foo
       }
 
-      public init?(rawValue: Int) {
+      init?(rawValue: Int) {
         switch rawValue {
         case 0: self = .foo
         default: return nil
         }
       }
 
-      public init?(name: String) {
+      init?(name: String) {
         switch name {
         case "foo": self = .foo
         default: return nil
         }
       }
 
-      public init?(jsonName: String) {
+      init?(jsonName: String) {
         switch jsonName {
         case "FOO": self = .foo
         default: return nil
         }
       }
 
-      public init?(protoName: String) {
+      init?(protoName: String) {
         switch protoName {
         case "FOO": self = .foo
         default: return nil
         }
       }
 
-      public var rawValue: Int {
+      var rawValue: Int {
         get {
           switch self {
           case .foo: return 0
@@ -141,7 +141,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
         }
       }
 
-      public var json: String {
+      var json: String {
         get {
           switch self {
           case .foo: return "\"FOO\""
@@ -149,9 +149,9 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
         }
       }
 
-      public var hashValue: Int { return rawValue }
+      var hashValue: Int { return rawValue }
 
-      public var debugDescription: String {
+      var debugDescription: String {
         get {
           switch self {
           case .foo: return ".foo"
@@ -163,7 +163,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
 
     ///   The circular reference here forces the generator to
     ///   implement heap-backed storage.
-    public var message: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage {
+    var message: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage {
       get {return _storage._message ?? ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage()}
       set {_uniqueStorage()._message = newValue}
     }
@@ -174,7 +174,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
       return _storage._message = nil
     }
 
-    public var optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage.Enum {
+    var optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage.Enum {
       get {return _storage._optionalEnum ?? ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage.Enum.foo}
       set {_uniqueStorage()._optionalEnum = newValue}
     }
@@ -185,7 +185,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
       return _storage._optionalEnum = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -221,42 +221,42 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
     public var unknown = ProtobufUnknownStorage()
 
     enum Enum: ProtobufEnum {
-      public typealias RawValue = Int
+      typealias RawValue = Int
       case foo // = 0
 
-      public init() {
+      init() {
         self = .foo
       }
 
-      public init?(rawValue: Int) {
+      init?(rawValue: Int) {
         switch rawValue {
         case 0: self = .foo
         default: return nil
         }
       }
 
-      public init?(name: String) {
+      init?(name: String) {
         switch name {
         case "foo": self = .foo
         default: return nil
         }
       }
 
-      public init?(jsonName: String) {
+      init?(jsonName: String) {
         switch jsonName {
         case "FOO": self = .foo
         default: return nil
         }
       }
 
-      public init?(protoName: String) {
+      init?(protoName: String) {
         switch protoName {
         case "FOO": self = .foo
         default: return nil
         }
       }
 
-      public var rawValue: Int {
+      var rawValue: Int {
         get {
           switch self {
           case .foo: return 0
@@ -264,7 +264,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
         }
       }
 
-      public var json: String {
+      var json: String {
         get {
           switch self {
           case .foo: return "\"FOO\""
@@ -272,9 +272,9 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
         }
       }
 
-      public var hashValue: Int { return rawValue }
+      var hashValue: Int { return rawValue }
 
-      public var debugDescription: String {
+      var debugDescription: String {
         get {
           switch self {
           case .foo: return ".foo"
@@ -285,7 +285,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
     }
 
     private var _optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2.Enum? = nil
-    public var optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2.Enum {
+    var optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2.Enum {
       get {return _optionalEnum ?? ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2.Enum.foo}
       set {_optionalEnum = newValue}
     }
@@ -296,7 +296,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
       return _optionalEnum = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -319,7 +319,7 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: ProtobufGeneratedMessage, Pr
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -58,7 +58,7 @@ struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage, ProtobufProto2Mess
       public var unknown = ProtobufUnknownStorage()
 
       private var _a: Int32? = nil
-      public var a: Int32 {
+      var a: Int32 {
         get {return _a ?? 0}
         set {_a = newValue}
       }
@@ -69,7 +69,7 @@ struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage, ProtobufProto2Mess
         return _a = nil
       }
 
-      public init() {}
+      init() {}
 
       public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
         switch protoFieldNumber {
@@ -117,7 +117,7 @@ struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage, ProtobufProto2Mess
       }
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     }
@@ -132,7 +132,7 @@ struct ProtobufUnittest_Extend_Foo: ProtobufGeneratedMessage, ProtobufProto2Mess
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -162,7 +162,7 @@ struct ProtobufUnittest_Extend_C: ProtobufGeneratedMessage, ProtobufProto2Messag
 
   ///        extensions 10 to 20;
   private var _c: Int64? = nil
-  public var c: Int64 {
+  var c: Int64 {
     get {return _c ?? 0}
     set {_c = newValue}
   }
@@ -173,7 +173,7 @@ struct ProtobufUnittest_Extend_C: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _c = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -217,7 +217,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     public var unknown = ProtobufUnknownStorage()
 
     private var _oo: Int64? = nil
-    public var oo: Int64 {
+    var oo: Int64 {
       get {return _oo ?? 0}
       set {_oo = newValue}
     }
@@ -229,7 +229,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
 
     private var _bb: Int32? = nil
-    public var bb: Int32 {
+    var bb: Int32 {
       get {return _bb ?? 0}
       set {_bb = newValue}
     }
@@ -240,7 +240,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
       return _bb = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -268,7 +268,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var myString: String {
+  var myString: String {
     get {return _storage._myString ?? ""}
     set {_uniqueStorage()._myString = newValue}
   }
@@ -279,7 +279,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     return _storage._myString = nil
   }
 
-  public var myInt: Int64 {
+  var myInt: Int64 {
     get {return _storage._myInt ?? 0}
     set {_uniqueStorage()._myInt = newValue}
   }
@@ -290,7 +290,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     return _storage._myInt = nil
   }
 
-  public var myFloat: Float {
+  var myFloat: Float {
     get {return _storage._myFloat ?? 0}
     set {_uniqueStorage()._myFloat = newValue}
   }
@@ -301,7 +301,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     return _storage._myFloat = nil
   }
 
-  public var oneofInt64: Int64 {
+  var oneofInt64: Int64 {
     get {
       if case .oneofInt64(let v) = _storage._options {
         return v
@@ -313,7 +313,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofBool: Bool {
+  var oneofBool: Bool {
     get {
       if case .oneofBool(let v) = _storage._options {
         return v
@@ -325,7 +325,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._options {
         return v
@@ -337,7 +337,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var oneofInt32: Int32 {
+  var oneofInt32: Int32 {
     get {
       if case .oneofInt32(let v) = _storage._options {
         return v
@@ -349,7 +349,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public var optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage {
+  var optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Swift_Protobuf_TestFieldOrderings.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
   }
@@ -367,7 +367,7 @@ struct Swift_Protobuf_TestFieldOrderings: ProtobufGeneratedMessage, ProtobufProt
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -55,7 +55,7 @@ struct SwiftTestGroupExtensions: ProtobufGeneratedMessage, ProtobufProto2Message
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -66,7 +66,7 @@ struct SwiftTestGroupExtensions: ProtobufGeneratedMessage, ProtobufProto2Message
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -128,7 +128,7 @@ struct ExtensionGroup: ProtobufGeneratedMessage, ProtobufProto2Message {
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -139,7 +139,7 @@ struct ExtensionGroup: ProtobufGeneratedMessage, ProtobufProto2Message {
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -176,7 +176,7 @@ struct RepeatedExtensionGroup: ProtobufGeneratedMessage, ProtobufProto2Message {
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -187,7 +187,7 @@ struct RepeatedExtensionGroup: ProtobufGeneratedMessage, ProtobufProto2Message {
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {
@@ -224,7 +224,7 @@ struct SwiftTestGroupUnextended: ProtobufGeneratedMessage, ProtobufProto2Message
   public var unknown = ProtobufUnknownStorage()
 
   private var _a: Int32? = nil
-  public var a: Int32 {
+  var a: Int32 {
     get {return _a ?? 0}
     set {_a = newValue}
   }
@@ -235,7 +235,7 @@ struct SwiftTestGroupUnextended: ProtobufGeneratedMessage, ProtobufProto2Message
     return _a = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     switch protoFieldNumber {

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -27,7 +27,7 @@ import SwiftProtobuf
 
 
 enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case a // = 0
   case string // = 1
   case int // = 2
@@ -238,11 +238,11 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
   case timeRecord // = 243
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .a
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .a
     case 1: self = .string
@@ -456,7 +456,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "a": self = .a
     case "string": self = .string
@@ -670,7 +670,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "A": self = .a
     case "String": self = .string
@@ -884,7 +884,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "A": self = .a
     case "String": self = .string
@@ -1098,7 +1098,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .a: return 0
@@ -1314,7 +1314,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .a: return "\"A\""
@@ -1530,9 +1530,9 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .a: return ".a"
@@ -1751,7 +1751,7 @@ enum SwiftUnittest_Names_EnumFieldNames: ProtobufEnum {
 }
 
 enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
-  public typealias RawValue = Int
+  typealias RawValue = Int
   case aa // = 0
 
   ///   protoc no longer allows enum naming that would differ only in underscores.
@@ -1764,11 +1764,11 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
   case ____ // = 1065
   case UNRECOGNIZED(Int)
 
-  public init() {
+  init() {
     self = .aa
   }
 
-  public init?(rawValue: Int) {
+  init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .aa
     case 1065: self = .____
@@ -1776,7 +1776,7 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public init?(name: String) {
+  init?(name: String) {
     switch name {
     case "aa": self = .aa
     case "____": self = .____
@@ -1784,7 +1784,7 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public init?(jsonName: String) {
+  init?(jsonName: String) {
     switch jsonName {
     case "AA": self = .aa
     case "__": self = .____
@@ -1792,7 +1792,7 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public init?(protoName: String) {
+  init?(protoName: String) {
     switch protoName {
     case "AA": self = .aa
     case "__": self = .____
@@ -1800,7 +1800,7 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public var rawValue: Int {
+  var rawValue: Int {
     get {
       switch self {
       case .aa: return 0
@@ -1810,7 +1810,7 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public var json: String {
+  var json: String {
     get {
       switch self {
       case .aa: return "\"AA\""
@@ -1820,9 +1820,9 @@ enum SwiftUnittest_Names_EnumFieldNames2: ProtobufEnum {
     }
   }
 
-  public var hashValue: Int { return rawValue }
+  var hashValue: Int { return rawValue }
 
-  public var debugDescription: String {
+  var debugDescription: String {
     get {
       switch self {
       case .aa: return ".aa"
@@ -3745,1047 +3745,1047 @@ struct SwiftUnittest_Names_FieldNames: ProtobufGeneratedMessage, ProtobufProto3M
   private var _storage = _StorageClass()
 
 
-  public var string: Int32 {
+  var string: Int32 {
     get {return _storage._string}
     set {_uniqueStorage()._string = newValue}
   }
 
-  public var int: Int32 {
+  var int: Int32 {
     get {return _storage._int}
     set {_uniqueStorage()._int = newValue}
   }
 
-  public var double: Int32 {
+  var double: Int32 {
     get {return _storage._double}
     set {_uniqueStorage()._double = newValue}
   }
 
-  public var float: Int32 {
+  var float: Int32 {
     get {return _storage._float}
     set {_uniqueStorage()._float = newValue}
   }
 
-  public var uint: Int32 {
+  var uint: Int32 {
     get {return _storage._uint}
     set {_uniqueStorage()._uint = newValue}
   }
 
-  public var hashValue_p: Int32 {
+  var hashValue_p: Int32 {
     get {return _storage._hashValue_p}
     set {_uniqueStorage()._hashValue_p = newValue}
   }
 
-  public var description_p: Int32 {
+  var description_p: Int32 {
     get {return _storage._description_p}
     set {_uniqueStorage()._description_p = newValue}
   }
 
-  public var debugDescription_p: Int32 {
+  var debugDescription_p: Int32 {
     get {return _storage._debugDescription_p}
     set {_uniqueStorage()._debugDescription_p = newValue}
   }
 
-  public var swift: Int32 {
+  var swift: Int32 {
     get {return _storage._swift}
     set {_uniqueStorage()._swift = newValue}
   }
 
-  public var unrecognized: Int32 {
+  var unrecognized: Int32 {
     get {return _storage._unrecognized}
     set {_uniqueStorage()._unrecognized = newValue}
   }
 
-  public var class_p: Int32 {
+  var class_p: Int32 {
     get {return _storage._class_p}
     set {_uniqueStorage()._class_p = newValue}
   }
 
-  public var deinit_p: Int32 {
+  var deinit_p: Int32 {
     get {return _storage._deinit_p}
     set {_uniqueStorage()._deinit_p = newValue}
   }
 
-  public var enum_p: Int32 {
+  var enum_p: Int32 {
     get {return _storage._enum_p}
     set {_uniqueStorage()._enum_p = newValue}
   }
 
-  public var extension_p: Int32 {
+  var extension_p: Int32 {
     get {return _storage._extension_p}
     set {_uniqueStorage()._extension_p = newValue}
   }
 
-  public var func_p: Int32 {
+  var func_p: Int32 {
     get {return _storage._func_p}
     set {_uniqueStorage()._func_p = newValue}
   }
 
-  public var import_p: Int32 {
+  var import_p: Int32 {
     get {return _storage._import_p}
     set {_uniqueStorage()._import_p = newValue}
   }
 
-  public var init_p: Int32 {
+  var init_p: Int32 {
     get {return _storage._init_p}
     set {_uniqueStorage()._init_p = newValue}
   }
 
-  public var inout_p: Int32 {
+  var inout_p: Int32 {
     get {return _storage._inout_p}
     set {_uniqueStorage()._inout_p = newValue}
   }
 
-  public var internal_p: Int32 {
+  var internal_p: Int32 {
     get {return _storage._internal_p}
     set {_uniqueStorage()._internal_p = newValue}
   }
 
-  public var let_p: Int32 {
+  var let_p: Int32 {
     get {return _storage._let_p}
     set {_uniqueStorage()._let_p = newValue}
   }
 
-  public var operator_p: Int32 {
+  var operator_p: Int32 {
     get {return _storage._operator_p}
     set {_uniqueStorage()._operator_p = newValue}
   }
 
-  public var private_p: Int32 {
+  var private_p: Int32 {
     get {return _storage._private_p}
     set {_uniqueStorage()._private_p = newValue}
   }
 
-  public var protocol_p: Int32 {
+  var protocol_p: Int32 {
     get {return _storage._protocol_p}
     set {_uniqueStorage()._protocol_p = newValue}
   }
 
-  public var public_p: Int32 {
+  var public_p: Int32 {
     get {return _storage._public_p}
     set {_uniqueStorage()._public_p = newValue}
   }
 
-  public var static_p: Int32 {
+  var static_p: Int32 {
     get {return _storage._static_p}
     set {_uniqueStorage()._static_p = newValue}
   }
 
-  public var struct_p: Int32 {
+  var struct_p: Int32 {
     get {return _storage._struct_p}
     set {_uniqueStorage()._struct_p = newValue}
   }
 
-  public var subscript_p: Int32 {
+  var subscript_p: Int32 {
     get {return _storage._subscript_p}
     set {_uniqueStorage()._subscript_p = newValue}
   }
 
-  public var typealias_p: Int32 {
+  var typealias_p: Int32 {
     get {return _storage._typealias_p}
     set {_uniqueStorage()._typealias_p = newValue}
   }
 
-  public var var_p: Int32 {
+  var var_p: Int32 {
     get {return _storage._var_p}
     set {_uniqueStorage()._var_p = newValue}
   }
 
-  public var break_p: Int32 {
+  var break_p: Int32 {
     get {return _storage._break_p}
     set {_uniqueStorage()._break_p = newValue}
   }
 
-  public var case_p: Int32 {
+  var case_p: Int32 {
     get {return _storage._case_p}
     set {_uniqueStorage()._case_p = newValue}
   }
 
-  public var continue_p: Int32 {
+  var continue_p: Int32 {
     get {return _storage._continue_p}
     set {_uniqueStorage()._continue_p = newValue}
   }
 
-  public var default_p: Int32 {
+  var default_p: Int32 {
     get {return _storage._default_p}
     set {_uniqueStorage()._default_p = newValue}
   }
 
-  public var defer_p: Int32 {
+  var defer_p: Int32 {
     get {return _storage._defer_p}
     set {_uniqueStorage()._defer_p = newValue}
   }
 
-  public var do_p: Int32 {
+  var do_p: Int32 {
     get {return _storage._do_p}
     set {_uniqueStorage()._do_p = newValue}
   }
 
-  public var else_p: Int32 {
+  var else_p: Int32 {
     get {return _storage._else_p}
     set {_uniqueStorage()._else_p = newValue}
   }
 
-  public var fallthrough_p: Int32 {
+  var fallthrough_p: Int32 {
     get {return _storage._fallthrough_p}
     set {_uniqueStorage()._fallthrough_p = newValue}
   }
 
-  public var for_p: Int32 {
+  var for_p: Int32 {
     get {return _storage._for_p}
     set {_uniqueStorage()._for_p = newValue}
   }
 
-  public var guard_p: Int32 {
+  var guard_p: Int32 {
     get {return _storage._guard_p}
     set {_uniqueStorage()._guard_p = newValue}
   }
 
-  public var if_p: Int32 {
+  var if_p: Int32 {
     get {return _storage._if_p}
     set {_uniqueStorage()._if_p = newValue}
   }
 
-  public var in_p: Int32 {
+  var in_p: Int32 {
     get {return _storage._in_p}
     set {_uniqueStorage()._in_p = newValue}
   }
 
-  public var repeat_p: Int32 {
+  var repeat_p: Int32 {
     get {return _storage._repeat_p}
     set {_uniqueStorage()._repeat_p = newValue}
   }
 
-  public var return_p: Int32 {
+  var return_p: Int32 {
     get {return _storage._return_p}
     set {_uniqueStorage()._return_p = newValue}
   }
 
-  public var switch_p: Int32 {
+  var switch_p: Int32 {
     get {return _storage._switch_p}
     set {_uniqueStorage()._switch_p = newValue}
   }
 
-  public var where_p: Int32 {
+  var where_p: Int32 {
     get {return _storage._where_p}
     set {_uniqueStorage()._where_p = newValue}
   }
 
-  public var while_p: Int32 {
+  var while_p: Int32 {
     get {return _storage._while_p}
     set {_uniqueStorage()._while_p = newValue}
   }
 
-  public var as_p: Int32 {
+  var as_p: Int32 {
     get {return _storage._as_p}
     set {_uniqueStorage()._as_p = newValue}
   }
 
-  public var catch_p: Int32 {
+  var catch_p: Int32 {
     get {return _storage._catch_p}
     set {_uniqueStorage()._catch_p = newValue}
   }
 
-  public var dynamicType_p: Int32 {
+  var dynamicType_p: Int32 {
     get {return _storage._dynamicType_p}
     set {_uniqueStorage()._dynamicType_p = newValue}
   }
 
-  public var false_p: Int32 {
+  var false_p: Int32 {
     get {return _storage._false_p}
     set {_uniqueStorage()._false_p = newValue}
   }
 
-  public var is_p: Int32 {
+  var is_p: Int32 {
     get {return _storage._is_p}
     set {_uniqueStorage()._is_p = newValue}
   }
 
-  public var nil_p: Int32 {
+  var nil_p: Int32 {
     get {return _storage._nil_p}
     set {_uniqueStorage()._nil_p = newValue}
   }
 
-  public var rethrows_p: Int32 {
+  var rethrows_p: Int32 {
     get {return _storage._rethrows_p}
     set {_uniqueStorage()._rethrows_p = newValue}
   }
 
-  public var super_p: Int32 {
+  var super_p: Int32 {
     get {return _storage._super_p}
     set {_uniqueStorage()._super_p = newValue}
   }
 
-  public var self_p: Int32 {
+  var self_p: Int32 {
     get {return _storage._self_p}
     set {_uniqueStorage()._self_p = newValue}
   }
 
-  public var throw_p: Int32 {
+  var throw_p: Int32 {
     get {return _storage._throw_p}
     set {_uniqueStorage()._throw_p = newValue}
   }
 
-  public var throws_p: Int32 {
+  var throws_p: Int32 {
     get {return _storage._throws_p}
     set {_uniqueStorage()._throws_p = newValue}
   }
 
-  public var true_p: Int32 {
+  var true_p: Int32 {
     get {return _storage._true_p}
     set {_uniqueStorage()._true_p = newValue}
   }
 
-  public var try_p: Int32 {
+  var try_p: Int32 {
     get {return _storage._try_p}
     set {_uniqueStorage()._try_p = newValue}
   }
 
-  public var _Column__: Int32 {
+  var _Column__: Int32 {
     get {return _storage.__Column__}
     set {_uniqueStorage().__Column__ = newValue}
   }
 
-  public var _File__: Int32 {
+  var _File__: Int32 {
     get {return _storage.__File__}
     set {_uniqueStorage().__File__ = newValue}
   }
 
-  public var _Function__: Int32 {
+  var _Function__: Int32 {
     get {return _storage.__Function__}
     set {_uniqueStorage().__Function__ = newValue}
   }
 
-  public var _Line__: Int32 {
+  var _Line__: Int32 {
     get {return _storage.__Line__}
     set {_uniqueStorage().__Line__ = newValue}
   }
 
-  public var ___: Int32 {
+  var ___: Int32 {
     get {return _storage.____}
     set {_uniqueStorage().____ = newValue}
   }
 
-  public var associativity: Int32 {
+  var associativity: Int32 {
     get {return _storage._associativity}
     set {_uniqueStorage()._associativity = newValue}
   }
 
-  public var convenience: Int32 {
+  var convenience: Int32 {
     get {return _storage._convenience}
     set {_uniqueStorage()._convenience = newValue}
   }
 
-  public var dynamic: Int32 {
+  var dynamic: Int32 {
     get {return _storage._dynamic}
     set {_uniqueStorage()._dynamic = newValue}
   }
 
-  public var didSet: Int32 {
+  var didSet: Int32 {
     get {return _storage._didSet}
     set {_uniqueStorage()._didSet = newValue}
   }
 
-  public var final: Int32 {
+  var final: Int32 {
     get {return _storage._final}
     set {_uniqueStorage()._final = newValue}
   }
 
-  public var get: Int32 {
+  var get: Int32 {
     get {return _storage._get}
     set {_uniqueStorage()._get = newValue}
   }
 
-  public var infix: Int32 {
+  var infix: Int32 {
     get {return _storage._infix}
     set {_uniqueStorage()._infix = newValue}
   }
 
-  public var indirect: Int32 {
+  var indirect: Int32 {
     get {return _storage._indirect}
     set {_uniqueStorage()._indirect = newValue}
   }
 
-  public var lazy: Int32 {
+  var lazy: Int32 {
     get {return _storage._lazy}
     set {_uniqueStorage()._lazy = newValue}
   }
 
-  public var left: Int32 {
+  var left: Int32 {
     get {return _storage._left}
     set {_uniqueStorage()._left = newValue}
   }
 
-  public var mutating: Int32 {
+  var mutating: Int32 {
     get {return _storage._mutating}
     set {_uniqueStorage()._mutating = newValue}
   }
 
-  public var none: Int32 {
+  var none: Int32 {
     get {return _storage._none}
     set {_uniqueStorage()._none = newValue}
   }
 
-  public var nonmutating: Int32 {
+  var nonmutating: Int32 {
     get {return _storage._nonmutating}
     set {_uniqueStorage()._nonmutating = newValue}
   }
 
-  public var optional: Int32 {
+  var optional: Int32 {
     get {return _storage._optional}
     set {_uniqueStorage()._optional = newValue}
   }
 
-  public var override: Int32 {
+  var override: Int32 {
     get {return _storage._override}
     set {_uniqueStorage()._override = newValue}
   }
 
-  public var postfix: Int32 {
+  var postfix: Int32 {
     get {return _storage._postfix}
     set {_uniqueStorage()._postfix = newValue}
   }
 
-  public var precedence: Int32 {
+  var precedence: Int32 {
     get {return _storage._precedence}
     set {_uniqueStorage()._precedence = newValue}
   }
 
-  public var prefix: Int32 {
+  var prefix: Int32 {
     get {return _storage._prefix}
     set {_uniqueStorage()._prefix = newValue}
   }
 
-  public var required: Int32 {
+  var required: Int32 {
     get {return _storage._required}
     set {_uniqueStorage()._required = newValue}
   }
 
-  public var right: Int32 {
+  var right: Int32 {
     get {return _storage._right}
     set {_uniqueStorage()._right = newValue}
   }
 
-  public var set: Int32 {
+  var set: Int32 {
     get {return _storage._set}
     set {_uniqueStorage()._set = newValue}
   }
 
-  public var type: Int32 {
+  var type: Int32 {
     get {return _storage._type}
     set {_uniqueStorage()._type = newValue}
   }
 
-  public var unowned: Int32 {
+  var unowned: Int32 {
     get {return _storage._unowned}
     set {_uniqueStorage()._unowned = newValue}
   }
 
-  public var weak: Int32 {
+  var weak: Int32 {
     get {return _storage._weak}
     set {_uniqueStorage()._weak = newValue}
   }
 
-  public var willSet: Int32 {
+  var willSet: Int32 {
     get {return _storage._willSet}
     set {_uniqueStorage()._willSet = newValue}
   }
 
-  public var id: Int32 {
+  var id: Int32 {
     get {return _storage._id}
     set {_uniqueStorage()._id = newValue}
   }
 
-  public var cmd: Int32 {
+  var cmd: Int32 {
     get {return _storage._cmd}
     set {_uniqueStorage()._cmd = newValue}
   }
 
-  public var out: Int32 {
+  var out: Int32 {
     get {return _storage._out}
     set {_uniqueStorage()._out = newValue}
   }
 
-  public var bycopy: Int32 {
+  var bycopy: Int32 {
     get {return _storage._bycopy}
     set {_uniqueStorage()._bycopy = newValue}
   }
 
-  public var byref: Int32 {
+  var byref: Int32 {
     get {return _storage._byref}
     set {_uniqueStorage()._byref = newValue}
   }
 
-  public var oneway: Int32 {
+  var oneway: Int32 {
     get {return _storage._oneway}
     set {_uniqueStorage()._oneway = newValue}
   }
 
-  public var and: Int32 {
+  var and: Int32 {
     get {return _storage._and}
     set {_uniqueStorage()._and = newValue}
   }
 
-  public var andEq: Int32 {
+  var andEq: Int32 {
     get {return _storage._andEq}
     set {_uniqueStorage()._andEq = newValue}
   }
 
-  public var alignas: Int32 {
+  var alignas: Int32 {
     get {return _storage._alignas}
     set {_uniqueStorage()._alignas = newValue}
   }
 
-  public var alignof: Int32 {
+  var alignof: Int32 {
     get {return _storage._alignof}
     set {_uniqueStorage()._alignof = newValue}
   }
 
-  public var asm: Int32 {
+  var asm: Int32 {
     get {return _storage._asm}
     set {_uniqueStorage()._asm = newValue}
   }
 
-  public var auto: Int32 {
+  var auto: Int32 {
     get {return _storage._auto}
     set {_uniqueStorage()._auto = newValue}
   }
 
-  public var bitand: Int32 {
+  var bitand: Int32 {
     get {return _storage._bitand}
     set {_uniqueStorage()._bitand = newValue}
   }
 
-  public var bitor: Int32 {
+  var bitor: Int32 {
     get {return _storage._bitor}
     set {_uniqueStorage()._bitor = newValue}
   }
 
-  public var bool: Int32 {
+  var bool: Int32 {
     get {return _storage._bool}
     set {_uniqueStorage()._bool = newValue}
   }
 
-  public var char: Int32 {
+  var char: Int32 {
     get {return _storage._char}
     set {_uniqueStorage()._char = newValue}
   }
 
-  public var char16T: Int32 {
+  var char16T: Int32 {
     get {return _storage._char16T}
     set {_uniqueStorage()._char16T = newValue}
   }
 
-  public var char32T: Int32 {
+  var char32T: Int32 {
     get {return _storage._char32T}
     set {_uniqueStorage()._char32T = newValue}
   }
 
-  public var compl: Int32 {
+  var compl: Int32 {
     get {return _storage._compl}
     set {_uniqueStorage()._compl = newValue}
   }
 
-  public var const: Int32 {
+  var const: Int32 {
     get {return _storage._const}
     set {_uniqueStorage()._const = newValue}
   }
 
-  public var constexpr: Int32 {
+  var constexpr: Int32 {
     get {return _storage._constexpr}
     set {_uniqueStorage()._constexpr = newValue}
   }
 
-  public var constCast: Int32 {
+  var constCast: Int32 {
     get {return _storage._constCast}
     set {_uniqueStorage()._constCast = newValue}
   }
 
-  public var decltype: Int32 {
+  var decltype: Int32 {
     get {return _storage._decltype}
     set {_uniqueStorage()._decltype = newValue}
   }
 
-  public var delete: Int32 {
+  var delete: Int32 {
     get {return _storage._delete}
     set {_uniqueStorage()._delete = newValue}
   }
 
-  public var dynamicCast: Int32 {
+  var dynamicCast: Int32 {
     get {return _storage._dynamicCast}
     set {_uniqueStorage()._dynamicCast = newValue}
   }
 
-  public var explicit: Int32 {
+  var explicit: Int32 {
     get {return _storage._explicit}
     set {_uniqueStorage()._explicit = newValue}
   }
 
-  public var export: Int32 {
+  var export: Int32 {
     get {return _storage._export}
     set {_uniqueStorage()._export = newValue}
   }
 
-  public var extern: Int32 {
+  var extern: Int32 {
     get {return _storage._extern}
     set {_uniqueStorage()._extern = newValue}
   }
 
-  public var friend: Int32 {
+  var friend: Int32 {
     get {return _storage._friend}
     set {_uniqueStorage()._friend = newValue}
   }
 
-  public var goto: Int32 {
+  var goto: Int32 {
     get {return _storage._goto}
     set {_uniqueStorage()._goto = newValue}
   }
 
-  public var inline: Int32 {
+  var inline: Int32 {
     get {return _storage._inline}
     set {_uniqueStorage()._inline = newValue}
   }
 
-  public var long: Int32 {
+  var long: Int32 {
     get {return _storage._long}
     set {_uniqueStorage()._long = newValue}
   }
 
-  public var mutable: Int32 {
+  var mutable: Int32 {
     get {return _storage._mutable}
     set {_uniqueStorage()._mutable = newValue}
   }
 
-  public var namespace: Int32 {
+  var namespace: Int32 {
     get {return _storage._namespace}
     set {_uniqueStorage()._namespace = newValue}
   }
 
-  public var new: Int32 {
+  var new: Int32 {
     get {return _storage._new}
     set {_uniqueStorage()._new = newValue}
   }
 
-  public var noexcept: Int32 {
+  var noexcept: Int32 {
     get {return _storage._noexcept}
     set {_uniqueStorage()._noexcept = newValue}
   }
 
-  public var not: Int32 {
+  var not: Int32 {
     get {return _storage._not}
     set {_uniqueStorage()._not = newValue}
   }
 
-  public var notEq: Int32 {
+  var notEq: Int32 {
     get {return _storage._notEq}
     set {_uniqueStorage()._notEq = newValue}
   }
 
-  public var nullptr: Int32 {
+  var nullptr: Int32 {
     get {return _storage._nullptr}
     set {_uniqueStorage()._nullptr = newValue}
   }
 
-  public var or: Int32 {
+  var or: Int32 {
     get {return _storage._or}
     set {_uniqueStorage()._or = newValue}
   }
 
-  public var orEq: Int32 {
+  var orEq: Int32 {
     get {return _storage._orEq}
     set {_uniqueStorage()._orEq = newValue}
   }
 
-  public var protected: Int32 {
+  var protected: Int32 {
     get {return _storage._protected}
     set {_uniqueStorage()._protected = newValue}
   }
 
-  public var register: Int32 {
+  var register: Int32 {
     get {return _storage._register}
     set {_uniqueStorage()._register = newValue}
   }
 
-  public var reinterpretCast: Int32 {
+  var reinterpretCast: Int32 {
     get {return _storage._reinterpretCast}
     set {_uniqueStorage()._reinterpretCast = newValue}
   }
 
-  public var short: Int32 {
+  var short: Int32 {
     get {return _storage._short}
     set {_uniqueStorage()._short = newValue}
   }
 
-  public var signed: Int32 {
+  var signed: Int32 {
     get {return _storage._signed}
     set {_uniqueStorage()._signed = newValue}
   }
 
-  public var sizeof: Int32 {
+  var sizeof: Int32 {
     get {return _storage._sizeof}
     set {_uniqueStorage()._sizeof = newValue}
   }
 
-  public var staticAssert: Int32 {
+  var staticAssert: Int32 {
     get {return _storage._staticAssert}
     set {_uniqueStorage()._staticAssert = newValue}
   }
 
-  public var staticCast: Int32 {
+  var staticCast: Int32 {
     get {return _storage._staticCast}
     set {_uniqueStorage()._staticCast = newValue}
   }
 
-  public var template: Int32 {
+  var template: Int32 {
     get {return _storage._template}
     set {_uniqueStorage()._template = newValue}
   }
 
-  public var this: Int32 {
+  var this: Int32 {
     get {return _storage._this}
     set {_uniqueStorage()._this = newValue}
   }
 
-  public var threadLocal: Int32 {
+  var threadLocal: Int32 {
     get {return _storage._threadLocal}
     set {_uniqueStorage()._threadLocal = newValue}
   }
 
-  public var typedef: Int32 {
+  var typedef: Int32 {
     get {return _storage._typedef}
     set {_uniqueStorage()._typedef = newValue}
   }
 
-  public var typeid: Int32 {
+  var typeid: Int32 {
     get {return _storage._typeid}
     set {_uniqueStorage()._typeid = newValue}
   }
 
-  public var typename: Int32 {
+  var typename: Int32 {
     get {return _storage._typename}
     set {_uniqueStorage()._typename = newValue}
   }
 
-  public var union: Int32 {
+  var union: Int32 {
     get {return _storage._union}
     set {_uniqueStorage()._union = newValue}
   }
 
-  public var unsigned: Int32 {
+  var unsigned: Int32 {
     get {return _storage._unsigned}
     set {_uniqueStorage()._unsigned = newValue}
   }
 
-  public var using: Int32 {
+  var using: Int32 {
     get {return _storage._using}
     set {_uniqueStorage()._using = newValue}
   }
 
-  public var virtual: Int32 {
+  var virtual: Int32 {
     get {return _storage._virtual}
     set {_uniqueStorage()._virtual = newValue}
   }
 
-  public var void: Int32 {
+  var void: Int32 {
     get {return _storage._void}
     set {_uniqueStorage()._void = newValue}
   }
 
-  public var volatile: Int32 {
+  var volatile: Int32 {
     get {return _storage._volatile}
     set {_uniqueStorage()._volatile = newValue}
   }
 
-  public var wcharT: Int32 {
+  var wcharT: Int32 {
     get {return _storage._wcharT}
     set {_uniqueStorage()._wcharT = newValue}
   }
 
-  public var xor: Int32 {
+  var xor: Int32 {
     get {return _storage._xor}
     set {_uniqueStorage()._xor = newValue}
   }
 
-  public var xorEq: Int32 {
+  var xorEq: Int32 {
     get {return _storage._xorEq}
     set {_uniqueStorage()._xorEq = newValue}
   }
 
-  public var restrict: Int32 {
+  var restrict: Int32 {
     get {return _storage._restrict}
     set {_uniqueStorage()._restrict = newValue}
   }
 
-  public var category: Int32 {
+  var category: Int32 {
     get {return _storage._category}
     set {_uniqueStorage()._category = newValue}
   }
 
-  public var ivar: Int32 {
+  var ivar: Int32 {
     get {return _storage._ivar}
     set {_uniqueStorage()._ivar = newValue}
   }
 
-  public var method: Int32 {
+  var method: Int32 {
     get {return _storage._method}
     set {_uniqueStorage()._method = newValue}
   }
 
-  public var finalize: Int32 {
+  var finalize: Int32 {
     get {return _storage._finalize}
     set {_uniqueStorage()._finalize = newValue}
   }
 
-  public var hash: Int32 {
+  var hash: Int32 {
     get {return _storage._hash}
     set {_uniqueStorage()._hash = newValue}
   }
 
-  public var dealloc: Int32 {
+  var dealloc: Int32 {
     get {return _storage._dealloc}
     set {_uniqueStorage()._dealloc = newValue}
   }
 
-  public var superclass: Int32 {
+  var superclass: Int32 {
     get {return _storage._superclass}
     set {_uniqueStorage()._superclass = newValue}
   }
 
-  public var retain: Int32 {
+  var retain: Int32 {
     get {return _storage._retain}
     set {_uniqueStorage()._retain = newValue}
   }
 
-  public var release: Int32 {
+  var release: Int32 {
     get {return _storage._release}
     set {_uniqueStorage()._release = newValue}
   }
 
-  public var autorelease: Int32 {
+  var autorelease: Int32 {
     get {return _storage._autorelease}
     set {_uniqueStorage()._autorelease = newValue}
   }
 
-  public var retainCount: Int32 {
+  var retainCount: Int32 {
     get {return _storage._retainCount}
     set {_uniqueStorage()._retainCount = newValue}
   }
 
-  public var zone: Int32 {
+  var zone: Int32 {
     get {return _storage._zone}
     set {_uniqueStorage()._zone = newValue}
   }
 
-  public var isProxy: Int32 {
+  var isProxy: Int32 {
     get {return _storage._isProxy}
     set {_uniqueStorage()._isProxy = newValue}
   }
 
-  public var copy: Int32 {
+  var copy: Int32 {
     get {return _storage._copy}
     set {_uniqueStorage()._copy = newValue}
   }
 
-  public var mutableCopy: Int32 {
+  var mutableCopy: Int32 {
     get {return _storage._mutableCopy}
     set {_uniqueStorage()._mutableCopy = newValue}
   }
 
-  public var classForCoder: Int32 {
+  var classForCoder: Int32 {
     get {return _storage._classForCoder}
     set {_uniqueStorage()._classForCoder = newValue}
   }
 
-  public var clear: Int32 {
+  var clear: Int32 {
     get {return _storage._clear}
     set {_uniqueStorage()._clear = newValue}
   }
 
-  public var data: Int32 {
+  var data: Int32 {
     get {return _storage._data}
     set {_uniqueStorage()._data = newValue}
   }
 
-  public var delimitedData: Int32 {
+  var delimitedData: Int32 {
     get {return _storage._delimitedData}
     set {_uniqueStorage()._delimitedData = newValue}
   }
 
-  public var descriptor: Int32 {
+  var descriptor: Int32 {
     get {return _storage._descriptor}
     set {_uniqueStorage()._descriptor = newValue}
   }
 
-  public var extensionRegistry: Int32 {
+  var extensionRegistry: Int32 {
     get {return _storage._extensionRegistry}
     set {_uniqueStorage()._extensionRegistry = newValue}
   }
 
-  public var extensionsCurrentlySet: Int32 {
+  var extensionsCurrentlySet: Int32 {
     get {return _storage._extensionsCurrentlySet}
     set {_uniqueStorage()._extensionsCurrentlySet = newValue}
   }
 
-  public var isInitialized: Int32 {
+  var isInitialized: Int32 {
     get {return _storage._isInitialized}
     set {_uniqueStorage()._isInitialized = newValue}
   }
 
-  public var serializedSize: Int32 {
+  var serializedSize: Int32 {
     get {return _storage._serializedSize}
     set {_uniqueStorage()._serializedSize = newValue}
   }
 
-  public var sortedExtensionsInUse: Int32 {
+  var sortedExtensionsInUse: Int32 {
     get {return _storage._sortedExtensionsInUse}
     set {_uniqueStorage()._sortedExtensionsInUse = newValue}
   }
 
-  public var unknownFields: Int32 {
+  var unknownFields: Int32 {
     get {return _storage._unknownFields}
     set {_uniqueStorage()._unknownFields = newValue}
   }
 
-  public var fixed: Int32 {
+  var fixed: Int32 {
     get {return _storage._fixed}
     set {_uniqueStorage()._fixed = newValue}
   }
 
-  public var fract: Int32 {
+  var fract: Int32 {
     get {return _storage._fract}
     set {_uniqueStorage()._fract = newValue}
   }
 
-  public var size: Int32 {
+  var size: Int32 {
     get {return _storage._size}
     set {_uniqueStorage()._size = newValue}
   }
 
-  public var logicalAddress: Int32 {
+  var logicalAddress: Int32 {
     get {return _storage._logicalAddress}
     set {_uniqueStorage()._logicalAddress = newValue}
   }
 
-  public var physicalAddress: Int32 {
+  var physicalAddress: Int32 {
     get {return _storage._physicalAddress}
     set {_uniqueStorage()._physicalAddress = newValue}
   }
 
-  public var byteCount: Int32 {
+  var byteCount: Int32 {
     get {return _storage._byteCount}
     set {_uniqueStorage()._byteCount = newValue}
   }
 
-  public var byteOffset: Int32 {
+  var byteOffset: Int32 {
     get {return _storage._byteOffset}
     set {_uniqueStorage()._byteOffset = newValue}
   }
 
-  public var duration: Int32 {
+  var duration: Int32 {
     get {return _storage._duration}
     set {_uniqueStorage()._duration = newValue}
   }
 
-  public var absoluteTime: Int32 {
+  var absoluteTime: Int32 {
     get {return _storage._absoluteTime}
     set {_uniqueStorage()._absoluteTime = newValue}
   }
 
-  public var optionBits: Int32 {
+  var optionBits: Int32 {
     get {return _storage._optionBits}
     set {_uniqueStorage()._optionBits = newValue}
   }
 
-  public var itemCount: Int32 {
+  var itemCount: Int32 {
     get {return _storage._itemCount}
     set {_uniqueStorage()._itemCount = newValue}
   }
 
-  public var pbversion: Int32 {
+  var pbversion: Int32 {
     get {return _storage._pbversion}
     set {_uniqueStorage()._pbversion = newValue}
   }
 
-  public var scriptCode: Int32 {
+  var scriptCode: Int32 {
     get {return _storage._scriptCode}
     set {_uniqueStorage()._scriptCode = newValue}
   }
 
-  public var langCode: Int32 {
+  var langCode: Int32 {
     get {return _storage._langCode}
     set {_uniqueStorage()._langCode = newValue}
   }
 
-  public var regionCode: Int32 {
+  var regionCode: Int32 {
     get {return _storage._regionCode}
     set {_uniqueStorage()._regionCode = newValue}
   }
 
-  public var ostype: Int32 {
+  var ostype: Int32 {
     get {return _storage._ostype}
     set {_uniqueStorage()._ostype = newValue}
   }
 
-  public var processSerialNumber: Int32 {
+  var processSerialNumber: Int32 {
     get {return _storage._processSerialNumber}
     set {_uniqueStorage()._processSerialNumber = newValue}
   }
 
-  public var point: Int32 {
+  var point: Int32 {
     get {return _storage._point}
     set {_uniqueStorage()._point = newValue}
   }
 
-  public var rect: Int32 {
+  var rect: Int32 {
     get {return _storage._rect}
     set {_uniqueStorage()._rect = newValue}
   }
 
-  public var fixedPoint: Int32 {
+  var fixedPoint: Int32 {
     get {return _storage._fixedPoint}
     set {_uniqueStorage()._fixedPoint = newValue}
   }
 
-  public var fixedRect: Int32 {
+  var fixedRect: Int32 {
     get {return _storage._fixedRect}
     set {_uniqueStorage()._fixedRect = newValue}
   }
 
-  public var style: Int32 {
+  var style: Int32 {
     get {return _storage._style}
     set {_uniqueStorage()._style = newValue}
   }
 
-  public var styleParameter: Int32 {
+  var styleParameter: Int32 {
     get {return _storage._styleParameter}
     set {_uniqueStorage()._styleParameter = newValue}
   }
 
-  public var styleField: Int32 {
+  var styleField: Int32 {
     get {return _storage._styleField}
     set {_uniqueStorage()._styleField = newValue}
   }
 
-  public var timeScale: Int32 {
+  var timeScale: Int32 {
     get {return _storage._timeScale}
     set {_uniqueStorage()._timeScale = newValue}
   }
 
-  public var timeBase: Int32 {
+  var timeBase: Int32 {
     get {return _storage._timeBase}
     set {_uniqueStorage()._timeBase = newValue}
   }
 
-  public var timeRecord: Int32 {
+  var timeRecord: Int32 {
     get {return _storage._timeRecord}
     set {_uniqueStorage()._timeRecord = newValue}
   }
 
-  public var jsonShouldBeOverriden: Int32 {
+  var jsonShouldBeOverriden: Int32 {
     get {return _storage._jsonShouldBeOverriden}
     set {_uniqueStorage()._jsonShouldBeOverriden = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -4827,9 +4827,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4862,9 +4862,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4897,9 +4897,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4932,9 +4932,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -4967,9 +4967,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5002,9 +5002,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5037,9 +5037,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5072,9 +5072,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5107,9 +5107,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5142,9 +5142,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5177,9 +5177,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5212,9 +5212,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5247,9 +5247,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5282,9 +5282,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5317,9 +5317,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5352,9 +5352,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5387,9 +5387,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5422,9 +5422,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5457,9 +5457,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5492,9 +5492,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5527,9 +5527,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5562,9 +5562,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5597,9 +5597,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5632,9 +5632,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5667,9 +5667,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5702,9 +5702,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5737,9 +5737,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5772,9 +5772,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5807,9 +5807,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5842,9 +5842,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5877,9 +5877,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5912,9 +5912,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5947,9 +5947,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -5982,9 +5982,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6017,9 +6017,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6052,9 +6052,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6087,9 +6087,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6122,9 +6122,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6157,9 +6157,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6192,9 +6192,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6227,9 +6227,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6262,9 +6262,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6297,9 +6297,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6332,9 +6332,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6367,9 +6367,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6402,9 +6402,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6437,9 +6437,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6472,9 +6472,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6507,9 +6507,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6542,9 +6542,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6577,9 +6577,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6612,9 +6612,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6647,9 +6647,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6682,9 +6682,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6717,9 +6717,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6752,9 +6752,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6787,9 +6787,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6822,9 +6822,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6857,9 +6857,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6892,9 +6892,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6927,9 +6927,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6962,9 +6962,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -6997,9 +6997,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7032,9 +7032,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7067,9 +7067,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7102,9 +7102,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7137,9 +7137,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7172,9 +7172,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7207,9 +7207,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7242,9 +7242,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7277,9 +7277,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7312,9 +7312,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7347,9 +7347,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7382,9 +7382,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7417,9 +7417,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7452,9 +7452,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7487,9 +7487,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7522,9 +7522,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7557,9 +7557,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7592,9 +7592,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7627,9 +7627,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7662,9 +7662,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7697,9 +7697,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7732,9 +7732,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7767,9 +7767,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7802,9 +7802,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7837,9 +7837,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7872,9 +7872,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7907,9 +7907,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7942,9 +7942,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -7977,9 +7977,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8012,9 +8012,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8047,9 +8047,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8082,9 +8082,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8117,9 +8117,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8152,9 +8152,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8187,9 +8187,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8222,9 +8222,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8257,9 +8257,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8292,9 +8292,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8327,9 +8327,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8362,9 +8362,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8397,9 +8397,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8432,9 +8432,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8467,9 +8467,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8502,9 +8502,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8537,9 +8537,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8572,9 +8572,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8607,9 +8607,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8642,9 +8642,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8677,9 +8677,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8712,9 +8712,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8747,9 +8747,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8782,9 +8782,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8817,9 +8817,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8852,9 +8852,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8887,9 +8887,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8922,9 +8922,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8957,9 +8957,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -8992,9 +8992,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9027,9 +9027,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9062,9 +9062,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9097,9 +9097,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9132,9 +9132,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9167,9 +9167,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9202,9 +9202,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9237,9 +9237,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9272,9 +9272,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9307,9 +9307,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9342,9 +9342,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9377,9 +9377,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9412,9 +9412,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9447,9 +9447,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9482,9 +9482,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9517,9 +9517,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9552,9 +9552,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9587,9 +9587,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9622,9 +9622,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9657,9 +9657,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9692,9 +9692,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9727,9 +9727,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9762,9 +9762,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9797,9 +9797,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9832,9 +9832,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9867,9 +9867,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9902,9 +9902,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9937,9 +9937,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -9972,9 +9972,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10007,9 +10007,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10042,9 +10042,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10077,9 +10077,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10112,9 +10112,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10147,9 +10147,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10182,9 +10182,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10217,9 +10217,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10252,9 +10252,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10287,9 +10287,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10322,9 +10322,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10357,9 +10357,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10392,9 +10392,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10427,9 +10427,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10462,9 +10462,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10497,9 +10497,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10532,9 +10532,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10567,9 +10567,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10602,9 +10602,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10637,9 +10637,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10672,9 +10672,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10707,9 +10707,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10742,9 +10742,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10777,9 +10777,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10812,9 +10812,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10847,9 +10847,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10882,9 +10882,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10917,9 +10917,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10952,9 +10952,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -10987,9 +10987,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11022,9 +11022,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11057,9 +11057,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11092,9 +11092,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11127,9 +11127,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11162,9 +11162,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11197,9 +11197,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11232,9 +11232,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11267,9 +11267,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11302,9 +11302,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11337,9 +11337,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11372,9 +11372,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11407,9 +11407,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11442,9 +11442,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11477,9 +11477,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11512,9 +11512,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11547,9 +11547,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11582,9 +11582,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11617,9 +11617,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11652,9 +11652,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11687,9 +11687,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11722,9 +11722,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11757,9 +11757,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11792,9 +11792,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11827,9 +11827,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11862,9 +11862,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11897,9 +11897,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11932,9 +11932,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -11967,9 +11967,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -12002,9 +12002,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -12037,9 +12037,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -12072,9 +12072,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -12107,9 +12107,9 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     ]}
 
 
-    public var a: Int32 = 0
+    var a: Int32 = 0
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -12130,7 +12130,7 @@ struct SwiftUnittest_Names_MessageNames: ProtobufGeneratedMessage, ProtobufProto
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }
@@ -12152,43 +12152,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
 
 
   enum StringEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aString // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aString
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aString
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aString": self = .aString
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aString": self = .aString
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aString": self = .aString
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aString: return 0
@@ -12197,7 +12197,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aString: return "\"aString\""
@@ -12206,9 +12206,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aString: return ".aString"
@@ -12220,43 +12220,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ProtocolEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aProtocol // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aProtocol
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aProtocol
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aProtocol": self = .aProtocol
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aProtocol": self = .aProtocol
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aProtocol": self = .aProtocol
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aProtocol: return 0
@@ -12265,7 +12265,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aProtocol: return "\"aProtocol\""
@@ -12274,9 +12274,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aProtocol: return ".aProtocol"
@@ -12288,43 +12288,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum IntEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aInt // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aInt
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aInt
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aInt": self = .aInt
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aInt": self = .aInt
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aInt": self = .aInt
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aInt: return 0
@@ -12333,7 +12333,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aInt: return "\"aInt\""
@@ -12342,9 +12342,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aInt: return ".aInt"
@@ -12356,43 +12356,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum DoubleEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aDouble // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aDouble
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aDouble
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aDouble": self = .aDouble
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aDouble": self = .aDouble
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aDouble": self = .aDouble
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aDouble: return 0
@@ -12401,7 +12401,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aDouble: return "\"aDouble\""
@@ -12410,9 +12410,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aDouble: return ".aDouble"
@@ -12424,43 +12424,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum FloatEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aFloat // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aFloat
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aFloat
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aFloat": self = .aFloat
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aFloat": self = .aFloat
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aFloat": self = .aFloat
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aFloat: return 0
@@ -12469,7 +12469,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aFloat: return "\"aFloat\""
@@ -12478,9 +12478,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aFloat: return ".aFloat"
@@ -12492,43 +12492,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum UIntEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aUint // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aUint
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aUint
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aUint": self = .aUint
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aUInt": self = .aUint
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aUInt": self = .aUint
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aUint: return 0
@@ -12537,7 +12537,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aUint: return "\"aUInt\""
@@ -12546,9 +12546,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aUint: return ".aUint"
@@ -12560,43 +12560,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum hashValueEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ahashValue // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ahashValue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ahashValue
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ahashValue": self = .ahashValue
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ahashValue": self = .ahashValue
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ahashValue": self = .ahashValue
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ahashValue: return 0
@@ -12605,7 +12605,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ahashValue: return "\"ahashValue\""
@@ -12614,9 +12614,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ahashValue: return ".ahashValue"
@@ -12628,43 +12628,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum descriptionEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adescription // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adescription
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adescription
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adescription": self = .adescription
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adescription": self = .adescription
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adescription": self = .adescription
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adescription: return 0
@@ -12673,7 +12673,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adescription: return "\"adescription\""
@@ -12682,9 +12682,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adescription: return ".adescription"
@@ -12696,43 +12696,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum debugDescriptionEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adebugDescription // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adebugDescription
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adebugDescription
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adebugDescription": self = .adebugDescription
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adebugDescription": self = .adebugDescription
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adebugDescription": self = .adebugDescription
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adebugDescription: return 0
@@ -12741,7 +12741,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adebugDescription: return "\"adebugDescription\""
@@ -12750,9 +12750,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adebugDescription: return ".adebugDescription"
@@ -12764,43 +12764,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Swift: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aSwift // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aSwift
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aSwift
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aSwift": self = .aSwift
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aSwift": self = .aSwift
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aSwift": self = .aSwift
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aSwift: return 0
@@ -12809,7 +12809,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aSwift: return "\"aSwift\""
@@ -12818,9 +12818,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aSwift: return ".aSwift"
@@ -12832,43 +12832,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum UNRECOGNIZED: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aUnrecognized // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aUnrecognized
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aUnrecognized
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aUnrecognized": self = .aUnrecognized
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aUNRECOGNIZED": self = .aUnrecognized
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aUNRECOGNIZED": self = .aUnrecognized
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aUnrecognized: return 0
@@ -12877,7 +12877,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aUnrecognized: return "\"aUNRECOGNIZED\""
@@ -12886,9 +12886,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aUnrecognized: return ".aUnrecognized"
@@ -12900,43 +12900,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum classEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aclass // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aclass
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aclass
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aclass": self = .aclass
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aclass": self = .aclass
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aclass": self = .aclass
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aclass: return 0
@@ -12945,7 +12945,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aclass: return "\"aclass\""
@@ -12954,9 +12954,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aclass: return ".aclass"
@@ -12968,43 +12968,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum deinitEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adeinit // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adeinit
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adeinit
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adeinit": self = .adeinit
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adeinit": self = .adeinit
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adeinit": self = .adeinit
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adeinit: return 0
@@ -13013,7 +13013,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adeinit: return "\"adeinit\""
@@ -13022,9 +13022,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adeinit: return ".adeinit"
@@ -13036,43 +13036,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum enumEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aenum // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aenum
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aenum
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aenum": self = .aenum
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aenum": self = .aenum
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aenum": self = .aenum
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aenum: return 0
@@ -13081,7 +13081,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aenum: return "\"aenum\""
@@ -13090,9 +13090,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aenum: return ".aenum"
@@ -13104,43 +13104,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum extensionEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aextension // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aextension
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aextension
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aextension": self = .aextension
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aextension": self = .aextension
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aextension": self = .aextension
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aextension: return 0
@@ -13149,7 +13149,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aextension: return "\"aextension\""
@@ -13158,9 +13158,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aextension: return ".aextension"
@@ -13172,43 +13172,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum funcEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afunc // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afunc
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afunc
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afunc": self = .afunc
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afunc": self = .afunc
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afunc": self = .afunc
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afunc: return 0
@@ -13217,7 +13217,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afunc: return "\"afunc\""
@@ -13226,9 +13226,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afunc: return ".afunc"
@@ -13240,43 +13240,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum importEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aimport // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aimport
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aimport
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aimport": self = .aimport
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aimport": self = .aimport
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aimport": self = .aimport
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aimport: return 0
@@ -13285,7 +13285,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aimport: return "\"aimport\""
@@ -13294,9 +13294,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aimport: return ".aimport"
@@ -13308,43 +13308,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum initEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ainit // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ainit
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ainit
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ainit": self = .ainit
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ainit": self = .ainit
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ainit": self = .ainit
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ainit: return 0
@@ -13353,7 +13353,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ainit: return "\"ainit\""
@@ -13362,9 +13362,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ainit: return ".ainit"
@@ -13376,43 +13376,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum inoutEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ainout // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ainout
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ainout
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ainout": self = .ainout
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ainout": self = .ainout
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ainout": self = .ainout
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ainout: return 0
@@ -13421,7 +13421,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ainout: return "\"ainout\""
@@ -13430,9 +13430,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ainout: return ".ainout"
@@ -13444,43 +13444,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum internalEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ainternal // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ainternal
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ainternal
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ainternal": self = .ainternal
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ainternal": self = .ainternal
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ainternal": self = .ainternal
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ainternal: return 0
@@ -13489,7 +13489,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ainternal: return "\"ainternal\""
@@ -13498,9 +13498,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ainternal: return ".ainternal"
@@ -13512,43 +13512,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum letEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case alet // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .alet
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .alet
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "alet": self = .alet
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "alet": self = .alet
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "alet": self = .alet
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .alet: return 0
@@ -13557,7 +13557,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .alet: return "\"alet\""
@@ -13566,9 +13566,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .alet: return ".alet"
@@ -13580,43 +13580,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum operatorEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aoperator // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aoperator
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aoperator
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aoperator": self = .aoperator
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aoperator": self = .aoperator
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aoperator": self = .aoperator
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aoperator: return 0
@@ -13625,7 +13625,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aoperator: return "\"aoperator\""
@@ -13634,9 +13634,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aoperator: return ".aoperator"
@@ -13648,43 +13648,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum privateEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aprivate // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aprivate
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aprivate
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aprivate": self = .aprivate
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aprivate": self = .aprivate
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aprivate": self = .aprivate
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aprivate: return 0
@@ -13693,7 +13693,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aprivate: return "\"aprivate\""
@@ -13702,9 +13702,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aprivate: return ".aprivate"
@@ -13716,43 +13716,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum protocolEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aprotocol // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aprotocol
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aprotocol
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aprotocol": self = .aprotocol
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aprotocol": self = .aprotocol
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aprotocol": self = .aprotocol
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aprotocol: return 0
@@ -13761,7 +13761,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aprotocol: return "\"aprotocol\""
@@ -13770,9 +13770,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aprotocol: return ".aprotocol"
@@ -13784,43 +13784,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum publicEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case apublic // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .apublic
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .apublic
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "apublic": self = .apublic
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "apublic": self = .apublic
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "apublic": self = .apublic
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .apublic: return 0
@@ -13829,7 +13829,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .apublic: return "\"apublic\""
@@ -13838,9 +13838,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .apublic: return ".apublic"
@@ -13852,43 +13852,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum staticEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case astatic // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .astatic
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .astatic
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "astatic": self = .astatic
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "astatic": self = .astatic
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "astatic": self = .astatic
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .astatic: return 0
@@ -13897,7 +13897,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .astatic: return "\"astatic\""
@@ -13906,9 +13906,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .astatic: return ".astatic"
@@ -13920,43 +13920,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum structEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case astruct // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .astruct
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .astruct
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "astruct": self = .astruct
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "astruct": self = .astruct
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "astruct": self = .astruct
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .astruct: return 0
@@ -13965,7 +13965,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .astruct: return "\"astruct\""
@@ -13974,9 +13974,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .astruct: return ".astruct"
@@ -13988,43 +13988,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum subscriptEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asubscript // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asubscript
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asubscript
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asubscript": self = .asubscript
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asubscript": self = .asubscript
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asubscript": self = .asubscript
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asubscript: return 0
@@ -14033,7 +14033,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asubscript: return "\"asubscript\""
@@ -14042,9 +14042,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asubscript: return ".asubscript"
@@ -14056,43 +14056,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum typealiasEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atypealias // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atypealias
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atypealias
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atypealias": self = .atypealias
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atypealias": self = .atypealias
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atypealias": self = .atypealias
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atypealias: return 0
@@ -14101,7 +14101,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atypealias: return "\"atypealias\""
@@ -14110,9 +14110,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atypealias: return ".atypealias"
@@ -14124,43 +14124,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum varEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case avar // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .avar
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .avar
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "avar": self = .avar
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "avar": self = .avar
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "avar": self = .avar
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .avar: return 0
@@ -14169,7 +14169,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .avar: return "\"avar\""
@@ -14178,9 +14178,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .avar: return ".avar"
@@ -14192,43 +14192,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum breakEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abreak // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abreak
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abreak
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abreak": self = .abreak
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abreak": self = .abreak
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abreak": self = .abreak
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abreak: return 0
@@ -14237,7 +14237,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abreak: return "\"abreak\""
@@ -14246,9 +14246,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abreak: return ".abreak"
@@ -14260,43 +14260,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum caseEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case acase // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .acase
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .acase
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "acase": self = .acase
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "acase": self = .acase
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "acase": self = .acase
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .acase: return 0
@@ -14305,7 +14305,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .acase: return "\"acase\""
@@ -14314,9 +14314,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .acase: return ".acase"
@@ -14328,43 +14328,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum continueEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case acontinue // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .acontinue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .acontinue
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "acontinue": self = .acontinue
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "acontinue": self = .acontinue
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "acontinue": self = .acontinue
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .acontinue: return 0
@@ -14373,7 +14373,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .acontinue: return "\"acontinue\""
@@ -14382,9 +14382,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .acontinue: return ".acontinue"
@@ -14396,43 +14396,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum defaultEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adefault // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adefault
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adefault
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adefault": self = .adefault
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adefault": self = .adefault
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adefault": self = .adefault
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adefault: return 0
@@ -14441,7 +14441,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adefault: return "\"adefault\""
@@ -14450,9 +14450,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adefault: return ".adefault"
@@ -14464,43 +14464,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum deferEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adefer // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adefer
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adefer
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adefer": self = .adefer
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adefer": self = .adefer
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adefer": self = .adefer
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adefer: return 0
@@ -14509,7 +14509,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adefer: return "\"adefer\""
@@ -14518,9 +14518,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adefer: return ".adefer"
@@ -14532,43 +14532,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum doEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ado // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ado
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ado
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ado": self = .ado
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ado": self = .ado
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ado": self = .ado
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ado: return 0
@@ -14577,7 +14577,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ado: return "\"ado\""
@@ -14586,9 +14586,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ado: return ".ado"
@@ -14600,43 +14600,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum elseEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aelse // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aelse
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aelse
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aelse": self = .aelse
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aelse": self = .aelse
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aelse": self = .aelse
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aelse: return 0
@@ -14645,7 +14645,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aelse: return "\"aelse\""
@@ -14654,9 +14654,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aelse: return ".aelse"
@@ -14668,43 +14668,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum fallthroughEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afallthrough // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afallthrough
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afallthrough
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afallthrough": self = .afallthrough
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afallthrough": self = .afallthrough
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afallthrough": self = .afallthrough
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afallthrough: return 0
@@ -14713,7 +14713,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afallthrough: return "\"afallthrough\""
@@ -14722,9 +14722,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afallthrough: return ".afallthrough"
@@ -14736,43 +14736,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum forEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afor // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afor
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afor
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afor": self = .afor
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afor": self = .afor
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afor": self = .afor
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afor: return 0
@@ -14781,7 +14781,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afor: return "\"afor\""
@@ -14790,9 +14790,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afor: return ".afor"
@@ -14804,43 +14804,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum guardEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aguard // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aguard
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aguard
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aguard": self = .aguard
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aguard": self = .aguard
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aguard": self = .aguard
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aguard: return 0
@@ -14849,7 +14849,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aguard: return "\"aguard\""
@@ -14858,9 +14858,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aguard: return ".aguard"
@@ -14872,43 +14872,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ifEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aif // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aif
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aif
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aif": self = .aif
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aif": self = .aif
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aif": self = .aif
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aif: return 0
@@ -14917,7 +14917,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aif: return "\"aif\""
@@ -14926,9 +14926,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aif: return ".aif"
@@ -14940,43 +14940,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum inEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ain // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ain
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ain
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ain": self = .ain
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ain": self = .ain
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ain": self = .ain
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ain: return 0
@@ -14985,7 +14985,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ain: return "\"ain\""
@@ -14994,9 +14994,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ain: return ".ain"
@@ -15008,43 +15008,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum repeatEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case arepeat // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .arepeat
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .arepeat
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "arepeat": self = .arepeat
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "arepeat": self = .arepeat
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "arepeat": self = .arepeat
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .arepeat: return 0
@@ -15053,7 +15053,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .arepeat: return "\"arepeat\""
@@ -15062,9 +15062,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .arepeat: return ".arepeat"
@@ -15076,43 +15076,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum returnEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case areturn // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .areturn
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .areturn
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "areturn": self = .areturn
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "areturn": self = .areturn
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "areturn": self = .areturn
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .areturn: return 0
@@ -15121,7 +15121,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .areturn: return "\"areturn\""
@@ -15130,9 +15130,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .areturn: return ".areturn"
@@ -15144,43 +15144,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum switchEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aswitch // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aswitch
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aswitch
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aswitch": self = .aswitch
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aswitch": self = .aswitch
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aswitch": self = .aswitch
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aswitch: return 0
@@ -15189,7 +15189,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aswitch: return "\"aswitch\""
@@ -15198,9 +15198,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aswitch: return ".aswitch"
@@ -15212,43 +15212,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum whereEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case awhere // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .awhere
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .awhere
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "awhere": self = .awhere
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "awhere": self = .awhere
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "awhere": self = .awhere
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .awhere: return 0
@@ -15257,7 +15257,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .awhere: return "\"awhere\""
@@ -15266,9 +15266,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .awhere: return ".awhere"
@@ -15280,43 +15280,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum whileEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case awhile // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .awhile
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .awhile
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "awhile": self = .awhile
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "awhile": self = .awhile
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "awhile": self = .awhile
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .awhile: return 0
@@ -15325,7 +15325,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .awhile: return "\"awhile\""
@@ -15334,9 +15334,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .awhile: return ".awhile"
@@ -15348,43 +15348,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum asEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aas // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aas
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aas
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aas": self = .aas
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aas": self = .aas
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aas": self = .aas
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aas: return 0
@@ -15393,7 +15393,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aas: return "\"aas\""
@@ -15402,9 +15402,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aas: return ".aas"
@@ -15416,43 +15416,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum catchEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case acatch // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .acatch
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .acatch
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "acatch": self = .acatch
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "acatch": self = .acatch
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "acatch": self = .acatch
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .acatch: return 0
@@ -15461,7 +15461,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .acatch: return "\"acatch\""
@@ -15470,9 +15470,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .acatch: return ".acatch"
@@ -15484,43 +15484,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum dynamicTypeEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adynamicType // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adynamicType
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adynamicType
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adynamicType": self = .adynamicType
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adynamicType": self = .adynamicType
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adynamicType": self = .adynamicType
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adynamicType: return 0
@@ -15529,7 +15529,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adynamicType: return "\"adynamicType\""
@@ -15538,9 +15538,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adynamicType: return ".adynamicType"
@@ -15552,43 +15552,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum falseEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afalse // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afalse
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afalse
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afalse": self = .afalse
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afalse": self = .afalse
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afalse": self = .afalse
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afalse: return 0
@@ -15597,7 +15597,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afalse: return "\"afalse\""
@@ -15606,9 +15606,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afalse: return ".afalse"
@@ -15620,43 +15620,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum isEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ais // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ais
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ais
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ais": self = .ais
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ais": self = .ais
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ais": self = .ais
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ais: return 0
@@ -15665,7 +15665,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ais: return "\"ais\""
@@ -15674,9 +15674,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ais: return ".ais"
@@ -15688,43 +15688,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum nilEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anil // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anil
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anil
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anil": self = .anil
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anil": self = .anil
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anil": self = .anil
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anil: return 0
@@ -15733,7 +15733,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anil: return "\"anil\""
@@ -15742,9 +15742,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anil: return ".anil"
@@ -15756,43 +15756,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum rethrowsEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case arethrows // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .arethrows
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .arethrows
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "arethrows": self = .arethrows
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "arethrows": self = .arethrows
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "arethrows": self = .arethrows
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .arethrows: return 0
@@ -15801,7 +15801,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .arethrows: return "\"arethrows\""
@@ -15810,9 +15810,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .arethrows: return ".arethrows"
@@ -15824,43 +15824,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum superEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asuper // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asuper
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asuper
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asuper": self = .asuper
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asuper": self = .asuper
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asuper": self = .asuper
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asuper: return 0
@@ -15869,7 +15869,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asuper: return "\"asuper\""
@@ -15878,9 +15878,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asuper: return ".asuper"
@@ -15892,43 +15892,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum selfEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aself // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aself
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aself
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aself": self = .aself
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aself": self = .aself
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aself": self = .aself
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aself: return 0
@@ -15937,7 +15937,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aself: return "\"aself\""
@@ -15946,9 +15946,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aself: return ".aself"
@@ -15960,43 +15960,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum throwEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case athrow // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .athrow
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .athrow
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "athrow": self = .athrow
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "athrow": self = .athrow
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "athrow": self = .athrow
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .athrow: return 0
@@ -16005,7 +16005,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .athrow: return "\"athrow\""
@@ -16014,9 +16014,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .athrow: return ".athrow"
@@ -16028,43 +16028,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum throwsEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case athrows // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .athrows
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .athrows
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "athrows": self = .athrows
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "athrows": self = .athrows
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "athrows": self = .athrows
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .athrows: return 0
@@ -16073,7 +16073,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .athrows: return "\"athrows\""
@@ -16082,9 +16082,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .athrows: return ".athrows"
@@ -16096,43 +16096,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum trueEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atrue // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atrue
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atrue
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atrue": self = .atrue
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atrue": self = .atrue
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atrue": self = .atrue
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atrue: return 0
@@ -16141,7 +16141,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atrue: return "\"atrue\""
@@ -16150,9 +16150,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atrue: return ".atrue"
@@ -16164,43 +16164,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum tryEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atry // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atry
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atry
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atry": self = .atry
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atry": self = .atry
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atry": self = .atry
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atry: return 0
@@ -16209,7 +16209,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atry: return "\"atry\""
@@ -16218,9 +16218,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atry: return ".atry"
@@ -16232,43 +16232,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum __COLUMN__Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a_Column__ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a_Column__
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a_Column__
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a_Column__": self = .a_Column__
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a__COLUMN__": self = .a_Column__
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a__COLUMN__": self = .a_Column__
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a_Column__: return 0
@@ -16277,7 +16277,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a_Column__: return "\"a__COLUMN__\""
@@ -16286,9 +16286,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a_Column__: return ".a_Column__"
@@ -16300,43 +16300,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum __FILE__Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a_File__ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a_File__
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a_File__
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a_File__": self = .a_File__
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a__FILE__": self = .a_File__
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a__FILE__": self = .a_File__
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a_File__: return 0
@@ -16345,7 +16345,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a_File__: return "\"a__FILE__\""
@@ -16354,9 +16354,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a_File__: return ".a_File__"
@@ -16368,43 +16368,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum __FUNCTION__Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a_Function__ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a_Function__
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a_Function__
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a_Function__": self = .a_Function__
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a__FUNCTION__": self = .a_Function__
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a__FUNCTION__": self = .a_Function__
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a_Function__: return 0
@@ -16413,7 +16413,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a_Function__: return "\"a__FUNCTION__\""
@@ -16422,9 +16422,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a_Function__: return ".a_Function__"
@@ -16436,43 +16436,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum __LINE__Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a_Line__ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a_Line__
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a_Line__
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a_Line__": self = .a_Line__
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a__LINE__": self = .a_Line__
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a__LINE__": self = .a_Line__
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a_Line__: return 0
@@ -16481,7 +16481,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a_Line__: return "\"a__LINE__\""
@@ -16490,9 +16490,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a_Line__: return ".a_Line__"
@@ -16504,43 +16504,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum _Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a_ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a_
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a_
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a_": self = .a_
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a_": self = .a_
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a_": self = .a_
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a_: return 0
@@ -16549,7 +16549,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a_: return "\"a_\""
@@ -16558,9 +16558,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a_: return ".a_"
@@ -16572,43 +16572,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum __Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a__ // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .a__
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .a__
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a__": self = .a__
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a__": self = .a__
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a__": self = .a__
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a__: return 0
@@ -16617,7 +16617,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a__: return "\"a__\""
@@ -16626,9 +16626,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a__: return ".a__"
@@ -16640,43 +16640,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum associativity: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aassociativity // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aassociativity
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aassociativity
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aassociativity": self = .aassociativity
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aassociativity": self = .aassociativity
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aassociativity": self = .aassociativity
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aassociativity: return 0
@@ -16685,7 +16685,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aassociativity: return "\"aassociativity\""
@@ -16694,9 +16694,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aassociativity: return ".aassociativity"
@@ -16708,43 +16708,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum convenience: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aconvenience // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aconvenience
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aconvenience
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aconvenience": self = .aconvenience
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aconvenience": self = .aconvenience
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aconvenience": self = .aconvenience
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aconvenience: return 0
@@ -16753,7 +16753,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aconvenience: return "\"aconvenience\""
@@ -16762,9 +16762,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aconvenience: return ".aconvenience"
@@ -16776,43 +16776,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum dynamic: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adynamic // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adynamic
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adynamic
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adynamic": self = .adynamic
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adynamic": self = .adynamic
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adynamic": self = .adynamic
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adynamic: return 0
@@ -16821,7 +16821,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adynamic: return "\"adynamic\""
@@ -16830,9 +16830,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adynamic: return ".adynamic"
@@ -16844,43 +16844,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum didSet: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adidSet // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adidSet
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adidSet
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adidSet": self = .adidSet
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adidSet": self = .adidSet
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adidSet": self = .adidSet
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adidSet: return 0
@@ -16889,7 +16889,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adidSet: return "\"adidSet\""
@@ -16898,9 +16898,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adidSet: return ".adidSet"
@@ -16912,43 +16912,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum final: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afinal // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afinal
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afinal
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afinal": self = .afinal
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afinal": self = .afinal
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afinal": self = .afinal
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afinal: return 0
@@ -16957,7 +16957,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afinal: return "\"afinal\""
@@ -16966,9 +16966,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afinal: return ".afinal"
@@ -16980,43 +16980,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum get: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aget // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aget
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aget
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aget": self = .aget
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aget": self = .aget
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aget": self = .aget
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aget: return 0
@@ -17025,7 +17025,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aget: return "\"aget\""
@@ -17034,9 +17034,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aget: return ".aget"
@@ -17048,43 +17048,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum infix: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ainfix // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ainfix
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ainfix
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ainfix": self = .ainfix
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ainfix": self = .ainfix
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ainfix": self = .ainfix
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ainfix: return 0
@@ -17093,7 +17093,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ainfix: return "\"ainfix\""
@@ -17102,9 +17102,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ainfix: return ".ainfix"
@@ -17116,43 +17116,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum indirect: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aindirect // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aindirect
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aindirect
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aindirect": self = .aindirect
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aindirect": self = .aindirect
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aindirect": self = .aindirect
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aindirect: return 0
@@ -17161,7 +17161,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aindirect: return "\"aindirect\""
@@ -17170,9 +17170,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aindirect: return ".aindirect"
@@ -17184,43 +17184,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum lazy: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case alazy // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .alazy
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .alazy
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "alazy": self = .alazy
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "alazy": self = .alazy
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "alazy": self = .alazy
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .alazy: return 0
@@ -17229,7 +17229,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .alazy: return "\"alazy\""
@@ -17238,9 +17238,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .alazy: return ".alazy"
@@ -17252,43 +17252,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum left: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aleft // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aleft
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aleft
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aleft": self = .aleft
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aleft": self = .aleft
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aleft": self = .aleft
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aleft: return 0
@@ -17297,7 +17297,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aleft: return "\"aleft\""
@@ -17306,9 +17306,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aleft: return ".aleft"
@@ -17320,43 +17320,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum mutating: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case amutating // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .amutating
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .amutating
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "amutating": self = .amutating
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "amutating": self = .amutating
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "amutating": self = .amutating
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .amutating: return 0
@@ -17365,7 +17365,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .amutating: return "\"amutating\""
@@ -17374,9 +17374,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .amutating: return ".amutating"
@@ -17388,43 +17388,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum none: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anone // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anone
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anone
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anone": self = .anone
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anone": self = .anone
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anone": self = .anone
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anone: return 0
@@ -17433,7 +17433,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anone: return "\"anone\""
@@ -17442,9 +17442,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anone: return ".anone"
@@ -17456,43 +17456,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum nonmutating: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anonmutating // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anonmutating
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anonmutating
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anonmutating": self = .anonmutating
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anonmutating": self = .anonmutating
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anonmutating": self = .anonmutating
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anonmutating: return 0
@@ -17501,7 +17501,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anonmutating: return "\"anonmutating\""
@@ -17510,9 +17510,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anonmutating: return ".anonmutating"
@@ -17524,43 +17524,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum optional: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aoptional // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aoptional
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aoptional
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aoptional": self = .aoptional
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aoptional": self = .aoptional
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aoptional": self = .aoptional
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aoptional: return 0
@@ -17569,7 +17569,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aoptional: return "\"aoptional\""
@@ -17578,9 +17578,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aoptional: return ".aoptional"
@@ -17592,43 +17592,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum override: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aoverride // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aoverride
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aoverride
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aoverride": self = .aoverride
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aoverride": self = .aoverride
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aoverride": self = .aoverride
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aoverride: return 0
@@ -17637,7 +17637,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aoverride: return "\"aoverride\""
@@ -17646,9 +17646,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aoverride: return ".aoverride"
@@ -17660,43 +17660,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum postfix: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case apostfix // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .apostfix
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .apostfix
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "apostfix": self = .apostfix
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "apostfix": self = .apostfix
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "apostfix": self = .apostfix
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .apostfix: return 0
@@ -17705,7 +17705,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .apostfix: return "\"apostfix\""
@@ -17714,9 +17714,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .apostfix: return ".apostfix"
@@ -17728,43 +17728,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum precedence: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aprecedence // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aprecedence
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aprecedence
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aprecedence": self = .aprecedence
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aprecedence": self = .aprecedence
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aprecedence": self = .aprecedence
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aprecedence: return 0
@@ -17773,7 +17773,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aprecedence: return "\"aprecedence\""
@@ -17782,9 +17782,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aprecedence: return ".aprecedence"
@@ -17796,43 +17796,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum prefix: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aprefix // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aprefix
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aprefix
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aprefix": self = .aprefix
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aprefix": self = .aprefix
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aprefix": self = .aprefix
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aprefix: return 0
@@ -17841,7 +17841,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aprefix: return "\"aprefix\""
@@ -17850,9 +17850,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aprefix: return ".aprefix"
@@ -17864,43 +17864,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum required: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case arequired // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .arequired
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .arequired
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "arequired": self = .arequired
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "arequired": self = .arequired
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "arequired": self = .arequired
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .arequired: return 0
@@ -17909,7 +17909,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .arequired: return "\"arequired\""
@@ -17918,9 +17918,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .arequired: return ".arequired"
@@ -17932,43 +17932,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum right: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aright // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aright
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aright
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aright": self = .aright
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aright": self = .aright
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aright": self = .aright
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aright: return 0
@@ -17977,7 +17977,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aright: return "\"aright\""
@@ -17986,9 +17986,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aright: return ".aright"
@@ -18000,43 +18000,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum set: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aset // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aset
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aset
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aset": self = .aset
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aset": self = .aset
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aset": self = .aset
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aset: return 0
@@ -18045,7 +18045,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aset: return "\"aset\""
@@ -18054,9 +18054,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aset: return ".aset"
@@ -18068,43 +18068,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum TypeEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aType // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aType
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aType
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aType": self = .aType
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aType": self = .aType
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aType": self = .aType
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aType: return 0
@@ -18113,7 +18113,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aType: return "\"aType\""
@@ -18122,9 +18122,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aType: return ".aType"
@@ -18136,43 +18136,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum unowned: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aunowned // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aunowned
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aunowned
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aunowned": self = .aunowned
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aunowned": self = .aunowned
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aunowned": self = .aunowned
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aunowned: return 0
@@ -18181,7 +18181,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aunowned: return "\"aunowned\""
@@ -18190,9 +18190,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aunowned: return ".aunowned"
@@ -18204,43 +18204,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum weak: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aweak // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aweak
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aweak
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aweak": self = .aweak
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aweak": self = .aweak
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aweak": self = .aweak
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aweak: return 0
@@ -18249,7 +18249,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aweak: return "\"aweak\""
@@ -18258,9 +18258,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aweak: return ".aweak"
@@ -18272,43 +18272,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum willSet: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case awillSet // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .awillSet
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .awillSet
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "awillSet": self = .awillSet
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "awillSet": self = .awillSet
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "awillSet": self = .awillSet
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .awillSet: return 0
@@ -18317,7 +18317,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .awillSet: return "\"awillSet\""
@@ -18326,9 +18326,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .awillSet: return ".awillSet"
@@ -18340,43 +18340,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum id: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aid // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aid
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aid
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aid": self = .aid
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aid": self = .aid
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aid": self = .aid
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aid: return 0
@@ -18385,7 +18385,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aid: return "\"aid\""
@@ -18394,9 +18394,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aid: return ".aid"
@@ -18408,43 +18408,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum _cmd: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aCmd // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aCmd
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aCmd
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aCmd": self = .aCmd
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a_cmd": self = .aCmd
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a_cmd": self = .aCmd
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aCmd: return 0
@@ -18453,7 +18453,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aCmd: return "\"a_cmd\""
@@ -18462,9 +18462,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aCmd: return ".aCmd"
@@ -18476,43 +18476,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum out: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aout // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aout
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aout
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aout": self = .aout
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aout": self = .aout
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aout": self = .aout
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aout: return 0
@@ -18521,7 +18521,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aout: return "\"aout\""
@@ -18530,9 +18530,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aout: return ".aout"
@@ -18544,43 +18544,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum bycopy: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abycopy // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abycopy
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abycopy
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abycopy": self = .abycopy
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abycopy": self = .abycopy
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abycopy": self = .abycopy
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abycopy: return 0
@@ -18589,7 +18589,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abycopy: return "\"abycopy\""
@@ -18598,9 +18598,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abycopy: return ".abycopy"
@@ -18612,43 +18612,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum byref: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abyref // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abyref
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abyref
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abyref": self = .abyref
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abyref": self = .abyref
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abyref": self = .abyref
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abyref: return 0
@@ -18657,7 +18657,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abyref: return "\"abyref\""
@@ -18666,9 +18666,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abyref: return ".abyref"
@@ -18680,43 +18680,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum oneway: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aoneway // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aoneway
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aoneway
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aoneway": self = .aoneway
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aoneway": self = .aoneway
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aoneway": self = .aoneway
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aoneway: return 0
@@ -18725,7 +18725,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aoneway: return "\"aoneway\""
@@ -18734,9 +18734,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aoneway: return ".aoneway"
@@ -18748,43 +18748,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum and: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aand // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aand
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aand
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aand": self = .aand
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aand": self = .aand
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aand": self = .aand
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aand: return 0
@@ -18793,7 +18793,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aand: return "\"aand\""
@@ -18802,9 +18802,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aand: return ".aand"
@@ -18816,43 +18816,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum and_eq: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aandEq // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aandEq
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aandEq
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aandEq": self = .aandEq
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aand_eq": self = .aandEq
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aand_eq": self = .aandEq
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aandEq: return 0
@@ -18861,7 +18861,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aandEq: return "\"aand_eq\""
@@ -18870,9 +18870,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aandEq: return ".aandEq"
@@ -18884,43 +18884,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum alignas: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aalignas // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aalignas
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aalignas
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aalignas": self = .aalignas
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aalignas": self = .aalignas
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aalignas": self = .aalignas
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aalignas: return 0
@@ -18929,7 +18929,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aalignas: return "\"aalignas\""
@@ -18938,9 +18938,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aalignas: return ".aalignas"
@@ -18952,43 +18952,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum alignof: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aalignof // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aalignof
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aalignof
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aalignof": self = .aalignof
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aalignof": self = .aalignof
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aalignof": self = .aalignof
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aalignof: return 0
@@ -18997,7 +18997,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aalignof: return "\"aalignof\""
@@ -19006,9 +19006,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aalignof: return ".aalignof"
@@ -19020,43 +19020,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum asm: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aasm // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aasm
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aasm
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aasm": self = .aasm
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aasm": self = .aasm
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aasm": self = .aasm
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aasm: return 0
@@ -19065,7 +19065,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aasm: return "\"aasm\""
@@ -19074,9 +19074,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aasm: return ".aasm"
@@ -19088,43 +19088,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum auto: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aauto // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aauto
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aauto
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aauto": self = .aauto
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aauto": self = .aauto
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aauto": self = .aauto
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aauto: return 0
@@ -19133,7 +19133,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aauto: return "\"aauto\""
@@ -19142,9 +19142,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aauto: return ".aauto"
@@ -19156,43 +19156,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum bitand: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abitand // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abitand
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abitand
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abitand": self = .abitand
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abitand": self = .abitand
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abitand": self = .abitand
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abitand: return 0
@@ -19201,7 +19201,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abitand: return "\"abitand\""
@@ -19210,9 +19210,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abitand: return ".abitand"
@@ -19224,43 +19224,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum bitor: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abitor // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abitor
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abitor
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abitor": self = .abitor
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abitor": self = .abitor
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abitor": self = .abitor
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abitor: return 0
@@ -19269,7 +19269,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abitor: return "\"abitor\""
@@ -19278,9 +19278,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abitor: return ".abitor"
@@ -19292,43 +19292,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum bool: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case abool // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .abool
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .abool
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "abool": self = .abool
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "abool": self = .abool
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "abool": self = .abool
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .abool: return 0
@@ -19337,7 +19337,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .abool: return "\"abool\""
@@ -19346,9 +19346,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .abool: return ".abool"
@@ -19360,43 +19360,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum char: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case achar // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .achar
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .achar
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "achar": self = .achar
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "achar": self = .achar
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "achar": self = .achar
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .achar: return 0
@@ -19405,7 +19405,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .achar: return "\"achar\""
@@ -19414,9 +19414,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .achar: return ".achar"
@@ -19428,43 +19428,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum char16_t: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case achar16T // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .achar16T
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .achar16T
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "achar16T": self = .achar16T
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "achar16_t": self = .achar16T
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "achar16_t": self = .achar16T
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .achar16T: return 0
@@ -19473,7 +19473,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .achar16T: return "\"achar16_t\""
@@ -19482,9 +19482,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .achar16T: return ".achar16T"
@@ -19496,43 +19496,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum char32_t: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case achar32T // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .achar32T
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .achar32T
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "achar32T": self = .achar32T
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "achar32_t": self = .achar32T
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "achar32_t": self = .achar32T
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .achar32T: return 0
@@ -19541,7 +19541,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .achar32T: return "\"achar32_t\""
@@ -19550,9 +19550,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .achar32T: return ".achar32T"
@@ -19564,43 +19564,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum compl: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case acompl // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .acompl
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .acompl
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "acompl": self = .acompl
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "acompl": self = .acompl
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "acompl": self = .acompl
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .acompl: return 0
@@ -19609,7 +19609,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .acompl: return "\"acompl\""
@@ -19618,9 +19618,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .acompl: return ".acompl"
@@ -19632,43 +19632,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum const: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aconst // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aconst
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aconst
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aconst": self = .aconst
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aconst": self = .aconst
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aconst": self = .aconst
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aconst: return 0
@@ -19677,7 +19677,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aconst: return "\"aconst\""
@@ -19686,9 +19686,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aconst: return ".aconst"
@@ -19700,43 +19700,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum constexpr: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aconstexpr // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aconstexpr
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aconstexpr
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aconstexpr": self = .aconstexpr
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aconstexpr": self = .aconstexpr
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aconstexpr": self = .aconstexpr
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aconstexpr: return 0
@@ -19745,7 +19745,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aconstexpr: return "\"aconstexpr\""
@@ -19754,9 +19754,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aconstexpr: return ".aconstexpr"
@@ -19768,43 +19768,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum const_cast: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aconstCast // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aconstCast
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aconstCast
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aconstCast": self = .aconstCast
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aconst_cast": self = .aconstCast
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aconst_cast": self = .aconstCast
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aconstCast: return 0
@@ -19813,7 +19813,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aconstCast: return "\"aconst_cast\""
@@ -19822,9 +19822,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aconstCast: return ".aconstCast"
@@ -19836,43 +19836,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum decltype: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adecltype // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adecltype
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adecltype
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adecltype": self = .adecltype
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adecltype": self = .adecltype
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adecltype": self = .adecltype
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adecltype: return 0
@@ -19881,7 +19881,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adecltype: return "\"adecltype\""
@@ -19890,9 +19890,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adecltype: return ".adecltype"
@@ -19904,43 +19904,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum delete: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adelete // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adelete
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adelete
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adelete": self = .adelete
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adelete": self = .adelete
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adelete": self = .adelete
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adelete: return 0
@@ -19949,7 +19949,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adelete: return "\"adelete\""
@@ -19958,9 +19958,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adelete: return ".adelete"
@@ -19972,43 +19972,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum dynamic_cast: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adynamicCast // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adynamicCast
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adynamicCast
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adynamicCast": self = .adynamicCast
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adynamic_cast": self = .adynamicCast
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adynamic_cast": self = .adynamicCast
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adynamicCast: return 0
@@ -20017,7 +20017,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adynamicCast: return "\"adynamic_cast\""
@@ -20026,9 +20026,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adynamicCast: return ".adynamicCast"
@@ -20040,43 +20040,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum explicit: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aexplicit // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aexplicit
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aexplicit
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aexplicit": self = .aexplicit
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aexplicit": self = .aexplicit
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aexplicit": self = .aexplicit
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aexplicit: return 0
@@ -20085,7 +20085,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aexplicit: return "\"aexplicit\""
@@ -20094,9 +20094,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aexplicit: return ".aexplicit"
@@ -20108,43 +20108,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum export: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aexport // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aexport
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aexport
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aexport": self = .aexport
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aexport": self = .aexport
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aexport": self = .aexport
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aexport: return 0
@@ -20153,7 +20153,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aexport: return "\"aexport\""
@@ -20162,9 +20162,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aexport: return ".aexport"
@@ -20176,43 +20176,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum extern: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aextern // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aextern
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aextern
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aextern": self = .aextern
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aextern": self = .aextern
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aextern": self = .aextern
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aextern: return 0
@@ -20221,7 +20221,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aextern: return "\"aextern\""
@@ -20230,9 +20230,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aextern: return ".aextern"
@@ -20244,43 +20244,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum friend: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afriend // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afriend
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afriend
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afriend": self = .afriend
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afriend": self = .afriend
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afriend": self = .afriend
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afriend: return 0
@@ -20289,7 +20289,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afriend: return "\"afriend\""
@@ -20298,9 +20298,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afriend: return ".afriend"
@@ -20312,43 +20312,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum goto: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case agoto // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .agoto
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .agoto
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "agoto": self = .agoto
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "agoto": self = .agoto
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "agoto": self = .agoto
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .agoto: return 0
@@ -20357,7 +20357,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .agoto: return "\"agoto\""
@@ -20366,9 +20366,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .agoto: return ".agoto"
@@ -20380,43 +20380,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum inline: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ainline // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ainline
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ainline
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ainline": self = .ainline
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ainline": self = .ainline
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ainline": self = .ainline
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ainline: return 0
@@ -20425,7 +20425,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ainline: return "\"ainline\""
@@ -20434,9 +20434,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ainline: return ".ainline"
@@ -20448,43 +20448,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum long: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case along // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .along
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .along
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "along": self = .along
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "along": self = .along
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "along": self = .along
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .along: return 0
@@ -20493,7 +20493,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .along: return "\"along\""
@@ -20502,9 +20502,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .along: return ".along"
@@ -20516,43 +20516,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum mutable: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case amutable // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .amutable
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .amutable
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "amutable": self = .amutable
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "amutable": self = .amutable
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "amutable": self = .amutable
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .amutable: return 0
@@ -20561,7 +20561,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .amutable: return "\"amutable\""
@@ -20570,9 +20570,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .amutable: return ".amutable"
@@ -20584,43 +20584,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum namespace: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anamespace // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anamespace
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anamespace
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anamespace": self = .anamespace
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anamespace": self = .anamespace
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anamespace": self = .anamespace
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anamespace: return 0
@@ -20629,7 +20629,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anamespace: return "\"anamespace\""
@@ -20638,9 +20638,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anamespace: return ".anamespace"
@@ -20652,43 +20652,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum new: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anew // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anew
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anew
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anew": self = .anew
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anew": self = .anew
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anew": self = .anew
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anew: return 0
@@ -20697,7 +20697,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anew: return "\"anew\""
@@ -20706,9 +20706,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anew: return ".anew"
@@ -20720,43 +20720,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum noexcept: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anoexcept // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anoexcept
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anoexcept
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anoexcept": self = .anoexcept
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anoexcept": self = .anoexcept
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anoexcept": self = .anoexcept
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anoexcept: return 0
@@ -20765,7 +20765,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anoexcept: return "\"anoexcept\""
@@ -20774,9 +20774,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anoexcept: return ".anoexcept"
@@ -20788,43 +20788,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum not: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anot // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anot
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anot
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anot": self = .anot
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anot": self = .anot
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anot": self = .anot
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anot: return 0
@@ -20833,7 +20833,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anot: return "\"anot\""
@@ -20842,9 +20842,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anot: return ".anot"
@@ -20856,43 +20856,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum not_eq: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anotEq // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anotEq
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anotEq
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anotEq": self = .anotEq
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anot_eq": self = .anotEq
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anot_eq": self = .anotEq
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anotEq: return 0
@@ -20901,7 +20901,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anotEq: return "\"anot_eq\""
@@ -20910,9 +20910,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anotEq: return ".anotEq"
@@ -20924,43 +20924,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum nullptr: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case anullptr // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .anullptr
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .anullptr
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "anullptr": self = .anullptr
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "anullptr": self = .anullptr
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "anullptr": self = .anullptr
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .anullptr: return 0
@@ -20969,7 +20969,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .anullptr: return "\"anullptr\""
@@ -20978,9 +20978,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .anullptr: return ".anullptr"
@@ -20992,43 +20992,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum or: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aor // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aor
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aor
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aor": self = .aor
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aor": self = .aor
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aor": self = .aor
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aor: return 0
@@ -21037,7 +21037,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aor: return "\"aor\""
@@ -21046,9 +21046,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aor: return ".aor"
@@ -21060,43 +21060,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum or_eq: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aorEq // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aorEq
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aorEq
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aorEq": self = .aorEq
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aor_eq": self = .aorEq
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aor_eq": self = .aorEq
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aorEq: return 0
@@ -21105,7 +21105,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aorEq: return "\"aor_eq\""
@@ -21114,9 +21114,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aorEq: return ".aorEq"
@@ -21128,43 +21128,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum protected: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aprotected // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aprotected
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aprotected
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aprotected": self = .aprotected
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aprotected": self = .aprotected
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aprotected": self = .aprotected
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aprotected: return 0
@@ -21173,7 +21173,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aprotected: return "\"aprotected\""
@@ -21182,9 +21182,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aprotected: return ".aprotected"
@@ -21196,43 +21196,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum register: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aregister // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aregister
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aregister
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aregister": self = .aregister
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aregister": self = .aregister
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aregister": self = .aregister
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aregister: return 0
@@ -21241,7 +21241,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aregister: return "\"aregister\""
@@ -21250,9 +21250,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aregister: return ".aregister"
@@ -21264,43 +21264,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum reinterpret_cast: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case areinterpretCast // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .areinterpretCast
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .areinterpretCast
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "areinterpretCast": self = .areinterpretCast
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "areinterpret_cast": self = .areinterpretCast
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "areinterpret_cast": self = .areinterpretCast
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .areinterpretCast: return 0
@@ -21309,7 +21309,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .areinterpretCast: return "\"areinterpret_cast\""
@@ -21318,9 +21318,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .areinterpretCast: return ".areinterpretCast"
@@ -21332,43 +21332,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum short: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ashort // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ashort
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ashort
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ashort": self = .ashort
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ashort": self = .ashort
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ashort": self = .ashort
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ashort: return 0
@@ -21377,7 +21377,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ashort: return "\"ashort\""
@@ -21386,9 +21386,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ashort: return ".ashort"
@@ -21400,43 +21400,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum signed: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asigned // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asigned
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asigned
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asigned": self = .asigned
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asigned": self = .asigned
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asigned": self = .asigned
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asigned: return 0
@@ -21445,7 +21445,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asigned: return "\"asigned\""
@@ -21454,9 +21454,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asigned: return ".asigned"
@@ -21468,43 +21468,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum sizeof: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asizeof // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asizeof
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asizeof
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asizeof": self = .asizeof
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asizeof": self = .asizeof
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asizeof": self = .asizeof
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asizeof: return 0
@@ -21513,7 +21513,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asizeof: return "\"asizeof\""
@@ -21522,9 +21522,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asizeof: return ".asizeof"
@@ -21536,43 +21536,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum static_assert: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case astaticAssert // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .astaticAssert
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .astaticAssert
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "astaticAssert": self = .astaticAssert
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "astatic_assert": self = .astaticAssert
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "astatic_assert": self = .astaticAssert
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .astaticAssert: return 0
@@ -21581,7 +21581,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .astaticAssert: return "\"astatic_assert\""
@@ -21590,9 +21590,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .astaticAssert: return ".astaticAssert"
@@ -21604,43 +21604,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum static_cast: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case astaticCast // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .astaticCast
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .astaticCast
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "astaticCast": self = .astaticCast
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "astatic_cast": self = .astaticCast
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "astatic_cast": self = .astaticCast
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .astaticCast: return 0
@@ -21649,7 +21649,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .astaticCast: return "\"astatic_cast\""
@@ -21658,9 +21658,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .astaticCast: return ".astaticCast"
@@ -21672,43 +21672,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum template: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atemplate // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atemplate
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atemplate
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atemplate": self = .atemplate
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atemplate": self = .atemplate
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atemplate": self = .atemplate
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atemplate: return 0
@@ -21717,7 +21717,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atemplate: return "\"atemplate\""
@@ -21726,9 +21726,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atemplate: return ".atemplate"
@@ -21740,43 +21740,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum this: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case athis // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .athis
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .athis
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "athis": self = .athis
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "athis": self = .athis
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "athis": self = .athis
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .athis: return 0
@@ -21785,7 +21785,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .athis: return "\"athis\""
@@ -21794,9 +21794,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .athis: return ".athis"
@@ -21808,43 +21808,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum thread_local: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case athreadLocal // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .athreadLocal
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .athreadLocal
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "athreadLocal": self = .athreadLocal
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "athread_local": self = .athreadLocal
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "athread_local": self = .athreadLocal
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .athreadLocal: return 0
@@ -21853,7 +21853,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .athreadLocal: return "\"athread_local\""
@@ -21862,9 +21862,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .athreadLocal: return ".athreadLocal"
@@ -21876,43 +21876,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum typedef: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atypedef // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atypedef
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atypedef
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atypedef": self = .atypedef
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atypedef": self = .atypedef
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atypedef": self = .atypedef
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atypedef: return 0
@@ -21921,7 +21921,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atypedef: return "\"atypedef\""
@@ -21930,9 +21930,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atypedef: return ".atypedef"
@@ -21944,43 +21944,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum typeid: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atypeid // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atypeid
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atypeid
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atypeid": self = .atypeid
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atypeid": self = .atypeid
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atypeid": self = .atypeid
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atypeid: return 0
@@ -21989,7 +21989,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atypeid: return "\"atypeid\""
@@ -21998,9 +21998,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atypeid: return ".atypeid"
@@ -22012,43 +22012,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum typename: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case atypename // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .atypename
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .atypename
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "atypename": self = .atypename
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "atypename": self = .atypename
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "atypename": self = .atypename
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .atypename: return 0
@@ -22057,7 +22057,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .atypename: return "\"atypename\""
@@ -22066,9 +22066,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .atypename: return ".atypename"
@@ -22080,43 +22080,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum union: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aunion // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aunion
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aunion
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aunion": self = .aunion
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aunion": self = .aunion
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aunion": self = .aunion
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aunion: return 0
@@ -22125,7 +22125,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aunion: return "\"aunion\""
@@ -22134,9 +22134,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aunion: return ".aunion"
@@ -22148,43 +22148,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum unsigned: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aunsigned // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aunsigned
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aunsigned
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aunsigned": self = .aunsigned
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aunsigned": self = .aunsigned
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aunsigned": self = .aunsigned
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aunsigned: return 0
@@ -22193,7 +22193,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aunsigned: return "\"aunsigned\""
@@ -22202,9 +22202,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aunsigned: return ".aunsigned"
@@ -22216,43 +22216,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum using: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ausing // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ausing
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ausing
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ausing": self = .ausing
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ausing": self = .ausing
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ausing": self = .ausing
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ausing: return 0
@@ -22261,7 +22261,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ausing: return "\"ausing\""
@@ -22270,9 +22270,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ausing: return ".ausing"
@@ -22284,43 +22284,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum virtual: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case avirtual // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .avirtual
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .avirtual
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "avirtual": self = .avirtual
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "avirtual": self = .avirtual
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "avirtual": self = .avirtual
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .avirtual: return 0
@@ -22329,7 +22329,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .avirtual: return "\"avirtual\""
@@ -22338,9 +22338,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .avirtual: return ".avirtual"
@@ -22352,43 +22352,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum void: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case avoid // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .avoid
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .avoid
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "avoid": self = .avoid
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "avoid": self = .avoid
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "avoid": self = .avoid
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .avoid: return 0
@@ -22397,7 +22397,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .avoid: return "\"avoid\""
@@ -22406,9 +22406,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .avoid: return ".avoid"
@@ -22420,43 +22420,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum volatile: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case avolatile // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .avolatile
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .avolatile
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "avolatile": self = .avolatile
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "avolatile": self = .avolatile
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "avolatile": self = .avolatile
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .avolatile: return 0
@@ -22465,7 +22465,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .avolatile: return "\"avolatile\""
@@ -22474,9 +22474,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .avolatile: return ".avolatile"
@@ -22488,43 +22488,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum wchar_t: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case awcharT // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .awcharT
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .awcharT
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "awcharT": self = .awcharT
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "awchar_t": self = .awcharT
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "awchar_t": self = .awcharT
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .awcharT: return 0
@@ -22533,7 +22533,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .awcharT: return "\"awchar_t\""
@@ -22542,9 +22542,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .awcharT: return ".awcharT"
@@ -22556,43 +22556,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum xor: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case axor // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .axor
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .axor
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "axor": self = .axor
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "axor": self = .axor
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "axor": self = .axor
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .axor: return 0
@@ -22601,7 +22601,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .axor: return "\"axor\""
@@ -22610,9 +22610,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .axor: return ".axor"
@@ -22624,43 +22624,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum xor_eq: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case axorEq // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .axorEq
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .axorEq
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "axorEq": self = .axorEq
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "axor_eq": self = .axorEq
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "axor_eq": self = .axorEq
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .axorEq: return 0
@@ -22669,7 +22669,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .axorEq: return "\"axor_eq\""
@@ -22678,9 +22678,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .axorEq: return ".axorEq"
@@ -22692,43 +22692,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum restrict: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case arestrict // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .arestrict
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .arestrict
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "arestrict": self = .arestrict
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "arestrict": self = .arestrict
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "arestrict": self = .arestrict
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .arestrict: return 0
@@ -22737,7 +22737,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .arestrict: return "\"arestrict\""
@@ -22746,9 +22746,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .arestrict: return ".arestrict"
@@ -22760,43 +22760,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Category: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aCategory // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aCategory
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aCategory
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aCategory": self = .aCategory
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aCategory": self = .aCategory
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aCategory": self = .aCategory
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aCategory: return 0
@@ -22805,7 +22805,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aCategory: return "\"aCategory\""
@@ -22814,9 +22814,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aCategory: return ".aCategory"
@@ -22828,43 +22828,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Ivar: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aIvar // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aIvar
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aIvar
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aIvar": self = .aIvar
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aIvar": self = .aIvar
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aIvar": self = .aIvar
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aIvar: return 0
@@ -22873,7 +22873,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aIvar: return "\"aIvar\""
@@ -22882,9 +22882,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aIvar: return ".aIvar"
@@ -22896,43 +22896,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Method: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aMethod // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aMethod
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aMethod
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aMethod": self = .aMethod
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aMethod": self = .aMethod
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aMethod": self = .aMethod
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aMethod: return 0
@@ -22941,7 +22941,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aMethod: return "\"aMethod\""
@@ -22950,9 +22950,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aMethod: return ".aMethod"
@@ -22964,43 +22964,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum finalize: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case afinalize // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .afinalize
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .afinalize
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "afinalize": self = .afinalize
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "afinalize": self = .afinalize
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "afinalize": self = .afinalize
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .afinalize: return 0
@@ -23009,7 +23009,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .afinalize: return "\"afinalize\""
@@ -23018,9 +23018,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .afinalize: return ".afinalize"
@@ -23032,43 +23032,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum hash: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case ahash // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .ahash
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .ahash
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "ahash": self = .ahash
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "ahash": self = .ahash
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "ahash": self = .ahash
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .ahash: return 0
@@ -23077,7 +23077,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .ahash: return "\"ahash\""
@@ -23086,9 +23086,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .ahash: return ".ahash"
@@ -23100,43 +23100,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum dealloc: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adealloc // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adealloc
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adealloc
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adealloc": self = .adealloc
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adealloc": self = .adealloc
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adealloc": self = .adealloc
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adealloc: return 0
@@ -23145,7 +23145,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adealloc: return "\"adealloc\""
@@ -23154,9 +23154,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adealloc: return ".adealloc"
@@ -23168,43 +23168,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum superclass: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asuperclass // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asuperclass
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asuperclass
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asuperclass": self = .asuperclass
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asuperclass": self = .asuperclass
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asuperclass": self = .asuperclass
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asuperclass: return 0
@@ -23213,7 +23213,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asuperclass: return "\"asuperclass\""
@@ -23222,9 +23222,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asuperclass: return ".asuperclass"
@@ -23236,43 +23236,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum retain: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aretain // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aretain
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aretain
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aretain": self = .aretain
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aretain": self = .aretain
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aretain": self = .aretain
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aretain: return 0
@@ -23281,7 +23281,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aretain: return "\"aretain\""
@@ -23290,9 +23290,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aretain: return ".aretain"
@@ -23304,43 +23304,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum release: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case arelease // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .arelease
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .arelease
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "arelease": self = .arelease
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "arelease": self = .arelease
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "arelease": self = .arelease
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .arelease: return 0
@@ -23349,7 +23349,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .arelease: return "\"arelease\""
@@ -23358,9 +23358,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .arelease: return ".arelease"
@@ -23372,43 +23372,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum autorelease: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aautorelease // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aautorelease
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aautorelease
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aautorelease": self = .aautorelease
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aautorelease": self = .aautorelease
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aautorelease": self = .aautorelease
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aautorelease: return 0
@@ -23417,7 +23417,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aautorelease: return "\"aautorelease\""
@@ -23426,9 +23426,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aautorelease: return ".aautorelease"
@@ -23440,43 +23440,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum retainCount: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aretainCount // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aretainCount
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aretainCount
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aretainCount": self = .aretainCount
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aretainCount": self = .aretainCount
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aretainCount": self = .aretainCount
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aretainCount: return 0
@@ -23485,7 +23485,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aretainCount: return "\"aretainCount\""
@@ -23494,9 +23494,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aretainCount: return ".aretainCount"
@@ -23508,43 +23508,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum zone: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case azone // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .azone
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .azone
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "azone": self = .azone
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "azone": self = .azone
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "azone": self = .azone
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .azone: return 0
@@ -23553,7 +23553,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .azone: return "\"azone\""
@@ -23562,9 +23562,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .azone: return ".azone"
@@ -23576,43 +23576,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum isProxy: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aisProxy // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aisProxy
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aisProxy
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aisProxy": self = .aisProxy
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aisProxy": self = .aisProxy
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aisProxy": self = .aisProxy
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aisProxy: return 0
@@ -23621,7 +23621,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aisProxy: return "\"aisProxy\""
@@ -23630,9 +23630,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aisProxy: return ".aisProxy"
@@ -23644,43 +23644,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum copy: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case acopy // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .acopy
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .acopy
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "acopy": self = .acopy
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "acopy": self = .acopy
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "acopy": self = .acopy
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .acopy: return 0
@@ -23689,7 +23689,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .acopy: return "\"acopy\""
@@ -23698,9 +23698,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .acopy: return ".acopy"
@@ -23712,43 +23712,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum mutableCopy: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case amutableCopy // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .amutableCopy
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .amutableCopy
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "amutableCopy": self = .amutableCopy
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "amutableCopy": self = .amutableCopy
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "amutableCopy": self = .amutableCopy
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .amutableCopy: return 0
@@ -23757,7 +23757,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .amutableCopy: return "\"amutableCopy\""
@@ -23766,9 +23766,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .amutableCopy: return ".amutableCopy"
@@ -23780,43 +23780,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum classForCoder: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aclassForCoder // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aclassForCoder
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aclassForCoder
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aclassForCoder": self = .aclassForCoder
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aclassForCoder": self = .aclassForCoder
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aclassForCoder": self = .aclassForCoder
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aclassForCoder: return 0
@@ -23825,7 +23825,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aclassForCoder: return "\"aclassForCoder\""
@@ -23834,9 +23834,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aclassForCoder: return ".aclassForCoder"
@@ -23848,43 +23848,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum clear: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aclear // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aclear
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aclear
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aclear": self = .aclear
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aclear": self = .aclear
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aclear": self = .aclear
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aclear: return 0
@@ -23893,7 +23893,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aclear: return "\"aclear\""
@@ -23902,9 +23902,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aclear: return ".aclear"
@@ -23916,43 +23916,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum data: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adata // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adata
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adata
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adata": self = .adata
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adata": self = .adata
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adata": self = .adata
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adata: return 0
@@ -23961,7 +23961,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adata: return "\"adata\""
@@ -23970,9 +23970,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adata: return ".adata"
@@ -23984,43 +23984,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum delimitedData: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adelimitedData // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adelimitedData
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adelimitedData
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adelimitedData": self = .adelimitedData
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adelimitedData": self = .adelimitedData
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adelimitedData": self = .adelimitedData
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adelimitedData: return 0
@@ -24029,7 +24029,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adelimitedData: return "\"adelimitedData\""
@@ -24038,9 +24038,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adelimitedData: return ".adelimitedData"
@@ -24052,43 +24052,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum descriptor: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case adescriptor // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .adescriptor
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .adescriptor
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "adescriptor": self = .adescriptor
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "adescriptor": self = .adescriptor
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "adescriptor": self = .adescriptor
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .adescriptor: return 0
@@ -24097,7 +24097,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .adescriptor: return "\"adescriptor\""
@@ -24106,9 +24106,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .adescriptor: return ".adescriptor"
@@ -24120,43 +24120,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum extensionRegistry: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aextensionRegistry // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aextensionRegistry
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aextensionRegistry
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aextensionRegistry": self = .aextensionRegistry
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aextensionRegistry": self = .aextensionRegistry
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aextensionRegistry": self = .aextensionRegistry
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aextensionRegistry: return 0
@@ -24165,7 +24165,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aextensionRegistry: return "\"aextensionRegistry\""
@@ -24174,9 +24174,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aextensionRegistry: return ".aextensionRegistry"
@@ -24188,43 +24188,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum extensionsCurrentlySet: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aextensionsCurrentlySet // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aextensionsCurrentlySet
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aextensionsCurrentlySet
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aextensionsCurrentlySet": self = .aextensionsCurrentlySet
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aextensionsCurrentlySet": self = .aextensionsCurrentlySet
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aextensionsCurrentlySet": self = .aextensionsCurrentlySet
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aextensionsCurrentlySet: return 0
@@ -24233,7 +24233,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aextensionsCurrentlySet: return "\"aextensionsCurrentlySet\""
@@ -24242,9 +24242,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aextensionsCurrentlySet: return ".aextensionsCurrentlySet"
@@ -24256,43 +24256,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum isInitialized: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aisInitialized // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aisInitialized
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aisInitialized
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aisInitialized": self = .aisInitialized
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aisInitialized": self = .aisInitialized
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aisInitialized": self = .aisInitialized
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aisInitialized: return 0
@@ -24301,7 +24301,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aisInitialized: return "\"aisInitialized\""
@@ -24310,9 +24310,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aisInitialized: return ".aisInitialized"
@@ -24324,43 +24324,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum serializedSize: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aserializedSize // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aserializedSize
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aserializedSize
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aserializedSize": self = .aserializedSize
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aserializedSize": self = .aserializedSize
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aserializedSize": self = .aserializedSize
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aserializedSize: return 0
@@ -24369,7 +24369,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aserializedSize: return "\"aserializedSize\""
@@ -24378,9 +24378,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aserializedSize: return ".aserializedSize"
@@ -24392,43 +24392,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum sortedExtensionsInUse: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case asortedExtensionsInUse // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .asortedExtensionsInUse
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .asortedExtensionsInUse
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "asortedExtensionsInUse": self = .asortedExtensionsInUse
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "asortedExtensionsInUse": self = .asortedExtensionsInUse
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "asortedExtensionsInUse": self = .asortedExtensionsInUse
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .asortedExtensionsInUse: return 0
@@ -24437,7 +24437,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .asortedExtensionsInUse: return "\"asortedExtensionsInUse\""
@@ -24446,9 +24446,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .asortedExtensionsInUse: return ".asortedExtensionsInUse"
@@ -24460,43 +24460,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum unknownFields: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aunknownFields // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aunknownFields
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aunknownFields
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aunknownFields": self = .aunknownFields
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aunknownFields": self = .aunknownFields
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aunknownFields": self = .aunknownFields
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aunknownFields: return 0
@@ -24505,7 +24505,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aunknownFields: return "\"aunknownFields\""
@@ -24514,9 +24514,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aunknownFields: return ".aunknownFields"
@@ -24528,43 +24528,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Fixed: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aFixed // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aFixed
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aFixed
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aFixed": self = .aFixed
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aFixed": self = .aFixed
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aFixed": self = .aFixed
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aFixed: return 0
@@ -24573,7 +24573,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aFixed: return "\"aFixed\""
@@ -24582,9 +24582,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aFixed: return ".aFixed"
@@ -24596,43 +24596,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Fract: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aFract // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aFract
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aFract
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aFract": self = .aFract
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aFract": self = .aFract
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aFract": self = .aFract
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aFract: return 0
@@ -24641,7 +24641,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aFract: return "\"aFract\""
@@ -24650,9 +24650,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aFract: return ".aFract"
@@ -24664,43 +24664,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Size: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aSize // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aSize
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aSize
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aSize": self = .aSize
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aSize": self = .aSize
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aSize": self = .aSize
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aSize: return 0
@@ -24709,7 +24709,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aSize: return "\"aSize\""
@@ -24718,9 +24718,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aSize: return ".aSize"
@@ -24732,43 +24732,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum LogicalAddress: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aLogicalAddress // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aLogicalAddress
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aLogicalAddress
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aLogicalAddress": self = .aLogicalAddress
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aLogicalAddress": self = .aLogicalAddress
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aLogicalAddress": self = .aLogicalAddress
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aLogicalAddress: return 0
@@ -24777,7 +24777,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aLogicalAddress: return "\"aLogicalAddress\""
@@ -24786,9 +24786,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aLogicalAddress: return ".aLogicalAddress"
@@ -24800,43 +24800,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum PhysicalAddress: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aPhysicalAddress // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aPhysicalAddress
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aPhysicalAddress
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aPhysicalAddress": self = .aPhysicalAddress
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aPhysicalAddress": self = .aPhysicalAddress
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aPhysicalAddress": self = .aPhysicalAddress
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aPhysicalAddress: return 0
@@ -24845,7 +24845,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aPhysicalAddress: return "\"aPhysicalAddress\""
@@ -24854,9 +24854,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aPhysicalAddress: return ".aPhysicalAddress"
@@ -24868,43 +24868,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ByteCount: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aByteCount // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aByteCount
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aByteCount
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aByteCount": self = .aByteCount
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aByteCount": self = .aByteCount
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aByteCount": self = .aByteCount
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aByteCount: return 0
@@ -24913,7 +24913,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aByteCount: return "\"aByteCount\""
@@ -24922,9 +24922,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aByteCount: return ".aByteCount"
@@ -24936,43 +24936,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ByteOffset: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aByteOffset // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aByteOffset
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aByteOffset
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aByteOffset": self = .aByteOffset
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aByteOffset": self = .aByteOffset
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aByteOffset": self = .aByteOffset
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aByteOffset: return 0
@@ -24981,7 +24981,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aByteOffset: return "\"aByteOffset\""
@@ -24990,9 +24990,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aByteOffset: return ".aByteOffset"
@@ -25004,43 +25004,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Duration: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aDuration // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aDuration
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aDuration
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aDuration": self = .aDuration
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aDuration": self = .aDuration
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aDuration": self = .aDuration
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aDuration: return 0
@@ -25049,7 +25049,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aDuration: return "\"aDuration\""
@@ -25058,9 +25058,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aDuration: return ".aDuration"
@@ -25072,43 +25072,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum AbsoluteTime: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aAbsoluteTime // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aAbsoluteTime
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aAbsoluteTime
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aAbsoluteTime": self = .aAbsoluteTime
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aAbsoluteTime": self = .aAbsoluteTime
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aAbsoluteTime": self = .aAbsoluteTime
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aAbsoluteTime: return 0
@@ -25117,7 +25117,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aAbsoluteTime: return "\"aAbsoluteTime\""
@@ -25126,9 +25126,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aAbsoluteTime: return ".aAbsoluteTime"
@@ -25140,43 +25140,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum OptionBits: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aOptionBits // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aOptionBits
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aOptionBits
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aOptionBits": self = .aOptionBits
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aOptionBits": self = .aOptionBits
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aOptionBits": self = .aOptionBits
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aOptionBits: return 0
@@ -25185,7 +25185,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aOptionBits: return "\"aOptionBits\""
@@ -25194,9 +25194,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aOptionBits: return ".aOptionBits"
@@ -25208,43 +25208,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ItemCount: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aItemCount // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aItemCount
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aItemCount
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aItemCount": self = .aItemCount
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aItemCount": self = .aItemCount
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aItemCount": self = .aItemCount
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aItemCount: return 0
@@ -25253,7 +25253,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aItemCount: return "\"aItemCount\""
@@ -25262,9 +25262,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aItemCount: return ".aItemCount"
@@ -25276,43 +25276,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum PBVersion: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aPbversion // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aPbversion
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aPbversion
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aPbversion": self = .aPbversion
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aPBVersion": self = .aPbversion
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aPBVersion": self = .aPbversion
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aPbversion: return 0
@@ -25321,7 +25321,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aPbversion: return "\"aPBVersion\""
@@ -25330,9 +25330,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aPbversion: return ".aPbversion"
@@ -25344,43 +25344,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ScriptCode: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aScriptCode // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aScriptCode
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aScriptCode
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aScriptCode": self = .aScriptCode
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aScriptCode": self = .aScriptCode
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aScriptCode": self = .aScriptCode
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aScriptCode: return 0
@@ -25389,7 +25389,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aScriptCode: return "\"aScriptCode\""
@@ -25398,9 +25398,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aScriptCode: return ".aScriptCode"
@@ -25412,43 +25412,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum LangCode: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aLangCode // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aLangCode
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aLangCode
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aLangCode": self = .aLangCode
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aLangCode": self = .aLangCode
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aLangCode": self = .aLangCode
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aLangCode: return 0
@@ -25457,7 +25457,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aLangCode: return "\"aLangCode\""
@@ -25466,9 +25466,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aLangCode: return ".aLangCode"
@@ -25480,43 +25480,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum RegionCode: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aRegionCode // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aRegionCode
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aRegionCode
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aRegionCode": self = .aRegionCode
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aRegionCode": self = .aRegionCode
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aRegionCode": self = .aRegionCode
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aRegionCode: return 0
@@ -25525,7 +25525,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aRegionCode: return "\"aRegionCode\""
@@ -25534,9 +25534,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aRegionCode: return ".aRegionCode"
@@ -25548,43 +25548,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum OSType: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aOstype // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aOstype
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aOstype
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aOstype": self = .aOstype
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aOSType": self = .aOstype
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aOSType": self = .aOstype
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aOstype: return 0
@@ -25593,7 +25593,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aOstype: return "\"aOSType\""
@@ -25602,9 +25602,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aOstype: return ".aOstype"
@@ -25616,43 +25616,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum ProcessSerialNumber: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aProcessSerialNumber // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aProcessSerialNumber
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aProcessSerialNumber
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aProcessSerialNumber": self = .aProcessSerialNumber
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aProcessSerialNumber": self = .aProcessSerialNumber
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aProcessSerialNumber": self = .aProcessSerialNumber
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aProcessSerialNumber: return 0
@@ -25661,7 +25661,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aProcessSerialNumber: return "\"aProcessSerialNumber\""
@@ -25670,9 +25670,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aProcessSerialNumber: return ".aProcessSerialNumber"
@@ -25684,43 +25684,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Point: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aPoint // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aPoint
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aPoint
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aPoint": self = .aPoint
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aPoint": self = .aPoint
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aPoint": self = .aPoint
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aPoint: return 0
@@ -25729,7 +25729,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aPoint: return "\"aPoint\""
@@ -25738,9 +25738,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aPoint: return ".aPoint"
@@ -25752,43 +25752,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Rect: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aRect // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aRect
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aRect
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aRect": self = .aRect
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aRect": self = .aRect
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aRect": self = .aRect
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aRect: return 0
@@ -25797,7 +25797,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aRect: return "\"aRect\""
@@ -25806,9 +25806,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aRect: return ".aRect"
@@ -25820,43 +25820,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum FixedPoint: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aFixedPoint // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aFixedPoint
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aFixedPoint
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aFixedPoint": self = .aFixedPoint
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aFixedPoint": self = .aFixedPoint
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aFixedPoint": self = .aFixedPoint
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aFixedPoint: return 0
@@ -25865,7 +25865,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aFixedPoint: return "\"aFixedPoint\""
@@ -25874,9 +25874,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aFixedPoint: return ".aFixedPoint"
@@ -25888,43 +25888,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum FixedRect: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aFixedRect // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aFixedRect
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aFixedRect
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aFixedRect": self = .aFixedRect
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aFixedRect": self = .aFixedRect
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aFixedRect": self = .aFixedRect
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aFixedRect: return 0
@@ -25933,7 +25933,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aFixedRect: return "\"aFixedRect\""
@@ -25942,9 +25942,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aFixedRect: return ".aFixedRect"
@@ -25956,43 +25956,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum Style: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aStyle // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aStyle
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aStyle
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aStyle": self = .aStyle
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aStyle": self = .aStyle
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aStyle": self = .aStyle
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aStyle: return 0
@@ -26001,7 +26001,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aStyle: return "\"aStyle\""
@@ -26010,9 +26010,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aStyle: return ".aStyle"
@@ -26024,43 +26024,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum StyleParameter: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aStyleParameter // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aStyleParameter
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aStyleParameter
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aStyleParameter": self = .aStyleParameter
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aStyleParameter": self = .aStyleParameter
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aStyleParameter": self = .aStyleParameter
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aStyleParameter: return 0
@@ -26069,7 +26069,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aStyleParameter: return "\"aStyleParameter\""
@@ -26078,9 +26078,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aStyleParameter: return ".aStyleParameter"
@@ -26092,43 +26092,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum StyleField: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aStyleField // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aStyleField
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aStyleField
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aStyleField": self = .aStyleField
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aStyleField": self = .aStyleField
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aStyleField": self = .aStyleField
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aStyleField: return 0
@@ -26137,7 +26137,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aStyleField: return "\"aStyleField\""
@@ -26146,9 +26146,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aStyleField: return ".aStyleField"
@@ -26160,43 +26160,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum TimeScale: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aTimeScale // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aTimeScale
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aTimeScale
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aTimeScale": self = .aTimeScale
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aTimeScale": self = .aTimeScale
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aTimeScale": self = .aTimeScale
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aTimeScale: return 0
@@ -26205,7 +26205,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aTimeScale: return "\"aTimeScale\""
@@ -26214,9 +26214,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aTimeScale: return ".aTimeScale"
@@ -26228,43 +26228,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum TimeBase: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aTimeBase // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aTimeBase
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aTimeBase
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aTimeBase": self = .aTimeBase
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aTimeBase": self = .aTimeBase
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aTimeBase": self = .aTimeBase
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aTimeBase: return 0
@@ -26273,7 +26273,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aTimeBase: return "\"aTimeBase\""
@@ -26282,9 +26282,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aTimeBase: return ".aTimeBase"
@@ -26296,43 +26296,43 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
   }
 
   enum TimeRecord: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case aTimeRecord // = 0
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .aTimeRecord
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .aTimeRecord
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "aTimeRecord": self = .aTimeRecord
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "aTimeRecord": self = .aTimeRecord
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "aTimeRecord": self = .aTimeRecord
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .aTimeRecord: return 0
@@ -26341,7 +26341,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .aTimeRecord: return "\"aTimeRecord\""
@@ -26350,9 +26350,9 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .aTimeRecord: return ".aTimeRecord"
@@ -26363,7 +26363,7 @@ struct SwiftUnittest_Names_EnumNames: ProtobufGeneratedMessage, ProtobufProto3Me
 
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
@@ -365,169 +365,169 @@ struct Swift_Performance_TestAllTypes: ProtobufGeneratedMessage, ProtobufProto3M
 
 
   ///   One of every singular field type
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  public var repeatedRecursiveMessage: [Swift_Performance_TestAllTypes] {
+  var repeatedRecursiveMessage: [Swift_Performance_TestAllTypes] {
     get {return _storage._repeatedRecursiveMessage}
     set {_uniqueStorage()._repeatedRecursiveMessage = newValue}
   }
 
   ///   Repeated
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
   ///   Map
-  public var mapStringMessage: Dictionary<String,Swift_Performance_TestAllTypes> {
+  var mapStringMessage: Dictionary<String,Swift_Performance_TestAllTypes> {
     get {return _storage._mapStringMessage}
     set {_uniqueStorage()._mapStringMessage = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -36,7 +36,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
   public var unknown = ProtobufUnknownStorage()
 
   enum Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case double // = 1
     case json_ // = 2
     case `class` // = 3
@@ -44,11 +44,11 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
     case self_ // = 5
     case type // = 6
 
-    public init() {
+    init() {
       self = .double
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .double
       case 2: self = .json_
@@ -60,7 +60,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "double": self = .double
       case "json_": self = .json_
@@ -72,7 +72,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "DOUBLE": self = .double
       case "JSON": self = .json_
@@ -84,7 +84,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "DOUBLE": self = .double
       case "JSON": self = .json_
@@ -96,7 +96,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .double: return 1
@@ -109,7 +109,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .double: return "\"DOUBLE\""
@@ -122,9 +122,9 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .double: return ".double"
@@ -140,42 +140,42 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
   }
 
   enum ProtocolEnum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case a // = 1
 
-    public init() {
+    init() {
       self = .a
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 1: self = .a
       default: return nil
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "a": self = .a
       default: return nil
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "a": self = .a
       default: return nil
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "a": self = .a
       default: return nil
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .a: return 1
@@ -183,7 +183,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .a: return "\"a\""
@@ -191,9 +191,9 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .a: return ".a"
@@ -212,7 +212,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
 
     public var unknown = ProtobufUnknownStorage()
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     }
@@ -236,7 +236,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
 
     public var unknown = ProtobufUnknownStorage()
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     }
@@ -260,7 +260,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
 
     public var unknown = ProtobufUnknownStorage()
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     }
@@ -275,7 +275,7 @@ struct ProtobufUnittest_SwiftReservedTest: ProtobufGeneratedMessage, ProtobufPro
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -847,17 +847,17 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
   }
 
   enum Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case extra2 // = 20
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -867,7 +867,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -877,7 +877,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -887,7 +887,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -897,7 +897,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -908,7 +908,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -919,9 +919,9 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -948,7 +948,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -959,7 +959,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -996,7 +996,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 0}
       set {_a = newValue}
     }
@@ -1007,7 +1007,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       return _a = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1046,7 +1046,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     public var unknown = ProtobufUnknownStorage()
 
     private var _a: Int32? = nil
-    public var a: Int32 {
+    var a: Int32 {
       get {return _a ?? 116}
       set {_a = newValue}
     }
@@ -1058,7 +1058,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
 
     private var _b: Int32? = nil
-    public var b: Int32 {
+    var b: Int32 {
       get {return _b ?? 0}
       set {_b = newValue}
     }
@@ -1069,7 +1069,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
       return _b = nil
     }
 
-    public init() {}
+    init() {}
 
     public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
       switch protoFieldNumber {
@@ -1097,7 +1097,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
@@ -1108,7 +1108,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalInt32 = nil
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64 ?? 0}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
@@ -1119,7 +1119,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalInt64 = nil
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32 ?? 0}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
@@ -1130,7 +1130,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalUint32 = nil
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64 ?? 0}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
@@ -1141,7 +1141,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalUint64 = nil
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32 ?? 0}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
@@ -1152,7 +1152,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalSint32 = nil
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64 ?? 0}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
@@ -1163,7 +1163,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalSint64 = nil
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32 ?? 0}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
@@ -1174,7 +1174,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalFixed32 = nil
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64 ?? 0}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
@@ -1185,7 +1185,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalFixed64 = nil
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32 ?? 0}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
@@ -1196,7 +1196,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalSfixed32 = nil
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64 ?? 0}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
@@ -1207,7 +1207,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalSfixed64 = nil
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat ?? 0}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
@@ -1218,7 +1218,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalFloat = nil
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble ?? 0}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
@@ -1229,7 +1229,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalDouble = nil
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool ?? false}
     set {_uniqueStorage()._optionalBool = newValue}
   }
@@ -1240,7 +1240,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalBool = nil
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString ?? ""}
     set {_uniqueStorage()._optionalString = newValue}
   }
@@ -1251,7 +1251,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalString = nil
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes ?? Data()}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
@@ -1262,7 +1262,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalBytes = nil
   }
 
-  public var optionalGroup: ProtobufUnittest_Message2.OptionalGroup {
+  var optionalGroup: ProtobufUnittest_Message2.OptionalGroup {
     get {return _storage._optionalGroup ?? ProtobufUnittest_Message2.OptionalGroup()}
     set {_uniqueStorage()._optionalGroup = newValue}
   }
@@ -1273,7 +1273,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalGroup = nil
   }
 
-  public var optionalMessage: ProtobufUnittest_Message2 {
+  var optionalMessage: ProtobufUnittest_Message2 {
     get {return _storage._optionalMessage ?? ProtobufUnittest_Message2()}
     set {_uniqueStorage()._optionalMessage = newValue}
   }
@@ -1284,7 +1284,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalMessage = nil
   }
 
-  public var optionalEnum: ProtobufUnittest_Message2.Enum {
+  var optionalEnum: ProtobufUnittest_Message2.Enum {
     get {return _storage._optionalEnum ?? ProtobufUnittest_Message2.Enum.foo}
     set {_uniqueStorage()._optionalEnum = newValue}
   }
@@ -1295,97 +1295,97 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     return _storage._optionalEnum = nil
   }
 
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  public var repeatedGroup: [ProtobufUnittest_Message2.RepeatedGroup] {
+  var repeatedGroup: [ProtobufUnittest_Message2.RepeatedGroup] {
     get {return _storage._repeatedGroup}
     set {_uniqueStorage()._repeatedGroup = newValue}
   }
 
-  public var repeatedMessage: [ProtobufUnittest_Message2] {
+  var repeatedMessage: [ProtobufUnittest_Message2] {
     get {return _storage._repeatedMessage}
     set {_uniqueStorage()._repeatedMessage = newValue}
   }
 
-  public var repeatedEnum: [ProtobufUnittest_Message2.Enum] {
+  var repeatedEnum: [ProtobufUnittest_Message2.Enum] {
     get {return _storage._repeatedEnum}
     set {_uniqueStorage()._repeatedEnum = newValue}
   }
 
-  public var oneofInt32: Int32 {
+  var oneofInt32: Int32 {
     get {
       if case .oneofInt32(let v) = _storage._o {
         return v
@@ -1397,7 +1397,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofInt64: Int64 {
+  var oneofInt64: Int64 {
     get {
       if case .oneofInt64(let v) = _storage._o {
         return v
@@ -1409,7 +1409,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._o {
         return v
@@ -1421,7 +1421,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofUint64: UInt64 {
+  var oneofUint64: UInt64 {
     get {
       if case .oneofUint64(let v) = _storage._o {
         return v
@@ -1433,7 +1433,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofSint32: Int32 {
+  var oneofSint32: Int32 {
     get {
       if case .oneofSint32(let v) = _storage._o {
         return v
@@ -1445,7 +1445,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofSint64: Int64 {
+  var oneofSint64: Int64 {
     get {
       if case .oneofSint64(let v) = _storage._o {
         return v
@@ -1457,7 +1457,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofFixed32: UInt32 {
+  var oneofFixed32: UInt32 {
     get {
       if case .oneofFixed32(let v) = _storage._o {
         return v
@@ -1469,7 +1469,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofFixed64: UInt64 {
+  var oneofFixed64: UInt64 {
     get {
       if case .oneofFixed64(let v) = _storage._o {
         return v
@@ -1481,7 +1481,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofSfixed32: Int32 {
+  var oneofSfixed32: Int32 {
     get {
       if case .oneofSfixed32(let v) = _storage._o {
         return v
@@ -1493,7 +1493,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofSfixed64: Int64 {
+  var oneofSfixed64: Int64 {
     get {
       if case .oneofSfixed64(let v) = _storage._o {
         return v
@@ -1505,7 +1505,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofFloat: Float {
+  var oneofFloat: Float {
     get {
       if case .oneofFloat(let v) = _storage._o {
         return v
@@ -1517,7 +1517,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofDouble: Double {
+  var oneofDouble: Double {
     get {
       if case .oneofDouble(let v) = _storage._o {
         return v
@@ -1529,7 +1529,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofBool: Bool {
+  var oneofBool: Bool {
     get {
       if case .oneofBool(let v) = _storage._o {
         return v
@@ -1541,7 +1541,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._o {
         return v
@@ -1553,7 +1553,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._o {
         return v
@@ -1565,7 +1565,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofGroup: ProtobufUnittest_Message2.OneofGroup {
+  var oneofGroup: ProtobufUnittest_Message2.OneofGroup {
     get {
       if case .oneofGroup(let v) = _storage._o {
         return v
@@ -1577,7 +1577,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofMessage: ProtobufUnittest_Message2 {
+  var oneofMessage: ProtobufUnittest_Message2 {
     get {
       if case .oneofMessage(let v) = _storage._o {
         return v
@@ -1589,7 +1589,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public var oneofEnum: ProtobufUnittest_Message2.Enum {
+  var oneofEnum: ProtobufUnittest_Message2.Enum {
     get {
       if case .oneofEnum(let v) = _storage._o {
         return v
@@ -1602,97 +1602,97 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
   }
 
   ///   Some token map cases, too many combinations to list them all.
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapStringBytes: Dictionary<String,Data> {
+  var mapStringBytes: Dictionary<String,Data> {
     get {return _storage._mapStringBytes}
     set {_uniqueStorage()._mapStringBytes = newValue}
   }
 
-  public var mapStringMessage: Dictionary<String,ProtobufUnittest_Message2> {
+  var mapStringMessage: Dictionary<String,ProtobufUnittest_Message2> {
     get {return _storage._mapStringMessage}
     set {_uniqueStorage()._mapStringMessage = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_Message2.Enum> {
+  var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_Message2.Enum> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32Message: Dictionary<Int32,ProtobufUnittest_Message2> {
+  var mapInt32Message: Dictionary<Int32,ProtobufUnittest_Message2> {
     get {return _storage._mapInt32Message}
     set {_uniqueStorage()._mapInt32Message = newValue}
   }
@@ -1704,7 +1704,7 @@ struct ProtobufUnittest_Message2: ProtobufGeneratedMessage, ProtobufProto2Messag
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -776,18 +776,18 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
   }
 
   enum Enum: ProtobufEnum {
-    public typealias RawValue = Int
+    typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case extra3 // = 30
     case UNRECOGNIZED(Int)
 
-    public init() {
+    init() {
       self = .foo
     }
 
-    public init?(rawValue: Int) {
+    init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .foo
       case 1: self = .bar
@@ -797,7 +797,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public init?(name: String) {
+    init?(name: String) {
       switch name {
       case "foo": self = .foo
       case "bar": self = .bar
@@ -807,7 +807,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public init?(jsonName: String) {
+    init?(jsonName: String) {
       switch jsonName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -817,7 +817,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public init?(protoName: String) {
+    init?(protoName: String) {
       switch protoName {
       case "FOO": self = .foo
       case "BAR": self = .bar
@@ -827,7 +827,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public var rawValue: Int {
+    var rawValue: Int {
       get {
         switch self {
         case .foo: return 0
@@ -839,7 +839,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public var json: String {
+    var json: String {
       get {
         switch self {
         case .foo: return "\"FOO\""
@@ -851,9 +851,9 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
       }
     }
 
-    public var hashValue: Int { return rawValue }
+    var hashValue: Int { return rawValue }
 
-    public var debugDescription: String {
+    var debugDescription: String {
       get {
         switch self {
         case .foo: return ".foo"
@@ -867,83 +867,83 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
 
   }
 
-  public var optionalInt32: Int32 {
+  var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
   }
 
-  public var optionalInt64: Int64 {
+  var optionalInt64: Int64 {
     get {return _storage._optionalInt64}
     set {_uniqueStorage()._optionalInt64 = newValue}
   }
 
-  public var optionalUint32: UInt32 {
+  var optionalUint32: UInt32 {
     get {return _storage._optionalUint32}
     set {_uniqueStorage()._optionalUint32 = newValue}
   }
 
-  public var optionalUint64: UInt64 {
+  var optionalUint64: UInt64 {
     get {return _storage._optionalUint64}
     set {_uniqueStorage()._optionalUint64 = newValue}
   }
 
-  public var optionalSint32: Int32 {
+  var optionalSint32: Int32 {
     get {return _storage._optionalSint32}
     set {_uniqueStorage()._optionalSint32 = newValue}
   }
 
-  public var optionalSint64: Int64 {
+  var optionalSint64: Int64 {
     get {return _storage._optionalSint64}
     set {_uniqueStorage()._optionalSint64 = newValue}
   }
 
-  public var optionalFixed32: UInt32 {
+  var optionalFixed32: UInt32 {
     get {return _storage._optionalFixed32}
     set {_uniqueStorage()._optionalFixed32 = newValue}
   }
 
-  public var optionalFixed64: UInt64 {
+  var optionalFixed64: UInt64 {
     get {return _storage._optionalFixed64}
     set {_uniqueStorage()._optionalFixed64 = newValue}
   }
 
-  public var optionalSfixed32: Int32 {
+  var optionalSfixed32: Int32 {
     get {return _storage._optionalSfixed32}
     set {_uniqueStorage()._optionalSfixed32 = newValue}
   }
 
-  public var optionalSfixed64: Int64 {
+  var optionalSfixed64: Int64 {
     get {return _storage._optionalSfixed64}
     set {_uniqueStorage()._optionalSfixed64 = newValue}
   }
 
-  public var optionalFloat: Float {
+  var optionalFloat: Float {
     get {return _storage._optionalFloat}
     set {_uniqueStorage()._optionalFloat = newValue}
   }
 
-  public var optionalDouble: Double {
+  var optionalDouble: Double {
     get {return _storage._optionalDouble}
     set {_uniqueStorage()._optionalDouble = newValue}
   }
 
-  public var optionalBool: Bool {
+  var optionalBool: Bool {
     get {return _storage._optionalBool}
     set {_uniqueStorage()._optionalBool = newValue}
   }
 
-  public var optionalString: String {
+  var optionalString: String {
     get {return _storage._optionalString}
     set {_uniqueStorage()._optionalString = newValue}
   }
 
-  public var optionalBytes: Data {
+  var optionalBytes: Data {
     get {return _storage._optionalBytes}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
   ///   No 'group' in proto3.
-  public var optionalMessage: ProtobufUnittest_Message3 {
+  var optionalMessage: ProtobufUnittest_Message3 {
     get {return _storage._optionalMessage ?? ProtobufUnittest_Message3()}
     set {_uniqueStorage()._optionalMessage = newValue}
   }
@@ -954,98 +954,98 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     return _storage._optionalMessage = nil
   }
 
-  public var optionalEnum: ProtobufUnittest_Message3.Enum {
+  var optionalEnum: ProtobufUnittest_Message3.Enum {
     get {return _storage._optionalEnum}
     set {_uniqueStorage()._optionalEnum = newValue}
   }
 
-  public var repeatedInt32: [Int32] {
+  var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
   }
 
-  public var repeatedInt64: [Int64] {
+  var repeatedInt64: [Int64] {
     get {return _storage._repeatedInt64}
     set {_uniqueStorage()._repeatedInt64 = newValue}
   }
 
-  public var repeatedUint32: [UInt32] {
+  var repeatedUint32: [UInt32] {
     get {return _storage._repeatedUint32}
     set {_uniqueStorage()._repeatedUint32 = newValue}
   }
 
-  public var repeatedUint64: [UInt64] {
+  var repeatedUint64: [UInt64] {
     get {return _storage._repeatedUint64}
     set {_uniqueStorage()._repeatedUint64 = newValue}
   }
 
-  public var repeatedSint32: [Int32] {
+  var repeatedSint32: [Int32] {
     get {return _storage._repeatedSint32}
     set {_uniqueStorage()._repeatedSint32 = newValue}
   }
 
-  public var repeatedSint64: [Int64] {
+  var repeatedSint64: [Int64] {
     get {return _storage._repeatedSint64}
     set {_uniqueStorage()._repeatedSint64 = newValue}
   }
 
-  public var repeatedFixed32: [UInt32] {
+  var repeatedFixed32: [UInt32] {
     get {return _storage._repeatedFixed32}
     set {_uniqueStorage()._repeatedFixed32 = newValue}
   }
 
-  public var repeatedFixed64: [UInt64] {
+  var repeatedFixed64: [UInt64] {
     get {return _storage._repeatedFixed64}
     set {_uniqueStorage()._repeatedFixed64 = newValue}
   }
 
-  public var repeatedSfixed32: [Int32] {
+  var repeatedSfixed32: [Int32] {
     get {return _storage._repeatedSfixed32}
     set {_uniqueStorage()._repeatedSfixed32 = newValue}
   }
 
-  public var repeatedSfixed64: [Int64] {
+  var repeatedSfixed64: [Int64] {
     get {return _storage._repeatedSfixed64}
     set {_uniqueStorage()._repeatedSfixed64 = newValue}
   }
 
-  public var repeatedFloat: [Float] {
+  var repeatedFloat: [Float] {
     get {return _storage._repeatedFloat}
     set {_uniqueStorage()._repeatedFloat = newValue}
   }
 
-  public var repeatedDouble: [Double] {
+  var repeatedDouble: [Double] {
     get {return _storage._repeatedDouble}
     set {_uniqueStorage()._repeatedDouble = newValue}
   }
 
-  public var repeatedBool: [Bool] {
+  var repeatedBool: [Bool] {
     get {return _storage._repeatedBool}
     set {_uniqueStorage()._repeatedBool = newValue}
   }
 
-  public var repeatedString: [String] {
+  var repeatedString: [String] {
     get {return _storage._repeatedString}
     set {_uniqueStorage()._repeatedString = newValue}
   }
 
-  public var repeatedBytes: [Data] {
+  var repeatedBytes: [Data] {
     get {return _storage._repeatedBytes}
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
   ///   No 'group' in proto3.
-  public var repeatedMessage: [ProtobufUnittest_Message3] {
+  var repeatedMessage: [ProtobufUnittest_Message3] {
     get {return _storage._repeatedMessage}
     set {_uniqueStorage()._repeatedMessage = newValue}
   }
 
-  public var repeatedEnum: [ProtobufUnittest_Message3.Enum] {
+  var repeatedEnum: [ProtobufUnittest_Message3.Enum] {
     get {return _storage._repeatedEnum}
     set {_uniqueStorage()._repeatedEnum = newValue}
   }
 
-  public var oneofInt32: Int32 {
+  var oneofInt32: Int32 {
     get {
       if case .oneofInt32(let v) = _storage._o {
         return v
@@ -1057,7 +1057,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofInt64: Int64 {
+  var oneofInt64: Int64 {
     get {
       if case .oneofInt64(let v) = _storage._o {
         return v
@@ -1069,7 +1069,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofUint32: UInt32 {
+  var oneofUint32: UInt32 {
     get {
       if case .oneofUint32(let v) = _storage._o {
         return v
@@ -1081,7 +1081,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofUint64: UInt64 {
+  var oneofUint64: UInt64 {
     get {
       if case .oneofUint64(let v) = _storage._o {
         return v
@@ -1093,7 +1093,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofSint32: Int32 {
+  var oneofSint32: Int32 {
     get {
       if case .oneofSint32(let v) = _storage._o {
         return v
@@ -1105,7 +1105,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofSint64: Int64 {
+  var oneofSint64: Int64 {
     get {
       if case .oneofSint64(let v) = _storage._o {
         return v
@@ -1117,7 +1117,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofFixed32: UInt32 {
+  var oneofFixed32: UInt32 {
     get {
       if case .oneofFixed32(let v) = _storage._o {
         return v
@@ -1129,7 +1129,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofFixed64: UInt64 {
+  var oneofFixed64: UInt64 {
     get {
       if case .oneofFixed64(let v) = _storage._o {
         return v
@@ -1141,7 +1141,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofSfixed32: Int32 {
+  var oneofSfixed32: Int32 {
     get {
       if case .oneofSfixed32(let v) = _storage._o {
         return v
@@ -1153,7 +1153,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofSfixed64: Int64 {
+  var oneofSfixed64: Int64 {
     get {
       if case .oneofSfixed64(let v) = _storage._o {
         return v
@@ -1165,7 +1165,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofFloat: Float {
+  var oneofFloat: Float {
     get {
       if case .oneofFloat(let v) = _storage._o {
         return v
@@ -1177,7 +1177,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofDouble: Double {
+  var oneofDouble: Double {
     get {
       if case .oneofDouble(let v) = _storage._o {
         return v
@@ -1189,7 +1189,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofBool: Bool {
+  var oneofBool: Bool {
     get {
       if case .oneofBool(let v) = _storage._o {
         return v
@@ -1201,7 +1201,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofString: String {
+  var oneofString: String {
     get {
       if case .oneofString(let v) = _storage._o {
         return v
@@ -1213,7 +1213,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofBytes: Data {
+  var oneofBytes: Data {
     get {
       if case .oneofBytes(let v) = _storage._o {
         return v
@@ -1226,7 +1226,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
   }
 
   ///   No 'group' in proto3.
-  public var oneofMessage: ProtobufUnittest_Message3 {
+  var oneofMessage: ProtobufUnittest_Message3 {
     get {
       if case .oneofMessage(let v) = _storage._o {
         return v
@@ -1238,7 +1238,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public var oneofEnum: ProtobufUnittest_Message3.Enum {
+  var oneofEnum: ProtobufUnittest_Message3.Enum {
     get {
       if case .oneofEnum(let v) = _storage._o {
         return v
@@ -1251,97 +1251,97 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
   }
 
   ///   Some token map cases, too many combinations to list them all.
-  public var mapInt32Int32: Dictionary<Int32,Int32> {
+  var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
   }
 
-  public var mapInt64Int64: Dictionary<Int64,Int64> {
+  var mapInt64Int64: Dictionary<Int64,Int64> {
     get {return _storage._mapInt64Int64}
     set {_uniqueStorage()._mapInt64Int64 = newValue}
   }
 
-  public var mapUint32Uint32: Dictionary<UInt32,UInt32> {
+  var mapUint32Uint32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapUint32Uint32}
     set {_uniqueStorage()._mapUint32Uint32 = newValue}
   }
 
-  public var mapUint64Uint64: Dictionary<UInt64,UInt64> {
+  var mapUint64Uint64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapUint64Uint64}
     set {_uniqueStorage()._mapUint64Uint64 = newValue}
   }
 
-  public var mapSint32Sint32: Dictionary<Int32,Int32> {
+  var mapSint32Sint32: Dictionary<Int32,Int32> {
     get {return _storage._mapSint32Sint32}
     set {_uniqueStorage()._mapSint32Sint32 = newValue}
   }
 
-  public var mapSint64Sint64: Dictionary<Int64,Int64> {
+  var mapSint64Sint64: Dictionary<Int64,Int64> {
     get {return _storage._mapSint64Sint64}
     set {_uniqueStorage()._mapSint64Sint64 = newValue}
   }
 
-  public var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
+  var mapFixed32Fixed32: Dictionary<UInt32,UInt32> {
     get {return _storage._mapFixed32Fixed32}
     set {_uniqueStorage()._mapFixed32Fixed32 = newValue}
   }
 
-  public var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
+  var mapFixed64Fixed64: Dictionary<UInt64,UInt64> {
     get {return _storage._mapFixed64Fixed64}
     set {_uniqueStorage()._mapFixed64Fixed64 = newValue}
   }
 
-  public var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
+  var mapSfixed32Sfixed32: Dictionary<Int32,Int32> {
     get {return _storage._mapSfixed32Sfixed32}
     set {_uniqueStorage()._mapSfixed32Sfixed32 = newValue}
   }
 
-  public var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
+  var mapSfixed64Sfixed64: Dictionary<Int64,Int64> {
     get {return _storage._mapSfixed64Sfixed64}
     set {_uniqueStorage()._mapSfixed64Sfixed64 = newValue}
   }
 
-  public var mapInt32Float: Dictionary<Int32,Float> {
+  var mapInt32Float: Dictionary<Int32,Float> {
     get {return _storage._mapInt32Float}
     set {_uniqueStorage()._mapInt32Float = newValue}
   }
 
-  public var mapInt32Double: Dictionary<Int32,Double> {
+  var mapInt32Double: Dictionary<Int32,Double> {
     get {return _storage._mapInt32Double}
     set {_uniqueStorage()._mapInt32Double = newValue}
   }
 
-  public var mapBoolBool: Dictionary<Bool,Bool> {
+  var mapBoolBool: Dictionary<Bool,Bool> {
     get {return _storage._mapBoolBool}
     set {_uniqueStorage()._mapBoolBool = newValue}
   }
 
-  public var mapStringString: Dictionary<String,String> {
+  var mapStringString: Dictionary<String,String> {
     get {return _storage._mapStringString}
     set {_uniqueStorage()._mapStringString = newValue}
   }
 
-  public var mapStringBytes: Dictionary<String,Data> {
+  var mapStringBytes: Dictionary<String,Data> {
     get {return _storage._mapStringBytes}
     set {_uniqueStorage()._mapStringBytes = newValue}
   }
 
-  public var mapStringMessage: Dictionary<String,ProtobufUnittest_Message3> {
+  var mapStringMessage: Dictionary<String,ProtobufUnittest_Message3> {
     get {return _storage._mapStringMessage}
     set {_uniqueStorage()._mapStringMessage = newValue}
   }
 
-  public var mapInt32Bytes: Dictionary<Int32,Data> {
+  var mapInt32Bytes: Dictionary<Int32,Data> {
     get {return _storage._mapInt32Bytes}
     set {_uniqueStorage()._mapInt32Bytes = newValue}
   }
 
-  public var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_Message3.Enum> {
+  var mapInt32Enum: Dictionary<Int32,ProtobufUnittest_Message3.Enum> {
     get {return _storage._mapInt32Enum}
     set {_uniqueStorage()._mapInt32Enum = newValue}
   }
 
-  public var mapInt32Message: Dictionary<Int32,ProtobufUnittest_Message3> {
+  var mapInt32Message: Dictionary<Int32,ProtobufUnittest_Message3> {
     get {return _storage._mapInt32Message}
     set {_uniqueStorage()._mapInt32Message = newValue}
   }
@@ -1353,7 +1353,7 @@ struct ProtobufUnittest_Message3: ProtobufGeneratedMessage, ProtobufProto3Messag
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -49,7 +49,7 @@ struct ProtobufObjcUnittest_TestObjCStartupMessage: ProtobufGeneratedMessage, Pr
 
   public var unknown = ProtobufUnknownStorage()
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     if (1 <= protoFieldNumber && protoFieldNumber < 536870912) {
@@ -104,7 +104,7 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: ProtobufGeneratedMessage, Pro
     static let ProtobufObjcUnittest_TestObjCStartupMessage_nestedStringExtension = ProtobufGenericMessageExtension<ProtobufOptionalField<ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(protoFieldNumber: 3, protoFieldName: "nested_string_extension", jsonFieldName: "nestedStringExtension", swiftFieldName: "ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension", defaultValue: "")
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
   }

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -220,7 +220,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
   private var _storage = _StorageClass()
 
 
-  public var anyField: Google_Protobuf_Any {
+  var anyField: Google_Protobuf_Any {
     get {return _storage._anyField ?? Google_Protobuf_Any()}
     set {_uniqueStorage()._anyField = newValue}
   }
@@ -231,7 +231,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._anyField = nil
   }
 
-  public var apiField: Google_Protobuf_Api {
+  var apiField: Google_Protobuf_Api {
     get {return _storage._apiField ?? Google_Protobuf_Api()}
     set {_uniqueStorage()._apiField = newValue}
   }
@@ -242,7 +242,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._apiField = nil
   }
 
-  public var durationField: Google_Protobuf_Duration {
+  var durationField: Google_Protobuf_Duration {
     get {return _storage._durationField ?? Google_Protobuf_Duration()}
     set {_uniqueStorage()._durationField = newValue}
   }
@@ -253,7 +253,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._durationField = nil
   }
 
-  public var emptyField: Google_Protobuf_Empty {
+  var emptyField: Google_Protobuf_Empty {
     get {return _storage._emptyField ?? Google_Protobuf_Empty()}
     set {_uniqueStorage()._emptyField = newValue}
   }
@@ -264,7 +264,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._emptyField = nil
   }
 
-  public var fieldMaskField: Google_Protobuf_FieldMask {
+  var fieldMaskField: Google_Protobuf_FieldMask {
     get {return _storage._fieldMaskField ?? Google_Protobuf_FieldMask()}
     set {_uniqueStorage()._fieldMaskField = newValue}
   }
@@ -275,7 +275,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._fieldMaskField = nil
   }
 
-  public var sourceContextField: Google_Protobuf_SourceContext {
+  var sourceContextField: Google_Protobuf_SourceContext {
     get {return _storage._sourceContextField ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContextField = newValue}
   }
@@ -286,7 +286,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._sourceContextField = nil
   }
 
-  public var structField: Google_Protobuf_Struct {
+  var structField: Google_Protobuf_Struct {
     get {return _storage._structField ?? Google_Protobuf_Struct()}
     set {_uniqueStorage()._structField = newValue}
   }
@@ -297,7 +297,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._structField = nil
   }
 
-  public var timestampField: Google_Protobuf_Timestamp {
+  var timestampField: Google_Protobuf_Timestamp {
     get {return _storage._timestampField ?? Google_Protobuf_Timestamp()}
     set {_uniqueStorage()._timestampField = newValue}
   }
@@ -308,7 +308,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._timestampField = nil
   }
 
-  public var typeField: Google_Protobuf_Type {
+  var typeField: Google_Protobuf_Type {
     get {return _storage._typeField ?? Google_Protobuf_Type()}
     set {_uniqueStorage()._typeField = newValue}
   }
@@ -319,7 +319,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._typeField = nil
   }
 
-  public var doubleField: Google_Protobuf_DoubleValue {
+  var doubleField: Google_Protobuf_DoubleValue {
     get {return _storage._doubleField ?? Google_Protobuf_DoubleValue()}
     set {_uniqueStorage()._doubleField = newValue}
   }
@@ -330,7 +330,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._doubleField = nil
   }
 
-  public var floatField: Google_Protobuf_FloatValue {
+  var floatField: Google_Protobuf_FloatValue {
     get {return _storage._floatField ?? Google_Protobuf_FloatValue()}
     set {_uniqueStorage()._floatField = newValue}
   }
@@ -341,7 +341,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._floatField = nil
   }
 
-  public var int64Field: Google_Protobuf_Int64Value {
+  var int64Field: Google_Protobuf_Int64Value {
     get {return _storage._int64Field ?? Google_Protobuf_Int64Value()}
     set {_uniqueStorage()._int64Field = newValue}
   }
@@ -352,7 +352,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._int64Field = nil
   }
 
-  public var uint64Field: Google_Protobuf_UInt64Value {
+  var uint64Field: Google_Protobuf_UInt64Value {
     get {return _storage._uint64Field ?? Google_Protobuf_UInt64Value()}
     set {_uniqueStorage()._uint64Field = newValue}
   }
@@ -363,7 +363,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._uint64Field = nil
   }
 
-  public var int32Field: Google_Protobuf_Int32Value {
+  var int32Field: Google_Protobuf_Int32Value {
     get {return _storage._int32Field ?? Google_Protobuf_Int32Value()}
     set {_uniqueStorage()._int32Field = newValue}
   }
@@ -374,7 +374,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._int32Field = nil
   }
 
-  public var uint32Field: Google_Protobuf_UInt32Value {
+  var uint32Field: Google_Protobuf_UInt32Value {
     get {return _storage._uint32Field ?? Google_Protobuf_UInt32Value()}
     set {_uniqueStorage()._uint32Field = newValue}
   }
@@ -385,7 +385,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._uint32Field = nil
   }
 
-  public var boolField: Google_Protobuf_BoolValue {
+  var boolField: Google_Protobuf_BoolValue {
     get {return _storage._boolField ?? Google_Protobuf_BoolValue()}
     set {_uniqueStorage()._boolField = newValue}
   }
@@ -396,7 +396,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._boolField = nil
   }
 
-  public var stringField: Google_Protobuf_StringValue {
+  var stringField: Google_Protobuf_StringValue {
     get {return _storage._stringField ?? Google_Protobuf_StringValue()}
     set {_uniqueStorage()._stringField = newValue}
   }
@@ -407,7 +407,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._stringField = nil
   }
 
-  public var bytesField: Google_Protobuf_BytesValue {
+  var bytesField: Google_Protobuf_BytesValue {
     get {return _storage._bytesField ?? Google_Protobuf_BytesValue()}
     set {_uniqueStorage()._bytesField = newValue}
   }
@@ -419,7 +419,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
   }
 
   ///   Part of struct, but useful to be able to test separately
-  public var valueField: Google_Protobuf_Value {
+  var valueField: Google_Protobuf_Value {
     get {return _storage._valueField ?? Google_Protobuf_Value()}
     set {_uniqueStorage()._valueField = newValue}
   }
@@ -430,7 +430,7 @@ struct ProtobufUnittest_TestWellKnownTypes: ProtobufGeneratedMessage, ProtobufPr
     return _storage._valueField = nil
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -651,98 +651,98 @@ struct ProtobufUnittest_RepeatedWellKnownTypes: ProtobufGeneratedMessage, Protob
   private var _storage = _StorageClass()
 
 
-  public var anyField: [Google_Protobuf_Any] {
+  var anyField: [Google_Protobuf_Any] {
     get {return _storage._anyField}
     set {_uniqueStorage()._anyField = newValue}
   }
 
-  public var apiField: [Google_Protobuf_Api] {
+  var apiField: [Google_Protobuf_Api] {
     get {return _storage._apiField}
     set {_uniqueStorage()._apiField = newValue}
   }
 
-  public var durationField: [Google_Protobuf_Duration] {
+  var durationField: [Google_Protobuf_Duration] {
     get {return _storage._durationField}
     set {_uniqueStorage()._durationField = newValue}
   }
 
-  public var emptyField: [Google_Protobuf_Empty] {
+  var emptyField: [Google_Protobuf_Empty] {
     get {return _storage._emptyField}
     set {_uniqueStorage()._emptyField = newValue}
   }
 
-  public var fieldMaskField: [Google_Protobuf_FieldMask] {
+  var fieldMaskField: [Google_Protobuf_FieldMask] {
     get {return _storage._fieldMaskField}
     set {_uniqueStorage()._fieldMaskField = newValue}
   }
 
-  public var sourceContextField: [Google_Protobuf_SourceContext] {
+  var sourceContextField: [Google_Protobuf_SourceContext] {
     get {return _storage._sourceContextField}
     set {_uniqueStorage()._sourceContextField = newValue}
   }
 
-  public var structField: [Google_Protobuf_Struct] {
+  var structField: [Google_Protobuf_Struct] {
     get {return _storage._structField}
     set {_uniqueStorage()._structField = newValue}
   }
 
-  public var timestampField: [Google_Protobuf_Timestamp] {
+  var timestampField: [Google_Protobuf_Timestamp] {
     get {return _storage._timestampField}
     set {_uniqueStorage()._timestampField = newValue}
   }
 
-  public var typeField: [Google_Protobuf_Type] {
+  var typeField: [Google_Protobuf_Type] {
     get {return _storage._typeField}
     set {_uniqueStorage()._typeField = newValue}
   }
 
   ///   These don't actually make a lot of sense, but they're not prohibited...
-  public var doubleField: [Google_Protobuf_DoubleValue] {
+  var doubleField: [Google_Protobuf_DoubleValue] {
     get {return _storage._doubleField}
     set {_uniqueStorage()._doubleField = newValue}
   }
 
-  public var floatField: [Google_Protobuf_FloatValue] {
+  var floatField: [Google_Protobuf_FloatValue] {
     get {return _storage._floatField}
     set {_uniqueStorage()._floatField = newValue}
   }
 
-  public var int64Field: [Google_Protobuf_Int64Value] {
+  var int64Field: [Google_Protobuf_Int64Value] {
     get {return _storage._int64Field}
     set {_uniqueStorage()._int64Field = newValue}
   }
 
-  public var uint64Field: [Google_Protobuf_UInt64Value] {
+  var uint64Field: [Google_Protobuf_UInt64Value] {
     get {return _storage._uint64Field}
     set {_uniqueStorage()._uint64Field = newValue}
   }
 
-  public var int32Field: [Google_Protobuf_Int32Value] {
+  var int32Field: [Google_Protobuf_Int32Value] {
     get {return _storage._int32Field}
     set {_uniqueStorage()._int32Field = newValue}
   }
 
-  public var uint32Field: [Google_Protobuf_UInt32Value] {
+  var uint32Field: [Google_Protobuf_UInt32Value] {
     get {return _storage._uint32Field}
     set {_uniqueStorage()._uint32Field = newValue}
   }
 
-  public var boolField: [Google_Protobuf_BoolValue] {
+  var boolField: [Google_Protobuf_BoolValue] {
     get {return _storage._boolField}
     set {_uniqueStorage()._boolField = newValue}
   }
 
-  public var stringField: [Google_Protobuf_StringValue] {
+  var stringField: [Google_Protobuf_StringValue] {
     get {return _storage._stringField}
     set {_uniqueStorage()._stringField = newValue}
   }
 
-  public var bytesField: [Google_Protobuf_BytesValue] {
+  var bytesField: [Google_Protobuf_BytesValue] {
     get {return _storage._bytesField}
     set {_uniqueStorage()._bytesField = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1068,7 +1068,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var anyField: Google_Protobuf_Any {
+  var anyField: Google_Protobuf_Any {
     get {
       if case .anyField(let v) = _storage._oneofField {
         return v
@@ -1080,7 +1080,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var apiField: Google_Protobuf_Api {
+  var apiField: Google_Protobuf_Api {
     get {
       if case .apiField(let v) = _storage._oneofField {
         return v
@@ -1092,7 +1092,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var durationField: Google_Protobuf_Duration {
+  var durationField: Google_Protobuf_Duration {
     get {
       if case .durationField(let v) = _storage._oneofField {
         return v
@@ -1104,7 +1104,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var emptyField: Google_Protobuf_Empty {
+  var emptyField: Google_Protobuf_Empty {
     get {
       if case .emptyField(let v) = _storage._oneofField {
         return v
@@ -1116,7 +1116,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var fieldMaskField: Google_Protobuf_FieldMask {
+  var fieldMaskField: Google_Protobuf_FieldMask {
     get {
       if case .fieldMaskField(let v) = _storage._oneofField {
         return v
@@ -1128,7 +1128,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var sourceContextField: Google_Protobuf_SourceContext {
+  var sourceContextField: Google_Protobuf_SourceContext {
     get {
       if case .sourceContextField(let v) = _storage._oneofField {
         return v
@@ -1140,7 +1140,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var structField: Google_Protobuf_Struct {
+  var structField: Google_Protobuf_Struct {
     get {
       if case .structField(let v) = _storage._oneofField {
         return v
@@ -1152,7 +1152,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var timestampField: Google_Protobuf_Timestamp {
+  var timestampField: Google_Protobuf_Timestamp {
     get {
       if case .timestampField(let v) = _storage._oneofField {
         return v
@@ -1164,7 +1164,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var typeField: Google_Protobuf_Type {
+  var typeField: Google_Protobuf_Type {
     get {
       if case .typeField(let v) = _storage._oneofField {
         return v
@@ -1176,7 +1176,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var doubleField: Google_Protobuf_DoubleValue {
+  var doubleField: Google_Protobuf_DoubleValue {
     get {
       if case .doubleField(let v) = _storage._oneofField {
         return v
@@ -1188,7 +1188,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var floatField: Google_Protobuf_FloatValue {
+  var floatField: Google_Protobuf_FloatValue {
     get {
       if case .floatField(let v) = _storage._oneofField {
         return v
@@ -1200,7 +1200,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var int64Field: Google_Protobuf_Int64Value {
+  var int64Field: Google_Protobuf_Int64Value {
     get {
       if case .int64Field(let v) = _storage._oneofField {
         return v
@@ -1212,7 +1212,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var uint64Field: Google_Protobuf_UInt64Value {
+  var uint64Field: Google_Protobuf_UInt64Value {
     get {
       if case .uint64Field(let v) = _storage._oneofField {
         return v
@@ -1224,7 +1224,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var int32Field: Google_Protobuf_Int32Value {
+  var int32Field: Google_Protobuf_Int32Value {
     get {
       if case .int32Field(let v) = _storage._oneofField {
         return v
@@ -1236,7 +1236,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var uint32Field: Google_Protobuf_UInt32Value {
+  var uint32Field: Google_Protobuf_UInt32Value {
     get {
       if case .uint32Field(let v) = _storage._oneofField {
         return v
@@ -1248,7 +1248,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var boolField: Google_Protobuf_BoolValue {
+  var boolField: Google_Protobuf_BoolValue {
     get {
       if case .boolField(let v) = _storage._oneofField {
         return v
@@ -1260,7 +1260,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var stringField: Google_Protobuf_StringValue {
+  var stringField: Google_Protobuf_StringValue {
     get {
       if case .stringField(let v) = _storage._oneofField {
         return v
@@ -1272,7 +1272,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public var bytesField: Google_Protobuf_BytesValue {
+  var bytesField: Google_Protobuf_BytesValue {
     get {
       if case .bytesField(let v) = _storage._oneofField {
         return v
@@ -1291,7 +1291,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: ProtobufGeneratedMessage, ProtobufP
     }
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)
@@ -1514,97 +1514,97 @@ struct ProtobufUnittest_MapWellKnownTypes: ProtobufGeneratedMessage, ProtobufPro
   private var _storage = _StorageClass()
 
 
-  public var anyField: Dictionary<Int32,Google_Protobuf_Any> {
+  var anyField: Dictionary<Int32,Google_Protobuf_Any> {
     get {return _storage._anyField}
     set {_uniqueStorage()._anyField = newValue}
   }
 
-  public var apiField: Dictionary<Int32,Google_Protobuf_Api> {
+  var apiField: Dictionary<Int32,Google_Protobuf_Api> {
     get {return _storage._apiField}
     set {_uniqueStorage()._apiField = newValue}
   }
 
-  public var durationField: Dictionary<Int32,Google_Protobuf_Duration> {
+  var durationField: Dictionary<Int32,Google_Protobuf_Duration> {
     get {return _storage._durationField}
     set {_uniqueStorage()._durationField = newValue}
   }
 
-  public var emptyField: Dictionary<Int32,Google_Protobuf_Empty> {
+  var emptyField: Dictionary<Int32,Google_Protobuf_Empty> {
     get {return _storage._emptyField}
     set {_uniqueStorage()._emptyField = newValue}
   }
 
-  public var fieldMaskField: Dictionary<Int32,Google_Protobuf_FieldMask> {
+  var fieldMaskField: Dictionary<Int32,Google_Protobuf_FieldMask> {
     get {return _storage._fieldMaskField}
     set {_uniqueStorage()._fieldMaskField = newValue}
   }
 
-  public var sourceContextField: Dictionary<Int32,Google_Protobuf_SourceContext> {
+  var sourceContextField: Dictionary<Int32,Google_Protobuf_SourceContext> {
     get {return _storage._sourceContextField}
     set {_uniqueStorage()._sourceContextField = newValue}
   }
 
-  public var structField: Dictionary<Int32,Google_Protobuf_Struct> {
+  var structField: Dictionary<Int32,Google_Protobuf_Struct> {
     get {return _storage._structField}
     set {_uniqueStorage()._structField = newValue}
   }
 
-  public var timestampField: Dictionary<Int32,Google_Protobuf_Timestamp> {
+  var timestampField: Dictionary<Int32,Google_Protobuf_Timestamp> {
     get {return _storage._timestampField}
     set {_uniqueStorage()._timestampField = newValue}
   }
 
-  public var typeField: Dictionary<Int32,Google_Protobuf_Type> {
+  var typeField: Dictionary<Int32,Google_Protobuf_Type> {
     get {return _storage._typeField}
     set {_uniqueStorage()._typeField = newValue}
   }
 
-  public var doubleField: Dictionary<Int32,Google_Protobuf_DoubleValue> {
+  var doubleField: Dictionary<Int32,Google_Protobuf_DoubleValue> {
     get {return _storage._doubleField}
     set {_uniqueStorage()._doubleField = newValue}
   }
 
-  public var floatField: Dictionary<Int32,Google_Protobuf_FloatValue> {
+  var floatField: Dictionary<Int32,Google_Protobuf_FloatValue> {
     get {return _storage._floatField}
     set {_uniqueStorage()._floatField = newValue}
   }
 
-  public var int64Field: Dictionary<Int32,Google_Protobuf_Int64Value> {
+  var int64Field: Dictionary<Int32,Google_Protobuf_Int64Value> {
     get {return _storage._int64Field}
     set {_uniqueStorage()._int64Field = newValue}
   }
 
-  public var uint64Field: Dictionary<Int32,Google_Protobuf_UInt64Value> {
+  var uint64Field: Dictionary<Int32,Google_Protobuf_UInt64Value> {
     get {return _storage._uint64Field}
     set {_uniqueStorage()._uint64Field = newValue}
   }
 
-  public var int32Field: Dictionary<Int32,Google_Protobuf_Int32Value> {
+  var int32Field: Dictionary<Int32,Google_Protobuf_Int32Value> {
     get {return _storage._int32Field}
     set {_uniqueStorage()._int32Field = newValue}
   }
 
-  public var uint32Field: Dictionary<Int32,Google_Protobuf_UInt32Value> {
+  var uint32Field: Dictionary<Int32,Google_Protobuf_UInt32Value> {
     get {return _storage._uint32Field}
     set {_uniqueStorage()._uint32Field = newValue}
   }
 
-  public var boolField: Dictionary<Int32,Google_Protobuf_BoolValue> {
+  var boolField: Dictionary<Int32,Google_Protobuf_BoolValue> {
     get {return _storage._boolField}
     set {_uniqueStorage()._boolField = newValue}
   }
 
-  public var stringField: Dictionary<Int32,Google_Protobuf_StringValue> {
+  var stringField: Dictionary<Int32,Google_Protobuf_StringValue> {
     get {return _storage._stringField}
     set {_uniqueStorage()._stringField = newValue}
   }
 
-  public var bytesField: Dictionary<Int32,Google_Protobuf_BytesValue> {
+  var bytesField: Dictionary<Int32,Google_Protobuf_BytesValue> {
     get {return _storage._bytesField}
     set {_uniqueStorage()._bytesField = newValue}
   }
 
-  public init() {}
+  init() {}
 
   public mutating func _protoc_generated_decodeField(setter: inout ProtobufFieldDecoder, protoFieldNumber: Int) throws {
     try _uniqueStorage().decodeField(setter: &setter, protoFieldNumber: protoFieldNumber)


### PR DESCRIPTION
It would be nice to use same access control for properties and functions in a struct unless these are not defined in protocol. Since default value of `Visibility` is set to `Internal`, we might have public properties and functions in internal struct which looks unnecessary for some case. However, I don't know any background about why `Visibility` option applies to only struct itself, so it might be better to leave it as it is though.