### PR TITLE
Use numeric sorting when computing median

### DIFF
--- a/Performance/js/harness-visualization.js
+++ b/Performance/js/harness-visualization.js
@@ -91,7 +91,7 @@
 
   // Computes and returns the median of the given array of values.
   function median(values) {
-    values.sort();
+    values.sort(function(a,b){return a - b});
     var mid = Math.floor(values.length / 2);
     if (values.length % 2) {
       return values[mid];


### PR DESCRIPTION
Javascript's default sort converts to string and sorts strings.   To get a numeric sort, you have to provide an explicit comparator function.