### PR TITLE
Move == implementations into static methods.

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -248,6 +248,15 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
     case jsonPayload(String)
     case None
 
+    static func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
+      switch (lhs, rhs) {
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -366,6 +375,19 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
     case jsonPayload(String)
     case skipped(String)
     case None
+
+    static func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
+      switch (lhs, rhs) {
+      case (.parseError(let l), .parseError(let r)): return l == r
+      case (.serializeError(let l), .serializeError(let r)): return l == r
+      case (.runtimeError(let l), .runtimeError(let r)): return l == r
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.skipped(let l), .skipped(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
 
     public init(nilLiteral: ()) {
       self = .None
@@ -1493,6 +1515,22 @@ struct Conformance_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
     case oneofEnum(Conformance_TestAllTypes.NestedEnum)
     case None
 
+    static func ==(lhs: Conformance_TestAllTypes.OneOf_OneofField, rhs: Conformance_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -2605,43 +2643,5 @@ struct Conformance_ForeignMessage: SwiftProtobuf.Message, SwiftProtobuf.Proto3Me
   public func _protoc_generated_isEqualTo(other: Conformance_ForeignMessage) -> Bool {
     if c != other.c {return false}
     return true
-  }
-}
-
-func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
-  switch (lhs, rhs) {
-  case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
-  case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
-  switch (lhs, rhs) {
-  case (.parseError(let l), .parseError(let r)): return l == r
-  case (.serializeError(let l), .serializeError(let r)): return l == r
-  case (.runtimeError(let l), .runtimeError(let r)): return l == r
-  case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
-  case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
-  case (.skipped(let l), .skipped(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: Conformance_TestAllTypes.OneOf_OneofField, rhs: Conformance_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.oneofBool(let l), .oneofBool(let r)): return l == r
-  case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
-  case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
-  case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
-  case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -214,6 +214,19 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
     case listValue(Google_Protobuf_ListValue)
     case None
 
+    static func ==(lhs: Google_Protobuf_Value.OneOf_Kind, rhs: Google_Protobuf_Value.OneOf_Kind) -> Bool {
+      switch (lhs, rhs) {
+      case (.nullValue(let l), .nullValue(let r)): return l == r
+      case (.numberValue(let l), .numberValue(let r)): return l == r
+      case (.stringValue(let l), .stringValue(let r)): return l == r
+      case (.boolValue(let l), .boolValue(let r)): return l == r
+      case (.structValue(let l), .structValue(let r)): return l == r
+      case (.listValue(let l), .listValue(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -432,18 +445,5 @@ struct Google_Protobuf_ListValue: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
   public func _protoc_generated_isEqualTo(other: Google_Protobuf_ListValue) -> Bool {
     if values != other.values {return false}
     return true
-  }
-}
-
-func ==(lhs: Google_Protobuf_Value.OneOf_Kind, rhs: Google_Protobuf_Value.OneOf_Kind) -> Bool {
-  switch (lhs, rhs) {
-  case (.nullValue(let l), .nullValue(let r)): return l == r
-  case (.numberValue(let l), .numberValue(let r)): return l == r
-  case (.stringValue(let l), .stringValue(let r)): return l == r
-  case (.boolValue(let l), .boolValue(let r)): return l == r
-  case (.structValue(let l), .structValue(let r)): return l == r
-  case (.listValue(let l), .listValue(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -962,6 +962,17 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -5859,6 +5870,17 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
     case fooGroup(ProtobufUnittest_TestOneof.FooGroup)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.fooGroup(let l), .fooGroup(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -6363,6 +6385,22 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     case fooLazyMessage(ProtobufUnittest_TestOneof2.NestedMessage)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooCord(let l), .fooCord(let r)): return l == r
+      case (.fooStringPiece(let l), .fooStringPiece(let r)): return l == r
+      case (.fooBytes(let l), .fooBytes(let r)): return l == r
+      case (.fooEnum(let l), .fooEnum(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.fooGroup(let l), .fooGroup(let r)): return l == r
+      case (.fooLazyMessage(let l), .fooLazyMessage(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -6487,6 +6525,19 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     case barBytes(Data)
     case barEnum(ProtobufUnittest_TestOneof2.NestedEnum)
     case None
+
+    static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
+      switch (lhs, rhs) {
+      case (.barInt(let l), .barInt(let r)): return l == r
+      case (.barString(let l), .barString(let r)): return l == r
+      case (.barCord(let l), .barCord(let r)): return l == r
+      case (.barStringPiece(let l), .barStringPiece(let r)): return l == r
+      case (.barBytes(let l), .barBytes(let r)): return l == r
+      case (.barEnum(let l), .barEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
 
     public init(nilLiteral: ()) {
       self = .None
@@ -7063,6 +7114,16 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestRequiredOneof.NestedMessage)
     case None
+
+    static func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
 
     public init(nilLiteral: ()) {
       self = .None
@@ -9073,6 +9134,17 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -9588,17 +9660,6 @@ let ProtobufUnittest_Extensions_unpackedEnumExtension = SwiftProtobuf.MessageExt
 
 let ProtobufUnittest_Extensions_testAllTypes = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestHugeFieldNumbers>(protoFieldNumber: 536860000, fieldNames: .same(proto: "[protobuf_unittest.test_all_types]", swift: "ProtobufUnittest_testAllTypes"), defaultValue: ProtobufUnittest_TestAllTypes())
 
-func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
 extension ProtobufUnittest_TestAllExtensions {
   ///   Check for bug where string extensions declared in tested scope did not
   ///   compile.
@@ -9655,56 +9716,6 @@ extension ProtobufUnittest_TestAllExtensions {
   }
 }
 
-func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
-  switch (lhs, rhs) {
-  case (.fooInt(let l), .fooInt(let r)): return l == r
-  case (.fooString(let l), .fooString(let r)): return l == r
-  case (.fooMessage(let l), .fooMessage(let r)): return l == r
-  case (.fooGroup(let l), .fooGroup(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
-  switch (lhs, rhs) {
-  case (.fooInt(let l), .fooInt(let r)): return l == r
-  case (.fooString(let l), .fooString(let r)): return l == r
-  case (.fooCord(let l), .fooCord(let r)): return l == r
-  case (.fooStringPiece(let l), .fooStringPiece(let r)): return l == r
-  case (.fooBytes(let l), .fooBytes(let r)): return l == r
-  case (.fooEnum(let l), .fooEnum(let r)): return l == r
-  case (.fooMessage(let l), .fooMessage(let r)): return l == r
-  case (.fooGroup(let l), .fooGroup(let r)): return l == r
-  case (.fooLazyMessage(let l), .fooLazyMessage(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
-  switch (lhs, rhs) {
-  case (.barInt(let l), .barInt(let r)): return l == r
-  case (.barString(let l), .barString(let r)): return l == r
-  case (.barCord(let l), .barCord(let r)): return l == r
-  case (.barStringPiece(let l), .barStringPiece(let r)): return l == r
-  case (.barBytes(let l), .barBytes(let r)): return l == r
-  case (.barEnum(let l), .barEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
-  switch (lhs, rhs) {
-  case (.fooInt(let l), .fooInt(let r)): return l == r
-  case (.fooString(let l), .fooString(let r)): return l == r
-  case (.fooMessage(let l), .fooMessage(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
 extension ProtobufUnittest_TestParsingMerge {
   var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optionalExt) ?? ProtobufUnittest_TestAllTypes()}
@@ -9728,17 +9739,6 @@ extension ProtobufUnittest_TestParsingMerge {
   }
   mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt)
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }
 

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -199,6 +199,14 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message, Swi
     case oneofField(Int32)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof, rhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofField(let l), .oneofField(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -2024,14 +2032,6 @@ let ProtobufUnittest_Extensions_serviceopt = SwiftProtobuf.MessageExtension<Opti
 let ProtobufUnittest_Extensions_methodopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_MethodOptions>(protoFieldNumber: 15512713, fieldNames: .same(proto: "[protobuf_unittest.methodopt]", swift: "ProtobufUnittest_methodopt"), defaultValue: ProtobufUnittest_Aggregate())
 
 let ProtobufUnittest_Extensions_requiredEnumOpt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(protoFieldNumber: 106161807, fieldNames: .same(proto: "[protobuf_unittest.required_enum_opt]", swift: "ProtobufUnittest_requiredEnumOpt"), defaultValue: ProtobufUnittest_OldOptionType())
-
-func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof, rhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofField(let l), .oneofField(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -897,6 +897,18 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
     case oneofLazyNestedMessage(ProtobufUnittest_TestAllTypesLite.NestedMessage)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofLazyNestedMessage(let l), .oneofLazyNestedMessage(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -3334,6 +3346,17 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -3817,18 +3840,6 @@ let ProtobufUnittest_Extensions_packedEnumExtensionLite = SwiftProtobuf.MessageE
 
 let ProtobufUnittest_Extensions_testAllTypesLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestHugeFieldNumbersLite>(protoFieldNumber: 536860000, fieldNames: .same(proto: "[protobuf_unittest.test_all_types_lite]", swift: "ProtobufUnittest_testAllTypesLite"), defaultValue: ProtobufUnittest_TestAllTypesLite())
 
-func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.oneofLazyNestedMessage(let l), .oneofLazyNestedMessage(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension) ?? 0}
@@ -3865,17 +3876,6 @@ extension ProtobufUnittest_TestParsingMergeLite {
   }
   mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt)
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }
 

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -758,6 +758,18 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     case lazyOneofNestedMessage(ProtobufUnittestNoArena_TestAllTypes.NestedMessage)
     case None
 
+    static func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.lazyOneofNestedMessage(let l), .lazyOneofNestedMessage(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1913,17 +1925,5 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage: SwiftProtobuf.Message, SwiftP
       _storage = _storage.copy()
     }
     return _storage
-  }
-}
-
-func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.lazyOneofNestedMessage(let l), .lazyOneofNestedMessage(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -546,6 +546,17 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
     case oneofEnum(Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum)
     case None
 
+    static func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1166,16 +1177,5 @@ struct Proto2NofieldpresenceUnittest_ForeignMessage: SwiftProtobuf.Message, Swif
   public func _protoc_generated_isEqualTo(other: Proto2NofieldpresenceUnittest_ForeignMessage) -> Bool {
     if c != other.c {return false}
     return true
-  }
-}
-
-func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -122,6 +122,15 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     case stringField(String)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.integerField(let l), .integerField(let r)): return l == r
+      case (.stringField(let l), .stringField(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -392,15 +401,6 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message, Swi
       _storage = _storage.copy()
     }
     return _storage
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
-  switch (lhs, rhs) {
-  case (.integerField(let l), .integerField(let r)): return l == r
-  case (.stringField(let l), .stringField(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }
 

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -235,6 +235,15 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnum)
     case None
 
+    static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -370,6 +379,15 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
     case None
 
+    static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -482,23 +500,5 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     if repeatedPackedUnexpectedE != other.repeatedPackedUnexpectedE {return false}
     if o != other.o {return false}
     return true
-  }
-}
-
-func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofE1(let l), .oneofE1(let r)): return l == r
-  case (.oneofE2(let l), .oneofE2(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofE1(let l), .oneofE1(let r)): return l == r
-  case (.oneofE2(let l), .oneofE2(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -140,6 +140,15 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     case oneofE2(Proto2PreserveUnknownEnumUnittest_MyEnum)
     case None
 
+    static func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -269,14 +278,5 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     if o != other.o {return false}
     if unknown != other.unknown {return false}
     return true
-  }
-}
-
-func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofE1(let l), .oneofE1(let r)): return l == r
-  case (.oneofE2(let l), .oneofE2(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -769,6 +769,17 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, S
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: Proto3TestAllTypes.OneOf_OneofField, rhs: Proto3TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -2554,6 +2565,16 @@ struct Proto3TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, Swif
     case fooMessage(Proto3TestAllTypes)
     case None
 
+    static func ==(lhs: Proto3TestOneof.OneOf_Foo, rhs: Proto3TestOneof.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -3176,26 +3197,5 @@ struct Proto3BarResponse: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, Sw
 
   public func _protoc_generated_isEqualTo(other: Proto3BarResponse) -> Bool {
     return true
-  }
-}
-
-func ==(lhs: Proto3TestAllTypes.OneOf_OneofField, rhs: Proto3TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: Proto3TestOneof.OneOf_Foo, rhs: Proto3TestOneof.OneOf_Foo) -> Bool {
-  switch (lhs, rhs) {
-  case (.fooInt(let l), .fooInt(let r)): return l == r
-  case (.fooString(let l), .fooString(let r)): return l == r
-  case (.fooMessage(let l), .fooMessage(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -560,6 +560,17 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1544,16 +1555,5 @@ struct Proto3ArenaUnittest_TestEmptyMessage: SwiftProtobuf.Message, SwiftProtobu
 
   public func _protoc_generated_isEqualTo(other: Proto3ArenaUnittest_TestEmptyMessage) -> Bool {
     return true
-  }
-}
-
-func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -560,6 +560,17 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1544,16 +1555,5 @@ struct Proto3ArenaLiteUnittest_TestEmptyMessage: SwiftProtobuf.Message, SwiftPro
 
   public func _protoc_generated_isEqualTo(other: Proto3ArenaLiteUnittest_TestEmptyMessage) -> Bool {
     return true
-  }
-}
-
-func ==(lhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -560,6 +560,17 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1544,16 +1555,5 @@ struct Proto3LiteUnittest_TestEmptyMessage: SwiftProtobuf.Message, SwiftProtobuf
 
   public func _protoc_generated_isEqualTo(other: Proto3LiteUnittest_TestEmptyMessage) -> Bool {
     return true
-  }
-}
-
-func ==(lhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -801,6 +801,31 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
     case bytesField(Google_Protobuf_BytesValue)
     case None
 
+    static func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.anyField(let l), .anyField(let r)): return l == r
+      case (.apiField(let l), .apiField(let r)): return l == r
+      case (.durationField(let l), .durationField(let r)): return l == r
+      case (.emptyField(let l), .emptyField(let r)): return l == r
+      case (.fieldMaskField(let l), .fieldMaskField(let r)): return l == r
+      case (.sourceContextField(let l), .sourceContextField(let r)): return l == r
+      case (.structField(let l), .structField(let r)): return l == r
+      case (.timestampField(let l), .timestampField(let r)): return l == r
+      case (.typeField(let l), .typeField(let r)): return l == r
+      case (.doubleField(let l), .doubleField(let r)): return l == r
+      case (.floatField(let l), .floatField(let r)): return l == r
+      case (.int64Field(let l), .int64Field(let r)): return l == r
+      case (.uint64Field(let l), .uint64Field(let r)): return l == r
+      case (.int32Field(let l), .int32Field(let r)): return l == r
+      case (.uint32Field(let l), .uint32Field(let r)): return l == r
+      case (.boolField(let l), .boolField(let r)): return l == r
+      case (.stringField(let l), .stringField(let r)): return l == r
+      case (.bytesField(let l), .bytesField(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1542,30 +1567,5 @@ struct ProtobufUnittest_MapWellKnownTypes: SwiftProtobuf.Message, SwiftProtobuf.
       _storage = _storage.copy()
     }
     return _storage
-  }
-}
-
-func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.anyField(let l), .anyField(let r)): return l == r
-  case (.apiField(let l), .apiField(let r)): return l == r
-  case (.durationField(let l), .durationField(let r)): return l == r
-  case (.emptyField(let l), .emptyField(let r)): return l == r
-  case (.fieldMaskField(let l), .fieldMaskField(let r)): return l == r
-  case (.sourceContextField(let l), .sourceContextField(let r)): return l == r
-  case (.structField(let l), .structField(let r)): return l == r
-  case (.timestampField(let l), .timestampField(let r)): return l == r
-  case (.typeField(let l), .typeField(let r)): return l == r
-  case (.doubleField(let l), .doubleField(let r)): return l == r
-  case (.floatField(let l), .floatField(let r)): return l == r
-  case (.int64Field(let l), .int64Field(let r)): return l == r
-  case (.uint64Field(let l), .uint64Field(let r)): return l == r
-  case (.int32Field(let l), .int32Field(let r)): return l == r
-  case (.uint32Field(let l), .uint32Field(let r)): return l == r
-  case (.boolField(let l), .boolField(let r)): return l == r
-  case (.stringField(let l), .stringField(let r)): return l == r
-  case (.bytesField(let l), .bytesField(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -388,6 +388,17 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1404,16 +1415,5 @@ struct ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf.Message, SwiftProto
     if _requiredNestedEnum != other._requiredNestedEnum {return false}
     if unknown != other.unknown {return false}
     return true
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -125,6 +125,17 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
     case oneofInt32(Int32)
     case None
 
+    static func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -397,17 +408,6 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
 let Swift_Protobuf_Extensions_myExtensionString = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(protoFieldNumber: 50, fieldNames: .same(proto: "[swift.protobuf.my_extension_string]", swift: "Swift_Protobuf_myExtensionString"), defaultValue: "")
 
 let Swift_Protobuf_Extensions_myExtensionInt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(protoFieldNumber: 5, fieldNames: .same(proto: "[swift.protobuf.my_extension_int]", swift: "Swift_Protobuf_myExtensionInt"), defaultValue: 0)
-
-func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
-  case (.oneofBool(let l), .oneofBool(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
 
 extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionString: String {

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -565,6 +565,31 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
     case oneofEnum(ProtobufUnittest_Message2.Enum)
     case None
 
+    static func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
+      case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
+      case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
+      case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
+      case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
+      case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofGroup(let l), .oneofGroup(let r)): return l == r
+      case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1638,30 +1663,5 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
       _storage = _storage.copy()
     }
     return _storage
-  }
-}
-
-func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
-  case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
-  case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
-  case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
-  case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
-  case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
-  case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
-  case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
-  case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
-  case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
-  case (.oneofBool(let l), .oneofBool(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.oneofGroup(let l), .oneofGroup(let r)): return l == r
-  case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
-  case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -539,6 +539,30 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
     case oneofEnum(ProtobufUnittest_Message3.Enum)
     case None
 
+    static func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
+      case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
+      case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
+      case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
+      case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
+      case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1300,29 +1324,5 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
       _storage = _storage.copy()
     }
     return _storage
-  }
-}
-
-func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
-  case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
-  case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
-  case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
-  case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
-  case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
-  case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
-  case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
-  case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
-  case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
-  case (.oneofBool(let l), .oneofBool(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
-  case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -248,6 +248,15 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
     case jsonPayload(String)
     case None
 
+    static func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
+      switch (lhs, rhs) {
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -366,6 +375,19 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
     case jsonPayload(String)
     case skipped(String)
     case None
+
+    static func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
+      switch (lhs, rhs) {
+      case (.parseError(let l), .parseError(let r)): return l == r
+      case (.serializeError(let l), .serializeError(let r)): return l == r
+      case (.runtimeError(let l), .runtimeError(let r)): return l == r
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.skipped(let l), .skipped(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
 
     public init(nilLiteral: ()) {
       self = .None
@@ -1493,6 +1515,22 @@ struct Conformance_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
     case oneofEnum(Conformance_TestAllTypes.NestedEnum)
     case None
 
+    static func ==(lhs: Conformance_TestAllTypes.OneOf_OneofField, rhs: Conformance_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -2605,43 +2643,5 @@ struct Conformance_ForeignMessage: SwiftProtobuf.Message, SwiftProtobuf.Proto3Me
   public func _protoc_generated_isEqualTo(other: Conformance_ForeignMessage) -> Bool {
     if c != other.c {return false}
     return true
-  }
-}
-
-func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
-  switch (lhs, rhs) {
-  case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
-  case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
-  switch (lhs, rhs) {
-  case (.parseError(let l), .parseError(let r)): return l == r
-  case (.serializeError(let l), .serializeError(let r)): return l == r
-  case (.runtimeError(let l), .runtimeError(let r)): return l == r
-  case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
-  case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
-  case (.skipped(let l), .skipped(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: Conformance_TestAllTypes.OneOf_OneofField, rhs: Conformance_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.oneofBool(let l), .oneofBool(let r)): return l == r
-  case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
-  case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
-  case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
-  case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Sources/SwiftProtobuf/ExtensionFieldValueSet.swift
+++ b/Sources/SwiftProtobuf/ExtensionFieldValueSet.swift
@@ -16,60 +16,58 @@
 ///
 // -----------------------------------------------------------------------------
 
-import Swift
-
 public struct ExtensionFieldValueSet: Equatable, Sequence {
-    public typealias Iterator = Dictionary<Int, AnyExtensionField>.Iterator
-    fileprivate var values = [Int : AnyExtensionField]()
-    public init() {}
+  public typealias Iterator = Dictionary<Int, AnyExtensionField>.Iterator
+  fileprivate var values = [Int : AnyExtensionField]()
 
-    public func makeIterator() -> Iterator {
-        return values.makeIterator()
+  public static func ==(lhs: ExtensionFieldValueSet,
+                        rhs: ExtensionFieldValueSet) -> Bool {
+    guard lhs.values.count == rhs.values.count else {
+      return false
     }
-
-    public var hashValue: Int {
-        var hash: Int = 0
-        for i in values.keys.sorted() {
-            hash = (hash &* 16777619) ^ values[i]!.hashValue
-        }
-        return hash
-    }
-
-    public func traverse(visitor: inout Visitor, start: Int, end: Int) throws {
-        let validIndexes = values.keys.filter {$0 >= start && $0 < end}
-        for i in validIndexes.sorted() {
-            let value = values[i]!
-            try value.traverse(visitor: &visitor)
-        }
-    }
-
-    public subscript(index: Int) -> AnyExtensionField? {
-        get {return values[index]}
-        set(newValue) {values[index] = newValue}
-    }
-
-    public func fieldNames(for number: Int) -> FieldNameMap.Names? {
-        return values[number]?.protobufExtension.fieldNames
-    }
-}
-
-public func ==(lhs: ExtensionFieldValueSet, rhs: ExtensionFieldValueSet) -> Bool {
     for (index, l) in lhs.values {
-        if let r = rhs.values[index] {
-            if type(of: l) != type(of: r) {
-                return false
-            }
-            if !l.isEqual(other: r) {
-                return false
-            }
-        } else {
-            return false
+      if let r = rhs.values[index] {
+        if type(of: l) != type(of: r) {
+          return false
         }
-    }
-    for (index, _) in rhs.values {
-        if lhs.values[index] == nil {
-            return false
+        if !l.isEqual(other: r) {
+          return false
         }
+      } else {
+        return false
+      }
     }
     return true
+  }
+
+  public init() {}
+
+  public func makeIterator() -> Iterator {
+    return values.makeIterator()
+  }
+
+  public var hashValue: Int {
+    var hash: Int = 0
+    for i in values.keys.sorted() {
+      hash = (hash &* 16777619) ^ values[i]!.hashValue
+    }
+    return hash
+  }
+
+  public func traverse(visitor: inout Visitor, start: Int, end: Int) throws {
+    let validIndexes = values.keys.filter {$0 >= start && $0 < end}
+    for i in validIndexes.sorted() {
+      let value = values[i]!
+      try value.traverse(visitor: &visitor)
+    }
+  }
+
+  public subscript(index: Int) -> AnyExtensionField? {
+    get { return values[index] }
+    set { values[index] = newValue }
+  }
+
+  public func fieldNames(for number: Int) -> FieldNameMap.Names? {
+    return values[number]?.protobufExtension.fieldNames
+  }
 }

--- a/Sources/SwiftProtobuf/ExtensionFields.swift
+++ b/Sources/SwiftProtobuf/ExtensionFields.swift
@@ -14,8 +14,6 @@
 ///
 // -----------------------------------------------------------------------------
 
-import Swift
-
 private let i_2166136261 = Int(bitPattern: 2166136261)
 private let i_16777619 = Int(16777619)
 
@@ -30,133 +28,125 @@ private let i_16777619 = Int(16777619)
 // so you can't actually access the contained value itself.
 //
 public protocol AnyExtensionField: CustomDebugStringConvertible {
-    var hashValue: Int { get }
-    var protobufExtension: MessageExtensionBase { get }
-    func isEqual(other: AnyExtensionField) -> Bool
+  var hashValue: Int { get }
+  var protobufExtension: MessageExtensionBase { get }
+  func isEqual(other: AnyExtensionField) -> Bool
 
-    /// General field decoding
-    mutating func decodeField(setter: inout FieldDecoder) throws
+  /// General field decoding
+  mutating func decodeField(setter: inout FieldDecoder) throws
 
-    /// Fields know their own type, so can dispatch to a visitor
-    func traverse(visitor: inout Visitor) throws
+  /// Fields know their own type, so can dispatch to a visitor
+  func traverse(visitor: inout Visitor) throws
 }
 
 ///
 /// The regular ExtensionField type exposes the value directly.
 ///
 public protocol ExtensionField: AnyExtensionField, Hashable {
-    associatedtype ValueType
-    var value: ValueType {get set}
-    init(protobufExtension: MessageExtensionBase)
+  associatedtype ValueType
+  var value: ValueType { get set }
+  init(protobufExtension: MessageExtensionBase)
 }
 
 ///
 /// Singular field
 ///
 public struct OptionalExtensionField<T: FieldType>: ExtensionField {
-    public typealias BaseType = T.BaseType
-    public typealias ValueType = BaseType?
-    public var value: ValueType
-    public var protobufExtension: MessageExtensionBase
+  public typealias BaseType = T.BaseType
+  public typealias ValueType = BaseType?
+  public var value: ValueType
+  public var protobufExtension: MessageExtensionBase
 
-    public init(protobufExtension: MessageExtensionBase) {
-        self.protobufExtension = protobufExtension
-    }
+  public static func ==(lhs: OptionalExtensionField,
+                        rhs: OptionalExtensionField) -> Bool {
+    return lhs.value == rhs.value
+  }
 
-    public var debugDescription: String {
-        get {
-            if let value = value {
-                return String(reflecting: value)
-            }
-            return ""
-        }
-    }
+  public init(protobufExtension: MessageExtensionBase) {
+    self.protobufExtension = protobufExtension
+  }
 
-    public var hashValue: Int {
-        get { return value?.hashValue ?? 0 }
+  public var debugDescription: String {
+    get {
+      if let value = value {
+        return String(reflecting: value)
+      }
+      return ""
     }
+  }
 
-    public func isEqual(other: AnyExtensionField) -> Bool {
-        let o = other as! OptionalExtensionField<T>
-        return self == o
-    }
+  public var hashValue: Int {
+    get { return value?.hashValue ?? 0 }
+  }
 
-    public mutating func decodeField(setter: inout FieldDecoder) throws {
-        try setter.decodeSingularField(fieldType: T.self, value: &value)
-    }
+  public func isEqual(other: AnyExtensionField) -> Bool {
+    let o = other as! OptionalExtensionField<T>
+    return self == o
+  }
 
-    public func traverse(visitor: inout Visitor) throws {
-        if let v = value {
-            try visitor.visitSingularField(fieldType: T.self, value: v, protoFieldNumber: protobufExtension.protoFieldNumber)
-        }
-    }
-}
+  public mutating func decodeField(setter: inout FieldDecoder) throws {
+    try setter.decodeSingularField(fieldType: T.self, value: &value)
+  }
 
-public func ==<T: FieldType>(lhs: OptionalExtensionField<T>, rhs: OptionalExtensionField<T>) -> Bool {
-    if let l = lhs.value {
-        if let r = rhs.value {
-            return l == r
-        }
-        return false
-    } else if let _ = rhs.value {
-        return false
+  public func traverse(visitor: inout Visitor) throws {
+    if let v = value {
+      try visitor.visitSingularField(
+        fieldType: T.self,
+        value: v,
+        protoFieldNumber: protobufExtension.protoFieldNumber)
     }
-    return true // Both nil
+  }
 }
 
 ///
 /// Repeated fields
 ///
 public struct RepeatedExtensionField<T: FieldType>: ExtensionField {
-    public typealias BaseType = T.BaseType
-    public typealias ValueType = [BaseType]
-    public var value = ValueType()
-    public var protobufExtension: MessageExtensionBase
+  public typealias BaseType = T.BaseType
+  public typealias ValueType = [BaseType]
+  public var value = ValueType()
+  public var protobufExtension: MessageExtensionBase
 
-    public init(protobufExtension: MessageExtensionBase) {
-        self.protobufExtension = protobufExtension
-    }
+  public static func ==(lhs: RepeatedExtensionField,
+                        rhs: RepeatedExtensionField) -> Bool {
+    return lhs.value == rhs.value
+  }
 
-    public var hashValue: Int {
-        get {
-            var hash = i_2166136261
-            for e in value {
-                hash = (hash &* i_16777619) ^ e.hashValue
-            }
-            return hash
-        }
-    }
+  public init(protobufExtension: MessageExtensionBase) {
+    self.protobufExtension = protobufExtension
+  }
 
-    public func isEqual(other: AnyExtensionField) -> Bool {
-        let o = other as! RepeatedExtensionField<T>
-        return self == o
+  public var hashValue: Int {
+    get {
+      var hash = i_2166136261
+      for e in value {
+        hash = (hash &* i_16777619) ^ e.hashValue
+      }
+      return hash
     }
+  }
 
-    public var debugDescription: String {
-        return "[" + value.map{String(reflecting: $0)}.joined(separator: ",") + "]"
-    }
+  public func isEqual(other: AnyExtensionField) -> Bool {
+    let o = other as! RepeatedExtensionField<T>
+    return self == o
+  }
 
-    public mutating func decodeField(setter: inout FieldDecoder) throws {
-        try setter.decodeRepeatedField(fieldType: T.self, value: &value)
-    }
+  public var debugDescription: String {
+    return "[" + value.map{String(reflecting: $0)}.joined(separator: ",") + "]"
+  }
 
-    public func traverse(visitor: inout Visitor) throws {
-        if value.count > 0 {
-            try visitor.visitRepeatedField(fieldType: T.self, value: value, protoFieldNumber: protobufExtension.protoFieldNumber)
-        }
-    }
-}
+  public mutating func decodeField(setter: inout FieldDecoder) throws {
+    try setter.decodeRepeatedField(fieldType: T.self, value: &value)
+  }
 
-public func ==<T: FieldType>(lhs: RepeatedExtensionField<T>, rhs: RepeatedExtensionField<T>) -> Bool {
-    if lhs.value.count != rhs.value.count {
-        return false
+  public func traverse(visitor: inout Visitor) throws {
+    if value.count > 0 {
+      try visitor.visitRepeatedField(
+        fieldType: T.self,
+        value: value,
+        protoFieldNumber: protobufExtension.protoFieldNumber)
     }
-    for (l, r) in zip(lhs.value, rhs.value) {
-        if l != r {
-            return false
-        }
-    }
-    return true
+  }
 }
 
 ///
@@ -166,152 +156,145 @@ public func ==<T: FieldType>(lhs: RepeatedExtensionField<T>, rhs: RepeatedExtens
 /// find a way to collapse the implementations.
 ///
 public struct PackedExtensionField<T: FieldType>: ExtensionField {
+  public typealias BaseType = T.BaseType
+  public typealias ValueType = [BaseType]
+  public var value = ValueType()
+  public var protobufExtension: MessageExtensionBase
 
-    public typealias BaseType = T.BaseType
-    public typealias ValueType = [BaseType]
-    public var value = ValueType()
-    public var protobufExtension: MessageExtensionBase
+  public static func ==(lhs: PackedExtensionField,
+                        rhs: PackedExtensionField) -> Bool {
+    return lhs.value == rhs.value
+  }
 
-    public init(protobufExtension: MessageExtensionBase) {
-        self.protobufExtension = protobufExtension
-    }
+  public init(protobufExtension: MessageExtensionBase) {
+    self.protobufExtension = protobufExtension
+  }
 
-    public var hashValue: Int {
-        get {
-            var hash = i_2166136261
-            for e in value {
-                hash = (hash &* i_16777619) ^ e.hashValue
-            }
-            return hash
-        }
+  public var hashValue: Int {
+    get {
+      var hash = i_2166136261
+      for e in value {
+        hash = (hash &* i_16777619) ^ e.hashValue
+      }
+      return hash
     }
+  }
 
-    public func isEqual(other: AnyExtensionField) -> Bool {
-        let o = other as! PackedExtensionField<T>
-        return self == o
-    }
+  public func isEqual(other: AnyExtensionField) -> Bool {
+    let o = other as! PackedExtensionField<T>
+    return self == o
+  }
 
-    public var debugDescription: String {
-        return "[" + value.map{String(reflecting: $0)}.joined(separator: ",") + "]"
-    }
+  public var debugDescription: String {
+    return "[" + value.map{String(reflecting: $0)}.joined(separator: ",") + "]"
+  }
 
-    public mutating func decodeField(setter: inout FieldDecoder) throws {
-        try setter.decodePackedField(fieldType: T.self, value: &value)
-    }
+  public mutating func decodeField(setter: inout FieldDecoder) throws {
+    try setter.decodePackedField(fieldType: T.self, value: &value)
+  }
 
-    public func traverse(visitor: inout Visitor) throws {
-        if value.count > 0 {
-            try visitor.visitPackedField(fieldType: T.self, value: value, protoFieldNumber: protobufExtension.protoFieldNumber)
-        }
+  public func traverse(visitor: inout Visitor) throws {
+    if value.count > 0 {
+      try visitor.visitPackedField(
+        fieldType: T.self,
+        value: value,
+        protoFieldNumber: protobufExtension.protoFieldNumber)
     }
-}
-
-public func ==<T: FieldType>(lhs: PackedExtensionField<T>, rhs: PackedExtensionField<T>) -> Bool {
-    if lhs.value.count != rhs.value.count {
-        return false
-    }
-    for (l, r) in zip(lhs.value, rhs.value) {
-        if l != r {
-            return false
-        }
-    }
-    return true
+  }
 }
 
 //
 // ========== Message ==========
 //
-public struct OptionalMessageExtensionField<M: Message & Equatable>: ExtensionField {
-    public typealias BaseType = M
-    public typealias ValueType = BaseType?
-    public var value: ValueType
-    public var protobufExtension: MessageExtensionBase
+public struct OptionalMessageExtensionField<M: Message & Equatable>:
+  ExtensionField {
+  public typealias BaseType = M
+  public typealias ValueType = BaseType?
+  public var value: ValueType
+  public var protobufExtension: MessageExtensionBase
 
-    public init(protobufExtension: MessageExtensionBase) {
-        self.protobufExtension = protobufExtension
-    }
-
-    public var debugDescription: String {
-        get {
-            if let value = value {
-                return String(reflecting: value)
-            }
-            return ""
-        }
-    }
-
-    public var hashValue: Int {return value?.hashValue ?? 0}
-
-    public func isEqual(other: AnyExtensionField) -> Bool {
-        let o = other as! OptionalMessageExtensionField<M>
-        return self == o
-    }
-
-    public mutating func decodeField(setter: inout FieldDecoder) throws {
-        try setter.decodeSingularMessageField(fieldType: M.self, value: &value)
-    }
-
-    public func traverse(visitor: inout Visitor) throws {
-        if let v = value {
-            try visitor.visitSingularMessageField(value: v, protoFieldNumber: protobufExtension.protoFieldNumber)
-        }
-    }
-}
-
-public func ==<M: Message & Equatable>(lhs: OptionalMessageExtensionField<M>, rhs: OptionalMessageExtensionField<M>) -> Bool {
-    if let l = lhs.value {
-        if let r = rhs.value {
-            return l == r
-        }
-        return false
-    } else if let _ = rhs.value {
-        return false
-    }
-    return true // Both nil
-}
-
-public struct RepeatedMessageExtensionField<M: Message & Equatable>: ExtensionField {
-    public typealias BaseType = M
-    public typealias ValueType = [BaseType]
-    public var value = ValueType()
-    public var protobufExtension: MessageExtensionBase
-
-    public init(protobufExtension: MessageExtensionBase) {
-        self.protobufExtension = protobufExtension
-    }
-
-    public var hashValue: Int {
-        get {
-            var hash = i_2166136261
-            for e in value {
-                hash = (hash &* i_16777619) ^ e.hashValue
-            }
-            return hash
-        }
-    }
-
-    public func isEqual(other: AnyExtensionField) -> Bool {
-        let o = other as! RepeatedMessageExtensionField<M>
-        return self == o
-    }
-
-    public var debugDescription: String {
-        return "[" + value.map{String(reflecting: $0)}.joined(separator: ",") + "]"
-    }
-
-    public mutating func decodeField(setter: inout FieldDecoder) throws {
-        try setter.decodeRepeatedMessageField(fieldType: M.self, value: &value)
-    }
-
-    public func traverse(visitor: inout Visitor) throws {
-        if value.count > 0 {
-            try visitor.visitRepeatedMessageField(value: value, protoFieldNumber: protobufExtension.protoFieldNumber)
-        }
-    }
-}
-
-public func ==<M: Message & Equatable>(lhs: RepeatedMessageExtensionField<M>, rhs: RepeatedMessageExtensionField<M>) -> Bool {
+  public static func ==(lhs: OptionalMessageExtensionField,
+                        rhs: OptionalMessageExtensionField) -> Bool {
     return lhs.value == rhs.value
+  }
+
+  public init(protobufExtension: MessageExtensionBase) {
+    self.protobufExtension = protobufExtension
+  }
+
+  public var debugDescription: String {
+    get {
+      if let value = value {
+        return String(reflecting: value)
+      }
+      return ""
+    }
+  }
+
+  public var hashValue: Int {return value?.hashValue ?? 0}
+
+  public func isEqual(other: AnyExtensionField) -> Bool {
+    let o = other as! OptionalMessageExtensionField<M>
+    return self == o
+  }
+
+  public mutating func decodeField(setter: inout FieldDecoder) throws {
+    try setter.decodeSingularMessageField(fieldType: M.self, value: &value)
+  }
+
+  public func traverse(visitor: inout Visitor) throws {
+    if let v = value {
+      try visitor.visitSingularMessageField(
+        value: v, protoFieldNumber: protobufExtension.protoFieldNumber)
+    }
+  }
+}
+
+public struct RepeatedMessageExtensionField<M: Message & Equatable>:
+  ExtensionField {
+  public typealias BaseType = M
+  public typealias ValueType = [BaseType]
+  public var value = ValueType()
+  public var protobufExtension: MessageExtensionBase
+
+  public static func ==(lhs: RepeatedMessageExtensionField,
+                        rhs: RepeatedMessageExtensionField) -> Bool {
+    return lhs.value == rhs.value
+  }
+
+  public init(protobufExtension: MessageExtensionBase) {
+    self.protobufExtension = protobufExtension
+  }
+
+  public var hashValue: Int {
+    get {
+      var hash = i_2166136261
+      for e in value {
+        hash = (hash &* i_16777619) ^ e.hashValue
+      }
+      return hash
+    }
+  }
+
+  public func isEqual(other: AnyExtensionField) -> Bool {
+    let o = other as! RepeatedMessageExtensionField<M>
+    return self == o
+  }
+
+  public var debugDescription: String {
+    return "[" + value.map{String(reflecting: $0)}.joined(separator: ",") + "]"
+  }
+
+  public mutating func decodeField(setter: inout FieldDecoder) throws {
+    try setter.decodeRepeatedMessageField(fieldType: M.self, value: &value)
+  }
+
+  public func traverse(visitor: inout Visitor) throws {
+    if value.count > 0 {
+      try visitor.visitRepeatedMessageField(
+        value: value, protoFieldNumber: protobufExtension.protoFieldNumber)
+    }
+  }
 }
 
 //
@@ -320,87 +303,86 @@ public func ==<M: Message & Equatable>(lhs: RepeatedMessageExtensionField<M>, rh
 // Protoc internally treats groups the same as messages, but
 // they serialize very differently, so we have separate serialization
 // handling here...
-public struct OptionalGroupExtensionField<G: Message & Hashable>: ExtensionField {
-    public typealias BaseType = G
-    public typealias ValueType = BaseType?
-    public var value: G?
-    public var protobufExtension: MessageExtensionBase
+public struct OptionalGroupExtensionField<G: Message & Hashable>:
+  ExtensionField {
+  public typealias BaseType = G
+  public typealias ValueType = BaseType?
+  public var value: G?
+  public var protobufExtension: MessageExtensionBase
 
-    public init(protobufExtension: MessageExtensionBase) {
-        self.protobufExtension = protobufExtension
-    }
-
-    public var hashValue: Int {return value?.hashValue ?? 0}
-
-    public var debugDescription: String { get {return value?.debugDescription ?? ""} }
-
-    public func isEqual(other: AnyExtensionField) -> Bool {
-        let o = other as! OptionalGroupExtensionField<G>
-        return self == o
-    }
-
-    public mutating func decodeField(setter: inout FieldDecoder) throws {
-        try setter.decodeSingularGroupField(fieldType: G.self, value: &value)
-    }
-
-    public func traverse(visitor: inout Visitor) throws {
-        if let v = value {
-            try visitor.visitSingularGroupField(value: v, protoFieldNumber: protobufExtension.protoFieldNumber)
-        }
-    }
-}
-
-public func==<M: Message & Equatable>(lhs:OptionalGroupExtensionField<M>, rhs:OptionalGroupExtensionField<M>) -> Bool {
-    if let l = lhs.value {
-        if let r = rhs.value {
-            return l == r
-        }
-        return false
-    } else if let _ = rhs.value {
-        return false
-    }
-    return true // Both nil
-}
-
-
-public struct RepeatedGroupExtensionField<G: Message & Hashable>: ExtensionField {
-    public typealias BaseType = G
-    public typealias ValueType = [BaseType]
-    public var value = [G]()
-    public var protobufExtension: MessageExtensionBase
-
-    public init(protobufExtension: MessageExtensionBase) {
-        self.protobufExtension = protobufExtension
-    }
-
-    public var hashValue: Int {
-        get {
-            var hash = i_2166136261
-            for e in value {
-                hash = (hash &* i_16777619) ^ e.hashValue
-            }
-            return hash
-        }
-    }
-
-    public var debugDescription: String {return "[" + value.map{$0.debugDescription}.joined(separator: ",") + "]"}
-
-    public func isEqual(other: AnyExtensionField) -> Bool {
-        let o = other as! RepeatedGroupExtensionField<G>
-        return self == o
-    }
-
-    public mutating func decodeField(setter: inout FieldDecoder) throws {
-        try setter.decodeRepeatedGroupField(fieldType: G.self, value: &value)
-    }
-
-    public func traverse(visitor: inout Visitor) throws {
-        if value.count > 0 {
-            try visitor.visitRepeatedGroupField(value: value, protoFieldNumber: protobufExtension.protoFieldNumber)
-        }
-    }
-}
-
-public func ==<G: Message & Equatable>(lhs: RepeatedGroupExtensionField<G>, rhs: RepeatedGroupExtensionField<G>) -> Bool {
+  public static func ==(lhs: OptionalGroupExtensionField,
+                        rhs: OptionalGroupExtensionField) -> Bool {
     return lhs.value == rhs.value
+  }
+
+  public init(protobufExtension: MessageExtensionBase) {
+    self.protobufExtension = protobufExtension
+  }
+
+  public var hashValue: Int {return value?.hashValue ?? 0}
+
+  public var debugDescription: String { get {return value?.debugDescription ?? ""} }
+
+  public func isEqual(other: AnyExtensionField) -> Bool {
+    let o = other as! OptionalGroupExtensionField<G>
+    return self == o
+  }
+
+  public mutating func decodeField(setter: inout FieldDecoder) throws {
+    try setter.decodeSingularGroupField(fieldType: G.self, value: &value)
+  }
+
+  public func traverse(visitor: inout Visitor) throws {
+    if let v = value {
+      try visitor.visitSingularGroupField(
+        value: v, protoFieldNumber: protobufExtension.protoFieldNumber)
+    }
+  }
+}
+
+public struct RepeatedGroupExtensionField<G: Message & Hashable>:
+  ExtensionField {
+  public typealias BaseType = G
+  public typealias ValueType = [BaseType]
+  public var value = [G]()
+  public var protobufExtension: MessageExtensionBase
+
+  public static func ==(lhs: RepeatedGroupExtensionField,
+                        rhs: RepeatedGroupExtensionField) -> Bool {
+    return lhs.value == rhs.value
+  }
+
+  public init(protobufExtension: MessageExtensionBase) {
+    self.protobufExtension = protobufExtension
+  }
+
+  public var hashValue: Int {
+    get {
+      var hash = i_2166136261
+      for e in value {
+        hash = (hash &* i_16777619) ^ e.hashValue
+      }
+      return hash
+    }
+  }
+
+  public var debugDescription: String {
+    return "[" + value.map{$0.debugDescription}.joined(separator: ",") + "]"
+  }
+
+  public func isEqual(other: AnyExtensionField) -> Bool {
+    let o = other as! RepeatedGroupExtensionField<G>
+    return self == o
+  }
+
+  public mutating func decodeField(setter: inout FieldDecoder) throws {
+    try setter.decodeRepeatedGroupField(fieldType: G.self, value: &value)
+  }
+
+  public func traverse(visitor: inout Visitor) throws {
+    if value.count > 0 {
+      try visitor.visitRepeatedGroupField(
+        value: value, protoFieldNumber: protobufExtension.protoFieldNumber)
+    }
+  }
 }

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -19,7 +19,6 @@
 ///
 // -----------------------------------------------------------------------------
 
-import Swift
 
 ///
 /// See ProtobufBinaryTypes and ProtobufJSONTypes for extensions
@@ -206,21 +205,22 @@ public protocol Proto3Message: Message {
 /// tests or put it in a `Set<>`.
 ///
 public protocol _MessageImplementationBase: Message, Hashable, MapValueType {
-    func isEqualTo(other: Self) -> Bool
+  // The compiler actually generates the following methods. Default
+  // implementations below redirect the standard names. This allows developers
+  // to override the standard names to customize the behavior.
+  mutating func _protoc_generated_decodeField(setter: inout FieldDecoder,
+                                              protoFieldNumber: Int) throws
 
-    // The compiler actually generates the following methods. Default
-    // implementations below redirect the standard names. This allows developers
-    // to override the standard names to customize the behavior.
-    mutating func _protoc_generated_decodeField(
-        setter: inout FieldDecoder,
-        protoFieldNumber: Int) throws
+  func _protoc_generated_traverse(visitor: inout Visitor) throws
 
-    func _protoc_generated_traverse(visitor: inout Visitor) throws
-
-    func _protoc_generated_isEqualTo(other: Self) -> Bool
+  func _protoc_generated_isEqualTo(other: Self) -> Bool
 }
 
 public extension _MessageImplementationBase {
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    return lhs._protoc_generated_isEqualTo(other: rhs)
+  }
+
   // Default implementations simply redirect to the generated versions.
   public func traverse(visitor: inout Visitor) throws {
     try _protoc_generated_traverse(visitor: &visitor)
@@ -228,15 +228,7 @@ public extension _MessageImplementationBase {
 
   mutating func decodeField(setter: inout FieldDecoder,
                             protoFieldNumber: Int) throws {
-      try _protoc_generated_decodeField(setter: &setter,
-                                        protoFieldNumber: protoFieldNumber)
+    try _protoc_generated_decodeField(setter: &setter,
+                                      protoFieldNumber: protoFieldNumber)
   }
-
-  func isEqualTo(other: Self) -> Bool {
-    return _protoc_generated_isEqualTo(other: other)
-  }
-}
-
-public func ==<M: _MessageImplementationBase>(lhs: M, rhs: M) -> Bool {
-  return lhs.isEqualTo(other: rhs)
 }

--- a/Sources/SwiftProtobuf/TextToken.swift
+++ b/Sources/SwiftProtobuf/TextToken.swift
@@ -15,136 +15,135 @@
 // -----------------------------------------------------------------------------
 
 import Foundation
-import Swift
 
 
 private func fromOctalDigit(_ c: Character) -> UInt8? {
-    switch c {
-    case "0": return 0
-    case "1": return 1
-    case "2": return 2
-    case "3": return 3
-    case "4": return 4
-    case "5": return 5
-    case "6": return 6
-    case "7": return 7
-    default: return nil
-    }
+  switch c {
+  case "0": return 0
+  case "1": return 1
+  case "2": return 2
+  case "3": return 3
+  case "4": return 4
+  case "5": return 5
+  case "6": return 6
+  case "7": return 7
+  default: return nil
+  }
 }
 
 private func fromHexDigit(_ c: Character) -> UInt8? {
-    switch c {
-    case "0": return 0
-    case "1": return 1
-    case "2": return 2
-    case "3": return 3
-    case "4": return 4
-    case "5": return 5
-    case "6": return 6
-    case "7": return 7
-    case "8": return 8
-    case "9": return 9
-    case "a", "A": return 10
-    case "b", "B": return 11
-    case "c", "C": return 12
-    case "d", "D": return 13
-    case "e", "E": return 14
-    case "f", "F": return 15
-    default: return nil
-    }
+  switch c {
+  case "0": return 0
+  case "1": return 1
+  case "2": return 2
+  case "3": return 3
+  case "4": return 4
+  case "5": return 5
+  case "6": return 6
+  case "7": return 7
+  case "8": return 8
+  case "9": return 9
+  case "a", "A": return 10
+  case "b", "B": return 11
+  case "c", "C": return 12
+  case "d", "D": return 13
+  case "e", "E": return 14
+  case "f", "F": return 15
+  default: return nil
+  }
 }
 
 private func fromHexDigit(_ c: UInt8) -> UInt8? {
-    if c >= 48 && c <= 57 {
-        return c - 48
-    }
-    switch c {
-    case 65, 97: return 10
-    case 66, 98: return 11
-    case 67, 99: return 12
-    case 68, 100: return 13
-    case 69, 101: return 14
-    case 70, 102: return 15
-    default:
-        return nil
-    }
+  if c >= 48 && c <= 57 {
+    return c - 48
+  }
+  switch c {
+  case 65, 97: return 10
+  case 66, 98: return 11
+  case 67, 99: return 12
+  case 68, 100: return 13
+  case 69, 101: return 14
+  case 70, 102: return 15
+  default:
+    return nil
+  }
 }
 
 // Protobuf Text format uses C ASCII conventions for
 // encoding byte sequences, including the use of octal
 // and hexadecimal escapes.
 private func decodeBytes(_ s: String) -> Data? {
-    var out = [UInt8]()
-    var bytes = s.utf8.makeIterator()
-    while let byte = bytes.next() {
-        switch byte {
-        case 92: //  "\\"
-            if let escaped = bytes.next() {
-                switch escaped {
-                case 48, 49, 50, 51, 52, 53, 54, 55: // '0'...'9'
-                    // C standard allows 1, 2, or 3 octal digits.
-                    let savedPosition = bytes
-                    if let digit2 = bytes.next(), digit2 >= 48, digit2 <= 55 {
-                        let innerSavedPosition = bytes
-                        if let digit3 = bytes.next(), digit3 >= 48, digit3 <= 55 {
-                            let n = (escaped - 48) * 64 + (digit2 - 48) * 8 + (digit3 - 48)
-                            out.append(UInt8(n))
-                        } else {
-                            let n = (escaped - 48) * 8 + (digit2 - 48)
-                            out.append(UInt8(n))
-                            bytes = innerSavedPosition
-                        }
-                    } else {
-                        let n = (escaped - 48)
-                        out.append(UInt8(n))
-                        bytes = savedPosition
-                    }
-                case 120: // 'x' hexadecimal escape
-                    // C standard allows any number of digits after \x
-                    // We ignore all but the last two
-                    var n: UInt8 = 0
-                    var count = 0
-                    var savedPosition = bytes
-                    while let byte = bytes.next(), let digit = fromHexDigit(byte) {
-                        n &= 15
-                        n = n * 16
-                        n += digit
-                        count += 1
-                        savedPosition = bytes
-                    }
-                    bytes = savedPosition
-                    if count > 0 {
-                        out.append(n)
-                    } else {
-                        return nil // Hex escape must have at least 1 digit
-                    }
-                case 97: // \a
-                    out.append(UInt8(7))
-                case 98: // \b
-                    out.append(UInt8(8))
-                case 102: // \f
-                    out.append(UInt8(12))
-                case 110: // \n
-                    out.append(UInt8(10))
-                case 114: // \r
-                    out.append(UInt8(13))
-                case 116: // \t
-                    out.append(UInt8(9))
-                case 118: // \v
-                    out.append(UInt8(11))
-                case 39, 34, 63: // \'  \"  \?
-                    out.append(escaped)
-                default:
-                    return nil // Unrecognized escape
-                }
+  var out = [UInt8]()
+  var bytes = s.utf8.makeIterator()
+  while let byte = bytes.next() {
+    switch byte {
+    case 92: //  "\\"
+      if let escaped = bytes.next() {
+        switch escaped {
+        case 48, 49, 50, 51, 52, 53, 54, 55: // '0'...'9'
+          // C standard allows 1, 2, or 3 octal digits.
+          let savedPosition = bytes
+          if let digit2 = bytes.next(), digit2 >= 48, digit2 <= 55 {
+            let innerSavedPosition = bytes
+            if let digit3 = bytes.next(), digit3 >= 48, digit3 <= 55 {
+              let n = (escaped - 48) * 64 + (digit2 - 48) * 8 + (digit3 - 48)
+              out.append(UInt8(n))
             } else {
-                return nil // Input ends with backslash
+              let n = (escaped - 48) * 8 + (digit2 - 48)
+              out.append(UInt8(n))
+              bytes = innerSavedPosition
             }
+          } else {
+            let n = (escaped - 48)
+            out.append(UInt8(n))
+            bytes = savedPosition
+          }
+        case 120: // 'x' hexadecimal escape
+          // C standard allows any number of digits after \x
+          // We ignore all but the last two
+          var n: UInt8 = 0
+          var count = 0
+          var savedPosition = bytes
+          while let byte = bytes.next(), let digit = fromHexDigit(byte) {
+            n &= 15
+            n = n * 16
+            n += digit
+            count += 1
+            savedPosition = bytes
+          }
+          bytes = savedPosition
+          if count > 0 {
+            out.append(n)
+          } else {
+            return nil // Hex escape must have at least 1 digit
+          }
+        case 97: // \a
+          out.append(UInt8(7))
+        case 98: // \b
+          out.append(UInt8(8))
+        case 102: // \f
+          out.append(UInt8(12))
+        case 110: // \n
+          out.append(UInt8(10))
+        case 114: // \r
+          out.append(UInt8(13))
+        case 116: // \t
+          out.append(UInt8(9))
+        case 118: // \v
+          out.append(UInt8(11))
+        case 39, 34, 63: // \'  \"  \?
+          out.append(escaped)
         default:
-            out.append(byte)
+          return nil // Unrecognized escape
         }
+      } else {
+        return nil // Input ends with backslash
+      }
+    default:
+      out.append(byte)
     }
-    return Data(bytes: out)
+  }
+  return Data(bytes: out)
 }
 
 // Protobuf Text encoding assumes that you're working directly
@@ -152,299 +151,114 @@ private func decodeBytes(_ s: String) -> Data? {
 // then decodes it into a sequence of bytes, then converts
 // it back into a string.
 private func decodeString(_ s: String) -> String? {
-    var out = [UInt8]()
-    var bytes = s.utf8.makeIterator()
-    while let byte = bytes.next() {
-        switch byte {
-        case 92: // backslash
-            if let escaped = bytes.next() {
-                switch escaped {
-                case 48...55:
-                    // C standard allows 1, 2, or 3 octal digits.
-                    let savedPosition = bytes
-                    if let digit2 = bytes.next(),
-                       digit2 >= 48 && digit2 <= 55 {
-                        let digit2Value = digit2 - 48
-                        let innerSavedPosition = bytes
-                        if let digit3 = bytes.next(),
-                           digit3 >= 48 && digit3 <= 55 {
-                            let digit3Value = digit3 - 48
-                            let n = (escaped - 48) * 64 + digit2Value * 8 + digit3Value
-                            out.append(n)
-                        } else {
-                            let n = (escaped - 48) * 8 + digit2Value
-                            out.append(n)
-                            bytes = innerSavedPosition
-                        }
-                    } else {
-                        let n = escaped - 48
-                        out.append(n)
-                        bytes = savedPosition
-                    }
-                case 120: // "x"
-                    // C standard allows any number of digits after \x
-                    // We ignore all but the last two
-                    var n: UInt8 = 0
-                    var count = 0
-                    var savedPosition = bytes
-                    while let byte = bytes.next(), let digit = fromHexDigit(byte) {
-                        n &= 15
-                        n = n * 16
-                        n += digit
-                        count += 1
-                        savedPosition = bytes
-                    }
-                    bytes = savedPosition
-                    if count > 0 {
-                        out.append(n)
-                    } else {
-                        return nil // Hex escape must have at least 1 digit
-                    }
-                case 97: // \a
-                    out.append(7)
-                case 98: // \b
-                    out.append(8)
-                case 102: // \f
-                    out.append(12)
-                case 110: // \n
-                    out.append(10)
-                case 114: // \r
-                    out.append(13)
-                case 116: // \t
-                    out.append(9)
-                case 118: // \v
-                    out.append(11)
-                case 34, 39, 63, 92: // " ' ? \
-                    out.append(escaped)
-                default:
-                    return nil // Unrecognized escape
-                }
+  var out = [UInt8]()
+  var bytes = s.utf8.makeIterator()
+  while let byte = bytes.next() {
+    switch byte {
+    case 92: // backslash
+      if let escaped = bytes.next() {
+        switch escaped {
+        case 48...55:
+          // C standard allows 1, 2, or 3 octal digits.
+          let savedPosition = bytes
+          if let digit2 = bytes.next(),
+            digit2 >= 48 && digit2 <= 55 {
+            let digit2Value = digit2 - 48
+            let innerSavedPosition = bytes
+            if let digit3 = bytes.next(),
+              digit3 >= 48 && digit3 <= 55 {
+              let digit3Value = digit3 - 48
+              let n = (escaped - 48) * 64 + digit2Value * 8 + digit3Value
+              out.append(n)
             } else {
-                return nil // Input ends with backslash
+              let n = (escaped - 48) * 8 + digit2Value
+              out.append(n)
+              bytes = innerSavedPosition
             }
+          } else {
+            let n = escaped - 48
+            out.append(n)
+            bytes = savedPosition
+          }
+        case 120: // "x"
+          // C standard allows any number of digits after \x
+          // We ignore all but the last two
+          var n: UInt8 = 0
+          var count = 0
+          var savedPosition = bytes
+          while let byte = bytes.next(), let digit = fromHexDigit(byte) {
+            n &= 15
+            n = n * 16
+            n += digit
+            count += 1
+            savedPosition = bytes
+          }
+          bytes = savedPosition
+          if count > 0 {
+            out.append(n)
+          } else {
+            return nil // Hex escape must have at least 1 digit
+          }
+        case 97: // \a
+          out.append(7)
+        case 98: // \b
+          out.append(8)
+        case 102: // \f
+          out.append(12)
+        case 110: // \n
+          out.append(10)
+        case 114: // \r
+          out.append(13)
+        case 116: // \t
+          out.append(9)
+        case 118: // \v
+          out.append(11)
+        case 34, 39, 63, 92: // " ' ? \
+          out.append(escaped)
         default:
-            out.append(byte)
+          return nil // Unrecognized escape
         }
+      } else {
+        return nil // Input ends with backslash
+      }
+    default:
+      out.append(byte)
     }
-    // There has got to be an easier way to convert a [UInt8] into a String.
-    out.append(0)
-    return out.withUnsafeBufferPointer { ptr in
-        if let addr = ptr.baseAddress {
-            return addr.withMemoryRebound(to: CChar.self, capacity: ptr.count) { p in
-                let q = UnsafePointer<CChar>(p)
-                let s = String(validatingUTF8: q)
-                return s
-            }
-        } else {
-            return ""
-        }
+  }
+  // There has got to be an easier way to convert a [UInt8] into a String.
+  out.append(0)
+  return out.withUnsafeBufferPointer { ptr in
+    if let addr = ptr.baseAddress {
+      return addr.withMemoryRebound(to: CChar.self, capacity: ptr.count) { p in
+        let q = UnsafePointer<CChar>(p)
+        let s = String(validatingUTF8: q)
+        return s
+      }
+    } else {
+      return ""
     }
+  }
 }
 
 
 public enum TextToken: Equatable, FieldDecoder {
-    case colon
-    case semicolon
-    case comma
-    case beginObject
-    case endObject
-    case altBeginObject
-    case altEndObject
-    case beginArray
-    case endArray
-    case string(String)
-    case identifier(String)
-    case octalInteger(String)
-    case hexadecimalInteger(String)
-    case decimalInteger(String)
-    case floatingPointLiteral(String)
+  case colon
+  case semicolon
+  case comma
+  case beginObject
+  case endObject
+  case altBeginObject
+  case altEndObject
+  case beginArray
+  case endArray
+  case string(String)
+  case identifier(String)
+  case octalInteger(String)
+  case hexadecimalInteger(String)
+  case decimalInteger(String)
+  case floatingPointLiteral(String)
 
-    public var asBoolean: Bool? {
-        switch self {
-        case .identifier("true"): return true
-        case .identifier("True"): return true
-        case .identifier("t"): return true
-        case .decimalInteger("1"): return true
-        case .identifier("false"): return false
-        case .identifier("False"): return false
-        case .identifier("f"): return false
-        case .decimalInteger("0"): return false
-        default: return nil
-        }
-    }
-
-    var isNumber: Bool {
-        switch self {
-        case .octalInteger(_), .hexadecimalInteger(_),
-             .decimalInteger(_), .floatingPointLiteral(_):
-            return true
-        default:
-            return false
-        }
-    }
-
-    // The scanner only identifies tokens, it does not do detailed
-    // validation.  Normally, such validation requires schema information
-    // so gets handled when we process the tokens to set an actual
-    // field.  When skipping tokens, we need a way to verify that the
-    // token was actually valid, hence this hook:
-    //
-    // Hmmmm.... Actually, Text decoder does not skip and ignore
-    // unknown fields, so maybe we never need this?
-    var isValid: Bool {
-        // TODO: Implement this
-        return true
-    }
-
-    var asInt64: Int64? {
-        switch self {
-        case .decimalInteger(let n):
-            return Int64(n)
-        case .octalInteger(let n):
-            return Int64(n, radix: 8)
-        case .hexadecimalInteger(let n):
-            var s = n
-            if s.hasPrefix("0x") {
-                s.remove(at: s.startIndex)
-                s.remove(at: s.startIndex)
-                return Int64(s, radix: 16)
-            } else if s.hasPrefix("-0x") {
-                s.remove(at: s.startIndex)
-                s.remove(at: s.startIndex)
-                s.remove(at: s.startIndex)
-                return Int64("-" + s, radix: 16)
-            }
-        default: return nil
-        }
-        return nil
-    }
-
-    var asInt32: Int32? {
-        switch self {
-        case .decimalInteger(let n):
-            return Int32(n)
-        case .octalInteger(let n):
-            return Int32(n, radix: 8)
-        case .hexadecimalInteger(let n):
-            var s = n
-            if s.hasPrefix("0x") {
-                s.remove(at: s.startIndex)
-                s.remove(at: s.startIndex)
-                return Int32(s, radix: 16)
-            } else if s.hasPrefix("-0x") {
-                s.remove(at: s.startIndex)
-                s.remove(at: s.startIndex)
-                s.remove(at: s.startIndex)
-                return Int32("-" + s, radix: 16)
-            }
-        default:
-            return nil
-        }
-        return nil
-    }
-
-    var asUInt64: UInt64? {
-        switch self {
-        case .decimalInteger(let n):
-            return UInt64(n)
-        case .octalInteger(let n):
-            return UInt64(n, radix: 8)
-        case .hexadecimalInteger(let n):
-            var s = n
-            if s.hasPrefix("0x") {
-                s.remove(at: s.startIndex)
-                s.remove(at: s.startIndex)
-                return UInt64(s, radix: 16)
-            }
-        default: return nil
-        }
-        return nil
-    }
-
-    var asUInt32: UInt32? {
-        switch self {
-        case .decimalInteger(let n):
-            return UInt32(n)
-        case .octalInteger(let n):
-            return UInt32(n, radix: 8)
-        case .hexadecimalInteger(let n):
-            var s = n
-            if s.hasPrefix("0x") {
-                s.remove(at: s.startIndex)
-                s.remove(at: s.startIndex)
-                return UInt32(s, radix: 16)
-            }
-        default: return nil
-        }
-        return nil
-    }
-
-    var asFloat: Float? {
-        switch self {
-        case .identifier(let s):
-            let l = s.lowercased()
-            switch l {
-            case "inf": return Float.infinity
-            case "infinity": return Float.infinity
-            case "nan": return Float.nan
-            default: return nil
-            }
-        case .decimalInteger(let n):
-            return Float(n)
-        case .floatingPointLiteral(let n):
-            // There is special logic in the scanner to parse
-            // "-" followed by identifier as a single floatingPointLiteral
-            let l = n.lowercased()
-            switch l {
-            case "-inf": return -Float.infinity
-            case "-infinity": return -Float.infinity
-            default: return Float(n)
-            }
-        default: return nil
-        }
-    }
-
-    var asDouble: Double? {
-        switch self {
-        case .identifier(let s):
-            let l = s.lowercased()
-            switch l {
-            case "inf": return Double.infinity
-            case "infinity": return Double.infinity
-            case "nan": return Double.nan
-            default: return nil
-            }
-        case .decimalInteger(let n):
-            return Double(n)
-        case .floatingPointLiteral(let n):
-            // There is special logic in the scanner to parse
-            // "-" followed by identifier as a single floatingPointLiteral
-            let l = n.lowercased()
-            switch l {
-            case "-inf": return -Double.infinity
-            case "-infinity": return -Double.infinity
-            default: return Double(n)
-            }
-        default: return nil
-        }
-    }
-
-    var asString: String? {
-        switch self {
-        case .string(let s): return decodeString(s)
-        default: return nil
-        }
-    }
-
-    var asBytes: Data? {
-        switch self {
-        case .string(let s): return decodeBytes(s)
-        default: return nil
-        }
-    }
-}
-
-public func ==(lhs: TextToken, rhs: TextToken) -> Bool {
+  public static func ==(lhs: TextToken, rhs: TextToken) -> Bool {
     switch (lhs, rhs) {
     case (.colon, .colon),
          (.semicolon, .semicolon),
@@ -455,20 +269,205 @@ public func ==(lhs: TextToken, rhs: TextToken) -> Bool {
          (.altEndObject, .altEndObject),
          (.beginArray, .beginArray),
          (.endArray, .endArray):
-        return true
+      return true
     case (.string(let a), .string(let b)):
-        return a == b
+      return a == b
     case (.identifier(let a), .identifier(let b)):
-        return a == b
+      return a == b
     case (.octalInteger(let a), .octalInteger(let b)):
-        return a == b
+      return a == b
     case (.decimalInteger(let a), .decimalInteger(let b)):
-        return a == b
+      return a == b
     case (.hexadecimalInteger(let a), .hexadecimalInteger(let b)):
-        return a == b
+      return a == b
     case (.floatingPointLiteral(let a), .floatingPointLiteral(let b)):
-        return a == b
+      return a == b
     default:
-        return false
+      return false
     }
+  }
+
+  public var asBoolean: Bool? {
+    switch self {
+    case .identifier("true"): return true
+    case .identifier("True"): return true
+    case .identifier("t"): return true
+    case .decimalInteger("1"): return true
+    case .identifier("false"): return false
+    case .identifier("False"): return false
+    case .identifier("f"): return false
+    case .decimalInteger("0"): return false
+    default: return nil
+    }
+  }
+
+  var isNumber: Bool {
+    switch self {
+    case .octalInteger(_), .hexadecimalInteger(_),
+         .decimalInteger(_), .floatingPointLiteral(_):
+      return true
+    default:
+      return false
+    }
+  }
+
+  // The scanner only identifies tokens, it does not do detailed
+  // validation.  Normally, such validation requires schema information
+  // so gets handled when we process the tokens to set an actual
+  // field.  When skipping tokens, we need a way to verify that the
+  // token was actually valid, hence this hook:
+  //
+  // Hmmmm.... Actually, Text decoder does not skip and ignore
+  // unknown fields, so maybe we never need this?
+  var isValid: Bool {
+    // TODO: Implement this
+    return true
+  }
+
+  var asInt64: Int64? {
+    switch self {
+    case .decimalInteger(let n):
+      return Int64(n)
+    case .octalInteger(let n):
+      return Int64(n, radix: 8)
+    case .hexadecimalInteger(let n):
+      var s = n
+      if s.hasPrefix("0x") {
+        s.remove(at: s.startIndex)
+        s.remove(at: s.startIndex)
+        return Int64(s, radix: 16)
+      } else if s.hasPrefix("-0x") {
+        s.remove(at: s.startIndex)
+        s.remove(at: s.startIndex)
+        s.remove(at: s.startIndex)
+        return Int64("-" + s, radix: 16)
+      }
+    default: return nil
+    }
+    return nil
+  }
+
+  var asInt32: Int32? {
+    switch self {
+    case .decimalInteger(let n):
+      return Int32(n)
+    case .octalInteger(let n):
+      return Int32(n, radix: 8)
+    case .hexadecimalInteger(let n):
+      var s = n
+      if s.hasPrefix("0x") {
+        s.remove(at: s.startIndex)
+        s.remove(at: s.startIndex)
+        return Int32(s, radix: 16)
+      } else if s.hasPrefix("-0x") {
+        s.remove(at: s.startIndex)
+        s.remove(at: s.startIndex)
+        s.remove(at: s.startIndex)
+        return Int32("-" + s, radix: 16)
+      }
+    default:
+      return nil
+    }
+    return nil
+  }
+
+  var asUInt64: UInt64? {
+    switch self {
+    case .decimalInteger(let n):
+      return UInt64(n)
+    case .octalInteger(let n):
+      return UInt64(n, radix: 8)
+    case .hexadecimalInteger(let n):
+      var s = n
+      if s.hasPrefix("0x") {
+        s.remove(at: s.startIndex)
+        s.remove(at: s.startIndex)
+        return UInt64(s, radix: 16)
+      }
+    default: return nil
+    }
+    return nil
+  }
+
+  var asUInt32: UInt32? {
+    switch self {
+    case .decimalInteger(let n):
+      return UInt32(n)
+    case .octalInteger(let n):
+      return UInt32(n, radix: 8)
+    case .hexadecimalInteger(let n):
+      var s = n
+      if s.hasPrefix("0x") {
+        s.remove(at: s.startIndex)
+        s.remove(at: s.startIndex)
+        return UInt32(s, radix: 16)
+      }
+    default: return nil
+    }
+    return nil
+  }
+
+  var asFloat: Float? {
+    switch self {
+    case .identifier(let s):
+      let l = s.lowercased()
+      switch l {
+      case "inf": return Float.infinity
+      case "infinity": return Float.infinity
+      case "nan": return Float.nan
+      default: return nil
+      }
+    case .decimalInteger(let n):
+      return Float(n)
+    case .floatingPointLiteral(let n):
+      // There is special logic in the scanner to parse
+      // "-" followed by identifier as a single floatingPointLiteral
+      let l = n.lowercased()
+      switch l {
+      case "-inf": return -Float.infinity
+      case "-infinity": return -Float.infinity
+      default: return Float(n)
+      }
+    default: return nil
+    }
+  }
+
+  var asDouble: Double? {
+    switch self {
+    case .identifier(let s):
+      let l = s.lowercased()
+      switch l {
+      case "inf": return Double.infinity
+      case "infinity": return Double.infinity
+      case "nan": return Double.nan
+      default: return nil
+      }
+    case .decimalInteger(let n):
+      return Double(n)
+    case .floatingPointLiteral(let n):
+      // There is special logic in the scanner to parse
+      // "-" followed by identifier as a single floatingPointLiteral
+      let l = n.lowercased()
+      switch l {
+      case "-inf": return -Double.infinity
+      case "-infinity": return -Double.infinity
+      default: return Double(n)
+      }
+    default: return nil
+    }
+  }
+
+  var asString: String? {
+    switch self {
+    case .string(let s): return decodeString(s)
+    default: return nil
+    }
+  }
+
+  var asBytes: Data? {
+    switch self {
+    case .string(let s): return decodeBytes(s)
+    default: return nil
+    }
+  }
 }

--- a/Sources/SwiftProtobuf/UnknownStorage.swift
+++ b/Sources/SwiftProtobuf/UnknownStorage.swift
@@ -16,22 +16,22 @@
 ///
 // -----------------------------------------------------------------------------
 
-import Swift
 import Foundation
 
 public struct UnknownStorage: Equatable {
-    internal var data = Data()
-    public init() {}
+  internal var data = Data()
 
-    public mutating func append(protobufData: Data) {
-        data.append(protobufData)
-    }
-
-    public func traverse(visitor: inout Visitor) {
-        visitor.visitUnknown(bytes: data)
-    }
-}
-
-public func ==(lhs: UnknownStorage, rhs: UnknownStorage) -> Bool {
+  public static func ==(lhs: UnknownStorage, rhs: UnknownStorage) -> Bool {
     return lhs.data == rhs.data
+  }
+
+  public init() {}
+
+  public mutating func append(protobufData: Data) {
+    data.append(protobufData)
+  }
+
+  public func traverse(visitor: inout Visitor) {
+    visitor.visitUnknown(bytes: data)
+  }
 }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -722,11 +722,6 @@ class MessageGenerator {
     }
 
     func generateTopLevel(printer p: inout CodePrinter) {
-        // nested oneofs
-        for o in oneofs {
-            o.generateTopLevel(printer: &p)
-        }
-
         // nested messages
         for m in messages {
             m.generateTopLevel(printer: &p)

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -58,6 +58,20 @@ class OneofGenerator {
         }
         p.print("case None\n")
 
+        // Equatable conformance
+        p.print("\n")
+        p.print("\(generatorOptions.visibilitySourceSnippet)static func ==(lhs: \(swiftFullName), rhs: \(swiftFullName)) -> Bool {\n")
+        p.indent()
+        p.print("switch (lhs, rhs) {\n")
+        for f in fields {
+            p.print("case (.\(f.swiftName)(let l), .\(f.swiftName)(let r)): return l == r\n")
+        }
+        p.print("case (.None, .None): return true\n")
+        p.print("default: return false\n")
+        p.print("}\n")
+        p.outdent()
+        p.print("}\n")
+
         // ExpressibleByNilLiteral conformance
         p.print("\n")
         p.print("public init(nilLiteral: ()) {\n")
@@ -151,20 +165,5 @@ class OneofGenerator {
     func generateTopIvar(printer p: inout CodePrinter) {
         p.print("\n")
         p.print("public var \(descriptor.swiftFieldName): \(swiftFullName) = .None\n")
-    }
-
-    func generateTopLevel(printer p: inout CodePrinter) {
-        p.print("\n")
-        p.print("\(generatorOptions.visibilitySourceSnippet)func ==(lhs: \(swiftFullName), rhs: \(swiftFullName)) -> Bool {\n")
-        p.indent()
-        p.print("switch (lhs, rhs) {\n")
-        for f in fields {
-            p.print("case (.\(f.swiftName)(let l), .\(f.swiftName)(let r)): return l == r\n")
-        }
-        p.print("case (.None, .None): return true\n")
-        p.print("default: return false\n")
-        p.print("}\n")
-        p.outdent()
-        p.print("}\n")
     }
 }

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -248,6 +248,15 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
     case jsonPayload(String)
     case None
 
+    static func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
+      switch (lhs, rhs) {
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -366,6 +375,19 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
     case jsonPayload(String)
     case skipped(String)
     case None
+
+    static func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
+      switch (lhs, rhs) {
+      case (.parseError(let l), .parseError(let r)): return l == r
+      case (.serializeError(let l), .serializeError(let r)): return l == r
+      case (.runtimeError(let l), .runtimeError(let r)): return l == r
+      case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
+      case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
+      case (.skipped(let l), .skipped(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
 
     public init(nilLiteral: ()) {
       self = .None
@@ -1493,6 +1515,22 @@ struct Conformance_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
     case oneofEnum(Conformance_TestAllTypes.NestedEnum)
     case None
 
+    static func ==(lhs: Conformance_TestAllTypes.OneOf_OneofField, rhs: Conformance_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -2605,43 +2643,5 @@ struct Conformance_ForeignMessage: SwiftProtobuf.Message, SwiftProtobuf.Proto3Me
   public func _protoc_generated_isEqualTo(other: Conformance_ForeignMessage) -> Bool {
     if c != other.c {return false}
     return true
-  }
-}
-
-func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
-  switch (lhs, rhs) {
-  case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
-  case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
-  switch (lhs, rhs) {
-  case (.parseError(let l), .parseError(let r)): return l == r
-  case (.serializeError(let l), .serializeError(let r)): return l == r
-  case (.runtimeError(let l), .runtimeError(let r)): return l == r
-  case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
-  case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
-  case (.skipped(let l), .skipped(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: Conformance_TestAllTypes.OneOf_OneofField, rhs: Conformance_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.oneofBool(let l), .oneofBool(let r)): return l == r
-  case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
-  case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
-  case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
-  case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -962,6 +962,17 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -5859,6 +5870,17 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
     case fooGroup(ProtobufUnittest_TestOneof.FooGroup)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.fooGroup(let l), .fooGroup(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -6363,6 +6385,22 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     case fooLazyMessage(ProtobufUnittest_TestOneof2.NestedMessage)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooCord(let l), .fooCord(let r)): return l == r
+      case (.fooStringPiece(let l), .fooStringPiece(let r)): return l == r
+      case (.fooBytes(let l), .fooBytes(let r)): return l == r
+      case (.fooEnum(let l), .fooEnum(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.fooGroup(let l), .fooGroup(let r)): return l == r
+      case (.fooLazyMessage(let l), .fooLazyMessage(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -6487,6 +6525,19 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     case barBytes(Data)
     case barEnum(ProtobufUnittest_TestOneof2.NestedEnum)
     case None
+
+    static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
+      switch (lhs, rhs) {
+      case (.barInt(let l), .barInt(let r)): return l == r
+      case (.barString(let l), .barString(let r)): return l == r
+      case (.barCord(let l), .barCord(let r)): return l == r
+      case (.barStringPiece(let l), .barStringPiece(let r)): return l == r
+      case (.barBytes(let l), .barBytes(let r)): return l == r
+      case (.barEnum(let l), .barEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
 
     public init(nilLiteral: ()) {
       self = .None
@@ -7063,6 +7114,16 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestRequiredOneof.NestedMessage)
     case None
+
+    static func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
 
     public init(nilLiteral: ()) {
       self = .None
@@ -9073,6 +9134,17 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -9588,17 +9660,6 @@ let ProtobufUnittest_Extensions_unpackedEnumExtension = SwiftProtobuf.MessageExt
 
 let ProtobufUnittest_Extensions_testAllTypes = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestHugeFieldNumbers>(protoFieldNumber: 536860000, fieldNames: .same(proto: "[protobuf_unittest.test_all_types]", swift: "ProtobufUnittest_testAllTypes"), defaultValue: ProtobufUnittest_TestAllTypes())
 
-func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
 extension ProtobufUnittest_TestAllExtensions {
   ///   Check for bug where string extensions declared in tested scope did not
   ///   compile.
@@ -9655,56 +9716,6 @@ extension ProtobufUnittest_TestAllExtensions {
   }
 }
 
-func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
-  switch (lhs, rhs) {
-  case (.fooInt(let l), .fooInt(let r)): return l == r
-  case (.fooString(let l), .fooString(let r)): return l == r
-  case (.fooMessage(let l), .fooMessage(let r)): return l == r
-  case (.fooGroup(let l), .fooGroup(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
-  switch (lhs, rhs) {
-  case (.fooInt(let l), .fooInt(let r)): return l == r
-  case (.fooString(let l), .fooString(let r)): return l == r
-  case (.fooCord(let l), .fooCord(let r)): return l == r
-  case (.fooStringPiece(let l), .fooStringPiece(let r)): return l == r
-  case (.fooBytes(let l), .fooBytes(let r)): return l == r
-  case (.fooEnum(let l), .fooEnum(let r)): return l == r
-  case (.fooMessage(let l), .fooMessage(let r)): return l == r
-  case (.fooGroup(let l), .fooGroup(let r)): return l == r
-  case (.fooLazyMessage(let l), .fooLazyMessage(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
-  switch (lhs, rhs) {
-  case (.barInt(let l), .barInt(let r)): return l == r
-  case (.barString(let l), .barString(let r)): return l == r
-  case (.barCord(let l), .barCord(let r)): return l == r
-  case (.barStringPiece(let l), .barStringPiece(let r)): return l == r
-  case (.barBytes(let l), .barBytes(let r)): return l == r
-  case (.barEnum(let l), .barEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
-  switch (lhs, rhs) {
-  case (.fooInt(let l), .fooInt(let r)): return l == r
-  case (.fooString(let l), .fooString(let r)): return l == r
-  case (.fooMessage(let l), .fooMessage(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
 extension ProtobufUnittest_TestParsingMerge {
   var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optionalExt) ?? ProtobufUnittest_TestAllTypes()}
@@ -9728,17 +9739,6 @@ extension ProtobufUnittest_TestParsingMerge {
   }
   mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt)
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -199,6 +199,14 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message, Swi
     case oneofField(Int32)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof, rhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofField(let l), .oneofField(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -2024,14 +2032,6 @@ let ProtobufUnittest_Extensions_serviceopt = SwiftProtobuf.MessageExtension<Opti
 let ProtobufUnittest_Extensions_methodopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_MethodOptions>(protoFieldNumber: 15512713, fieldNames: .same(proto: "[protobuf_unittest.methodopt]", swift: "ProtobufUnittest_methodopt"), defaultValue: ProtobufUnittest_Aggregate())
 
 let ProtobufUnittest_Extensions_requiredEnumOpt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(protoFieldNumber: 106161807, fieldNames: .same(proto: "[protobuf_unittest.required_enum_opt]", swift: "ProtobufUnittest_requiredEnumOpt"), defaultValue: ProtobufUnittest_OldOptionType())
-
-func ==(lhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof, rhs: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofField(let l), .oneofField(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -897,6 +897,18 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
     case oneofLazyNestedMessage(ProtobufUnittest_TestAllTypesLite.NestedMessage)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofLazyNestedMessage(let l), .oneofLazyNestedMessage(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -3334,6 +3346,17 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -3817,18 +3840,6 @@ let ProtobufUnittest_Extensions_packedEnumExtensionLite = SwiftProtobuf.MessageE
 
 let ProtobufUnittest_Extensions_testAllTypesLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestHugeFieldNumbersLite>(protoFieldNumber: 536860000, fieldNames: .same(proto: "[protobuf_unittest.test_all_types_lite]", swift: "ProtobufUnittest_testAllTypesLite"), defaultValue: ProtobufUnittest_TestAllTypesLite())
 
-func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.oneofLazyNestedMessage(let l), .oneofLazyNestedMessage(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension) ?? 0}
@@ -3865,17 +3876,6 @@ extension ProtobufUnittest_TestParsingMergeLite {
   }
   mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt)
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -758,6 +758,18 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     case lazyOneofNestedMessage(ProtobufUnittestNoArena_TestAllTypes.NestedMessage)
     case None
 
+    static func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.lazyOneofNestedMessage(let l), .lazyOneofNestedMessage(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1913,17 +1925,5 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage: SwiftProtobuf.Message, SwiftP
       _storage = _storage.copy()
     }
     return _storage
-  }
-}
-
-func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.lazyOneofNestedMessage(let l), .lazyOneofNestedMessage(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -546,6 +546,17 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
     case oneofEnum(Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum)
     case None
 
+    static func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1166,16 +1177,5 @@ struct Proto2NofieldpresenceUnittest_ForeignMessage: SwiftProtobuf.Message, Swif
   public func _protoc_generated_isEqualTo(other: Proto2NofieldpresenceUnittest_ForeignMessage) -> Bool {
     if c != other.c {return false}
     return true
-  }
-}
-
-func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -122,6 +122,15 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     case stringField(String)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.integerField(let l), .integerField(let r)): return l == r
+      case (.stringField(let l), .stringField(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -392,15 +401,6 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message, Swi
       _storage = _storage.copy()
     }
     return _storage
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
-  switch (lhs, rhs) {
-  case (.integerField(let l), .integerField(let r)): return l == r
-  case (.stringField(let l), .stringField(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -235,6 +235,15 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnum)
     case None
 
+    static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -370,6 +379,15 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
     case None
 
+    static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -482,23 +500,5 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     if repeatedPackedUnexpectedE != other.repeatedPackedUnexpectedE {return false}
     if o != other.o {return false}
     return true
-  }
-}
-
-func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofE1(let l), .oneofE1(let r)): return l == r
-  case (.oneofE2(let l), .oneofE2(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofE1(let l), .oneofE1(let r)): return l == r
-  case (.oneofE2(let l), .oneofE2(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -140,6 +140,15 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     case oneofE2(Proto2PreserveUnknownEnumUnittest_MyEnum)
     case None
 
+    static func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofE1(let l), .oneofE1(let r)): return l == r
+      case (.oneofE2(let l), .oneofE2(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -269,14 +278,5 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     if o != other.o {return false}
     if unknown != other.unknown {return false}
     return true
-  }
-}
-
-func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofE1(let l), .oneofE1(let r)): return l == r
-  case (.oneofE2(let l), .oneofE2(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -769,6 +769,17 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, S
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: Proto3TestAllTypes.OneOf_OneofField, rhs: Proto3TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -2554,6 +2565,16 @@ struct Proto3TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, Swif
     case fooMessage(Proto3TestAllTypes)
     case None
 
+    static func ==(lhs: Proto3TestOneof.OneOf_Foo, rhs: Proto3TestOneof.OneOf_Foo) -> Bool {
+      switch (lhs, rhs) {
+      case (.fooInt(let l), .fooInt(let r)): return l == r
+      case (.fooString(let l), .fooString(let r)): return l == r
+      case (.fooMessage(let l), .fooMessage(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -3176,26 +3197,5 @@ struct Proto3BarResponse: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, Sw
 
   public func _protoc_generated_isEqualTo(other: Proto3BarResponse) -> Bool {
     return true
-  }
-}
-
-func ==(lhs: Proto3TestAllTypes.OneOf_OneofField, rhs: Proto3TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
-
-func ==(lhs: Proto3TestOneof.OneOf_Foo, rhs: Proto3TestOneof.OneOf_Foo) -> Bool {
-  switch (lhs, rhs) {
-  case (.fooInt(let l), .fooInt(let r)): return l == r
-  case (.fooString(let l), .fooString(let r)): return l == r
-  case (.fooMessage(let l), .fooMessage(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -560,6 +560,17 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1544,16 +1555,5 @@ struct Proto3ArenaUnittest_TestEmptyMessage: SwiftProtobuf.Message, SwiftProtobu
 
   public func _protoc_generated_isEqualTo(other: Proto3ArenaUnittest_TestEmptyMessage) -> Bool {
     return true
-  }
-}
-
-func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -388,6 +388,17 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
     case oneofBytes(Data)
     case None
 
+    static func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1404,16 +1415,5 @@ struct ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf.Message, SwiftProto
     if _requiredNestedEnum != other._requiredNestedEnum {return false}
     if unknown != other.unknown {return false}
     return true
-  }
-}
-
-func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -125,6 +125,17 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
     case oneofInt32(Int32)
     case None
 
+    static func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -397,17 +408,6 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
 let Swift_Protobuf_Extensions_myExtensionString = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(protoFieldNumber: 50, fieldNames: .same(proto: "[swift.protobuf.my_extension_string]", swift: "Swift_Protobuf_myExtensionString"), defaultValue: "")
 
 let Swift_Protobuf_Extensions_myExtensionInt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(protoFieldNumber: 5, fieldNames: .same(proto: "[swift.protobuf.my_extension_int]", swift: "Swift_Protobuf_myExtensionInt"), defaultValue: 0)
-
-func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
-  case (.oneofBool(let l), .oneofBool(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
-  }
-}
 
 extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionString: String {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -565,6 +565,31 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
     case oneofEnum(ProtobufUnittest_Message2.Enum)
     case None
 
+    static func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
+      case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
+      case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
+      case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
+      case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
+      case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofGroup(let l), .oneofGroup(let r)): return l == r
+      case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1638,30 +1663,5 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
       _storage = _storage.copy()
     }
     return _storage
-  }
-}
-
-func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
-  case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
-  case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
-  case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
-  case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
-  case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
-  case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
-  case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
-  case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
-  case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
-  case (.oneofBool(let l), .oneofBool(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.oneofGroup(let l), .oneofGroup(let r)): return l == r
-  case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
-  case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -539,6 +539,30 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
     case oneofEnum(ProtobufUnittest_Message3.Enum)
     case None
 
+    static func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
+      switch (lhs, rhs) {
+      case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
+      case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
+      case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
+      case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
+      case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
+      case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
+      case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
+      case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
+      case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
+      case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
+      case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
+      case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
+      case (.oneofBool(let l), .oneofBool(let r)): return l == r
+      case (.oneofString(let l), .oneofString(let r)): return l == r
+      case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
+      case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
+      case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1300,29 +1324,5 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
       _storage = _storage.copy()
     }
     return _storage
-  }
-}
-
-func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
-  switch (lhs, rhs) {
-  case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
-  case (.oneofInt64(let l), .oneofInt64(let r)): return l == r
-  case (.oneofUint32(let l), .oneofUint32(let r)): return l == r
-  case (.oneofUint64(let l), .oneofUint64(let r)): return l == r
-  case (.oneofSint32(let l), .oneofSint32(let r)): return l == r
-  case (.oneofSint64(let l), .oneofSint64(let r)): return l == r
-  case (.oneofFixed32(let l), .oneofFixed32(let r)): return l == r
-  case (.oneofFixed64(let l), .oneofFixed64(let r)): return l == r
-  case (.oneofSfixed32(let l), .oneofSfixed32(let r)): return l == r
-  case (.oneofSfixed64(let l), .oneofSfixed64(let r)): return l == r
-  case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
-  case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
-  case (.oneofBool(let l), .oneofBool(let r)): return l == r
-  case (.oneofString(let l), .oneofString(let r)): return l == r
-  case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-  case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
-  case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -801,6 +801,31 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
     case bytesField(Google_Protobuf_BytesValue)
     case None
 
+    static func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
+      switch (lhs, rhs) {
+      case (.anyField(let l), .anyField(let r)): return l == r
+      case (.apiField(let l), .apiField(let r)): return l == r
+      case (.durationField(let l), .durationField(let r)): return l == r
+      case (.emptyField(let l), .emptyField(let r)): return l == r
+      case (.fieldMaskField(let l), .fieldMaskField(let r)): return l == r
+      case (.sourceContextField(let l), .sourceContextField(let r)): return l == r
+      case (.structField(let l), .structField(let r)): return l == r
+      case (.timestampField(let l), .timestampField(let r)): return l == r
+      case (.typeField(let l), .typeField(let r)): return l == r
+      case (.doubleField(let l), .doubleField(let r)): return l == r
+      case (.floatField(let l), .floatField(let r)): return l == r
+      case (.int64Field(let l), .int64Field(let r)): return l == r
+      case (.uint64Field(let l), .uint64Field(let r)): return l == r
+      case (.int32Field(let l), .int32Field(let r)): return l == r
+      case (.uint32Field(let l), .uint32Field(let r)): return l == r
+      case (.boolField(let l), .boolField(let r)): return l == r
+      case (.stringField(let l), .stringField(let r)): return l == r
+      case (.bytesField(let l), .bytesField(let r)): return l == r
+      case (.None, .None): return true
+      default: return false
+      }
+    }
+
     public init(nilLiteral: ()) {
       self = .None
     }
@@ -1542,30 +1567,5 @@ struct ProtobufUnittest_MapWellKnownTypes: SwiftProtobuf.Message, SwiftProtobuf.
       _storage = _storage.copy()
     }
     return _storage
-  }
-}
-
-func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
-  switch (lhs, rhs) {
-  case (.anyField(let l), .anyField(let r)): return l == r
-  case (.apiField(let l), .apiField(let r)): return l == r
-  case (.durationField(let l), .durationField(let r)): return l == r
-  case (.emptyField(let l), .emptyField(let r)): return l == r
-  case (.fieldMaskField(let l), .fieldMaskField(let r)): return l == r
-  case (.sourceContextField(let l), .sourceContextField(let r)): return l == r
-  case (.structField(let l), .structField(let r)): return l == r
-  case (.timestampField(let l), .timestampField(let r)): return l == r
-  case (.typeField(let l), .typeField(let r)): return l == r
-  case (.doubleField(let l), .doubleField(let r)): return l == r
-  case (.floatField(let l), .floatField(let r)): return l == r
-  case (.int64Field(let l), .int64Field(let r)): return l == r
-  case (.uint64Field(let l), .uint64Field(let r)): return l == r
-  case (.int32Field(let l), .int32Field(let r)): return l == r
-  case (.uint32Field(let l), .uint32Field(let r)): return l == r
-  case (.boolField(let l), .boolField(let r)): return l == r
-  case (.stringField(let l), .stringField(let r)): return l == r
-  case (.bytesField(let l), .bytesField(let r)): return l == r
-  case (.None, .None): return true
-  default: return false
   }
 }


### PR DESCRIPTION
Per [SE-0091](https://github.com/apple/swift-evolution/blob/master/proposals/0091-improving-operators-in-protocols.md).

This also removes the redundant `isEqualTo` method from `_MessageImplementationBase`, since users can implement `static func ==` in a concrete message extension to replace the protocol default that calls the generated equality function.

Also reformatted the files that I touched, and removed some unnecessary `import Swift` lines.