### PR TITLE
Fix tests on Linux

### DIFF
--- a/Sources/SwiftProtobuf/HashVisitor.swift
+++ b/Sources/SwiftProtobuf/HashVisitor.swift
@@ -37,7 +37,9 @@ final class HashVisitor: Visitor {
   init() {}
 
   func visitUnknown(bytes: Data) {
-    mix(bytes.hashValue)
+    if bytes.count > 0 { // Workaround for Linux Foundation bug
+      mix(bytes.hashValue)
+    }
   }
 
   func visitSingularField<S: FieldType>(fieldType: S.Type,


### PR DESCRIPTION
Data on Linux seems to have problems with `hashValue` when there is no content.  Work around this for now...