### PR TITLE
Use Data(bytes:) where appropriate instead of the generic Data<S>(_:)

### DIFF
--- a/Tests/SwiftProtobufTests/ProtobufMessage+UInt8ArrayHelpers.swift
+++ b/Tests/SwiftProtobufTests/ProtobufMessage+UInt8ArrayHelpers.swift
@@ -19,7 +19,7 @@ import SwiftProtobuf
 
 extension SwiftProtobuf.Message {
     init(protobufBytes: [UInt8]) throws {
-        try self.init(protobuf: Data(protobufBytes))
+        try self.init(protobuf: Data(bytes: protobufBytes))
     }
 
     func serializeProtobufBytes() throws -> [UInt8] {

--- a/Tests/SwiftProtobufTests/Test_Map.swift
+++ b/Tests/SwiftProtobufTests/Test_Map.swift
@@ -69,7 +69,7 @@ class Test_Map: XCTestCase, PBTestHelpers {
             }
             XCTAssert(availableBlocks.isEmpty && t.isEmpty, "Did not encode correctly: got \(encoded)", file: file, line: line)
             do {
-                let decoded = try MessageTestType(protobuf: Data(bytes: encoded))
+                let decoded = try MessageTestType(protobufBytes: encoded)
                 XCTAssert(decoded == configured, "Encode/decode cycle should generate equal object", file: file, line: line)
             } catch {
                 XCTFail("Encode/decode cycle should not fail", file: file, line: line)


### PR DESCRIPTION
Data(bytes:) explicitly accepts a [UInt8].  This is more efficient
than treating the array as a generic sequence.