### PR TITLE
Fix test suite build on Linux

### DIFF
--- a/CollectTests.awk
+++ b/CollectTests.awk
@@ -69,7 +69,7 @@ BEGIN {
 }
 
 
-/ *func *test.*/ {
+/^ *func *test.*/ {
     split($0, a, "(")
     split(a[1], words, " ")
     FUNC=words[2]

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -721,13 +721,7 @@ extension Test_Required {
 
 extension Test_SmallRequired {
     static var allTests: [(String, (XCTestCase) throws -> ())] {
-        return [
-            ("func", {try run_test(test:($0 as! Test_SmallRequired).func)}),
-            ("func", {try run_test(test:($0 as! Test_SmallRequired).func)}),
-            ("func", {try run_test(test:($0 as! Test_SmallRequired).func)}),
-            ("func", {try run_test(test:($0 as! Test_SmallRequired).func)}),
-            ("func", {try run_test(test:($0 as! Test_SmallRequired).func)}),
-            ("func", {try run_test(test:($0 as! Test_SmallRequired).func)})        ]
+        return [        ]
     }
 }
 

--- a/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto2.swift
@@ -13,6 +13,7 @@
 // -----------------------------------------------------------------------------
 
 import XCTest
+import Foundation
 
 // NOTE: The generator changes what is generated based on the number/types
 // of fields (using a nested storage class or not), to be completel, all

--- a/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto3.swift
@@ -13,6 +13,7 @@
 // -----------------------------------------------------------------------------
 
 import XCTest
+import Foundation
 
 // NOTE: The generator changes what is generated based on the number/types
 // of fields (using a nested storage class or not), to be completel, all

--- a/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto2.swift
@@ -13,6 +13,7 @@
 // -----------------------------------------------------------------------------
 
 import XCTest
+import Foundation
 
 // NOTE: The generator changes what is generated based on the number/types
 // of fields (using a nested storage class or not), to be completel, all

--- a/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_MapFields_Access_Proto3.swift
@@ -13,6 +13,7 @@
 // -----------------------------------------------------------------------------
 
 import XCTest
+import Foundation
 
 // NOTE: The generator changes what is generated based on the number/types
 // of fields (using a nested storage class or not), to be completel, all

--- a/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto2.swift
@@ -13,6 +13,7 @@
 // -----------------------------------------------------------------------------
 
 import XCTest
+import Foundation
 
 // NOTE: The generator changes what is generated based on the number/types
 // of fields (using a nested storage class or not), to be completel, all

--- a/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto3.swift
@@ -13,6 +13,7 @@
 // -----------------------------------------------------------------------------
 
 import XCTest
+import Foundation
 
 // NOTE: The generator changes what is generated based on the number/types
 // of fields (using a nested storage class or not), to be completel, all


### PR DESCRIPTION
This corrects two failures when building the test suite on Linux:

1. The script that collects the list of tests was not ignoring commented-out tests.

2. On Linux, using the `Data` type requires you to first import Foundation
