### PR TITLE
Fix the conformance-host build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,10 +388,10 @@ test-conformance: check-for-protobufs-checkout $(SWIFT_CONFORMANCE_PLUGIN) $(CON
 # It generates test cases, feeds them to our plugin, and verifies the results:
 conformance-host $(CONFORMANCE_HOST): check-for-protobufs-checkout
 	( \
-		cd ${GOOGLE_PROTOBUFS_CHECKOUT}; \
-		./configure; \
-		$(MAKE) -C -j src; \
-		$(MAKE) -C -j conformance; \
+		cd ${GOOGLE_PROTOBUFS_CHECKOUT} && \
+		./configure && \
+		$(MAKE) -j -C src && \
+		$(MAKE) -j -C conformance \
 	)
 
 


### PR DESCRIPTION
- I reordered the args without thinking and broke things, the -C tags the
  argument.
- Make each step have to pass before the next one is invoked.