### PR TITLE
Fix Carthage installation snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ And run `pod install`.
 If you're using Carthage, add this to your `Cartfile` but adjust the tag to match the `[tag_name]` you used to build the plugin above:
 
 ```ruby
-github 'apple/swift-protobuf' '0.9.24'
+github "apple/swift-protobuf" "0.9.24"
 ```
 
 Run `carthage update` and drag `SwiftProtobuf.framework` into your Xcode.project.


### PR DESCRIPTION
This fixes an issue related to the installation via [Carthage](https://github.com/carthage/carthage). If someone copied the installation snippet directly into his `Cartfile` Carthage would have thrown the following error:
``` text
Parse error: unexpected trailing characters in line: github 'apple/swift-protobuf' '0.9.24'
```
I just updated the quotation marks to double quotation marks and it works fine.