### PR TITLE
Customize Jazzy documentation generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ xcuserdata
 xcbaselines
 /_test
 protoc-gen-swift
+/docs
+/build
 
 # Intermediate conformance test outputs
 failing_tests.txt

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,1 +1,1 @@
-documentation: "Documentation/*"
+documentation: "Documentation/{API,GENERATED_CODE,PLUGIN}.md"

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,0 +1,1 @@
+documentation: "Documentation/*"

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ endif
 	clean \
 	conformance-host \
 	default \
+	docs \
 	install \
 	reference \
 	regenerate \
@@ -255,6 +256,15 @@ clean:
 	swift build --clean
 	rm -rf .build _test ${PROTOC_GEN_SWIFT}
 	find . -name '*~' | xargs rm
+
+# Build a local copy of the API documentation, using the same process used
+# by cocoadocs.org.
+docs:
+	@if which jazzy >/dev/null; then \
+		jazzy; \
+	else \
+		echo "Jazzy not installed, use 'gem install jazzy' or download from https://github.com/realm/jazzy"; \
+	fi
 
 #
 # Test the runtime and the plugin

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ More information is available in the associated documentation:
  * [STYLE_GUIDELINES.md](Documentation/STYLE_GUIDELINES.md) documents the style
    guidelines we have adopted in our codebase if you are interested in
    contributing
+ * [cocoapods.org](http://cocoadocs.org/docsets/SwiftProtobuf/) has the latest
+   full API documentation
 
 ## Getting Started
 


### PR DESCRIPTION
This adds a makefile step for building the documentation, using the same process/tool used by the CocoaPods ecosystem. It also slightly customizes the output to include those files in `Documentation` targeted at users of the library and plugin, rather than project contributors.
