### PR TITLE
Print times for 1 operation, use tabular output, skip C++ Instruments

### DIFF
--- a/Performance/Harness.cc
+++ b/Performance/Harness.cc
@@ -39,26 +39,26 @@ Harness::Harness(std::ostream* results_stream) :
     repeated_count(10) {}
 
 void Harness::write_to_log(const string& name,
-                           const vector<milliseconds_d>& timings) const {
+                           const vector<microseconds_d>& timings) const {
   if (results_stream == nullptr) {
     return;
   }
 
   (*results_stream) << "\"" << name << "\": [";
   for (const auto& duration : timings) {
-    auto millis = duration_cast<milliseconds_d>(duration);
-    (*results_stream) << millis.count() << ", ";
+    auto micros = duration_cast<microseconds_d>(duration);
+    (*results_stream) << micros.count() / run_count << ", ";
   }
   (*results_stream) << "]," << endl;
 }
 
 Harness::Statistics Harness::compute_statistics(
     const vector<steady_clock::duration>& timings) const {
-  milliseconds_d::rep sum = 0;
-  milliseconds_d::rep sqsum = 0;
+  microseconds_d::rep sum = 0;
+  microseconds_d::rep sqsum = 0;
 
   for (const auto& duration : timings) {
-    auto millis = duration_cast<milliseconds_d>(duration);
+    auto millis = duration_cast<microseconds_d>(duration);
     auto count = millis.count();
     sum += count;
     sqsum += count * count;

--- a/Performance/Harness.cc
+++ b/Performance/Harness.cc
@@ -58,8 +58,8 @@ Harness::Statistics Harness::compute_statistics(
   microseconds_d::rep sqsum = 0;
 
   for (const auto& duration : timings) {
-    auto millis = duration_cast<microseconds_d>(duration);
-    auto count = millis.count();
+    auto micros = duration_cast<microseconds_d>(duration);
+    auto count = micros.count();
     sum += count;
     sqsum += count * count;
   }

--- a/Performance/Harness.h
+++ b/Performance/Harness.h
@@ -46,7 +46,9 @@ public:
   void run();
 
 private:
-  /** Include fractional parts in milliseconds. */
+  /** Microseconds unit for representing times. */
+  typedef std::chrono::duration<double, std::micro> microseconds_d;
+  /** Milliseconds unit for representing times. */
   typedef std::chrono::duration<double, std::milli> milliseconds_d;
 
   /**
@@ -62,6 +64,7 @@ private:
   std::ostream* results_stream;
 
   /** The number of times to loop the body of the run() method. */
+  /* Increase this to get better precision. */
   int run_count;
 
   /** The number of times to measure the function passed to measure(). */
@@ -70,8 +73,11 @@ private:
   /** The number of times to add values to repeated fields. */
   int repeated_count;
 
+  /** Ordered list of task names */
+  std::vector<std::string> subtask_names;
+
   /** The times taken by subtasks during each measured attempt. */
-  std::map<std::string, std::vector<milliseconds_d>> subtask_timings;
+  std::map<std::string, std::vector<microseconds_d>> subtask_timings;
 
   /** Times for the subtasks in the current attempt. */
   std::map<std::string, std::chrono::steady_clock::duration> current_subtasks;
@@ -95,7 +101,7 @@ private:
    * Writes the given subtask's name and timings to the visualization log.
    */
   void write_to_log(const std::string& name,
-                    const std::vector<milliseconds_d>& timings) const;
+                    const std::vector<microseconds_d>& timings) const;
 
   /**
    * Compute the mean and standard deviation of the given time points.
@@ -112,29 +118,48 @@ void Harness::measure(const Function& func) {
 
   vector<steady_clock::duration> timings;
   subtask_timings.clear();
+  bool displayed_titles = false;
+
+  printf("Running each check %d times, times in µs\n", run_count);
 
   // Do each measurement multiple times and collect the means and standard
   // deviation to account for noise.
   for (int attempt = 1; attempt <= measurement_count; attempt++) {
-    printf("Attempt %d, %d runs\n", attempt, run_count);
     current_subtasks.clear();
 
     auto start = steady_clock::now();
-    func();
+    for (auto i = 0; i < run_count; i++) {
+        subtask_names.clear();
+        func();
+    }
     auto end = steady_clock::now();
     auto duration = end - start;
     timings.push_back(duration);
 
-    for (const auto& entry : current_subtasks) {
-      auto millis = duration_cast<milliseconds_d>(entry.second);
-      printf("\"%s\" took %.3f ms\n",
-             entry.first.c_str(), millis.count());
-      subtask_timings[entry.first].push_back(millis);
+    if (!displayed_titles) {
+        auto names = std::vector<std::string>(subtask_names);
+        printf("%3s", "");
+        for (int i = 0; i < names.size(); i += 2) {
+            printf("%-18s", names[i].c_str());
+        }
+        printf("\n");
+        printf("%3s", "");
+        printf("%9s", "");
+        for (int i = 1; i < names.size(); i += 2) {
+            printf("%-18s", names[i].c_str());
+        }
+        printf("\n");
+        displayed_titles = true;
     }
 
-    auto millis = duration_cast<milliseconds_d>(duration);
-    printf("Total execution time: %.3f ms\n", millis.count());
-    printf("----\n");
+    printf("%3d", attempt);
+    for (const auto& name : subtask_names) {
+      const auto& total_interval = current_subtasks[name];
+      auto micros = duration_cast<microseconds_d>(total_interval);
+      printf("%9.3f", micros.count() / run_count);
+      subtask_timings[name].push_back(micros);
+    }
+    printf("\n");
   }
 
   for (const auto& entry : subtask_timings) {
@@ -142,12 +167,13 @@ void Harness::measure(const Function& func) {
   }
 
   auto stats = compute_statistics(timings);
-  printf("mean = %.3f sec, stddev = %.3f sec\n", stats.mean, stats.stddev);
+  printf("Relative stddev = %.1f%%\n", stats.stddev / stats.mean * 100.0);
 }
 
 template <typename Function>
 typename std::result_of<Function()>::type Harness::measure_subtask(
-    const std::string& name, Function&& func) {
+  const std::string& name, Function&& func) {
+  subtask_names.push_back(name);
   using std::chrono::steady_clock;
 
   auto start = steady_clock::now();

--- a/Performance/Harness.h
+++ b/Performance/Harness.h
@@ -48,8 +48,6 @@ public:
 private:
   /** Microseconds unit for representing times. */
   typedef std::chrono::duration<double, std::micro> microseconds_d;
-  /** Milliseconds unit for representing times. */
-  typedef std::chrono::duration<double, std::milli> milliseconds_d;
 
   /**
    * Statistics representing the mean and standard deviation of all measured
@@ -63,8 +61,10 @@ private:
   /** The output stream to which visualization results will be written. */
   std::ostream* results_stream;
 
-  /** The number of times to loop the body of the run() method. */
-  /* Increase this to get better precision. */
+  /**
+   * The number of times to loop the body of the run() method.
+   * Increase this for better precision.
+   */
   int run_count;
 
   /** The number of times to measure the function passed to measure(). */

--- a/Performance/Harness.swift
+++ b/Performance/Harness.swift
@@ -15,11 +15,7 @@
 import Foundation
 
 private func padded(_ input: String, to width: Int) -> String {
-    var s = input
-    while s.characters.count < width {
-        s += " "
-    }
-    return s
+  return input + String(repeating: " ", count: max(0, width - input.characters.count))
 }
 
 /// Harness used for performance tests.
@@ -133,7 +129,7 @@ class Harness {
     let start = Date()
     let result = try block()
     let end = Date()
-    let diff = end.timeIntervalSince(start) / Double(runCount) * Double(1000000.0)
+    let diff = end.timeIntervalSince(start) / Double(runCount) * 1000000.0
     currentSubtasks[name] = (currentSubtasks[name] ?? 0) + diff
     return result
   }

--- a/Performance/js/harness-visualization.js
+++ b/Performance/js/harness-visualization.js
@@ -6,7 +6,7 @@
     'Encode binary', 'Decode binary',
     'Encode JSON', 'Decode JSON',
     'Encode text', 'Decode text',
-    'Test equality',
+    'Equality',
   ];
 
   // The languages we have harnesses for. The results for each language will
@@ -27,7 +27,7 @@
       ticks: 'outside',
     },
     yaxis: {
-      title: 'Runtime (ms)',
+      title: 'Runtime (&micro;s)',
       autorange: true,
     },
     margin: {
@@ -162,7 +162,7 @@
         var valueCell = $('<td></td>').appendTo(tr);
         var multiplierCell = $('<td></td>').appendTo(tr);
         if (med) {
-          var formattedMedian = med.toFixed(3) + '&nbsp;ms';
+          var formattedMedian = med.toFixed(3) + '&nbsp;&micro;s';
           valueCell.html(formattedMedian);
           var multiplier = med / bestValue;
           decorateMultiplierCell(valueCell, multiplier);

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -114,10 +114,6 @@ EOF
   DYLD_LIBRARY_PATH="$script_dir/_generated" "$harness" "$partial_results"
   sleep 3
 
-  echo "Running $language test harness in Instruments..."
-  instruments -t "$script_dir/Protobuf" -D "$results_trace" \
-      "$harness" -e DYLD_LIBRARY_PATH "$script_dir/_generated"
-
   cp "$harness" "${harness}_stripped"
   strip -u -r "${harness}_stripped"
   unstripped_size=$(stat -f "%z" "$harness")
@@ -134,6 +130,15 @@ EOF
       },
     },
 EOF
+}
+
+function profile_harness() {
+  language="$1"
+  harness="$2"
+
+  echo "Running $language test harness in Instruments..."
+  instruments -t "$script_dir/Protobuf" -D "$results_trace" \
+      "$harness" -e DYLD_LIBRARY_PATH "$script_dir/_generated"
 }
 
 # Inserts the partial visualization results from all the languages tested into
@@ -237,14 +242,14 @@ for field_type in "${requested_field_types[@]}"; do
     uncommitted_changes: $([[ -z $(git status -s) ]] && echo false || echo true),
 EOF
 
+  harness_cpp="$script_dir/_generated/harness_cpp"
+  results_trace="$script_dir/_results/$field_count fields of $field_type (cpp)"
+  run_cpp_harness "$harness_cpp"
+
   harness_swift="$script_dir/_generated/harness_swift"
   results_trace="$script_dir/_results/$field_count fields of $field_type (swift)"
   display_results_trace="$results_trace"
   run_swift_harness "$harness_swift"
-
-  harness_cpp="$script_dir/_generated/harness_cpp"
-  results_trace="$script_dir/_results/$field_count fields of $field_type (cpp)"
-  run_cpp_harness "$harness_cpp"
 
   # Close out the session.
   cat >> "$partial_results" <<EOF

--- a/Performance/perf_runner_cpp.sh
+++ b/Performance/perf_runner_cpp.sh
@@ -93,8 +93,6 @@ void Harness::run() {
   type_url = new string(GetTypeUrl(PerfMessage::descriptor()));
 
   measure([&]() {
-    // Loop enough times to get meaningfully large measurements.
-    for (auto i = 0; i < run_count; i++) {
       auto message = PerfMessage();
 
       measure_subtask("Populate fields", [&]() {
@@ -138,10 +136,9 @@ void Harness::run() {
       });
 
       // Exercise equality.
-      measure_subtask("Test equality", [&]() {
+      measure_subtask("Equality", [&]() {
         return MessageDifferencer::Equals(message, decoded_message);
       });
-    }
   });
 
   google::protobuf::ShutdownProtobufLibrary();

--- a/Performance/perf_runner_swift.sh
+++ b/Performance/perf_runner_swift.sh
@@ -58,41 +58,39 @@ extension Harness {
   func run() {
     measure {
       // Loop enough times to get meaningfully large measurements.
-      for _ in 0..<runCount {
-        var message = PerfMessage()
-        measureSubtask("Populate fields") {
-          populateFields(of: &message)
-        }
+      var message = PerfMessage()
+      measureSubtask("Populate fields") {
+        populateFields(of: &message)
+      }
 
-        // Exercise binary serialization.
-        let data = try measureSubtask("Encode binary") {
-          return try message.serializeProtobuf()
-        }
-        message = try measureSubtask("Decode binary") {
-          return try PerfMessage(protobuf: data)
-        }
+      // Exercise binary serialization.
+      let data = try measureSubtask("Encode binary") {
+        return try message.serializeProtobuf()
+      }
+      message = try measureSubtask("Decode binary") {
+        return try PerfMessage(protobuf: data)
+      }
 
-        // Exercise JSON serialization.
-        let json = try measureSubtask("Encode JSON") {
-          return try message.serializeJSON()
-        }
-        let jsonDecodedMessage = try measureSubtask("Decode JSON") {
-          return try PerfMessage(json: json)
-        }
+      // Exercise JSON serialization.
+      let json = try measureSubtask("Encode JSON") {
+        return try message.serializeJSON()
+      }
+      let jsonDecodedMessage = try measureSubtask("Decode JSON") {
+        return try PerfMessage(json: json)
+      }
 
-        // Exercise text serialization.
-        let text = try measureSubtask("Encode text") {
-          return try message.serializeText()
-        }
-        _ = try measureSubtask("Decode text") {
-          return try PerfMessage(text: text)
-        }
+      // Exercise text serialization.
+      let text = try measureSubtask("Encode text") {
+        return try message.serializeText()
+      }
+      _ = try measureSubtask("Decode text") {
+        return try PerfMessage(text: text)
+      }
 
-        // Exercise equality.
-        measureSubtask("Test equality") {
-          guard message == jsonDecodedMessage else {
-            fatalError("Binary- and JSON-decoded messages were not equal!")
-          }
+      // Exercise equality.
+      measureSubtask("Equality") {
+        guard message == jsonDecodedMessage else {
+          fatalError("Binary- and JSON-decoded messages were not equal!")
         }
       }
     }
@@ -139,4 +137,5 @@ function run_swift_harness() {
   echo
 
   run_harness_and_concatenate_results "Swift" "$harness_swift" "$partial_results"
+  profile_harness "Swift" "$harness_swift"
 }


### PR DESCRIPTION
This changes the timing printout to divide by the run_count, effectively
printing the time for a single operation.  This also required changing the
units to microseconds instead of milliseconds.

This makes it feasible to change the run_count and get comparable results,
which is useful as things get faster and you want to bump up the run_count
to get better precision.  I've gone ahead and bumped the run_count to 1000
while I'm here.

I've also reworked the display during the run to use a tabular format
and reordered the overall flow to first run C++ alone, then Swift alone,
and finally run Swift under Instruments.  This allows you to look at and
think about the values while waiting on Instruments.

I've also shuffled the shell script a bit to omit C++ under Instruments;
it's easy to put that back if you really want to.