### PR TITLE
Drop ignore for protoc-gen-swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 xcuserdata
 xcbaselines
 /_test
-protoc-gen-swift
 /docs
 /build
 


### PR DESCRIPTION
It was matching Source/protoc-gen-swift, which we do need to watch for changes. Likely a
leftover from when there were multiple repos.