### PR TITLE
Revert "Switch debugDescription to TextFormat."

### DIFF
--- a/Sources/SwiftProtobuf/DebugDescriptionVisitor.swift
+++ b/Sources/SwiftProtobuf/DebugDescriptionVisitor.swift
@@ -1,0 +1,126 @@
+// Sources/SwiftProtobuf/DebugDescriptionVisitor.swift - debugDescription support
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// We treat the debugDescription as a serialization process, using the
+/// same traversal machinery that is used by binary and JSON serialization.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+
+/// Visitor that generates the debug description of a message.
+///
+/// TODO: Remove this and use text format instead.
+final class DebugDescriptionVisitor: Visitor {
+
+  var description = ""
+  private var separator = ""
+
+  private let nameResolver: (Int) -> String?
+
+  /// Creates a new visitor that generates the debug description for the given
+  /// message.
+  init(message: Message) {
+    self.nameResolver =
+      ProtoNameResolvers.swiftFieldNameResolver(for: message)
+
+    description.append(message.swiftClassName)
+    description.append("(")
+    do {
+      try message.traverse(visitor: self)
+    } catch let e {
+      description.append("\(e)")
+    }
+    description.append(")")
+  }
+
+  func visitUnknown(bytes: Data) {}
+
+  func visitSingularField<S: FieldType>(fieldType: S.Type,
+                                        value: S.BaseType,
+                                        fieldNumber: Int) throws {
+    let swiftFieldName = self.swiftFieldName(for: fieldNumber)
+    description.append(separator)
+    separator = ","
+    description.append(swiftFieldName + ":" + String(reflecting: value))
+  }
+
+  func visitRepeatedField<S: FieldType>(fieldType: S.Type,
+                                        value: [S.BaseType],
+                                        fieldNumber: Int) throws {
+    let swiftFieldName = self.swiftFieldName(for: fieldNumber)
+    description.append(separator)
+    description.append(swiftFieldName)
+    description.append(":[")
+    var arraySeparator = ""
+    for v in value {
+      description.append(arraySeparator)
+      arraySeparator = ","
+      description.append(String(reflecting: v))
+    }
+    description.append("]")
+    separator = ","
+  }
+
+  func visitSingularMessageField<M: Message>(value: M,
+                                             fieldNumber: Int) throws {
+    let swiftFieldName = self.swiftFieldName(for: fieldNumber)
+    description.append(separator)
+    description.append(swiftFieldName)
+    description.append(":")
+    let messageDescription = DebugDescriptionVisitor(message: value).description
+    description.append(messageDescription)
+    separator = ","
+  }
+
+  func visitRepeatedMessageField<M: Message>(value: [M],
+                                             fieldNumber: Int) throws {
+    let swiftFieldName = self.swiftFieldName(for: fieldNumber)
+    description.append(separator)
+    description.append(swiftFieldName)
+    description.append(":[")
+    var arraySeparator = ""
+    for v in value {
+      description.append(arraySeparator)
+      let messageDescription = DebugDescriptionVisitor(message: v).description
+      description.append(messageDescription)
+      arraySeparator = ","
+    }
+    description.append("]")
+    separator = ","
+  }
+
+  func visitMapField<KeyType: MapKeyType, ValueType: MapValueType>(
+    fieldType: ProtobufMap<KeyType, ValueType>.Type,
+    value: ProtobufMap<KeyType, ValueType>.BaseType,
+    fieldNumber: Int
+  ) throws where KeyType.BaseType: Hashable {
+    let swiftFieldName = self.swiftFieldName(for: fieldNumber)
+    description.append(separator)
+    description.append(swiftFieldName)
+    description.append(":{")
+    var mapSeparator = ""
+    for (k,v) in value {
+      description.append(mapSeparator)
+      description.append(String(reflecting: k))
+      description.append(":")
+      description.append(String(reflecting: v))
+      mapSeparator = ","
+    }
+    description.append("}")
+    separator = ","
+  }
+
+  /// Helper function that stringifies the field number if the name could not
+  /// be resolved.
+  private func swiftFieldName(for number: Int) -> String {
+    return nameResolver(number) ?? String(number)
+  }
+}

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -124,8 +124,7 @@ public extension Message {
   }
 
   var debugDescription: String {
-    if let result = try? serializeText() { return result }
-    return "<internal error>"
+    return DebugDescriptionVisitor(message: self).description
   }
 
   // TODO: Add an option to the generator to override this in particular

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		9C2F23851D7780D1008524F2 /* ProtobufDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* ProtobufDecoder.swift */; };
 		9C2F23861D7780D1008524F2 /* ProtobufEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* ProtobufEncoder.swift */; };
 		9C2F23871D7780D1008524F2 /* ProtobufTypeAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* ProtobufTypeAdditions.swift */; };
+		9C2F23881D7780D1008524F2 /* DebugDescriptionVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufDebugDescription.swift /* DebugDescriptionVisitor.swift */; };
 		9C2F23891D7780D1008524F2 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
 		9C2F238A1D7780D1008524F2 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufError.swift /* Errors.swift */; };
 		9C2F238B1D7780D1008524F2 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
@@ -243,6 +244,7 @@
 		F44F93821DAEA76700BC5B85 /* ProtobufEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* ProtobufEncoder.swift */; };
 		F44F93831DAEA76700BC5B85 /* ProtobufEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4AB1DA454DA00C866D9 /* ProtobufEncodingSizeVisitor.swift */; };
 		F44F93841DAEA76700BC5B85 /* ProtobufTypeAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* ProtobufTypeAdditions.swift */; };
+		F44F93851DAEA76700BC5B85 /* DebugDescriptionVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufDebugDescription.swift /* DebugDescriptionVisitor.swift */; };
 		F44F93861DAEA76700BC5B85 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
 		F44F93871DAEA76700BC5B85 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufError.swift /* Errors.swift */; };
 		F44F93881DAEA76700BC5B85 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
@@ -351,6 +353,7 @@
 		F44F94111DAEB23500BC5B85 /* ProtobufEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* ProtobufEncoder.swift */; };
 		F44F94121DAEB23500BC5B85 /* ProtobufEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4AB1DA454DA00C866D9 /* ProtobufEncodingSizeVisitor.swift */; };
 		F44F94131DAEB23500BC5B85 /* ProtobufTypeAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* ProtobufTypeAdditions.swift */; };
+		F44F94141DAEB23500BC5B85 /* DebugDescriptionVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufDebugDescription.swift /* DebugDescriptionVisitor.swift */; };
 		F44F94151DAEB23500BC5B85 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
 		F44F94161DAEB23500BC5B85 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufError.swift /* Errors.swift */; };
 		F44F94171DAEB23500BC5B85 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
@@ -402,6 +405,7 @@
 		__src_cc_ref_Sources/Protobuf/ProtobufBinaryDecoding.swift /* ProtobufDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* ProtobufDecoder.swift */; };
 		__src_cc_ref_Sources/Protobuf/ProtobufBinaryEncoding.swift /* ProtobufEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* ProtobufEncoder.swift */; };
 		__src_cc_ref_Sources/Protobuf/ProtobufBinaryTypes.swift /* ProtobufTypeAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* ProtobufTypeAdditions.swift */; };
+		__src_cc_ref_Sources/Protobuf/ProtobufDebugDescription.swift /* DebugDescriptionVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufDebugDescription.swift /* DebugDescriptionVisitor.swift */; };
 		__src_cc_ref_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
 		__src_cc_ref_Sources/Protobuf/ProtobufError.swift /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufError.swift /* Errors.swift */; };
 		__src_cc_ref_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
@@ -582,6 +586,7 @@
 		__PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* ProtobufDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufDecoder.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* ProtobufEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufEncoder.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* ProtobufTypeAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtobufTypeAdditions.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Sources/Protobuf/ProtobufDebugDescription.swift /* DebugDescriptionVisitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDescriptionVisitor.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enum.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufError.swift /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFields.swift; sourceTree = "<group>"; };
@@ -757,6 +762,7 @@
 			isa = PBXGroup;
 			children = (
 				__PBXFileRef_Sources/Protobuf/api.pb.swift /* api.pb.swift */,
+				__PBXFileRef_Sources/Protobuf/ProtobufDebugDescription.swift /* DebugDescriptionVisitor.swift */,
 				__PBXFileRef_Sources/Protobuf/duration.pb.swift /* duration.pb.swift */,
 				__PBXFileRef_Sources/Protobuf/empty.pb.swift /* empty.pb.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */,
@@ -1212,6 +1218,7 @@
 				9C2F23851D7780D1008524F2 /* ProtobufDecoder.swift in Sources */,
 				9C2F23861D7780D1008524F2 /* ProtobufEncoder.swift in Sources */,
 				9C2F23871D7780D1008524F2 /* ProtobufTypeAdditions.swift in Sources */,
+				9C2F23881D7780D1008524F2 /* DebugDescriptionVisitor.swift in Sources */,
 				9C2F23891D7780D1008524F2 /* Enum.swift in Sources */,
 				9C2F238A1D7780D1008524F2 /* Errors.swift in Sources */,
 				9C2F238B1D7780D1008524F2 /* ExtensionFields.swift in Sources */,
@@ -1256,6 +1263,7 @@
 			buildActionMask = 0;
 			files = (
 				__src_cc_ref_Sources/Protobuf/api.pb.swift /* api.pb.swift in Sources */,
+				__src_cc_ref_Sources/Protobuf/ProtobufDebugDescription.swift /* DebugDescriptionVisitor.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/duration.pb.swift /* duration.pb.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/empty.pb.swift /* empty.pb.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift in Sources */,
@@ -1431,6 +1439,7 @@
 				F44F938F1DAEA76700BC5B85 /* Message.swift in Sources */,
 				F44F93861DAEA76700BC5B85 /* Enum.swift in Sources */,
 				F44F938A1DAEA76700BC5B85 /* FieldDecoder.swift in Sources */,
+				F44F93851DAEA76700BC5B85 /* DebugDescriptionVisitor.swift in Sources */,
 				F44F938D1DAEA76700BC5B85 /* JSONEncoder.swift in Sources */,
 				F44F938B1DAEA76700BC5B85 /* HashVisitor.swift in Sources */,
 				9C75F88C1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */,
@@ -1575,6 +1584,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F44F94061DAEB23500BC5B85 /* api.pb.swift in Sources */,
+				F44F94141DAEB23500BC5B85 /* DebugDescriptionVisitor.swift in Sources */,
 				F44F94071DAEB23500BC5B85 /* duration.pb.swift in Sources */,
 				F44F94081DAEB23500BC5B85 /* empty.pb.swift in Sources */,
 				F44F94151DAEB23500BC5B85 /* Enum.swift in Sources */,


### PR DESCRIPTION
Reverts apple/swift-protobuf#228

Since the tests were broken for other reasons, I missed fixing up those.  Reverting to do this correctly.