### PR TITLE
Update docs and Makefile to use protoc's _opt support.

### DIFF
--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -68,17 +68,19 @@ but there are a few things that can be configured to specific needs.
 `protoc` supports passing generator options to the plugins, and the Swift plugin
 uses these to communicate changes from the default behaviors.
 
-The options are given as part of the `--swift-out` argument like this:
+The options are given with a `--swift_opt` argument like this:
 
 ```
-$ protoc --swift_out=[NAME]=[VALUE]:. foo/bar/*.proto mumble/*.proto
+$ protoc --swift_opt=[NAME]=[VALUE] --swift_out:. foo/bar/*.proto mumble/*.proto
 ```
 
-And more than one _NAME/VALUE_ pair can be passed by using a comma to seperate
-them:
+And more than one _NAME/VALUE_ pair can be passed by using the argument multiple times:
 
 ```
-$ protoc --swift_out=[NAME1]=[VALUE1],[NAME2]=[VALUE2]:. foo/bar/*.proto mumble/*.proto
+$ protoc \
+    --swift_opt=[NAME1]=[VALUE1] \
+    --swift_opt=[NAME2]=[VALUE2] \
+    --swift_out=. foo/bar/*.proto mumble/*.proto
 ```
 
 ##### Generation Option: `FileNaming` - Naming of Generated Sources
@@ -86,10 +88,10 @@ $ protoc --swift_out=[NAME1]=[VALUE1],[NAME2]=[VALUE2]:. foo/bar/*.proto mumble/
 By default, the paths to the proto files are maintained on the generated files.
 So if you pass `foo/bar/my.proto`, you will get `foo/bar/my.pb.swift` in the
 output directory. The Swift plugin supports an option to control the generated
-file names, the option is given as part of the `--swift-out` argument like this:
+file names, the option is given as part of the `--swift_out` argument like this:
 
 ```
-$ protoc --swift_out=FileNaming=[value]:. foo/bar/*.proto mumble/*.proto
+$ protoc --swift_opt=FileNaming=[value]: --swift_out=. foo/bar/*.proto mumble/*.proto
 ```
 
 The possible values for `FileNaming` are:
@@ -109,7 +111,7 @@ because no visibility is set on them.  If you want the types to be made public
 the option can be given as:
 
 ```
-$ protoc --swift_out=Visibility=[value]:. foo/bar/*.proto mumble/*.proto
+$ protoc --swift_opt=Visibility=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
 ```
 
 The possible values for `Visibility` are:

--- a/Makefile
+++ b/Makefile
@@ -329,11 +329,19 @@ regenerate: regenerate-library-protos regenerate-plugin-protos regenerate-test-p
 
 # Rebuild just the protos included in the runtime library
 regenerate-library-protos: build ${PROTOC_GEN_SWIFT}
-	${GENERATE_SRCS} --tfiws_out=FileNaming=DropPath,Visibility=Public:Sources/SwiftProtobuf ${LIBRARY_PROTOS}
+	${GENERATE_SRCS} \
+		--tfiws_opt=FileNaming=DropPath \
+		--tfiws_opt=Visibility=Public \
+		--tfiws_out=Sources/SwiftProtobuf \
+		${LIBRARY_PROTOS}
 
 # Rebuild just the protos used by the plugin
 regenerate-plugin-protos: build ${PROTOC_GEN_SWIFT}
-	${GENERATE_SRCS} --tfiws_out=FileNaming=DropPath,Visibility=Public:Sources/PluginLibrary ${PLUGIN_PROTOS}
+	${GENERATE_SRCS} \
+		--tfiws_opt=FileNaming=DropPath \
+		--tfiws_opt=Visibility=Public \
+		--tfiws_out=Sources/PluginLibrary \
+		${PLUGIN_PROTOS}
 
 # Rebuild just the protos used by the runtime test suite
 # Note: Some of these protos define the same package.(message|enum)s, so they
@@ -341,12 +349,18 @@ regenerate-plugin-protos: build ${PROTOC_GEN_SWIFT}
 # one at a time instead.
 regenerate-test-protos: build ${PROTOC_GEN_SWIFT}
 	for t in ${TEST_PROTOS}; do \
-		${GENERATE_SRCS} --tfiws_out=FileNaming=DropPath:Tests/SwiftProtobufTests $$t; \
+		${GENERATE_SRCS} \
+			--tfiws_opt=FileNaming=DropPath \
+			--tfiws_out=Tests/SwiftProtobufTests \
+			$$t; \
 	done
 
 # Rebuild just the protos used by the conformance test runner.
 regenerate-conformance-protos: build ${PROTOC_GEN_SWIFT}
-	${GENERATE_SRCS} --tfiws_out=FileNaming=DropPath:Sources/Conformance ${CONFORMANCE_PROTOS}
+	${GENERATE_SRCS} \
+		--tfiws_opt=FileNaming=DropPath \
+		--tfiws_out=Sources/Conformance \
+		${CONFORMANCE_PROTOS}
 
 # Helper to check if there is a protobuf checkout as expected.
 check-for-protobuf-checkout:


### PR DESCRIPTION
Fixes https://github.com/apple/swift-protobuf/issues/121

- Makefile: Move the options into _opt arguments.
- Docs: Update the docs to document the --swift_opt argument.