### PR TITLE
Properly serialize zero-valued wrappers.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Wrappers+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Wrappers+Extensions.swift
@@ -26,14 +26,6 @@ protocol ProtobufWrapper {
   /// Exposes the generated property to the extensions here.
   var value: WrappedType.BaseType { get set }
 
-  /// Returns true if the given value is the zero or empty value for the wrapped
-  /// type.
-  ///
-  /// TODO(#64): This currently exists to duplicate the current behavior of the
-  /// old hand-generated types. If these should be serialized as zero/empty
-  /// instead of null, remove this.
-  var isZeroOrEmpty: Bool { get }
-
   /// Exposes the parameterless initializer to the extensions here.
   init()
 
@@ -42,13 +34,14 @@ protocol ProtobufWrapper {
 
   /// Implements the JSON serialization logic for the wrapper types.
   ///
-  /// We cannot have the `ProtobufWrapper` extension below implement this method
-  /// because it is also implemented in extensions to other protocols. In other
-  /// words, the compiler cannot disambiguate between them because both are
-  /// equally valid. Instead, we have to override `serializeJSON` in the
-  /// extensions to the generated concrete structs -- since the struct extension
-  /// is more specific than the protocol extensions, it takes priority. In order
-  /// to share the implementation, we have those extensions "hop" to this one.
+  /// We cannot have the `ProtobufWrapper` extension below implement
+  /// `serializeJSON` because it is also implemented in extensions to other
+  /// protocols. In other words, the compiler cannot disambiguate between them
+  /// because both extension implementations have equal "weight". Instead, we
+  /// have to override `serializeJSON` in the extensions to the generated
+  /// concrete structs -- since the struct extension is more specific than the
+  /// protocol extensions, it takes priority. In order to share the
+  /// implementation, we have those extensions "hop" to this one.
   func serializeWrapperJSON() throws -> String
 }
 
@@ -61,13 +54,9 @@ extension ProtobufWrapper {
   // bloat.
 
   func serializeWrapperJSON() throws -> String {
-    if !isZeroOrEmpty {
-      var encoder = JSONEncoder()
-      try WrappedType.serializeJSONValue(encoder: &encoder, value: value)
-      return encoder.result
-    } else {
-      return "null"
-    }
+    var encoder = JSONEncoder()
+    try WrappedType.serializeJSONValue(encoder: &encoder, value: value)
+    return encoder.result
   }
 }
 
@@ -76,10 +65,6 @@ extension Google_Protobuf_DoubleValue:
 
   public typealias WrappedType = ProtobufDouble
   public typealias FloatLiteralType = WrappedType.BaseType
-
-  var isZeroOrEmpty: Bool {
-    return value == 0
-  }
 
   public init(_ value: WrappedType.BaseType) {
     self.init()
@@ -109,10 +94,6 @@ extension Google_Protobuf_FloatValue:
   public typealias WrappedType = ProtobufFloat
   public typealias FloatLiteralType = Float
 
-  var isZeroOrEmpty: Bool {
-    return value.isZero
-  }
-
   public init(_ value: WrappedType.BaseType) {
     self.init()
     self.value = value
@@ -140,10 +121,6 @@ extension Google_Protobuf_Int64Value:
 
   public typealias WrappedType = ProtobufInt64
   public typealias IntegerLiteralType = WrappedType.BaseType
-
-  var isZeroOrEmpty: Bool {
-    return value == 0
-  }
 
   public init(_ value: WrappedType.BaseType) {
     self.init()
@@ -173,10 +150,6 @@ extension Google_Protobuf_UInt64Value:
   public typealias WrappedType = ProtobufUInt64
   public typealias IntegerLiteralType = WrappedType.BaseType
 
-  var isZeroOrEmpty: Bool {
-    return value == 0
-  }
-
   public init(_ value: WrappedType.BaseType) {
     self.init()
     self.value = value
@@ -204,10 +177,6 @@ extension Google_Protobuf_Int32Value:
 
   public typealias WrappedType = ProtobufInt32
   public typealias IntegerLiteralType = WrappedType.BaseType
-
-  var isZeroOrEmpty: Bool {
-    return value == 0
-  }
 
   public init(_ value: WrappedType.BaseType) {
     self.init()
@@ -237,10 +206,6 @@ extension Google_Protobuf_UInt32Value:
   public typealias WrappedType = ProtobufUInt32
   public typealias IntegerLiteralType = WrappedType.BaseType
 
-  var isZeroOrEmpty: Bool {
-    return value == 0
-  }
-
   public init(_ value: WrappedType.BaseType) {
     self.init()
     self.value = value
@@ -268,10 +233,6 @@ extension Google_Protobuf_BoolValue:
 
   public typealias WrappedType = ProtobufBool
   public typealias BooleanLiteralType = Bool
-
-  var isZeroOrEmpty: Bool {
-    return !value
-  }
 
   public init(_ value: WrappedType.BaseType) {
     self.init()
@@ -302,10 +263,6 @@ extension Google_Protobuf_StringValue:
   public typealias StringLiteralType = String
   public typealias ExtendedGraphemeClusterLiteralType = String
   public typealias UnicodeScalarLiteralType = String
-
-  var isZeroOrEmpty: Bool {
-    return value.isEmpty
-  }
 
   public init(_ value: WrappedType.BaseType) {
     self.init()
@@ -340,10 +297,6 @@ extension Google_Protobuf_StringValue:
 extension Google_Protobuf_BytesValue: ProtobufWrapper {
 
   public typealias WrappedType = ProtobufBytes
-
-  var isZeroOrEmpty: Bool {
-    return value.isEmpty
-  }
 
   public init(_ value: WrappedType.BaseType) {
     self.init()

--- a/Tests/SwiftProtobufTests/Test_Wrappers.swift
+++ b/Tests/SwiftProtobufTests/Test_Wrappers.swift
@@ -25,7 +25,7 @@ class Test_Wrappers: XCTestCase {
 
     func testDoubleValue() throws {
         var m = Google_Protobuf_DoubleValue()
-        XCTAssertEqual("null", try m.serializeJSON())
+        XCTAssertEqual("0", try m.serializeJSON())
         XCTAssertEqual(m, try Google_Protobuf_DoubleValue(json:"null"))
         m.value = 1.0
         XCTAssertEqual("1", try m.serializeJSON())
@@ -59,7 +59,7 @@ class Test_Wrappers: XCTestCase {
 
     func testFloatValue() throws {
         var m = Google_Protobuf_FloatValue()
-        XCTAssertEqual("null", try m.serializeJSON())
+        XCTAssertEqual("0", try m.serializeJSON())
         XCTAssertEqual(m, try Google_Protobuf_FloatValue(json:"null"))
         m.value = 1.0
         XCTAssertEqual("1", try m.serializeJSON())
@@ -96,7 +96,7 @@ class Test_Wrappers: XCTestCase {
 
     func testInt64Value() throws {
         var m = Google_Protobuf_Int64Value()
-        XCTAssertEqual("null", try m.serializeJSON())
+        XCTAssertEqual("\"0\"", try m.serializeJSON())
         XCTAssertEqual(m, try Google_Protobuf_Int64Value(json: "null"))
         m.value = 777
         let j2 = try m.serializeJSON()
@@ -111,7 +111,7 @@ class Test_Wrappers: XCTestCase {
 
     func testUInt64Value() throws {
         var m = Google_Protobuf_UInt64Value()
-        XCTAssertEqual("null", try m.serializeJSON())
+        XCTAssertEqual("\"0\"", try m.serializeJSON())
         XCTAssertEqual(m, try Google_Protobuf_UInt64Value(json: "null"))
         m.value = 777
         XCTAssertEqual("\"777\"", try m.serializeJSON())
@@ -125,7 +125,7 @@ class Test_Wrappers: XCTestCase {
 
     func testInt32Value() throws {
         var m = Google_Protobuf_Int32Value()
-        XCTAssertEqual("null", try m.serializeJSON())
+        XCTAssertEqual("0", try m.serializeJSON())
         XCTAssertEqual(m, try Google_Protobuf_Int32Value(json: "null"))
         m.value = 777
         XCTAssertEqual("777", try m.serializeJSON())
@@ -139,7 +139,7 @@ class Test_Wrappers: XCTestCase {
 
     func testUInt32Value() throws {
         var m = Google_Protobuf_UInt32Value()
-        XCTAssertEqual("null", try m.serializeJSON())
+        XCTAssertEqual("0", try m.serializeJSON())
         XCTAssertEqual(m, try Google_Protobuf_UInt32Value(json: "null"))
         m.value = 777
         XCTAssertEqual("777", try m.serializeJSON())
@@ -153,7 +153,7 @@ class Test_Wrappers: XCTestCase {
 
     func testBoolValue() throws {
         var m = Google_Protobuf_BoolValue()
-        XCTAssertEqual("null", try m.serializeJSON())
+        XCTAssertEqual("false", try m.serializeJSON())
         XCTAssertEqual(m, try Google_Protobuf_BoolValue(json: "null"))
         m.value = true
         XCTAssertEqual("true", try m.serializeJSON())
@@ -167,7 +167,7 @@ class Test_Wrappers: XCTestCase {
 
     func testStringValue() throws {
         var m = Google_Protobuf_StringValue()
-        XCTAssertEqual("null", try m.serializeJSON())
+        XCTAssertEqual("\"\"", try m.serializeJSON())
         XCTAssertEqual(m, try Google_Protobuf_StringValue(json: "null"))
         m.value = "abc"
         XCTAssertEqual("\"abc\"", try m.serializeJSON())
@@ -184,7 +184,7 @@ class Test_Wrappers: XCTestCase {
 
     func testBytesValue() throws {
         var m = Google_Protobuf_BytesValue()
-        XCTAssertEqual("null", try m.serializeJSON())
+        XCTAssertEqual("\"\"", try m.serializeJSON())
         XCTAssertEqual(m, try Google_Protobuf_BytesValue(json: "null"))
         m.value = Data(bytes: [0, 1, 2])
         XCTAssertEqual("\"AAEC\"", try m.serializeJSON())


### PR DESCRIPTION
The conformance tests show that these should be serialized as 0/false/"", not null. This change makes those tests pass, and does not break any other tests.

Fixes #64.
