### PR TITLE
Performance harness fixes...

### DIFF
--- a/Performance/Harness.cc
+++ b/Performance/Harness.cc
@@ -36,7 +36,7 @@ Harness::Harness(std::ostream* results_stream) :
     results_stream(results_stream),
     measurement_count(10),
     run_count(100),
-    repeated_count(100) {}
+    repeated_count(10) {}
 
 void Harness::write_to_log(const string& name,
                            const vector<milliseconds_d>& timings) const {

--- a/Performance/css/harness-visualization.css
+++ b/Performance/css/harness-visualization.css
@@ -16,6 +16,7 @@ table.numeric td {
 
 table.numeric th {
   background-color: #eee;
+  text-align: right;
 }
 
 table.numeric tfoot td {

--- a/Performance/js/harness-visualization.js
+++ b/Performance/js/harness-visualization.js
@@ -100,18 +100,21 @@
     }
   }
 
-  // Populates a multiplier cell with the ratio between the given two values
-  // and sets its background color depending on the magnitude.
-    function decorateMultiplierCell(cell, multiplier) {
-      if (multiplier == 1) {
-          cell.addClass('bg-success');
-      } else if (multiplier < 3) {
-//        cssClass = 'bg-success';
-      } else if (multiplier < 10) {
-        cell.addClass('bg-warning');
-      } else {
-        cell.addClass('bg-danger');
-      }
+  // Decorate a cell with the an appropriate background based
+  // on the magnitude of the multiplier.
+  function decorateMultiplierCell(cell, multiplier) {
+    if (multiplier == 1) {
+      // Decorate the best case with green
+      cell.addClass('bg-success');
+    } else if (multiplier < 3) {
+      // < 3: Leave this cell white
+    } else if (multiplier < 10) {
+      // 3 - 10: Mark this cell yellow
+      cell.addClass('bg-warning');
+    } else {
+      // > 10: Mark this cell red
+      cell.addClass('bg-danger');
+    }
   }
 
   // Creates and returns the summary table displayed next to the chart for a

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -30,7 +30,10 @@
 
 set -eu
 
-readonly script_dir="$(dirname $0)"
+cd "$(dirname $0)"
+
+# Directory containing this script
+readonly script_dir="."
 
 # Change this if your checkout of github.com/google/protobuf is in a different
 # location.
@@ -211,7 +214,6 @@ fi
 # Iterate over the requested field types and run the harnesses.
 for field_type in "${requested_field_types[@]}"; do
   gen_message_path="$script_dir/_generated/message.proto"
-  results_trace="$script_dir/_results/$field_count fields of $field_type"
 
   echo "Generating test proto with $field_count fields of type $field_type..."
   generate_test_proto "$field_count" "$field_type"
@@ -233,9 +235,12 @@ for field_type in "${requested_field_types[@]}"; do
 EOF
 
   harness_swift="$script_dir/_generated/harness_swift"
+  results_trace="$script_dir/_results/$field_count fields of $field_type (swift)"
+  display_results_trace="$results_trace"
   run_swift_harness "$harness_swift"
 
   harness_cpp="$script_dir/_generated/harness_cpp"
+  results_trace="$script_dir/_results/$field_count fields of $field_type (cpp)"
   run_cpp_harness "$harness_cpp"
 
   # Close out the session.
@@ -245,7 +250,7 @@ EOF
 
   insert_visualization_results "$partial_results" "$results_js"
 
-  open -g "$results_trace.trace"
+  open -g "$display_results_trace.trace"
 done
 
 # Open the HTML once at the end.

--- a/Performance/perf_runner_cpp.sh
+++ b/Performance/perf_runner_cpp.sh
@@ -28,6 +28,11 @@ function print_cpp_set_field() {
       echo "          message.add_field$num(\"$((200+num))\");"
       echo "        }"
       ;;
+    repeated\ bytes)
+      echo "        for (auto i = 0; i < repeated_count; i++) {"
+      echo "          message.add_field$num(std::string(20, (char)$((num))));"
+      echo "        }"
+      ;;
     repeated\ *)
       echo "        for (auto i = 0; i < repeated_count; i++) {"
       echo "          message.add_field$num($((200+num)));"
@@ -35,6 +40,9 @@ function print_cpp_set_field() {
       ;;
     string)
       echo "        message.set_field$num(\"$((200+num))\");"
+      ;;
+    bytes)
+      echo "        message.set_field$num(std::string(20, (char)$((num))));"
       ;;
     *)
       echo "        message.set_field$num($((200+num)));"
@@ -75,7 +83,7 @@ static string GetTypeUrl(const Descriptor* message) {
 TypeResolver* type_resolver;
 string* type_url;
 
-static void populate_fields(PerfMessage& message);
+static void populate_fields(PerfMessage& message, int repeated_count);
 
 void Harness::run() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -90,7 +98,7 @@ void Harness::run() {
       auto message = PerfMessage();
 
       measure_subtask("Populate fields", [&]() {
-        populate_fields(message);
+        populate_fields(message, repeated_count);
         // Dummy return value since void won't propagate.
         return false;
       });
@@ -139,7 +147,9 @@ void Harness::run() {
   google::protobuf::ShutdownProtobufLibrary();
 }
 
-void populate_fields(PerfMessage& message) {
+void populate_fields(PerfMessage& message, int repeated_count) {
+  (void)repeated_count; /* Possibly unused: Quiet the compiler */
+
 EOF
 
   for field_number in $(seq 1 "$field_count"); do

--- a/Performance/perf_runner_swift.sh
+++ b/Performance/perf_runner_swift.sh
@@ -23,6 +23,11 @@ function print_swift_set_field() {
   type=$2
 
   case "$type" in
+    repeated\ bytes)
+      echo "        for _ in 0..<repeatedCount {"
+      echo "          message.field$num.append(Data(repeating:$((num)), count: 20))"
+      echo "        }"
+      ;;
     repeated\ string)
       echo "        for _ in 0..<repeatedCount {"
       echo "          message.field$num.append(\"$((200+num))\")"
@@ -32,6 +37,9 @@ function print_swift_set_field() {
       echo "        for _ in 0..<repeatedCount {"
       echo "          message.field$num.append($((200+num)))"
       echo "        }"
+      ;;
+    bytes)
+      echo "        message.field$num = Data(repeating:$((num)), count: 20)"
       ;;
     string)
       echo "        message.field$num = \"$((200+num))\""
@@ -44,6 +52,8 @@ function print_swift_set_field() {
 
 function generate_swift_harness() {
   cat >"$gen_harness_path" <<EOF
+import Foundation
+
 extension Harness {
   func run() {
     measure {


### PR DESCRIPTION
A few fixes/improvements for the perf harness:
 * Make it work when you invoke it as `Performance/perf_runner.sh`  In particular, the C++ protoc invocation is very sensitive to the current directory.
 * Write separate trace files for each language
 * Open the Swift trace file at the end of the run (before, it opened the last one, which was always C++)
 * In the summary table, decorate the fastest result in green, show multipliers for the slower language (even when C++ is slower ;-)
