### PR TITLE
Make perf_runner work with Swift 3.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,10 +20,3 @@ let package = Package(
            dependencies: ["SwiftProtobuf"]),
   ]
 )
-
-// Ensure that the dynamic library is created for the performance test harness.
-products.append(
-  Product(name: "SwiftProtobuf",
-          type: .Library(.Dynamic),
-          modules: "SwiftProtobuf")
-)

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -204,6 +204,9 @@ cp "$script_dir/../.build/release/protoc-gen-swift" \
 mkdir -p "$script_dir/_generated"
 mkdir -p "$script_dir/_results"
 
+# Build a dynamic library to use in the tests
+swiftc -emit-library -o "$script_dir/_generated/libSwiftProtobufDynamic.dylib" "$script_dir/../.build/release/SwiftProtobuf.build/"*.swift.o
+
 # If the visualization results file isn't there, copy it from the template so
 # that the harnesses can populate it.
 results_js="$script_dir/_results/results.js"

--- a/Performance/perf_runner_swift.sh
+++ b/Performance/perf_runner_swift.sh
@@ -122,16 +122,16 @@ function run_swift_harness() {
   time ( swiftc -O -target x86_64-apple-macosx10.10 \
       -o "$harness" \
       -I "$script_dir/../.build/release" \
-      -L "$script_dir/../.build/release" \
-      -lSwiftProtobuf \
+      -L "$script_dir/_generated" \
+      -lSwiftProtobufDynamic \
       "$gen_harness_path" \
       "$script_dir/Harness.swift" \
       "$script_dir/_generated/message.pb.swift" \
-      "$script_dir/main.swift" \
+      "$script_dir/main.swift"
   )
   echo
 
-  dylib="$script_dir/../.build/release/libSwiftProtobuf.dylib"
+  dylib="$script_dir/_generated/libSwiftProtobufDynamic.dylib"
   echo "Swift dylib size before stripping: $(stat -f "%z" "$dylib") bytes"
   cp "$dylib" "${dylib}_stripped"
   strip -u -r "${dylib}_stripped"


### PR DESCRIPTION
In particular, the 'product' support for SwiftPM is in flux,
and some people seem confused by the dynamic library
in the package manifest.
