### PR TITLE
Make oneof fields optional and remove the .None case.

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -147,44 +147,34 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
   ]
 
 
-  enum OneOf_Payload: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Payload: SwiftProtobuf.OneofEnum {
     case protobufPayload(Data)
     case jsonPayload(String)
-    case None
 
     static func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
       switch (lhs, rhs) {
       case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
       case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .protobufPayload(value)
+        return
       case 2:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .jsonPayload(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -197,15 +187,13 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
         if start <= 2 && 2 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 2)
         }
-      case .None:
-        break
       }
     }
   }
 
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v) = payload {
+      if case .protobufPayload(let v)? = payload {
         return v
       }
       return Data()
@@ -215,11 +203,11 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
     }
   }
 
-  var payload: Conformance_ConformanceRequest.OneOf_Payload = .None
+  var payload: Conformance_ConformanceRequest.OneOf_Payload? = nil
 
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v) = payload {
+      if case .jsonPayload(let v)? = payload {
         return v
       }
       return ""
@@ -240,14 +228,18 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
 
   mutating func _protoc_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2: try payload.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 1, 2:
+      if payload != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      payload = try Conformance_ConformanceRequest.OneOf_Payload(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     case 3: try decoder.decodeSingularEnumField(value: &requestedOutputFormat)
     default: break
     }
   }
 
   func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
-    try payload.traverse(visitor: visitor, start: 1, end: 3)
+    try payload?.traverse(visitor: visitor, start: 1, end: 3)
     if requestedOutputFormat != Conformance_WireFormat.unspecified {
       try visitor.visitSingularEnumField(value: requestedOutputFormat, fieldNumber: 3)
     }
@@ -274,14 +266,13 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ]
 
 
-  enum OneOf_Result: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Result: SwiftProtobuf.OneofEnum {
     case parseError(String)
     case serializeError(String)
     case runtimeError(String)
     case protobufPayload(Data)
     case jsonPayload(String)
     case skipped(String)
-    case None
 
     static func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
       switch (lhs, rhs) {
@@ -291,51 +282,46 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
       case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
       case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
       case (.skipped(let l), .skipped(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .parseError(value)
+        return
       case 2:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .runtimeError(value)
+        return
       case 3:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .protobufPayload(value)
+        return
       case 4:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .jsonPayload(value)
+        return
       case 5:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .skipped(value)
+        return
       case 6:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .serializeError(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -364,8 +350,6 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
         if start <= 6 && 6 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 6)
         }
-      case .None:
-        break
       }
     }
   }
@@ -377,7 +361,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   test.  Some of the test cases are intentionally invalid input.
   var parseError: String {
     get {
-      if case .parseError(let v) = result {
+      if case .parseError(let v)? = result {
         return v
       }
       return ""
@@ -387,14 +371,14 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
     }
   }
 
-  var result: Conformance_ConformanceResponse.OneOf_Result = .None
+  var result: Conformance_ConformanceResponse.OneOf_Result? = nil
 
   ///   If the input was successfully parsed but errors occurred when
   ///   serializing it to the requested output format, set the error message in
   ///   this field.
   var serializeError: String {
     get {
-      if case .serializeError(let v) = result {
+      if case .serializeError(let v)? = result {
         return v
       }
       return ""
@@ -409,7 +393,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   about the failure.
   var runtimeError: String {
     get {
-      if case .runtimeError(let v) = result {
+      if case .runtimeError(let v)? = result {
         return v
       }
       return ""
@@ -423,7 +407,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   protobuf, serialize it to protobuf and set it in this field.
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v) = result {
+      if case .protobufPayload(let v)? = result {
         return v
       }
       return Data()
@@ -437,7 +421,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   serialize to JSON and set it in this field.
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v) = result {
+      if case .jsonPayload(let v)? = result {
         return v
       }
       return ""
@@ -451,7 +435,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   wasn't supported, like JSON input/output.
   var skipped: String {
     get {
-      if case .skipped(let v) = result {
+      if case .skipped(let v)? = result {
         return v
       }
       return ""
@@ -469,13 +453,17 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
 
   mutating func _protoc_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 6, 2, 3, 4, 5: try result.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 1, 6, 2, 3, 4, 5:
+      if result != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      result = try Conformance_ConformanceResponse.OneOf_Result(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     default: break
     }
   }
 
   func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
-    try result.traverse(visitor: visitor, start: 1, end: 7)
+    try result?.traverse(visitor: visitor, start: 1, end: 7)
   }
 
   func _protoc_generated_isEqualTo(other: Conformance_ConformanceResponse) -> Bool {

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -170,7 +170,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
 
   private class _StorageClass {
     typealias ExtendedMessage = Google_Protobuf_Value
-    var _kind = Google_Protobuf_Value.OneOf_Kind()
+    var _kind: Google_Protobuf_Value.OneOf_Kind?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -180,13 +180,17 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
 
     func decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
       switch fieldNumber {
-      case 1, 2, 3, 4, 5, 6: try _kind.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 1, 2, 3, 4, 5, 6:
+        if _kind != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _kind = try Google_Protobuf_Value.OneOf_Kind(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      try _kind.traverse(visitor: visitor, start: 1, end: 7)
+      try _kind?.traverse(visitor: visitor, start: 1, end: 7)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -204,14 +208,13 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
   private var _storage = _StorageClass()
 
 
-  enum OneOf_Kind: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Kind: SwiftProtobuf.OneofEnum {
     case nullValue(Google_Protobuf_NullValue)
     case numberValue(Double)
     case stringValue(String)
     case boolValue(Bool)
     case structValue(Google_Protobuf_Struct)
     case listValue(Google_Protobuf_ListValue)
-    case None
 
     static func ==(lhs: Google_Protobuf_Value.OneOf_Kind, rhs: Google_Protobuf_Value.OneOf_Kind) -> Bool {
       switch (lhs, rhs) {
@@ -221,55 +224,50 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
       case (.boolValue(let l), .boolValue(let r)): return l == r
       case (.structValue(let l), .structValue(let r)): return l == r
       case (.listValue(let l), .listValue(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value = Google_Protobuf_NullValue()
         try decoder.decodeSingularEnumField(value: &value)
         self = .nullValue(value)
+        return
       case 2:
         var value = Double()
         try decoder.decodeSingularDoubleField(value: &value)
         self = .numberValue(value)
+        return
       case 3:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .stringValue(value)
+        return
       case 4:
         var value = Bool()
         try decoder.decodeSingularBoolField(value: &value)
         self = .boolValue(value)
+        return
       case 5:
         var value: Google_Protobuf_Struct?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .structValue(value)
+          return
         }
       case 6:
         var value: Google_Protobuf_ListValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .listValue(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -298,8 +296,6 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
         if start <= 6 && 6 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
         }
-      case .None:
-        break
       }
     }
   }
@@ -307,7 +303,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
   ///   Represents a null value.
   var nullValue: Google_Protobuf_NullValue {
     get {
-      if case .nullValue(let v) = _storage._kind {
+      if case .nullValue(let v)? = _storage._kind {
         return v
       }
       return Google_Protobuf_NullValue.nullValue
@@ -320,7 +316,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
   ///   Represents a double value.
   var numberValue: Double {
     get {
-      if case .numberValue(let v) = _storage._kind {
+      if case .numberValue(let v)? = _storage._kind {
         return v
       }
       return 0
@@ -333,7 +329,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
   ///   Represents a string value.
   var stringValue: String {
     get {
-      if case .stringValue(let v) = _storage._kind {
+      if case .stringValue(let v)? = _storage._kind {
         return v
       }
       return ""
@@ -346,7 +342,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
   ///   Represents a boolean value.
   var boolValue: Bool {
     get {
-      if case .boolValue(let v) = _storage._kind {
+      if case .boolValue(let v)? = _storage._kind {
         return v
       }
       return false
@@ -359,7 +355,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
   ///   Represents a structured value.
   var structValue: Google_Protobuf_Struct {
     get {
-      if case .structValue(let v) = _storage._kind {
+      if case .structValue(let v)? = _storage._kind {
         return v
       }
       return Google_Protobuf_Struct()
@@ -372,7 +368,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
   ///   Represents a repeated `Value`.
   var listValue: Google_Protobuf_ListValue {
     get {
-      if case .listValue(let v) = _storage._kind {
+      if case .listValue(let v)? = _storage._kind {
         return v
       }
       return Google_Protobuf_ListValue()
@@ -382,7 +378,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
     }
   }
 
-  var kind: OneOf_Kind {
+  var kind: OneOf_Kind? {
     get {return _storage._kind}
     set {
       _uniqueStorage()._kind = newValue

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -315,7 +315,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     var _mapStringForeignMessage: Dictionary<String,ProtobufTestMessages_Proto3_ForeignMessage> = [:]
     var _mapStringNestedEnum: Dictionary<String,ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum> = [:]
     var _mapStringForeignEnum: Dictionary<String,ProtobufTestMessages_Proto3_ForeignEnum> = [:]
-    var _oneofField = ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField()
+    var _oneofField: ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField?
     var _optionalBoolWrapper: Google_Protobuf_BoolValue? = nil
     var _optionalInt32Wrapper: Google_Protobuf_Int32Value? = nil
     var _optionalInt64Wrapper: Google_Protobuf_Int64Value? = nil
@@ -435,7 +435,11 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignMessage>.self, value: &_mapStringForeignMessage)
       case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum>.self, value: &_mapStringNestedEnum)
       case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: &_mapStringForeignEnum)
-      case 111, 112, 113, 114, 115, 116, 117, 118, 119: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114, 115, 116, 117, 118, 119:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 201: try decoder.decodeSingularMessageField(value: &_optionalBoolWrapper)
       case 202: try decoder.decodeSingularMessageField(value: &_optionalInt32Wrapper)
       case 203: try decoder.decodeSingularMessageField(value: &_optionalInt64Wrapper)
@@ -675,7 +679,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       if !_mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: _mapStringForeignEnum, fieldNumber: 74)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 120)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 120)
       if let v = _optionalBoolWrapper {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 201)
       }
@@ -1057,7 +1061,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -1067,7 +1071,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     case oneofFloat(Float)
     case oneofDouble(Double)
     case oneofEnum(ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum)
-    case None
 
     static func ==(lhs: ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField, rhs: ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -1080,65 +1083,63 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
       case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
       case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 112:
         var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 114:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .oneofBytes(value)
+        return
       case 115:
         var value = Bool()
         try decoder.decodeSingularBoolField(value: &value)
         self = .oneofBool(value)
+        return
       case 116:
         var value = UInt64()
         try decoder.decodeSingularUInt64Field(value: &value)
         self = .oneofUint64(value)
+        return
       case 117:
         var value = Float()
         try decoder.decodeSingularFloatField(value: &value)
         self = .oneofFloat(value)
+        return
       case 118:
         var value = Double()
         try decoder.decodeSingularDoubleField(value: &value)
         self = .oneofDouble(value)
+        return
       case 119:
         var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofEnum(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -1179,8 +1180,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
         if start <= 119 && 119 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1683,7 +1682,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1695,7 +1694,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofNestedMessage: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage()
@@ -1707,7 +1706,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1719,7 +1718,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1731,7 +1730,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v) = _storage._oneofField {
+      if case .oneofBool(let v)? = _storage._oneofField {
         return v
       }
       return false
@@ -1743,7 +1742,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v) = _storage._oneofField {
+      if case .oneofUint64(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1755,7 +1754,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v) = _storage._oneofField {
+      if case .oneofFloat(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1767,7 +1766,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v) = _storage._oneofField {
+      if case .oneofDouble(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1779,7 +1778,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofEnum: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum {
     get {
-      if case .oneofEnum(let v) = _storage._oneofField {
+      if case .oneofEnum(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum.foo
@@ -2122,7 +2121,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     set {_uniqueStorage()._fieldName18__ = newValue}
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -431,7 +431,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
     var _defaultImportEnum: ProtobufUnittestImport_ImportEnum? = nil
     var _defaultStringPiece: String? = nil
     var _defaultCord: String? = nil
-    var _oneofField = ProtobufUnittest_TestAllTypes.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_TestAllTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -512,7 +512,11 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
       case 83: try decoder.decodeSingularEnumField(value: &_defaultImportEnum)
       case 84: try decoder.decodeSingularStringField(value: &_defaultStringPiece)
       case 85: try decoder.decodeSingularStringField(value: &_defaultCord)
-      case 111, 112, 113, 114: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -731,7 +735,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
       if let v = _defaultCord {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 85)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 115)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 115)
       unknown.traverse(visitor: visitor)
     }
 
@@ -898,12 +902,11 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -911,51 +914,44 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
       case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 112:
         var value: ProtobufUnittest_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 114:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -976,8 +972,6 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
         if start <= 114 && 114 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 114)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1835,7 +1829,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1847,7 +1841,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
 
   var oneofNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllTypes.NestedMessage()
@@ -1859,7 +1853,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1871,7 +1865,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1881,7 +1875,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue
@@ -5970,7 +5964,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
   private class _StorageClass {
     typealias ExtendedMessage = ProtobufUnittest_TestOneof
     var unknown = SwiftProtobuf.UnknownStorage()
-    var _foo = ProtobufUnittest_TestOneof.OneOf_Foo()
+    var _foo: ProtobufUnittest_TestOneof.OneOf_Foo?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5980,13 +5974,17 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
     func decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
       switch fieldNumber {
-      case 1, 2, 3, 4: try _foo.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 1, 2, 3, 4:
+        if _foo != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _foo = try ProtobufUnittest_TestOneof.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      try _foo.traverse(visitor: visitor, start: 1, end: 5)
+      try _foo?.traverse(visitor: visitor, start: 1, end: 5)
       unknown.traverse(visitor: visitor)
     }
 
@@ -6011,12 +6009,11 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_Foo: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Foo: SwiftProtobuf.OneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestAllTypes)
     case fooGroup(ProtobufUnittest_TestOneof.FooGroup)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
       switch (lhs, rhs) {
@@ -6024,51 +6021,44 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
       case (.fooString(let l), .fooString(let r)): return l == r
       case (.fooMessage(let l), .fooMessage(let r)): return l == r
       case (.fooGroup(let l), .fooGroup(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .fooInt(value)
+          return
         }
       case 2:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .fooString(value)
+          return
         }
       case 3:
         var value: ProtobufUnittest_TestAllTypes?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .fooMessage(value)
+          return
         }
       case 4:
         var value: ProtobufUnittest_TestOneof.FooGroup?
         try decoder.decodeSingularGroupField(value: &value)
         if let value = value {
           self = .fooGroup(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -6089,8 +6079,6 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
         if start <= 4 && 4 < end {
           try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
         }
-      case .None:
-        break
       }
     }
   }
@@ -6163,7 +6151,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v) = _storage._foo {
+      if case .fooInt(let v)? = _storage._foo {
         return v
       }
       return 0
@@ -6175,7 +6163,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
   var fooString: String {
     get {
-      if case .fooString(let v) = _storage._foo {
+      if case .fooString(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -6187,7 +6175,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
   var fooMessage: ProtobufUnittest_TestAllTypes {
     get {
-      if case .fooMessage(let v) = _storage._foo {
+      if case .fooMessage(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestAllTypes()
@@ -6199,7 +6187,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
   var fooGroup: ProtobufUnittest_TestOneof.FooGroup {
     get {
-      if case .fooGroup(let v) = _storage._foo {
+      if case .fooGroup(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestOneof.FooGroup()
@@ -6209,7 +6197,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
     }
   }
 
-  var foo: OneOf_Foo {
+  var foo: OneOf_Foo? {
     get {return _storage._foo}
     set {
       _uniqueStorage()._foo = newValue
@@ -6477,8 +6465,8 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
   private class _StorageClass {
     typealias ExtendedMessage = ProtobufUnittest_TestOneof2
     var unknown = SwiftProtobuf.UnknownStorage()
-    var _foo = ProtobufUnittest_TestOneof2.OneOf_Foo()
-    var _bar = ProtobufUnittest_TestOneof2.OneOf_Bar()
+    var _foo: ProtobufUnittest_TestOneof2.OneOf_Foo?
+    var _bar: ProtobufUnittest_TestOneof2.OneOf_Bar?
     var _bazInt: Int32? = nil
     var _bazString: String? = nil
 
@@ -6490,8 +6478,16 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
     func decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
       switch fieldNumber {
-      case 1, 2, 3, 4, 5, 6, 7, 8, 11: try _foo.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
-      case 12, 13, 14, 15, 16, 17: try _bar.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 1, 2, 3, 4, 5, 6, 7, 8, 11:
+        if _foo != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _foo = try ProtobufUnittest_TestOneof2.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
+      case 12, 13, 14, 15, 16, 17:
+        if _bar != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _bar = try ProtobufUnittest_TestOneof2.OneOf_Bar(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 18: try decoder.decodeSingularInt32Field(value: &_bazInt)
       case 19: try decoder.decodeSingularStringField(value: &_bazString)
       default: break
@@ -6499,8 +6495,8 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      try _foo.traverse(visitor: visitor, start: 1, end: 12)
-      try _bar.traverse(visitor: visitor, start: 12, end: 18)
+      try _foo?.traverse(visitor: visitor, start: 1, end: 12)
+      try _bar?.traverse(visitor: visitor, start: 12, end: 18)
       if let v = _bazInt {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt32.self, value: v, fieldNumber: 18)
       }
@@ -6537,7 +6533,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_Foo: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Foo: SwiftProtobuf.OneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooCord(String)
@@ -6547,7 +6543,6 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     case fooMessage(ProtobufUnittest_TestOneof2.NestedMessage)
     case fooGroup(ProtobufUnittest_TestOneof2.FooGroup)
     case fooLazyMessage(ProtobufUnittest_TestOneof2.NestedMessage)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
       switch (lhs, rhs) {
@@ -6560,81 +6555,79 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
       case (.fooMessage(let l), .fooMessage(let r)): return l == r
       case (.fooGroup(let l), .fooGroup(let r)): return l == r
       case (.fooLazyMessage(let l), .fooLazyMessage(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .fooInt(value)
+          return
         }
       case 2:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .fooString(value)
+          return
         }
       case 3:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .fooCord(value)
+          return
         }
       case 4:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .fooStringPiece(value)
+          return
         }
       case 5:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .fooBytes(value)
+          return
         }
       case 6:
         var value: ProtobufUnittest_TestOneof2.NestedEnum?
         try decoder.decodeSingularEnumField(value: &value)
         if let value = value {
           self = .fooEnum(value)
+          return
         }
       case 7:
         var value: ProtobufUnittest_TestOneof2.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .fooMessage(value)
+          return
         }
       case 8:
         var value: ProtobufUnittest_TestOneof2.FooGroup?
         try decoder.decodeSingularGroupField(value: &value)
         if let value = value {
           self = .fooGroup(value)
+          return
         }
       case 11:
         var value: ProtobufUnittest_TestOneof2.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .fooLazyMessage(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -6675,20 +6668,17 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
         if start <= 11 && 11 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
         }
-      case .None:
-        break
       }
     }
   }
 
-  enum OneOf_Bar: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Bar: SwiftProtobuf.OneofEnum {
     case barInt(Int32)
     case barString(String)
     case barCord(String)
     case barStringPiece(String)
     case barBytes(Data)
     case barEnum(ProtobufUnittest_TestOneof2.NestedEnum)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
       switch (lhs, rhs) {
@@ -6698,63 +6688,58 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
       case (.barStringPiece(let l), .barStringPiece(let r)): return l == r
       case (.barBytes(let l), .barBytes(let r)): return l == r
       case (.barEnum(let l), .barEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 12:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .barInt(value)
+          return
         }
       case 13:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .barString(value)
+          return
         }
       case 14:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .barCord(value)
+          return
         }
       case 15:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .barStringPiece(value)
+          return
         }
       case 16:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .barBytes(value)
+          return
         }
       case 17:
         var value: ProtobufUnittest_TestOneof2.NestedEnum?
         try decoder.decodeSingularEnumField(value: &value)
         if let value = value {
           self = .barEnum(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -6783,8 +6768,6 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
         if start <= 17 && 17 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
         }
-      case .None:
-        break
       }
     }
   }
@@ -6974,7 +6957,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v) = _storage._foo {
+      if case .fooInt(let v)? = _storage._foo {
         return v
       }
       return 0
@@ -6986,7 +6969,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooString: String {
     get {
-      if case .fooString(let v) = _storage._foo {
+      if case .fooString(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -6998,7 +6981,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooCord: String {
     get {
-      if case .fooCord(let v) = _storage._foo {
+      if case .fooCord(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -7010,7 +6993,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooStringPiece: String {
     get {
-      if case .fooStringPiece(let v) = _storage._foo {
+      if case .fooStringPiece(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -7022,7 +7005,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooBytes: Data {
     get {
-      if case .fooBytes(let v) = _storage._foo {
+      if case .fooBytes(let v)? = _storage._foo {
         return v
       }
       return Data()
@@ -7034,7 +7017,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .fooEnum(let v) = _storage._foo {
+      if case .fooEnum(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestOneof2.NestedEnum.foo
@@ -7046,7 +7029,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooMessage(let v) = _storage._foo {
+      if case .fooMessage(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestOneof2.NestedMessage()
@@ -7058,7 +7041,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooGroup: ProtobufUnittest_TestOneof2.FooGroup {
     get {
-      if case .fooGroup(let v) = _storage._foo {
+      if case .fooGroup(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestOneof2.FooGroup()
@@ -7070,7 +7053,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooLazyMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooLazyMessage(let v) = _storage._foo {
+      if case .fooLazyMessage(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestOneof2.NestedMessage()
@@ -7082,7 +7065,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barInt: Int32 {
     get {
-      if case .barInt(let v) = _storage._bar {
+      if case .barInt(let v)? = _storage._bar {
         return v
       }
       return 5
@@ -7094,7 +7077,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barString: String {
     get {
-      if case .barString(let v) = _storage._bar {
+      if case .barString(let v)? = _storage._bar {
         return v
       }
       return "STRING"
@@ -7106,7 +7089,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barCord: String {
     get {
-      if case .barCord(let v) = _storage._bar {
+      if case .barCord(let v)? = _storage._bar {
         return v
       }
       return "CORD"
@@ -7118,7 +7101,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barStringPiece: String {
     get {
-      if case .barStringPiece(let v) = _storage._bar {
+      if case .barStringPiece(let v)? = _storage._bar {
         return v
       }
       return "SPIECE"
@@ -7130,7 +7113,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barBytes: Data {
     get {
-      if case .barBytes(let v) = _storage._bar {
+      if case .barBytes(let v)? = _storage._bar {
         return v
       }
       return Data(bytes: [66, 89, 84, 69, 83])
@@ -7142,7 +7125,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .barEnum(let v) = _storage._bar {
+      if case .barEnum(let v)? = _storage._bar {
         return v
       }
       return ProtobufUnittest_TestOneof2.NestedEnum.bar
@@ -7174,14 +7157,14 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     return _storage._bazString = nil
   }
 
-  var foo: OneOf_Foo {
+  var foo: OneOf_Foo? {
     get {return _storage._foo}
     set {
       _uniqueStorage()._foo = newValue
     }
   }
 
-  var bar: OneOf_Bar {
+  var bar: OneOf_Bar? {
     get {return _storage._bar}
     set {
       _uniqueStorage()._bar = newValue
@@ -7224,14 +7207,12 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
   private class _StorageClass {
     typealias ExtendedMessage = ProtobufUnittest_TestRequiredOneof
     var unknown = SwiftProtobuf.UnknownStorage()
-    var _foo = ProtobufUnittest_TestRequiredOneof.OneOf_Foo()
+    var _foo: ProtobufUnittest_TestRequiredOneof.OneOf_Foo?
 
     var isInitialized: Bool {
       switch _foo {
-      case .fooMessage(let v):
+      case .fooMessage(let v)?:
         if !v.isInitialized {return false}
-      case .None:
-        break
       default:
         break
       }
@@ -7246,13 +7227,17 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
 
     func decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
       switch fieldNumber {
-      case 1, 2, 3: try _foo.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 1, 2, 3:
+        if _foo != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _foo = try ProtobufUnittest_TestRequiredOneof.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      try _foo.traverse(visitor: visitor, start: 1, end: 4)
+      try _foo?.traverse(visitor: visitor, start: 1, end: 4)
       unknown.traverse(visitor: visitor)
     }
 
@@ -7277,56 +7262,47 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_Foo: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Foo: SwiftProtobuf.OneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestRequiredOneof.NestedMessage)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
       switch (lhs, rhs) {
       case (.fooInt(let l), .fooInt(let r)): return l == r
       case (.fooString(let l), .fooString(let r)): return l == r
       case (.fooMessage(let l), .fooMessage(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .fooInt(value)
+          return
         }
       case 2:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .fooString(value)
+          return
         }
       case 3:
         var value: ProtobufUnittest_TestRequiredOneof.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .fooMessage(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -7343,8 +7319,6 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
         if start <= 3 && 3 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
         }
-      case .None:
-        break
       }
     }
   }
@@ -7404,7 +7378,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v) = _storage._foo {
+      if case .fooInt(let v)? = _storage._foo {
         return v
       }
       return 0
@@ -7416,7 +7390,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
 
   var fooString: String {
     get {
-      if case .fooString(let v) = _storage._foo {
+      if case .fooString(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -7428,7 +7402,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
 
   var fooMessage: ProtobufUnittest_TestRequiredOneof.NestedMessage {
     get {
-      if case .fooMessage(let v) = _storage._foo {
+      if case .fooMessage(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestRequiredOneof.NestedMessage()
@@ -7438,7 +7412,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
     }
   }
 
-  var foo: OneOf_Foo {
+  var foo: OneOf_Foo? {
     get {return _storage._foo}
     set {
       _uniqueStorage()._foo = newValue
@@ -9292,7 +9266,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
     var _optionalMessage: ProtobufUnittest_ForeignMessage? = nil
     var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup? = nil
     var _stringStringMap: Dictionary<String,String> = [:]
-    var _oneofField = ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField?
 
     var isInitialized: Bool {
       if !extensionFieldValues.isInitialized {return false}
@@ -9317,7 +9291,11 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       case 536870007: try decoder.decodeSingularMessageField(value: &_optionalMessage)
       case 536870008: try decoder.decodeSingularGroupField(value: &_optionalGroup)
       case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_stringStringMap)
-      case 536870011, 536870012, 536870013, 536870014: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 536870011, 536870012, 536870013, 536870014:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: if (536860000 <= fieldNumber && fieldNumber < 536870000) {
           try decoder.decodeExtensionField(values: &extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber)
         }
@@ -9356,7 +9334,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       if !_stringStringMap.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _stringStringMap, fieldNumber: 536870010)
       }
-      try _oneofField.traverse(visitor: visitor, start: 536870011, end: 536870015)
+      try _oneofField?.traverse(visitor: visitor, start: 536870011, end: 536870015)
       unknown.traverse(visitor: visitor)
     }
 
@@ -9403,12 +9381,11 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofTestAllTypes(ProtobufUnittest_TestAllTypes)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -9416,51 +9393,44 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 536870011:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 536870012:
         var value: ProtobufUnittest_TestAllTypes?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofTestAllTypes(value)
+          return
         }
       case 536870013:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 536870014:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -9481,8 +9451,6 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
         if start <= 536870014 && 536870014 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 536870014)
         }
-      case .None:
-        break
       }
     }
   }
@@ -9629,7 +9597,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -9641,7 +9609,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypes {
     get {
-      if case .oneofTestAllTypes(let v) = _storage._oneofField {
+      if case .oneofTestAllTypes(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllTypes()
@@ -9653,7 +9621,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -9665,7 +9633,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -9675,7 +9643,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -376,7 +376,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
     var _defaultImportEnum: ProtobufUnittestImport_ImportEnumLite? = nil
     var _defaultStringPiece: String? = nil
     var _defaultCord: String? = nil
-    var _oneofField = ProtobufUnittest_TestAllTypesLite.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField?
     var _deceptivelyNamedList: Int32? = nil
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -458,7 +458,11 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
       case 83: try decoder.decodeSingularEnumField(value: &_defaultImportEnum)
       case 84: try decoder.decodeSingularStringField(value: &_defaultStringPiece)
       case 85: try decoder.decodeSingularStringField(value: &_defaultCord)
-      case 111, 112, 113, 114, 115: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114, 115:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_TestAllTypesLite.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 116: try decoder.decodeSingularInt32Field(value: &_deceptivelyNamedList)
       default: break
       }
@@ -678,7 +682,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
       if let v = _defaultCord {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 85)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 116)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 116)
       if let v = _deceptivelyNamedList {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt32.self, value: v, fieldNumber: 116)
       }
@@ -850,13 +854,12 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllTypesLite.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
     case oneofLazyNestedMessage(ProtobufUnittest_TestAllTypesLite.NestedMessage)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -865,57 +868,51 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
       case (.oneofLazyNestedMessage(let l), .oneofLazyNestedMessage(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 112:
         var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 114:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       case 115:
         var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofLazyNestedMessage(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -940,8 +937,6 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
         if start <= 115 && 115 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1806,7 +1801,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1818,7 +1813,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllTypesLite.NestedMessage()
@@ -1830,7 +1825,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1842,7 +1837,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1854,7 +1849,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofLazyNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
-      if case .oneofLazyNestedMessage(let v) = _storage._oneofField {
+      if case .oneofLazyNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllTypesLite.NestedMessage()
@@ -1876,7 +1871,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
     return _storage._deceptivelyNamedList = nil
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue
@@ -3304,7 +3299,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
     var _optionalMessage: ProtobufUnittest_ForeignMessageLite? = nil
     var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup? = nil
     var _stringStringMap: Dictionary<String,String> = [:]
-    var _oneofField = ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField?
 
     var isInitialized: Bool {
       if !extensionFieldValues.isInitialized {return false}
@@ -3329,7 +3324,11 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       case 536870007: try decoder.decodeSingularMessageField(value: &_optionalMessage)
       case 536870008: try decoder.decodeSingularGroupField(value: &_optionalGroup)
       case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_stringStringMap)
-      case 536870011, 536870012, 536870013, 536870014: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 536870011, 536870012, 536870013, 536870014:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: if (536860000 <= fieldNumber && fieldNumber < 536870000) {
           try decoder.decodeExtensionField(values: &extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber)
         }
@@ -3368,7 +3367,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       if !_stringStringMap.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _stringStringMap, fieldNumber: 536870010)
       }
-      try _oneofField.traverse(visitor: visitor, start: 536870011, end: 536870015)
+      try _oneofField?.traverse(visitor: visitor, start: 536870011, end: 536870015)
       unknown.traverse(visitor: visitor)
     }
 
@@ -3415,12 +3414,11 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofTestAllTypes(ProtobufUnittest_TestAllTypesLite)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -3428,51 +3426,44 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 536870011:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 536870012:
         var value: ProtobufUnittest_TestAllTypesLite?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofTestAllTypes(value)
+          return
         }
       case 536870013:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 536870014:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -3493,8 +3484,6 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
         if start <= 536870014 && 536870014 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 536870014)
         }
-      case .None:
-        break
       }
     }
   }
@@ -3641,7 +3630,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -3653,7 +3642,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypesLite {
     get {
-      if case .oneofTestAllTypes(let v) = _storage._oneofField {
+      if case .oneofTestAllTypes(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllTypesLite()
@@ -3665,7 +3654,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -3677,7 +3666,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -3687,7 +3676,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -276,7 +276,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     var _defaultImportEnum: ProtobufUnittestImport_ImportEnum? = nil
     var _defaultStringPiece: String? = nil
     var _defaultCord: String? = nil
-    var _oneofField = ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField()
+    var _oneofField: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -357,7 +357,11 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
       case 83: try decoder.decodeSingularEnumField(value: &_defaultImportEnum)
       case 84: try decoder.decodeSingularStringField(value: &_defaultStringPiece)
       case 85: try decoder.decodeSingularStringField(value: &_defaultCord)
-      case 111, 112, 113, 114, 115: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114, 115:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -576,7 +580,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
       if let v = _defaultCord {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 85)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 116)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 116)
       unknown.traverse(visitor: visitor)
     }
 
@@ -743,13 +747,12 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittestNoArena_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
     case lazyOneofNestedMessage(ProtobufUnittestNoArena_TestAllTypes.NestedMessage)
-    case None
 
     static func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -758,57 +761,51 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
       case (.lazyOneofNestedMessage(let l), .lazyOneofNestedMessage(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 112:
         var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 114:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       case 115:
         var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .lazyOneofNestedMessage(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -833,8 +830,6 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
         if start <= 115 && 115 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1692,7 +1687,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1704,7 +1699,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittestNoArena_TestAllTypes.NestedMessage()
@@ -1716,7 +1711,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1728,7 +1723,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1740,7 +1735,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var lazyOneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
-      if case .lazyOneofNestedMessage(let v) = _storage._oneofField {
+      if case .lazyOneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittestNoArena_TestAllTypes.NestedMessage()
@@ -1750,7 +1745,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -221,7 +221,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
     var _repeatedLazyMessage: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage] = []
-    var _oneofField = Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField()
+    var _oneofField: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -277,7 +277,11 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
       case 54: try decoder.decodeRepeatedStringField(value: &_repeatedStringPiece)
       case 55: try decoder.decodeRepeatedStringField(value: &_repeatedCord)
       case 57: try decoder.decodeRepeatedMessageField(value: &_repeatedLazyMessage)
-      case 111, 112, 113, 114: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -421,7 +425,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
       if !_repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _repeatedLazyMessage, fieldNumber: 57)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 115)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 115)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -531,12 +535,11 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofEnum(Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum)
-    case None
 
     static func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -544,45 +547,38 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
       case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 112:
         var value: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 114:
         var value = Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofEnum(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -603,8 +599,6 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
         if start <= 114 && 114 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
         }
-      case .None:
-        break
       }
     }
   }
@@ -971,7 +965,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -983,7 +977,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
 
   var oneofNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage()
@@ -995,7 +989,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1007,7 +1001,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
 
   var oneofEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
     get {
-      if case .oneofEnum(let v) = _storage._oneofField {
+      if case .oneofEnum(let v)? = _storage._oneofField {
         return v
       }
       return Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum.foo
@@ -1017,7 +1011,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -71,7 +71,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     var unknown = SwiftProtobuf.UnknownStorage()
     var _i: Int32? = nil
     var _msg: ProtobufUnittest_ForeignMessage? = nil
-    var _foo = ProtobufUnittest_TestOptimizedForSize.OneOf_Foo()
+    var _foo: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo?
 
     var isInitialized: Bool {
       if !extensionFieldValues.isInitialized {return false}
@@ -88,7 +88,11 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
       switch fieldNumber {
       case 1: try decoder.decodeSingularInt32Field(value: &_i)
       case 19: try decoder.decodeSingularMessageField(value: &_msg)
-      case 2, 3: try _foo.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 2, 3:
+        if _foo != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _foo = try ProtobufUnittest_TestOptimizedForSize.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
           try decoder.decodeExtensionField(values: &extensionFieldValues, messageType: ProtobufUnittest_TestOptimizedForSize.self, fieldNumber: fieldNumber)
         }
@@ -99,7 +103,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
       if let v = _i {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt32.self, value: v, fieldNumber: 1)
       }
-      try _foo.traverse(visitor: visitor, start: 2, end: 4)
+      try _foo?.traverse(visitor: visitor, start: 2, end: 4)
       if let v = _msg {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 19)
       }
@@ -134,48 +138,38 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_Foo: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Foo: SwiftProtobuf.OneofEnum {
     case integerField(Int32)
     case stringField(String)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
       switch (lhs, rhs) {
       case (.integerField(let l), .integerField(let r)): return l == r
       case (.stringField(let l), .stringField(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 2:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .integerField(value)
+          return
         }
       case 3:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .stringField(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -188,8 +182,6 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
         if start <= 3 && 3 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 3)
         }
-      case .None:
-        break
       }
     }
   }
@@ -233,7 +225,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
 
   var integerField: Int32 {
     get {
-      if case .integerField(let v) = _storage._foo {
+      if case .integerField(let v)? = _storage._foo {
         return v
       }
       return 0
@@ -245,7 +237,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
 
   var stringField: String {
     get {
-      if case .stringField(let v) = _storage._foo {
+      if case .stringField(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -255,7 +247,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     }
   }
 
-  var foo: OneOf_Foo {
+  var foo: OneOf_Foo? {
     get {return _storage._foo}
     set {
       _uniqueStorage()._foo = newValue

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -196,44 +196,34 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
   ]
 
 
-  enum OneOf_O: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_O: SwiftProtobuf.OneofEnum {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnum)
-    case None
 
     static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
       switch (lhs, rhs) {
       case (.oneofE1(let l), .oneofE1(let r)): return l == r
       case (.oneofE2(let l), .oneofE2(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 5:
         var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofE1(value)
+        return
       case 6:
         var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofE2(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -246,8 +236,6 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
         if start <= 6 && 6 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
         }
-      case .None:
-        break
       }
     }
   }
@@ -263,7 +251,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
 
   var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE1(let v) = o {
+      if case .oneofE1(let v)? = o {
         return v
       }
       return Proto3PreserveUnknownEnumUnittest_MyEnum.foo
@@ -273,11 +261,11 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     }
   }
 
-  var o: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O = .None
+  var o: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O? = nil
 
   var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE2(let v) = o {
+      if case .oneofE2(let v)? = o {
         return v
       }
       return Proto3PreserveUnknownEnumUnittest_MyEnum.foo
@@ -299,7 +287,11 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     case 2: try decoder.decodeRepeatedEnumField(value: &repeatedE)
     case 3: try decoder.decodeRepeatedEnumField(value: &repeatedPackedE)
     case 4: try decoder.decodeRepeatedEnumField(value: &repeatedPackedUnexpectedE)
-    case 5, 6: try o.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 5, 6:
+      if o != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      o = try Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     default: break
     }
   }
@@ -317,7 +309,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     if !repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitPackedEnumField(value: repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try o.traverse(visitor: visitor, start: 5, end: 7)
+    try o?.traverse(visitor: visitor, start: 5, end: 7)
   }
 
   func _protoc_generated_isEqualTo(other: Proto3PreserveUnknownEnumUnittest_MyMessage) -> Bool {
@@ -343,44 +335,34 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
   ]
 
 
-  enum OneOf_O: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_O: SwiftProtobuf.OneofEnum {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
-    case None
 
     static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
       switch (lhs, rhs) {
       case (.oneofE1(let l), .oneofE1(let r)): return l == r
       case (.oneofE2(let l), .oneofE2(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 5:
         var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofE1(value)
+        return
       case 6:
         var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofE2(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -393,8 +375,6 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
         if start <= 6 && 6 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
         }
-      case .None:
-        break
       }
     }
   }
@@ -409,7 +389,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
 
   var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
-      if case .oneofE1(let v) = o {
+      if case .oneofE1(let v)? = o {
         return v
       }
       return Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
@@ -419,11 +399,11 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     }
   }
 
-  var o: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O = .None
+  var o: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O? = nil
 
   var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
-      if case .oneofE2(let v) = o {
+      if case .oneofE2(let v)? = o {
         return v
       }
       return Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
@@ -445,7 +425,11 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     case 2: try decoder.decodeRepeatedEnumField(value: &repeatedE)
     case 3: try decoder.decodeRepeatedEnumField(value: &repeatedPackedE)
     case 4: try decoder.decodeRepeatedEnumField(value: &repeatedPackedUnexpectedE)
-    case 5, 6: try o.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 5, 6:
+      if o != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      o = try Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     default: break
     }
   }
@@ -463,7 +447,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     if !repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitPackedEnumField(value: repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try o.traverse(visitor: visitor, start: 5, end: 7)
+    try o?.traverse(visitor: visitor, start: 5, end: 7)
   }
 
   func _protoc_generated_isEqualTo(other: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra) -> Bool {

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -124,48 +124,38 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
 
   var unknown = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_O: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_O: SwiftProtobuf.OneofEnum {
     case oneofE1(Proto2PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto2PreserveUnknownEnumUnittest_MyEnum)
-    case None
 
     static func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
       switch (lhs, rhs) {
       case (.oneofE1(let l), .oneofE1(let r)): return l == r
       case (.oneofE2(let l), .oneofE2(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 5:
         var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &value)
         if let value = value {
           self = .oneofE1(value)
+          return
         }
       case 6:
         var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &value)
         if let value = value {
           self = .oneofE2(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -178,8 +168,6 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
         if start <= 6 && 6 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
         }
-      case .None:
-        break
       }
     }
   }
@@ -205,7 +193,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
 
   var oneofE1: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE1(let v) = o {
+      if case .oneofE1(let v)? = o {
         return v
       }
       return Proto2PreserveUnknownEnumUnittest_MyEnum.foo
@@ -215,11 +203,11 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     }
   }
 
-  var o: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O = .None
+  var o: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O? = nil
 
   var oneofE2: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE2(let v) = o {
+      if case .oneofE2(let v)? = o {
         return v
       }
       return Proto2PreserveUnknownEnumUnittest_MyEnum.foo
@@ -241,7 +229,11 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     case 2: try decoder.decodeRepeatedEnumField(value: &repeatedE)
     case 3: try decoder.decodeRepeatedEnumField(value: &repeatedPackedE)
     case 4: try decoder.decodeRepeatedEnumField(value: &repeatedPackedUnexpectedE)
-    case 5, 6: try o.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 5, 6:
+      if o != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      o = try Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     default: break
     }
   }
@@ -259,7 +251,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     if !repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitRepeatedEnumField(value: repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try o.traverse(visitor: visitor, start: 5, end: 7)
+    try o?.traverse(visitor: visitor, start: 5, end: 7)
     unknown.traverse(visitor: visitor)
   }
 

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -227,7 +227,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
     var _repeatedLazyMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] = []
-    var _oneofField = Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField()
+    var _oneofField: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -284,7 +284,11 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
       case 54: try decoder.decodeRepeatedStringField(value: &_repeatedStringPiece)
       case 55: try decoder.decodeRepeatedStringField(value: &_repeatedCord)
       case 57: try decoder.decodeRepeatedMessageField(value: &_repeatedLazyMessage)
-      case 111, 112, 113, 114: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -431,7 +435,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
       if !_repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _repeatedLazyMessage, fieldNumber: 57)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 115)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 115)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -543,12 +547,11 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto3ArenaUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -556,45 +559,38 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
       case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 112:
         var value: Proto3ArenaUnittest_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 114:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .oneofBytes(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -615,8 +611,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
         if start <= 114 && 114 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 114)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1027,7 +1021,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1039,7 +1033,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
 
   var oneofNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return Proto3ArenaUnittest_TestAllTypes.NestedMessage()
@@ -1051,7 +1045,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1063,7 +1057,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1073,7 +1067,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -227,7 +227,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
     var _repeatedLazyMessage: [Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage] = []
-    var _oneofField = Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField()
+    var _oneofField: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -284,7 +284,11 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
       case 54: try decoder.decodeRepeatedStringField(value: &_repeatedStringPiece)
       case 55: try decoder.decodeRepeatedStringField(value: &_repeatedCord)
       case 57: try decoder.decodeRepeatedMessageField(value: &_repeatedLazyMessage)
-      case 111, 112, 113, 114: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -431,7 +435,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
       if !_repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _repeatedLazyMessage, fieldNumber: 57)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 115)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 115)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -543,12 +547,11 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -556,45 +559,38 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
       case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 112:
         var value: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 114:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .oneofBytes(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -615,8 +611,6 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
         if start <= 114 && 114 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 114)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1027,7 +1021,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1039,7 +1033,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofNestedMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage()
@@ -1051,7 +1045,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1063,7 +1057,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1073,7 +1067,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -227,7 +227,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
     var _repeatedLazyMessage: [Proto3LiteUnittest_TestAllTypes.NestedMessage] = []
-    var _oneofField = Proto3LiteUnittest_TestAllTypes.OneOf_OneofField()
+    var _oneofField: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -284,7 +284,11 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
       case 54: try decoder.decodeRepeatedStringField(value: &_repeatedStringPiece)
       case 55: try decoder.decodeRepeatedStringField(value: &_repeatedCord)
       case 57: try decoder.decodeRepeatedMessageField(value: &_repeatedLazyMessage)
-      case 111, 112, 113, 114: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try Proto3LiteUnittest_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -431,7 +435,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
       if !_repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _repeatedLazyMessage, fieldNumber: 57)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 115)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 115)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -543,12 +547,11 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto3LiteUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3LiteUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -556,45 +559,38 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
       case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 112:
         var value: Proto3LiteUnittest_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 114:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .oneofBytes(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -615,8 +611,6 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
         if start <= 114 && 114 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 114)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1027,7 +1021,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1039,7 +1033,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
 
   var oneofNestedMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return Proto3LiteUnittest_TestAllTypes.NestedMessage()
@@ -1051,7 +1045,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1063,7 +1057,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1073,7 +1067,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -768,7 +768,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   private class _StorageClass {
     typealias ExtendedMessage = ProtobufUnittest_OneofWellKnownTypes
-    var _oneofField = ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -778,13 +778,17 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
     func decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
       switch fieldNumber {
-      case 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      try _oneofField.traverse(visitor: visitor, start: 1, end: 19)
+      try _oneofField?.traverse(visitor: visitor, start: 1, end: 19)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -802,7 +806,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case anyField(Google_Protobuf_Any)
     case apiField(Google_Protobuf_Api)
     case durationField(Google_Protobuf_Duration)
@@ -821,7 +825,6 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
     case boolField(Google_Protobuf_BoolValue)
     case stringField(Google_Protobuf_StringValue)
     case bytesField(Google_Protobuf_BytesValue)
-    case None
 
     static func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -843,135 +846,142 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
       case (.boolField(let l), .boolField(let r)): return l == r
       case (.stringField(let l), .stringField(let r)): return l == r
       case (.bytesField(let l), .bytesField(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value: Google_Protobuf_Any?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .anyField(value)
+          return
         }
       case 2:
         var value: Google_Protobuf_Api?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .apiField(value)
+          return
         }
       case 3:
         var value: Google_Protobuf_Duration?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .durationField(value)
+          return
         }
       case 4:
         var value: Google_Protobuf_Empty?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .emptyField(value)
+          return
         }
       case 5:
         var value: Google_Protobuf_FieldMask?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .fieldMaskField(value)
+          return
         }
       case 6:
         var value: Google_Protobuf_SourceContext?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .sourceContextField(value)
+          return
         }
       case 7:
         var value: Google_Protobuf_Struct?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .structField(value)
+          return
         }
       case 8:
         var value: Google_Protobuf_Timestamp?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .timestampField(value)
+          return
         }
       case 9:
         var value: Google_Protobuf_Type?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .typeField(value)
+          return
         }
       case 10:
         var value: Google_Protobuf_DoubleValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .doubleField(value)
+          return
         }
       case 11:
         var value: Google_Protobuf_FloatValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .floatField(value)
+          return
         }
       case 12:
         var value: Google_Protobuf_Int64Value?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .int64Field(value)
+          return
         }
       case 13:
         var value: Google_Protobuf_UInt64Value?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .uint64Field(value)
+          return
         }
       case 14:
         var value: Google_Protobuf_Int32Value?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .int32Field(value)
+          return
         }
       case 15:
         var value: Google_Protobuf_UInt32Value?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .uint32Field(value)
+          return
         }
       case 16:
         var value: Google_Protobuf_BoolValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .boolField(value)
+          return
         }
       case 17:
         var value: Google_Protobuf_StringValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .stringField(value)
+          return
         }
       case 18:
         var value: Google_Protobuf_BytesValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .bytesField(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -1048,15 +1058,13 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
         if start <= 18 && 18 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
         }
-      case .None:
-        break
       }
     }
   }
 
   var anyField: Google_Protobuf_Any {
     get {
-      if case .anyField(let v) = _storage._oneofField {
+      if case .anyField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Any()
@@ -1068,7 +1076,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var apiField: Google_Protobuf_Api {
     get {
-      if case .apiField(let v) = _storage._oneofField {
+      if case .apiField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Api()
@@ -1080,7 +1088,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var durationField: Google_Protobuf_Duration {
     get {
-      if case .durationField(let v) = _storage._oneofField {
+      if case .durationField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Duration()
@@ -1092,7 +1100,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var emptyField: Google_Protobuf_Empty {
     get {
-      if case .emptyField(let v) = _storage._oneofField {
+      if case .emptyField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Empty()
@@ -1104,7 +1112,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var fieldMaskField: Google_Protobuf_FieldMask {
     get {
-      if case .fieldMaskField(let v) = _storage._oneofField {
+      if case .fieldMaskField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_FieldMask()
@@ -1116,7 +1124,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var sourceContextField: Google_Protobuf_SourceContext {
     get {
-      if case .sourceContextField(let v) = _storage._oneofField {
+      if case .sourceContextField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_SourceContext()
@@ -1128,7 +1136,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var structField: Google_Protobuf_Struct {
     get {
-      if case .structField(let v) = _storage._oneofField {
+      if case .structField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Struct()
@@ -1140,7 +1148,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var timestampField: Google_Protobuf_Timestamp {
     get {
-      if case .timestampField(let v) = _storage._oneofField {
+      if case .timestampField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Timestamp()
@@ -1152,7 +1160,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var typeField: Google_Protobuf_Type {
     get {
-      if case .typeField(let v) = _storage._oneofField {
+      if case .typeField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Type()
@@ -1164,7 +1172,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var doubleField: Google_Protobuf_DoubleValue {
     get {
-      if case .doubleField(let v) = _storage._oneofField {
+      if case .doubleField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_DoubleValue()
@@ -1176,7 +1184,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var floatField: Google_Protobuf_FloatValue {
     get {
-      if case .floatField(let v) = _storage._oneofField {
+      if case .floatField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_FloatValue()
@@ -1188,7 +1196,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var int64Field: Google_Protobuf_Int64Value {
     get {
-      if case .int64Field(let v) = _storage._oneofField {
+      if case .int64Field(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Int64Value()
@@ -1200,7 +1208,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var uint64Field: Google_Protobuf_UInt64Value {
     get {
-      if case .uint64Field(let v) = _storage._oneofField {
+      if case .uint64Field(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_UInt64Value()
@@ -1212,7 +1220,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var int32Field: Google_Protobuf_Int32Value {
     get {
-      if case .int32Field(let v) = _storage._oneofField {
+      if case .int32Field(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Int32Value()
@@ -1224,7 +1232,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var uint32Field: Google_Protobuf_UInt32Value {
     get {
-      if case .uint32Field(let v) = _storage._oneofField {
+      if case .uint32Field(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_UInt32Value()
@@ -1236,7 +1244,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var boolField: Google_Protobuf_BoolValue {
     get {
-      if case .boolField(let v) = _storage._oneofField {
+      if case .boolField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_BoolValue()
@@ -1248,7 +1256,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var stringField: Google_Protobuf_StringValue {
     get {
-      if case .stringField(let v) = _storage._oneofField {
+      if case .stringField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_StringValue()
@@ -1260,7 +1268,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var bytesField: Google_Protobuf_BytesValue {
     get {
-      if case .bytesField(let v) = _storage._oneofField {
+      if case .bytesField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_BytesValue()
@@ -1270,7 +1278,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -156,7 +156,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
     var _defaultImportEnum: ProtobufUnittestImport_ImportEnum? = nil
     var _defaultStringPiece: String? = nil
     var _defaultCord: String? = nil
-    var _oneofField = ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField?
 
     var isInitialized: Bool {
       if _requiredInt32 == nil {return false}
@@ -209,10 +209,8 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
       if let v = _requiredNestedMessage, !v.isInitialized {return false}
       if let v = _requiredLazyMessage, !v.isInitialized {return false}
       switch _oneofField {
-      case .oneofNestedMessage(let v):
+      case .oneofNestedMessage(let v)?:
         if !v.isInitialized {return false}
-      case .None:
-        break
       default:
         break
       }
@@ -273,7 +271,11 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
       case 83: try decoder.decodeSingularEnumField(value: &_defaultImportEnum)
       case 84: try decoder.decodeSingularStringField(value: &_defaultStringPiece)
       case 85: try decoder.decodeSingularStringField(value: &_defaultCord)
-      case 111, 112, 113, 114: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -417,7 +419,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
       if let v = _defaultCord {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 85)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 115)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 115)
       unknown.traverse(visitor: visitor)
     }
 
@@ -534,12 +536,11 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllRequiredTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -547,51 +548,44 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
       case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 112:
         var value: ProtobufUnittest_TestAllRequiredTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 114:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -612,8 +606,6 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
         if start <= 114 && 114 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 114)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1307,7 +1299,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1319,7 +1311,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
 
   var oneofNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllRequiredTypes.NestedMessage()
@@ -1331,7 +1323,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1343,7 +1335,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1353,7 +1345,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -56,7 +56,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
     var _myString: String? = nil
     var _myInt: Int64? = nil
     var _myFloat: Float? = nil
-    var _options = Swift_Protobuf_TestFieldOrderings.OneOf_Options()
+    var _options: Swift_Protobuf_TestFieldOrderings.OneOf_Options?
     var _optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage? = nil
 
     var isInitialized: Bool {
@@ -75,7 +75,11 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
       case 11: try decoder.decodeSingularStringField(value: &_myString)
       case 1: try decoder.decodeSingularInt64Field(value: &_myInt)
       case 101: try decoder.decodeSingularFloatField(value: &_myFloat)
-      case 60, 9, 150, 10: try _options.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 60, 9, 150, 10:
+        if _options != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _options = try Swift_Protobuf_TestFieldOrderings.OneOf_Options(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 200: try decoder.decodeSingularMessageField(value: &_optionalNestedMessage)
       default: if (2 <= fieldNumber && fieldNumber < 9) || (12 <= fieldNumber && fieldNumber < 56) {
           try decoder.decodeExtensionField(values: &extensionFieldValues, messageType: Swift_Protobuf_TestFieldOrderings.self, fieldNumber: fieldNumber)
@@ -88,16 +92,16 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt64.self, value: v, fieldNumber: 1)
       }
       try visitor.visitExtensionFields(fields: extensionFieldValues, start: 2, end: 9)
-      try _options.traverse(visitor: visitor, start: 9, end: 11)
+      try _options?.traverse(visitor: visitor, start: 9, end: 11)
       if let v = _myString {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 11)
       }
       try visitor.visitExtensionFields(fields: extensionFieldValues, start: 12, end: 56)
-      try _options.traverse(visitor: visitor, start: 60, end: 61)
+      try _options?.traverse(visitor: visitor, start: 60, end: 61)
       if let v = _myFloat {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufFloat.self, value: v, fieldNumber: 101)
       }
-      try _options.traverse(visitor: visitor, start: 150, end: 151)
+      try _options?.traverse(visitor: visitor, start: 150, end: 151)
       if let v = _optionalNestedMessage {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
       }
@@ -135,12 +139,11 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_Options: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Options: SwiftProtobuf.OneofEnum {
     case oneofInt64(Int64)
     case oneofBool(Bool)
     case oneofString(String)
     case oneofInt32(Int32)
-    case None
 
     static func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
       switch (lhs, rhs) {
@@ -148,51 +151,44 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
       case (.oneofBool(let l), .oneofBool(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 9:
         var value: Bool?
         try decoder.decodeSingularBoolField(value: &value)
         if let value = value {
           self = .oneofBool(value)
+          return
         }
       case 10:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .oneofInt32(value)
+          return
         }
       case 60:
         var value: Int64?
         try decoder.decodeSingularInt64Field(value: &value)
         if let value = value {
           self = .oneofInt64(value)
+          return
         }
       case 150:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -213,8 +209,6 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
         if start <= 150 && 150 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 150)
         }
-      case .None:
-        break
       }
     }
   }
@@ -320,7 +314,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v) = _storage._options {
+      if case .oneofInt64(let v)? = _storage._options {
         return v
       }
       return 0
@@ -332,7 +326,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v) = _storage._options {
+      if case .oneofBool(let v)? = _storage._options {
         return v
       }
       return false
@@ -344,7 +338,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._options {
+      if case .oneofString(let v)? = _storage._options {
         return v
       }
       return ""
@@ -356,7 +350,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v) = _storage._options {
+      if case .oneofInt32(let v)? = _storage._options {
         return v
       }
       return 0
@@ -377,7 +371,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
     return _storage._optionalNestedMessage = nil
   }
 
-  var options: OneOf_Options {
+  var options: OneOf_Options? {
     get {return _storage._options}
     set {
       _uniqueStorage()._options = newValue

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -166,7 +166,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
     var _repeatedGroup: [ProtobufUnittest_Message2.RepeatedGroup] = []
     var _repeatedMessage: [ProtobufUnittest_Message2] = []
     var _repeatedEnum: [ProtobufUnittest_Message2.Enum] = []
-    var _o = ProtobufUnittest_Message2.OneOf_O()
+    var _o: ProtobufUnittest_Message2.OneOf_O?
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -231,7 +231,11 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
       case 46: try decoder.decodeRepeatedGroupField(value: &_repeatedGroup)
       case 48: try decoder.decodeRepeatedMessageField(value: &_repeatedMessage)
       case 49: try decoder.decodeRepeatedEnumField(value: &_repeatedEnum)
-      case 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 68, 69: try _o.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 68, 69:
+        if _o != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _o = try ProtobufUnittest_Message2.OneOf_O(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 70: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: &_mapInt32Int32)
       case 71: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt64,SwiftProtobuf.ProtobufInt64>.self, value: &_mapInt64Int64)
       case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufUInt32,SwiftProtobuf.ProtobufUInt32>.self, value: &_mapUint32Uint32)
@@ -364,7 +368,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
       if !_repeatedEnum.isEmpty {
         try visitor.visitRepeatedEnumField(value: _repeatedEnum, fieldNumber: 49)
       }
-      try _o.traverse(visitor: visitor, start: 51, end: 70)
+      try _o?.traverse(visitor: visitor, start: 51, end: 70)
       if !_mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _mapInt32Int32, fieldNumber: 70)
       }
@@ -556,7 +560,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_O: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_O: SwiftProtobuf.OneofEnum {
     case oneofInt32(Int32)
     case oneofInt64(Int64)
     case oneofUint32(UInt32)
@@ -575,7 +579,6 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
     case oneofGroup(ProtobufUnittest_Message2.OneofGroup)
     case oneofMessage(ProtobufUnittest_Message2)
     case oneofEnum(ProtobufUnittest_Message2.Enum)
-    case None
 
     static func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
       switch (lhs, rhs) {
@@ -597,135 +600,142 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
       case (.oneofGroup(let l), .oneofGroup(let r)): return l == r
       case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
       case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 51:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .oneofInt32(value)
+          return
         }
       case 52:
         var value: Int64?
         try decoder.decodeSingularInt64Field(value: &value)
         if let value = value {
           self = .oneofInt64(value)
+          return
         }
       case 53:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 54:
         var value: UInt64?
         try decoder.decodeSingularUInt64Field(value: &value)
         if let value = value {
           self = .oneofUint64(value)
+          return
         }
       case 55:
         var value: Int32?
         try decoder.decodeSingularSInt32Field(value: &value)
         if let value = value {
           self = .oneofSint32(value)
+          return
         }
       case 56:
         var value: Int64?
         try decoder.decodeSingularSInt64Field(value: &value)
         if let value = value {
           self = .oneofSint64(value)
+          return
         }
       case 57:
         var value: UInt32?
         try decoder.decodeSingularFixed32Field(value: &value)
         if let value = value {
           self = .oneofFixed32(value)
+          return
         }
       case 58:
         var value: UInt64?
         try decoder.decodeSingularFixed64Field(value: &value)
         if let value = value {
           self = .oneofFixed64(value)
+          return
         }
       case 59:
         var value: Int32?
         try decoder.decodeSingularSFixed32Field(value: &value)
         if let value = value {
           self = .oneofSfixed32(value)
+          return
         }
       case 60:
         var value: Int64?
         try decoder.decodeSingularSFixed64Field(value: &value)
         if let value = value {
           self = .oneofSfixed64(value)
+          return
         }
       case 61:
         var value: Float?
         try decoder.decodeSingularFloatField(value: &value)
         if let value = value {
           self = .oneofFloat(value)
+          return
         }
       case 62:
         var value: Double?
         try decoder.decodeSingularDoubleField(value: &value)
         if let value = value {
           self = .oneofDouble(value)
+          return
         }
       case 63:
         var value: Bool?
         try decoder.decodeSingularBoolField(value: &value)
         if let value = value {
           self = .oneofBool(value)
+          return
         }
       case 64:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 65:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       case 66:
         var value: ProtobufUnittest_Message2.OneofGroup?
         try decoder.decodeSingularGroupField(value: &value)
         if let value = value {
           self = .oneofGroup(value)
+          return
         }
       case 68:
         var value: ProtobufUnittest_Message2?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofMessage(value)
+          return
         }
       case 69:
         var value: ProtobufUnittest_Message2.Enum?
         try decoder.decodeSingularEnumField(value: &value)
         if let value = value {
           self = .oneofEnum(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -802,8 +812,6 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
         if start <= 69 && 69 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1327,7 +1335,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v) = _storage._o {
+      if case .oneofInt32(let v)? = _storage._o {
         return v
       }
       return 100
@@ -1339,7 +1347,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v) = _storage._o {
+      if case .oneofInt64(let v)? = _storage._o {
         return v
       }
       return 101
@@ -1351,7 +1359,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._o {
+      if case .oneofUint32(let v)? = _storage._o {
         return v
       }
       return 102
@@ -1363,7 +1371,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v) = _storage._o {
+      if case .oneofUint64(let v)? = _storage._o {
         return v
       }
       return 103
@@ -1375,7 +1383,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofSint32: Int32 {
     get {
-      if case .oneofSint32(let v) = _storage._o {
+      if case .oneofSint32(let v)? = _storage._o {
         return v
       }
       return 104
@@ -1387,7 +1395,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofSint64: Int64 {
     get {
-      if case .oneofSint64(let v) = _storage._o {
+      if case .oneofSint64(let v)? = _storage._o {
         return v
       }
       return 105
@@ -1399,7 +1407,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofFixed32: UInt32 {
     get {
-      if case .oneofFixed32(let v) = _storage._o {
+      if case .oneofFixed32(let v)? = _storage._o {
         return v
       }
       return 106
@@ -1411,7 +1419,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofFixed64: UInt64 {
     get {
-      if case .oneofFixed64(let v) = _storage._o {
+      if case .oneofFixed64(let v)? = _storage._o {
         return v
       }
       return 107
@@ -1423,7 +1431,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofSfixed32: Int32 {
     get {
-      if case .oneofSfixed32(let v) = _storage._o {
+      if case .oneofSfixed32(let v)? = _storage._o {
         return v
       }
       return 108
@@ -1435,7 +1443,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofSfixed64: Int64 {
     get {
-      if case .oneofSfixed64(let v) = _storage._o {
+      if case .oneofSfixed64(let v)? = _storage._o {
         return v
       }
       return 109
@@ -1447,7 +1455,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v) = _storage._o {
+      if case .oneofFloat(let v)? = _storage._o {
         return v
       }
       return 110
@@ -1459,7 +1467,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v) = _storage._o {
+      if case .oneofDouble(let v)? = _storage._o {
         return v
       }
       return 111
@@ -1471,7 +1479,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v) = _storage._o {
+      if case .oneofBool(let v)? = _storage._o {
         return v
       }
       return true
@@ -1483,7 +1491,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._o {
+      if case .oneofString(let v)? = _storage._o {
         return v
       }
       return "string"
@@ -1495,7 +1503,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._o {
+      if case .oneofBytes(let v)? = _storage._o {
         return v
       }
       return Data(bytes: [100, 97, 116, 97])
@@ -1507,7 +1515,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofGroup: ProtobufUnittest_Message2.OneofGroup {
     get {
-      if case .oneofGroup(let v) = _storage._o {
+      if case .oneofGroup(let v)? = _storage._o {
         return v
       }
       return ProtobufUnittest_Message2.OneofGroup()
@@ -1519,7 +1527,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofMessage: ProtobufUnittest_Message2 {
     get {
-      if case .oneofMessage(let v) = _storage._o {
+      if case .oneofMessage(let v)? = _storage._o {
         return v
       }
       return ProtobufUnittest_Message2()
@@ -1531,7 +1539,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofEnum: ProtobufUnittest_Message2.Enum {
     get {
-      if case .oneofEnum(let v) = _storage._o {
+      if case .oneofEnum(let v)? = _storage._o {
         return v
       }
       return ProtobufUnittest_Message2.Enum.baz
@@ -1637,7 +1645,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
     set {_uniqueStorage()._mapInt32Message = newValue}
   }
 
-  var o: OneOf_O {
+  var o: OneOf_O? {
     get {return _storage._o}
     set {
       _uniqueStorage()._o = newValue

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -160,7 +160,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
     var _repeatedBytes: [Data] = []
     var _repeatedMessage: [ProtobufUnittest_Message3] = []
     var _repeatedEnum: [ProtobufUnittest_Message3.Enum] = []
-    var _o = ProtobufUnittest_Message3.OneOf_O()
+    var _o: ProtobufUnittest_Message3.OneOf_O?
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -223,7 +223,11 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
       case 45: try decoder.decodeRepeatedBytesField(value: &_repeatedBytes)
       case 48: try decoder.decodeRepeatedMessageField(value: &_repeatedMessage)
       case 49: try decoder.decodeRepeatedEnumField(value: &_repeatedEnum)
-      case 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 68, 69: try _o.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 68, 69:
+        if _o != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _o = try ProtobufUnittest_Message3.OneOf_O(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 70: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: &_mapInt32Int32)
       case 71: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt64,SwiftProtobuf.ProtobufInt64>.self, value: &_mapInt64Int64)
       case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufUInt32,SwiftProtobuf.ProtobufUInt32>.self, value: &_mapUint32Uint32)
@@ -350,7 +354,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
       if !_repeatedEnum.isEmpty {
         try visitor.visitPackedEnumField(value: _repeatedEnum, fieldNumber: 49)
       }
-      try _o.traverse(visitor: visitor, start: 51, end: 70)
+      try _o?.traverse(visitor: visitor, start: 51, end: 70)
       if !_mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _mapInt32Int32, fieldNumber: 70)
       }
@@ -531,7 +535,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
   private var _storage = _StorageClass()
 
 
-  enum OneOf_O: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_O: SwiftProtobuf.OneofEnum {
     case oneofInt32(Int32)
     case oneofInt64(Int64)
     case oneofUint32(UInt32)
@@ -549,7 +553,6 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
     case oneofBytes(Data)
     case oneofMessage(ProtobufUnittest_Message3)
     case oneofEnum(ProtobufUnittest_Message3.Enum)
-    case None
 
     static func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
       switch (lhs, rhs) {
@@ -570,97 +573,103 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
       case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
       case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 51:
         var value = Int32()
         try decoder.decodeSingularInt32Field(value: &value)
         self = .oneofInt32(value)
+        return
       case 52:
         var value = Int64()
         try decoder.decodeSingularInt64Field(value: &value)
         self = .oneofInt64(value)
+        return
       case 53:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 54:
         var value = UInt64()
         try decoder.decodeSingularUInt64Field(value: &value)
         self = .oneofUint64(value)
+        return
       case 55:
         var value = Int32()
         try decoder.decodeSingularSInt32Field(value: &value)
         self = .oneofSint32(value)
+        return
       case 56:
         var value = Int64()
         try decoder.decodeSingularSInt64Field(value: &value)
         self = .oneofSint64(value)
+        return
       case 57:
         var value = UInt32()
         try decoder.decodeSingularFixed32Field(value: &value)
         self = .oneofFixed32(value)
+        return
       case 58:
         var value = UInt64()
         try decoder.decodeSingularFixed64Field(value: &value)
         self = .oneofFixed64(value)
+        return
       case 59:
         var value = Int32()
         try decoder.decodeSingularSFixed32Field(value: &value)
         self = .oneofSfixed32(value)
+        return
       case 60:
         var value = Int64()
         try decoder.decodeSingularSFixed64Field(value: &value)
         self = .oneofSfixed64(value)
+        return
       case 61:
         var value = Float()
         try decoder.decodeSingularFloatField(value: &value)
         self = .oneofFloat(value)
+        return
       case 62:
         var value = Double()
         try decoder.decodeSingularDoubleField(value: &value)
         self = .oneofDouble(value)
+        return
       case 63:
         var value = Bool()
         try decoder.decodeSingularBoolField(value: &value)
         self = .oneofBool(value)
+        return
       case 64:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 65:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .oneofBytes(value)
+        return
       case 68:
         var value: ProtobufUnittest_Message3?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofMessage(value)
+          return
         }
       case 69:
         var value = ProtobufUnittest_Message3.Enum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofEnum(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -733,8 +742,6 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
         if start <= 69 && 69 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
         }
-      case .None:
-        break
       }
     }
   }
@@ -989,7 +996,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v) = _storage._o {
+      if case .oneofInt32(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1001,7 +1008,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v) = _storage._o {
+      if case .oneofInt64(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1013,7 +1020,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._o {
+      if case .oneofUint32(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1025,7 +1032,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v) = _storage._o {
+      if case .oneofUint64(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1037,7 +1044,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofSint32: Int32 {
     get {
-      if case .oneofSint32(let v) = _storage._o {
+      if case .oneofSint32(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1049,7 +1056,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofSint64: Int64 {
     get {
-      if case .oneofSint64(let v) = _storage._o {
+      if case .oneofSint64(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1061,7 +1068,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofFixed32: UInt32 {
     get {
-      if case .oneofFixed32(let v) = _storage._o {
+      if case .oneofFixed32(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1073,7 +1080,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofFixed64: UInt64 {
     get {
-      if case .oneofFixed64(let v) = _storage._o {
+      if case .oneofFixed64(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1085,7 +1092,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofSfixed32: Int32 {
     get {
-      if case .oneofSfixed32(let v) = _storage._o {
+      if case .oneofSfixed32(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1097,7 +1104,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofSfixed64: Int64 {
     get {
-      if case .oneofSfixed64(let v) = _storage._o {
+      if case .oneofSfixed64(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1109,7 +1116,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v) = _storage._o {
+      if case .oneofFloat(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1121,7 +1128,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v) = _storage._o {
+      if case .oneofDouble(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1133,7 +1140,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v) = _storage._o {
+      if case .oneofBool(let v)? = _storage._o {
         return v
       }
       return false
@@ -1145,7 +1152,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._o {
+      if case .oneofString(let v)? = _storage._o {
         return v
       }
       return ""
@@ -1157,7 +1164,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._o {
+      if case .oneofBytes(let v)? = _storage._o {
         return v
       }
       return Data()
@@ -1170,7 +1177,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
   ///   No 'group' in proto3.
   var oneofMessage: ProtobufUnittest_Message3 {
     get {
-      if case .oneofMessage(let v) = _storage._o {
+      if case .oneofMessage(let v)? = _storage._o {
         return v
       }
       return ProtobufUnittest_Message3()
@@ -1182,7 +1189,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofEnum: ProtobufUnittest_Message3.Enum {
     get {
-      if case .oneofEnum(let v) = _storage._o {
+      if case .oneofEnum(let v)? = _storage._o {
         return v
       }
       return ProtobufUnittest_Message3.Enum.foo
@@ -1288,7 +1295,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
     set {_uniqueStorage()._mapInt32Message = newValue}
   }
 
-  var o: OneOf_O {
+  var o: OneOf_O? {
     get {return _storage._o}
     set {
       _uniqueStorage()._o = newValue

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -147,44 +147,34 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
   ]
 
 
-  enum OneOf_Payload: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Payload: SwiftProtobuf.OneofEnum {
     case protobufPayload(Data)
     case jsonPayload(String)
-    case None
 
     static func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
       switch (lhs, rhs) {
       case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
       case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .protobufPayload(value)
+        return
       case 2:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .jsonPayload(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -197,15 +187,13 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
         if start <= 2 && 2 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 2)
         }
-      case .None:
-        break
       }
     }
   }
 
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v) = payload {
+      if case .protobufPayload(let v)? = payload {
         return v
       }
       return Data()
@@ -215,11 +203,11 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
     }
   }
 
-  var payload: Conformance_ConformanceRequest.OneOf_Payload = .None
+  var payload: Conformance_ConformanceRequest.OneOf_Payload? = nil
 
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v) = payload {
+      if case .jsonPayload(let v)? = payload {
         return v
       }
       return ""
@@ -240,14 +228,18 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
 
   mutating func _protoc_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2: try payload.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 1, 2:
+      if payload != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      payload = try Conformance_ConformanceRequest.OneOf_Payload(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     case 3: try decoder.decodeSingularEnumField(value: &requestedOutputFormat)
     default: break
     }
   }
 
   func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
-    try payload.traverse(visitor: visitor, start: 1, end: 3)
+    try payload?.traverse(visitor: visitor, start: 1, end: 3)
     if requestedOutputFormat != Conformance_WireFormat.unspecified {
       try visitor.visitSingularEnumField(value: requestedOutputFormat, fieldNumber: 3)
     }
@@ -274,14 +266,13 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ]
 
 
-  enum OneOf_Result: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Result: SwiftProtobuf.OneofEnum {
     case parseError(String)
     case serializeError(String)
     case runtimeError(String)
     case protobufPayload(Data)
     case jsonPayload(String)
     case skipped(String)
-    case None
 
     static func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
       switch (lhs, rhs) {
@@ -291,51 +282,46 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
       case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
       case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
       case (.skipped(let l), .skipped(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .parseError(value)
+        return
       case 2:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .runtimeError(value)
+        return
       case 3:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .protobufPayload(value)
+        return
       case 4:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .jsonPayload(value)
+        return
       case 5:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .skipped(value)
+        return
       case 6:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .serializeError(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -364,8 +350,6 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
         if start <= 6 && 6 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 6)
         }
-      case .None:
-        break
       }
     }
   }
@@ -377,7 +361,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   test.  Some of the test cases are intentionally invalid input.
   var parseError: String {
     get {
-      if case .parseError(let v) = result {
+      if case .parseError(let v)? = result {
         return v
       }
       return ""
@@ -387,14 +371,14 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
     }
   }
 
-  var result: Conformance_ConformanceResponse.OneOf_Result = .None
+  var result: Conformance_ConformanceResponse.OneOf_Result? = nil
 
   ///   If the input was successfully parsed but errors occurred when
   ///   serializing it to the requested output format, set the error message in
   ///   this field.
   var serializeError: String {
     get {
-      if case .serializeError(let v) = result {
+      if case .serializeError(let v)? = result {
         return v
       }
       return ""
@@ -409,7 +393,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   about the failure.
   var runtimeError: String {
     get {
-      if case .runtimeError(let v) = result {
+      if case .runtimeError(let v)? = result {
         return v
       }
       return ""
@@ -423,7 +407,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   protobuf, serialize it to protobuf and set it in this field.
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v) = result {
+      if case .protobufPayload(let v)? = result {
         return v
       }
       return Data()
@@ -437,7 +421,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   serialize to JSON and set it in this field.
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v) = result {
+      if case .jsonPayload(let v)? = result {
         return v
       }
       return ""
@@ -451,7 +435,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   wasn't supported, like JSON input/output.
   var skipped: String {
     get {
-      if case .skipped(let v) = result {
+      if case .skipped(let v)? = result {
         return v
       }
       return ""
@@ -469,13 +453,17 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
 
   mutating func _protoc_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 6, 2, 3, 4, 5: try result.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 1, 6, 2, 3, 4, 5:
+      if result != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      result = try Conformance_ConformanceResponse.OneOf_Result(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     default: break
     }
   }
 
   func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
-    try result.traverse(visitor: visitor, start: 1, end: 7)
+    try result?.traverse(visitor: visitor, start: 1, end: 7)
   }
 
   func _protoc_generated_isEqualTo(other: Conformance_ConformanceResponse) -> Bool {

--- a/Sources/Conformance/main.swift
+++ b/Sources/Conformance/main.swift
@@ -62,14 +62,14 @@ func buildResponse(protobuf: Data) -> Conformance_ConformanceResponse {
 
     let parsed: ProtobufTestMessages_Proto3_TestAllTypes?
     switch request.payload {
-    case .protobufPayload(let data):
+    case .protobufPayload(let data)?:
         do {
             parsed = try ProtobufTestMessages_Proto3_TestAllTypes(protobuf: data)
         } catch let e {
             response.parseError = "Protobuf failed to parse: \(e)"
             return response
         }
-    case .jsonPayload(let json):
+    case .jsonPayload(let json)?:
         do {
             parsed = try ProtobufTestMessages_Proto3_TestAllTypes(json: json)
         } catch let e {

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -315,7 +315,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     var _mapStringForeignMessage: Dictionary<String,ProtobufTestMessages_Proto3_ForeignMessage> = [:]
     var _mapStringNestedEnum: Dictionary<String,ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum> = [:]
     var _mapStringForeignEnum: Dictionary<String,ProtobufTestMessages_Proto3_ForeignEnum> = [:]
-    var _oneofField = ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField()
+    var _oneofField: ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField?
     var _optionalBoolWrapper: Google_Protobuf_BoolValue? = nil
     var _optionalInt32Wrapper: Google_Protobuf_Int32Value? = nil
     var _optionalInt64Wrapper: Google_Protobuf_Int64Value? = nil
@@ -435,7 +435,11 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignMessage>.self, value: &_mapStringForeignMessage)
       case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum>.self, value: &_mapStringNestedEnum)
       case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: &_mapStringForeignEnum)
-      case 111, 112, 113, 114, 115, 116, 117, 118, 119: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114, 115, 116, 117, 118, 119:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 201: try decoder.decodeSingularMessageField(value: &_optionalBoolWrapper)
       case 202: try decoder.decodeSingularMessageField(value: &_optionalInt32Wrapper)
       case 203: try decoder.decodeSingularMessageField(value: &_optionalInt64Wrapper)
@@ -675,7 +679,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       if !_mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: _mapStringForeignEnum, fieldNumber: 74)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 120)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 120)
       if let v = _optionalBoolWrapper {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 201)
       }
@@ -1057,7 +1061,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -1067,7 +1071,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     case oneofFloat(Float)
     case oneofDouble(Double)
     case oneofEnum(ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum)
-    case None
 
     static func ==(lhs: ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField, rhs: ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -1080,65 +1083,63 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
       case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
       case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 112:
         var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 114:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .oneofBytes(value)
+        return
       case 115:
         var value = Bool()
         try decoder.decodeSingularBoolField(value: &value)
         self = .oneofBool(value)
+        return
       case 116:
         var value = UInt64()
         try decoder.decodeSingularUInt64Field(value: &value)
         self = .oneofUint64(value)
+        return
       case 117:
         var value = Float()
         try decoder.decodeSingularFloatField(value: &value)
         self = .oneofFloat(value)
+        return
       case 118:
         var value = Double()
         try decoder.decodeSingularDoubleField(value: &value)
         self = .oneofDouble(value)
+        return
       case 119:
         var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofEnum(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -1179,8 +1180,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
         if start <= 119 && 119 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1683,7 +1682,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1695,7 +1694,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofNestedMessage: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage()
@@ -1707,7 +1706,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1719,7 +1718,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1731,7 +1730,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v) = _storage._oneofField {
+      if case .oneofBool(let v)? = _storage._oneofField {
         return v
       }
       return false
@@ -1743,7 +1742,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v) = _storage._oneofField {
+      if case .oneofUint64(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1755,7 +1754,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v) = _storage._oneofField {
+      if case .oneofFloat(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1767,7 +1766,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v) = _storage._oneofField {
+      if case .oneofDouble(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1779,7 +1778,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofEnum: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum {
     get {
-      if case .oneofEnum(let v) = _storage._oneofField {
+      if case .oneofEnum(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum.foo
@@ -2122,7 +2121,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     set {_uniqueStorage()._fieldName18__ = newValue}
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Sources/SwiftProtobuf/Google_Protobuf_Struct.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Struct.swift
@@ -248,7 +248,10 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
     mutating public func _protoc_generated_decodeField<T: Decoder>(decoder: inout T, fieldNumber: Int) throws {
         switch fieldNumber {
         case 1, 2, 3, 4, 5, 6:
-            try kind.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+            if kind != nil {
+                try decoder.handleConflictingOneOf()
+            }
+            kind = try OneOf_Kind(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
         default: break
         }
     }
@@ -265,7 +268,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
     }
 
     fileprivate func serializeJSONValue(jsonEncoder: inout JSONEncoder) throws {
-        try kind.serializeJSONField(encoder: &jsonEncoder)
+        try kind?.serializeJSONField(encoder: &jsonEncoder)
     }
 
     public mutating func decodeJSON(from decoder: inout JSONDecoder) throws {
@@ -304,16 +307,16 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
     }
 
     public func _protoc_generated_traverse(visitor: Visitor) throws {
-        try kind.traverse(visitor: visitor, start:1, end: 7)
+        try kind?.traverse(visitor: visitor, start:1, end: 7)
     }
 
     // Storage ivars
-    private var kind = Google_Protobuf_Value.OneOf_Kind()
+    private var kind: Google_Protobuf_Value.OneOf_Kind?
 
     ///   Represents a null value.
     public var nullValue: Google_Protobuf_NullValue? {
         get {
-            if case .nullValue(let v) = kind {
+            if case .nullValue(let v)? = kind {
                 return v
             }
             return nil
@@ -322,7 +325,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
             if let newValue = newValue {
                 kind = .nullValue(newValue)
             } else {
-                kind = .None
+                kind = nil
             }
         }
     }
@@ -330,7 +333,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
     ///   Represents a double value.
     public var numberValue: Double? {
         get {
-            if case .numberValue(let v) = kind {
+            if case .numberValue(let v)? = kind {
                 return v
             }
             return nil
@@ -339,7 +342,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
             if let newValue = newValue {
                 kind = .numberValue(newValue)
             } else {
-                kind = .None
+                kind = nil
             }
         }
     }
@@ -347,7 +350,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
     ///   Represents a string value.
     public var stringValue: String? {
         get {
-            if case .stringValue(let v) = kind {
+            if case .stringValue(let v)? = kind {
                 return v
             }
             return nil
@@ -356,7 +359,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
             if let newValue = newValue {
                 kind = .stringValue(newValue)
             } else {
-                kind = .None
+                kind = nil
             }
         }
     }
@@ -364,7 +367,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
     ///   Represents a boolean value.
     public var boolValue: Bool? {
         get {
-            if case .boolValue(let v) = kind {
+            if case .boolValue(let v)? = kind {
                 return v
             }
             return nil
@@ -373,7 +376,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
             if let newValue = newValue {
                 kind = .boolValue(newValue)
             } else {
-                kind = .None
+                kind = nil
             }
         }
     }
@@ -381,7 +384,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
     ///   Represents a structured value.
     public var structValue: Google_Protobuf_Struct? {
         get {
-            if case .structValue(let v) = kind {
+            if case .structValue(let v)? = kind {
                 return v
             }
             return nil
@@ -390,7 +393,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
             if let newValue = newValue {
                 kind = .structValue(newValue)
             } else {
-                kind = .None
+                kind = nil
             }
         }
     }
@@ -398,7 +401,7 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
     ///   Represents a repeated `Value`.
     public var listValue: Google_Protobuf_ListValue? {
         get {
-            if case .listValue(let v) = kind {
+            if case .listValue(let v)? = kind {
                 return v
             }
             return nil
@@ -407,69 +410,67 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
             if let newValue = newValue {
                 kind = .listValue(newValue)
             } else {
-                kind = .None
+                kind = nil
             }
         }
     }
 
-    public enum OneOf_Kind: ExpressibleByNilLiteral, OneofEnum {
+    public enum OneOf_Kind: OneofEnum {
         case nullValue(Google_Protobuf_NullValue)
         case numberValue(Double)
         case stringValue(String)
         case boolValue(Bool)
         case structValue(Google_Protobuf_Struct)
         case listValue(Google_Protobuf_ListValue)
-        case None
 
-        public init(nilLiteral: ()) {
-            self = .None
-        }
-
-        public init() {
-            self = .None
-        }
-
-        public mutating func decodeField<T: Decoder>(decoder: inout T, fieldNumber: Int) throws {
+        public init?<T: Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
             switch fieldNumber {
             case 1:
                 var value: Google_Protobuf_NullValue?
                 try decoder.decodeSingularEnumField(value: &value)
                 if let value = value {
                     self = .nullValue(value)
+                    return
                 }
             case 2:
                 var value: Double?
                 try decoder.decodeSingularDoubleField(value: &value)
                 if let value = value {
                     self = .numberValue(value)
+                    return
                 }
             case 3:
                 var value: String?
                 try decoder.decodeSingularStringField(value: &value)
                 if let value = value {
                     self = .stringValue(value)
+                    return
                 }
             case 4:
                 var value: Bool?
                 try decoder.decodeSingularBoolField(value: &value)
                 if let value = value {
                     self = .boolValue(value)
+                    return
                 }
             case 5:
                 var value: Google_Protobuf_Struct?
                 try decoder.decodeSingularMessageField(value: &value)
                 if let value = value {
                     self = .structValue(value)
+                    return
                 }
             case 6:
                 var value: Google_Protobuf_ListValue?
                 try decoder.decodeSingularMessageField(value: &value)
                 if let value = value {
                     self = .listValue(value)
+                    return
                 }
             default:
                 break
             }
+            return nil
         }
 
         fileprivate func serializeJSONField(encoder: inout JSONEncoder) throws {
@@ -480,8 +481,6 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
             case .boolValue(let v): encoder.putBoolValue(value: v, quote: false)
             case .structValue(let v): encoder.append(text: try v.serializeJSON())
             case .listValue(let v): encoder.append(text: try v.serializeJSON())
-            case .None:
-                break
             }
         }
 
@@ -511,8 +510,6 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
                 if start <= 6 && 6 < end {
                     try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
                 }
-            case .None:
-                break
             }
         }
 
@@ -524,7 +521,6 @@ public struct Google_Protobuf_Value: Message, Proto3Message, _MessageImplementat
             case .boolValue(let v): return v.hashValue
             case .structValue(let v): return v.hashValue
             case .listValue(let v): return v.hashValue
-            case .None: return 0
             }
         }
     }
@@ -639,7 +635,6 @@ public func ==(lhs: Google_Protobuf_Value.OneOf_Kind, rhs: Google_Protobuf_Value
   case (.boolValue(let l), .boolValue(let r)): return l == r
   case (.structValue(let l), .structValue(let r)): return l == r
   case (.listValue(let l), .listValue(let r)): return l == r
-  case (.None, .None): return true
   default: return false
   }
 }

--- a/Sources/SwiftProtobuf/OneofEnum.swift
+++ b/Sources/SwiftProtobuf/OneofEnum.swift
@@ -14,10 +14,7 @@
 
 public protocol OneofEnum: Equatable {
 
-  init()
+  init?<D: Decoder>(byDecodingFrom decoder: inout D, fieldNumber: Int) throws
 
   func traverse(visitor: Visitor, start: Int, end: Int) throws
-
-  mutating func decodeField<D: Decoder>(decoder: inout D,
-                                        fieldNumber: Int) throws
 }

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -163,7 +163,7 @@ extension Google_Protobuf_FieldDescriptorProto {
         case .enum:
             let e = context.enumByProtoName[typeName]!
             if e.value.count == 0 {
-                return ".None"
+                return "nil"
             } else {
                 let defaultCase = e.value[0].name
                 return context.getSwiftNameForEnumCase(path: typeName, caseName: defaultCase)
@@ -388,7 +388,7 @@ struct MessageFieldGenerator {
             p.indent()
             p.print("get {\n")
             p.indent()
-            p.print("if case .\(swiftName)(let v) = \(oneof.swiftFieldName) {\n")
+            p.print("if case .\(swiftName)(let v)? = \(oneof.swiftFieldName) {\n")
             p.indent()
             p.print("return v\n")
             p.outdent()
@@ -426,7 +426,7 @@ struct MessageFieldGenerator {
         if let oneof = oneof {
             p.print("get {\n")
             p.indent()
-            p.print("if case .\(swiftName)(let v) = _storage.\(oneof.swiftStorageFieldName) {\n")
+            p.print("if case .\(swiftName)(let v)? = _storage.\(oneof.swiftStorageFieldName) {\n")
             p.indent()
             p.print("return v\n")
             p.outdent()

--- a/Tests/SwiftProtobufTests/Test_AllTypes.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes.swift
@@ -1933,7 +1933,7 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
         assertEncode([248, 6, 0]) {(o: inout MessageTestType) in o.oneofUint32 = 0}
         assertDecodeSucceeds([248, 6, 255, 255, 255, 255, 15]) {$0.oneofUint32 == UInt32.max}
         assertDecodeSucceeds([138, 7, 1, 97, 248, 6, 1]) {(o: MessageTestType) in
-            if case .oneofUint32 = o.oneofField, o.oneofUint32 == UInt32(1) {
+            if case .oneofUint32? = o.oneofField, o.oneofUint32 == UInt32(1) {
                 return true
             }
             return false
@@ -1971,16 +1971,16 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
             o.oneofNestedMessage = nested
         }
         assertDecodeSucceeds([130, 7, 0]) {(o: MessageTestType) in
-            if case .oneofNestedMessage(let m) = o.oneofField {
+            if case .oneofNestedMessage(let m)? = o.oneofField {
                 return !m.hasBb
             }
             return false
         }
         assertDecodeSucceeds([248, 6, 0, 130, 7, 2, 8, 1]) {(o: MessageTestType) in
-            if case .oneofUint32 = o.oneofField {
+            if case .oneofUint32? = o.oneofField {
                 return false
             }
-            if case .oneofNestedMessage(let m) = o.oneofField {
+            if case .oneofNestedMessage(let m)? = o.oneofField {
                 return m.bb == 1
             }
             return false
@@ -1988,14 +1988,14 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
     }
     func testEncoding_oneofNestedMessage1() {
         assertDecodeSucceeds([130, 7, 2, 8, 1, 248, 6, 0]) {(o: MessageTestType) in
-            if case .oneofUint32 = o.oneofField, o.oneofUint32 == 0 {
+            if case .oneofUint32? = o.oneofField, o.oneofUint32 == 0 {
                 return true
             }
             return false
         }
         // Unkonwn field within nested message should not break decoding
         assertDecodeSucceeds([130, 7, 5, 128, 127, 0, 8, 1, 248, 6, 0]) {(o: MessageTestType) in
-            if case .oneofUint32 = o.oneofField, o.oneofUint32 == 0 {
+            if case .oneofUint32? = o.oneofField, o.oneofUint32 == 0 {
                 return true
             }
             return false
@@ -2037,7 +2037,7 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
         assertDecodeSucceeds([138, 7, 1, 97]) {$0.oneofString == "a"}
         assertDecodeSucceeds([138, 7, 0]) {$0.oneofString == ""}
         assertDecodeSucceeds([146, 7, 0, 138, 7, 1, 97]) {(o:MessageTestType) in
-            if case .oneofString = o.oneofField, o.oneofString == "a" {
+            if case .oneofString? = o.oneofField, o.oneofString == "a" {
                 return true
             }
             return false
@@ -2071,7 +2071,7 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
     func testEncoding_oneofBytes2() {
         assertDecodeSucceeds([146, 7, 1, 1]) {(o: MessageTestType) in
             let expectedB = Data(bytes: [1])
-            if case .oneofBytes(let b) = o.oneofField {
+            if case .oneofBytes(let b)? = o.oneofField {
                 let s = o.oneofString
                 return b == expectedB && s == ""
             }
@@ -2081,7 +2081,7 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
     func testEncoding_oneofBytes3() {
         assertDecodeSucceeds([146, 7, 0]) {(o: MessageTestType) in
             let expectedB = Data()
-            if case .oneofBytes(let b) = o.oneofField {
+            if case .oneofBytes(let b)? = o.oneofField {
                 let s = o.oneofString
                 return b == expectedB && s == ""
             }
@@ -2091,7 +2091,7 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
     func testEncoding_oneofBytes4() {
         assertDecodeSucceeds([138, 7, 1, 97, 146, 7, 0]) {(o: MessageTestType) in
             let expectedB = Data()
-            if case .oneofBytes(let b) = o.oneofField {
+            if case .oneofBytes(let b)? = o.oneofField {
                 let s = o.oneofString
                 return b == expectedB && s == ""
             }

--- a/Tests/SwiftProtobufTests/Test_AllTypes_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes_Proto3.swift
@@ -1184,7 +1184,7 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
         assertEncode([248, 6, 0]) {(o: inout MessageTestType) in o.oneofUint32 = 0}
         assertDecodeSucceeds([248, 6, 255, 255, 255, 255, 15]) {$0.oneofUint32 == UInt32.max}
         assertDecodeSucceeds([138, 7, 1, 97, 248, 6, 1]) {(o: MessageTestType) in
-            if case .oneofUint32 = o.oneofField, o.oneofUint32 == UInt32(1) {
+            if case .oneofUint32? = o.oneofField, o.oneofUint32 == UInt32(1) {
               return true
             }
             return false
@@ -1221,16 +1221,16 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
             o.oneofNestedMessage.bb = 1
         }
         assertDecodeSucceeds([130, 7, 0]) {(o: MessageTestType) in
-            if case .oneofNestedMessage(let m) = o.oneofField {
+            if case .oneofNestedMessage(let m)? = o.oneofField {
                 return m.bb == 0
             }
             return false
         }
         assertDecodeSucceeds([248, 6, 0, 130, 7, 2, 8, 1]) {(o: MessageTestType) in
-            if case .oneofUint32 = o.oneofField {
+            if case .oneofUint32? = o.oneofField {
                 return false
             }
-            if case .oneofNestedMessage(let m) = o.oneofField {
+            if case .oneofNestedMessage(let m)? = o.oneofField {
                 return m.bb == 1
             }
             return false
@@ -1238,14 +1238,14 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
     }
     func testEncoding_oneofNestedMessage1() {
         assertDecodeSucceeds([130, 7, 2, 8, 1, 248, 6, 0]) {(o: MessageTestType) in
-            if case .oneofUint32 = o.oneofField, o.oneofUint32 == UInt32(0) {
+            if case .oneofUint32? = o.oneofField, o.oneofUint32 == UInt32(0) {
                 return true
             }
             return false
         }
         // Unkonwn field within nested message should not break decoding
         assertDecodeSucceeds([130, 7, 5, 128, 127, 0, 8, 1, 248, 6, 0]) {(o: MessageTestType) in
-            if case .oneofUint32 = o.oneofField, o.oneofUint32 == 0 {
+            if case .oneofUint32? = o.oneofField, o.oneofUint32 == 0 {
                 return true
             }
             return false
@@ -1285,7 +1285,7 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
         assertDecodeSucceeds([138, 7, 1, 97]) {$0.oneofString == "a"}
         assertDecodeSucceeds([138, 7, 0]) {$0.oneofString == ""}
         assertDecodeSucceeds([146, 7, 0, 138, 7, 1, 97]) {(o:MessageTestType) in
-            if case .oneofString = o.oneofField, o.oneofString == "a" {
+            if case .oneofString? = o.oneofField, o.oneofString == "a" {
               return true
             }
             return false
@@ -1319,7 +1319,7 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
     func testEncoding_oneofBytes2() {
         assertDecodeSucceeds([146, 7, 1, 1]) {(o: MessageTestType) in
             let expectedB = Data(bytes: [1])
-            if case .oneofBytes(let b) = o.oneofField {
+            if case .oneofBytes(let b)? = o.oneofField {
                 let s = o.oneofString
                 return b == expectedB && s == ""
             }
@@ -1329,7 +1329,7 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
     func testEncoding_oneofBytes3() {
         assertDecodeSucceeds([146, 7, 0]) {(o: MessageTestType) in
             let expectedB = Data()
-            if case .oneofBytes(let b) = o.oneofField {
+            if case .oneofBytes(let b)? = o.oneofField {
                 let s = o.oneofString
                 return b == expectedB && s == ""
             }
@@ -1339,7 +1339,7 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
     func testEncoding_oneofBytes4() {
         assertDecodeSucceeds([138, 7, 1, 97, 146, 7, 0]) {(o: MessageTestType) in
             let expectedB = Data()
-            if case .oneofBytes(let b) = o.oneofField {
+            if case .oneofBytes(let b)? = o.oneofField {
                 let s = o.oneofString
                 return b == expectedB && s == ""
             }

--- a/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto2.swift
@@ -31,13 +31,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofInt32() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofInt32, 100)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofInt32 = 51
     XCTAssertEqual(msg.oneofInt32, 51)
     XCTAssertEqual(msg.o, .oneofInt32(51))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofInt32, 100)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofInt32 = 100
     XCTAssertEqual(msg.oneofInt32, 100)
     XCTAssertEqual(msg.o, .oneofInt32(100))
@@ -46,13 +46,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofInt64() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofInt64, 101)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofInt64 = 52
     XCTAssertEqual(msg.oneofInt64, 52)
     XCTAssertEqual(msg.o, .oneofInt64(52))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofInt64, 101)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofInt64 = 101
     XCTAssertEqual(msg.oneofInt64, 101)
     XCTAssertEqual(msg.o, .oneofInt64(101))
@@ -61,13 +61,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofUint32() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofUint32, 102)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofUint32 = 53
     XCTAssertEqual(msg.oneofUint32, 53)
     XCTAssertEqual(msg.o, .oneofUint32(53))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofUint32, 102)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofUint32 = 102
     XCTAssertEqual(msg.oneofUint32, 102)
     XCTAssertEqual(msg.o, .oneofUint32(102))
@@ -76,13 +76,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofUint64() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofUint64, 103)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofUint64 = 54
     XCTAssertEqual(msg.oneofUint64, 54)
     XCTAssertEqual(msg.o, .oneofUint64(54))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofUint64, 103)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofUint64 = 103
     XCTAssertEqual(msg.oneofUint64, 103)
     XCTAssertEqual(msg.o, .oneofUint64(103))
@@ -91,13 +91,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofSint32() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofSint32, 104)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSint32 = 55
     XCTAssertEqual(msg.oneofSint32, 55)
     XCTAssertEqual(msg.o, .oneofSint32(55))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofSint32, 104)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSint32 = 104
     XCTAssertEqual(msg.oneofSint32, 104)
     XCTAssertEqual(msg.o, .oneofSint32(104))
@@ -106,13 +106,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofSint64() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofSint64, 105)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSint64 = 56
     XCTAssertEqual(msg.oneofSint64, 56)
     XCTAssertEqual(msg.o, .oneofSint64(56))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofSint64, 105)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSint64 = 105
     XCTAssertEqual(msg.oneofSint64, 105)
     XCTAssertEqual(msg.o, .oneofSint64(105))
@@ -121,13 +121,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofFixed32() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofFixed32, 106)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFixed32 = 57
     XCTAssertEqual(msg.oneofFixed32, 57)
     XCTAssertEqual(msg.o, .oneofFixed32(57))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofFixed32, 106)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFixed32 = 106
     XCTAssertEqual(msg.oneofFixed32, 106)
     XCTAssertEqual(msg.o, .oneofFixed32(106))
@@ -136,13 +136,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofFixed64() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofFixed64, 107)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFixed64 = 58
     XCTAssertEqual(msg.oneofFixed64, 58)
     XCTAssertEqual(msg.o, .oneofFixed64(58))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofFixed64, 107)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFixed64 = 107
     XCTAssertEqual(msg.oneofFixed64, 107)
     XCTAssertEqual(msg.o, .oneofFixed64(107))
@@ -151,13 +151,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofSfixed32() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofSfixed32, 108)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSfixed32 = 59
     XCTAssertEqual(msg.oneofSfixed32, 59)
     XCTAssertEqual(msg.o, .oneofSfixed32(59))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofSfixed32, 108)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSfixed32 = 108
     XCTAssertEqual(msg.oneofSfixed32, 108)
     XCTAssertEqual(msg.o, .oneofSfixed32(108))
@@ -166,13 +166,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofSfixed64() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofSfixed64, 109)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSfixed64 = 60
     XCTAssertEqual(msg.oneofSfixed64, 60)
     XCTAssertEqual(msg.o, .oneofSfixed64(60))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofSfixed64, 109)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSfixed64 = 109
     XCTAssertEqual(msg.oneofSfixed64, 109)
     XCTAssertEqual(msg.o, .oneofSfixed64(109))
@@ -181,13 +181,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofFloat() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofFloat, 110.0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFloat = 61.0
     XCTAssertEqual(msg.oneofFloat, 61.0)
     XCTAssertEqual(msg.o, .oneofFloat(61.0))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofFloat, 110.0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFloat = 110.0
     XCTAssertEqual(msg.oneofFloat, 110.0)
     XCTAssertEqual(msg.o, .oneofFloat(110.0))
@@ -196,13 +196,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofDouble() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofDouble, 111.0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofDouble = 62.0
     XCTAssertEqual(msg.oneofDouble, 62.0)
     XCTAssertEqual(msg.o, .oneofDouble(62.0))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofDouble, 111.0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofDouble = 111.0
     XCTAssertEqual(msg.oneofDouble, 111.0)
     XCTAssertEqual(msg.o, .oneofDouble(111.0))
@@ -211,13 +211,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofBool() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofBool, true)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofBool = false
     XCTAssertEqual(msg.oneofBool, false)
     XCTAssertEqual(msg.o, .oneofBool(false))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofBool, true)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofBool = true
     XCTAssertEqual(msg.oneofBool, true)
     XCTAssertEqual(msg.o, .oneofBool(true))
@@ -226,13 +226,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofString() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofString, "string")
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofString = "64"
     XCTAssertEqual(msg.oneofString, "64")
     XCTAssertEqual(msg.o, .oneofString("64"))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofString, "string")
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofString = "string"
     XCTAssertEqual(msg.oneofString, "string")
     XCTAssertEqual(msg.o, .oneofString("string"))
@@ -241,13 +241,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofBytes() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8))
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofBytes = Data([65])
     XCTAssertEqual(msg.oneofBytes, Data([65]))
     XCTAssertEqual(msg.o, .oneofBytes(Data([65])))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8))
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofBytes = "data".data(using: .utf8)!
     XCTAssertEqual(msg.oneofBytes, "data".data(using: .utf8))
     XCTAssertEqual(msg.o, .oneofBytes("data".data(using: .utf8)!))
@@ -257,24 +257,24 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofGroup.a, 116)
     XCTAssertFalse(msg.oneofGroup.hasA)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     var grp = ProtobufUnittest_Message2.OneofGroup()
     grp.a = 66
     msg.oneofGroup = grp
     XCTAssertEqual(msg.oneofGroup.a, 66)
     XCTAssertTrue(msg.oneofGroup.hasA)
     XCTAssertEqual(msg.oneofGroup, grp)
-    if case .oneofGroup(let v) = msg.o {
+    if case .oneofGroup(let v)? = msg.o {
       XCTAssertTrue(v.hasA)
       XCTAssertEqual(v.a, 66)
       XCTAssertEqual(v, grp)
     } else {
       XCTFail("Wasn't the right case")
     }
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofGroup.a, 116)
     XCTAssertFalse(msg.oneofGroup.hasA)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     // Default within the group
     var grp2 = ProtobufUnittest_Message2.OneofGroup()
     grp2.a = 116
@@ -282,21 +282,21 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
     XCTAssertEqual(msg.oneofGroup.a, 116)
     XCTAssertTrue(msg.oneofGroup.hasA)
     XCTAssertEqual(msg.oneofGroup, grp2)
-    if case .oneofGroup(let v) = msg.o {
+    if case .oneofGroup(let v)? = msg.o {
       XCTAssertTrue(v.hasA)
       XCTAssertEqual(v.a, 116)
       XCTAssertEqual(v, grp2)
     } else {
       XCTFail("Wasn't the right case")
     }
-    msg.o = .None
+    msg.o = nil
     // Group with nothing set.
     let grp3 = ProtobufUnittest_Message2.OneofGroup()
     msg.oneofGroup = grp3
     XCTAssertEqual(msg.oneofGroup.a, 116)
     XCTAssertFalse(msg.oneofGroup.hasA)
     XCTAssertEqual(msg.oneofGroup, grp3)
-    if case .oneofGroup(let v) = msg.o {
+    if case .oneofGroup(let v)? = msg.o {
       XCTAssertFalse(v.hasA)
       XCTAssertEqual(v.a, 116)
       XCTAssertEqual(v, grp3)
@@ -308,21 +308,21 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofMessage() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     var subMsg = ProtobufUnittest_Message2()
     subMsg.optionalInt32 = 66
     msg.oneofMessage = subMsg
     XCTAssertEqual(msg.oneofMessage.optionalInt32, 66)
     XCTAssertEqual(msg.oneofMessage, subMsg)
-    if case .oneofMessage(let v) = msg.o {
+    if case .oneofMessage(let v)? = msg.o {
       XCTAssertEqual(v.optionalInt32, 66)
       XCTAssertEqual(v, subMsg)
     } else {
       XCTFail("Wasn't the right case")
     }
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     // Default within the message
     var subMsg2 = ProtobufUnittest_Message2()
     subMsg2.optionalInt32 = 0
@@ -330,21 +330,21 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
     XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
     XCTAssertTrue(msg.oneofMessage.hasOptionalInt32)
     XCTAssertEqual(msg.oneofMessage, subMsg2)
-    if case .oneofMessage(let v) = msg.o {
+    if case .oneofMessage(let v)? = msg.o {
       XCTAssertTrue(v.hasOptionalInt32)
       XCTAssertEqual(v.optionalInt32, 0)
       XCTAssertEqual(v, subMsg2)
     } else {
       XCTFail("Wasn't the right case")
     }
-    msg.o = .None
+    msg.o = nil
     // Message with nothing set.
     let subMsg3 = ProtobufUnittest_Message2()
     msg.oneofMessage = subMsg3
     XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
     XCTAssertFalse(msg.oneofMessage.hasOptionalInt32)
     XCTAssertEqual(msg.oneofMessage, subMsg3)
-    if case .oneofMessage(let v) = msg.o {
+    if case .oneofMessage(let v)? = msg.o {
       XCTAssertFalse(v.hasOptionalInt32)
       XCTAssertEqual(v.optionalInt32, 0)
       XCTAssertEqual(v, subMsg3)
@@ -356,13 +356,13 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
   func testOneofEnum() {
     var msg = ProtobufUnittest_Message2()
     XCTAssertEqual(msg.oneofEnum, .baz)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofEnum = .bar
     XCTAssertEqual(msg.oneofEnum, .bar)
     XCTAssertEqual(msg.o, .oneofEnum(.bar))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofEnum, .baz)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofEnum = .baz
     XCTAssertEqual(msg.oneofEnum, .baz)
     XCTAssertEqual(msg.o, .oneofEnum(.baz))
@@ -376,62 +376,62 @@ class Test_OneofFields_Access_Proto2: XCTestCase {
     func assertRightFiledSet(_ i: Int) {
       // Make sure the case is correct for the enum based access.
       switch msg.o {
-      case .None:
+      case nil:
         XCTAssertEqual(i, 0)
-      case .oneofInt32(let v):
+      case .oneofInt32(let v)?:
         XCTAssertEqual(i, 1)
         XCTAssertEqual(v, 51)
-      case .oneofInt64(let v):
+      case .oneofInt64(let v)?:
         XCTAssertEqual(i, 2)
         XCTAssertEqual(v, 52)
-      case .oneofUint32(let v):
+      case .oneofUint32(let v)?:
         XCTAssertEqual(i, 3)
         XCTAssertEqual(v, 53)
-      case .oneofUint64(let v):
+      case .oneofUint64(let v)?:
         XCTAssertEqual(i, 4)
         XCTAssertEqual(v, 54)
-      case .oneofSint32(let v):
+      case .oneofSint32(let v)?:
         XCTAssertEqual(i, 5)
         XCTAssertEqual(v, 55)
-      case .oneofSint64(let v):
+      case .oneofSint64(let v)?:
         XCTAssertEqual(i, 6)
         XCTAssertEqual(v, 56)
-      case .oneofFixed32(let v):
+      case .oneofFixed32(let v)?:
         XCTAssertEqual(i, 7)
         XCTAssertEqual(v, 57)
-      case .oneofFixed64(let v):
+      case .oneofFixed64(let v)?:
         XCTAssertEqual(i, 8)
         XCTAssertEqual(v, 58)
-      case .oneofSfixed32(let v):
+      case .oneofSfixed32(let v)?:
         XCTAssertEqual(i, 9)
         XCTAssertEqual(v, 59)
-      case .oneofSfixed64(let v):
+      case .oneofSfixed64(let v)?:
         XCTAssertEqual(i, 10)
         XCTAssertEqual(v, 60)
-      case .oneofFloat(let v):
+      case .oneofFloat(let v)?:
         XCTAssertEqual(i, 11)
         XCTAssertEqual(v, 61.0)
-      case .oneofDouble(let v):
+      case .oneofDouble(let v)?:
         XCTAssertEqual(i, 12)
         XCTAssertEqual(v, 62.0)
-      case .oneofBool(let v):
+      case .oneofBool(let v)?:
         XCTAssertEqual(i, 13)
         XCTAssertEqual(v, false)
-      case .oneofString(let v):
+      case .oneofString(let v)?:
         XCTAssertEqual(i, 14)
         XCTAssertEqual(v, "64")
-      case .oneofBytes(let v):
+      case .oneofBytes(let v)?:
         XCTAssertEqual(i, 15)
         XCTAssertEqual(v, Data([65]))
-      case .oneofGroup(let v):
+      case .oneofGroup(let v)?:
         XCTAssertEqual(i, 16)
         XCTAssertTrue(v.hasA)
         XCTAssertEqual(v.a, 66)
-      case .oneofMessage(let v):
+      case .oneofMessage(let v)?:
         XCTAssertEqual(i, 17)
         XCTAssertTrue(v.hasOptionalInt32)
         XCTAssertEqual(v.optionalInt32, 68)
-      case .oneofEnum(let v):
+      case .oneofEnum(let v)?:
         XCTAssertEqual(i, 18)
         XCTAssertEqual(v, .bar)
       }

--- a/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_OneofFields_Access_Proto3.swift
@@ -31,13 +31,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofInt32() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofInt32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofInt32 = 51
     XCTAssertEqual(msg.oneofInt32, 51)
     XCTAssertEqual(msg.o, .oneofInt32(51))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofInt32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofInt32 = 0
     XCTAssertEqual(msg.oneofInt32, 0)
     XCTAssertEqual(msg.o, .oneofInt32(0))
@@ -46,13 +46,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofInt64() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofInt64, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofInt64 = 52
     XCTAssertEqual(msg.oneofInt64, 52)
     XCTAssertEqual(msg.o, .oneofInt64(52))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofInt64, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofInt64 = 0
     XCTAssertEqual(msg.oneofInt64, 0)
     XCTAssertEqual(msg.o, .oneofInt64(0))
@@ -61,13 +61,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofUint32() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofUint32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofUint32 = 53
     XCTAssertEqual(msg.oneofUint32, 53)
     XCTAssertEqual(msg.o, .oneofUint32(53))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofUint32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofUint32 = 0
     XCTAssertEqual(msg.oneofUint32, 0)
     XCTAssertEqual(msg.o, .oneofUint32(0))
@@ -76,13 +76,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofUint64() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofUint64, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofUint64 = 54
     XCTAssertEqual(msg.oneofUint64, 54)
     XCTAssertEqual(msg.o, .oneofUint64(54))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofUint64, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofUint64 = 0
     XCTAssertEqual(msg.oneofUint64, 0)
     XCTAssertEqual(msg.o, .oneofUint64(0))
@@ -91,13 +91,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofSint32() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofSint32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSint32 = 55
     XCTAssertEqual(msg.oneofSint32, 55)
     XCTAssertEqual(msg.o, .oneofSint32(55))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofSint32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSint32 = 0
     XCTAssertEqual(msg.oneofSint32, 0)
     XCTAssertEqual(msg.o, .oneofSint32(0))
@@ -106,13 +106,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofSint64() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofSint64, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSint64 = 56
     XCTAssertEqual(msg.oneofSint64, 56)
     XCTAssertEqual(msg.o, .oneofSint64(56))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofSint64, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSint64 = 0
     XCTAssertEqual(msg.oneofSint64, 0)
     XCTAssertEqual(msg.o, .oneofSint64(0))
@@ -121,13 +121,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofFixed32() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofFixed32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFixed32 = 57
     XCTAssertEqual(msg.oneofFixed32, 57)
     XCTAssertEqual(msg.o, .oneofFixed32(57))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofFixed32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFixed32 = 0
     XCTAssertEqual(msg.oneofFixed32, 0)
     XCTAssertEqual(msg.o, .oneofFixed32(0))
@@ -136,13 +136,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofFixed64() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofFixed64, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFixed64 = 58
     XCTAssertEqual(msg.oneofFixed64, 58)
     XCTAssertEqual(msg.o, .oneofFixed64(58))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofFixed64, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFixed64 = 0
     XCTAssertEqual(msg.oneofFixed64, 0)
     XCTAssertEqual(msg.o, .oneofFixed64(0))
@@ -151,13 +151,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofSfixed32() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofSfixed32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSfixed32 = 59
     XCTAssertEqual(msg.oneofSfixed32, 59)
     XCTAssertEqual(msg.o, .oneofSfixed32(59))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofSfixed32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSfixed32 = 0
     XCTAssertEqual(msg.oneofSfixed32, 0)
     XCTAssertEqual(msg.o, .oneofSfixed32(0))
@@ -166,13 +166,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofSfixed64() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofSfixed64, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSfixed64 = 60
     XCTAssertEqual(msg.oneofSfixed64, 60)
     XCTAssertEqual(msg.o, .oneofSfixed64(60))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofSfixed64, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofSfixed64 = 0
     XCTAssertEqual(msg.oneofSfixed64, 0)
     XCTAssertEqual(msg.o, .oneofSfixed64(0))
@@ -181,13 +181,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofFloat() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofFloat, 0.0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFloat = 61.0
     XCTAssertEqual(msg.oneofFloat, 61.0)
     XCTAssertEqual(msg.o, .oneofFloat(61.0))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofFloat, 0.0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofFloat = 0.0
     XCTAssertEqual(msg.oneofFloat, 0.0)
     XCTAssertEqual(msg.o, .oneofFloat(0.0))
@@ -196,13 +196,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofDouble() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofDouble, 0.0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofDouble = 62.0
     XCTAssertEqual(msg.oneofDouble, 62.0)
     XCTAssertEqual(msg.o, .oneofDouble(62.0))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofDouble, 0.0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofDouble = 0.0
     XCTAssertEqual(msg.oneofDouble, 0.0)
     XCTAssertEqual(msg.o, .oneofDouble(0.0))
@@ -211,13 +211,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofBool() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofBool, false)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofBool = true
     XCTAssertEqual(msg.oneofBool, true)
     XCTAssertEqual(msg.o, .oneofBool(true))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofBool, false)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofBool = false
     XCTAssertEqual(msg.oneofBool, false)
     XCTAssertEqual(msg.o, .oneofBool(false))
@@ -226,13 +226,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofString() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofString, "")
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofString = "64"
     XCTAssertEqual(msg.oneofString, "64")
     XCTAssertEqual(msg.o, .oneofString("64"))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofString, "")
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofString = ""
     XCTAssertEqual(msg.oneofString, "")
     XCTAssertEqual(msg.o, .oneofString(""))
@@ -241,13 +241,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofBytes() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofBytes, Data())
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofBytes = Data([65])
     XCTAssertEqual(msg.oneofBytes, Data([65]))
     XCTAssertEqual(msg.o, .oneofBytes(Data([65])))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofBytes, Data())
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofBytes = Data()
     XCTAssertEqual(msg.oneofBytes, Data())
     XCTAssertEqual(msg.o, .oneofBytes(Data()))
@@ -258,40 +258,40 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofMessage() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     var subMsg = ProtobufUnittest_Message3()
     subMsg.optionalInt32 = 66
     msg.oneofMessage = subMsg
     XCTAssertEqual(msg.oneofMessage.optionalInt32, 66)
     XCTAssertEqual(msg.oneofMessage, subMsg)
-    if case .oneofMessage(let v) = msg.o {
+    if case .oneofMessage(let v)? = msg.o {
       XCTAssertEqual(v.optionalInt32, 66)
       XCTAssertEqual(v, subMsg)
     } else {
       XCTFail("Wasn't the right case")
     }
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     // Default within the message
     var subMsg2 = ProtobufUnittest_Message3()
     subMsg2.optionalInt32 = 0
     msg.oneofMessage = subMsg2
     XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
     XCTAssertEqual(msg.oneofMessage, subMsg2)
-    if case .oneofMessage(let v) = msg.o {
+    if case .oneofMessage(let v)? = msg.o {
       XCTAssertEqual(v.optionalInt32, 0)
       XCTAssertEqual(v, subMsg2)
     } else {
       XCTFail("Wasn't the right case")
     }
-    msg.o = .None
+    msg.o = nil
     // Message with nothing set.
     let subMsg3 = ProtobufUnittest_Message3()
     msg.oneofMessage = subMsg3
     XCTAssertEqual(msg.oneofMessage.optionalInt32, 0)
     XCTAssertEqual(msg.oneofMessage, subMsg3)
-    if case .oneofMessage(let v) = msg.o {
+    if case .oneofMessage(let v)? = msg.o {
       XCTAssertEqual(v.optionalInt32, 0)
       XCTAssertEqual(v, subMsg3)
     } else {
@@ -302,13 +302,13 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
   func testOneofEnum() {
     var msg = ProtobufUnittest_Message3()
     XCTAssertEqual(msg.oneofEnum, .foo)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofEnum = .bar
     XCTAssertEqual(msg.oneofEnum, .bar)
     XCTAssertEqual(msg.o, .oneofEnum(.bar))
-    msg.o = .None
+    msg.o = nil
     XCTAssertEqual(msg.oneofEnum, .foo)
-    XCTAssertEqual(msg.o, .None)
+    XCTAssertNil(msg.o)
     msg.oneofEnum = .foo
     XCTAssertEqual(msg.oneofEnum, .foo)
     XCTAssertEqual(msg.o, .oneofEnum(.foo))
@@ -322,58 +322,58 @@ class Test_OneofFields_Access_Proto3: XCTestCase {
     func assertRightFiledSet(_ i: Int) {
       // Make sure the case is correct for the enum based access.
       switch msg.o {
-      case .None:
+      case nil:
         XCTAssertEqual(i, 0)
-      case .oneofInt32(let v):
+      case .oneofInt32(let v)?:
         XCTAssertEqual(i, 1)
         XCTAssertEqual(v, 51)
-      case .oneofInt64(let v):
+      case .oneofInt64(let v)?:
         XCTAssertEqual(i, 2)
         XCTAssertEqual(v, 52)
-      case .oneofUint32(let v):
+      case .oneofUint32(let v)?:
         XCTAssertEqual(i, 3)
         XCTAssertEqual(v, 53)
-      case .oneofUint64(let v):
+      case .oneofUint64(let v)?:
         XCTAssertEqual(i, 4)
         XCTAssertEqual(v, 54)
-      case .oneofSint32(let v):
+      case .oneofSint32(let v)?:
         XCTAssertEqual(i, 5)
         XCTAssertEqual(v, 55)
-      case .oneofSint64(let v):
+      case .oneofSint64(let v)?:
         XCTAssertEqual(i, 6)
         XCTAssertEqual(v, 56)
-      case .oneofFixed32(let v):
+      case .oneofFixed32(let v)?:
         XCTAssertEqual(i, 7)
         XCTAssertEqual(v, 57)
-      case .oneofFixed64(let v):
+      case .oneofFixed64(let v)?:
         XCTAssertEqual(i, 8)
         XCTAssertEqual(v, 58)
-      case .oneofSfixed32(let v):
+      case .oneofSfixed32(let v)?:
         XCTAssertEqual(i, 9)
         XCTAssertEqual(v, 59)
-      case .oneofSfixed64(let v):
+      case .oneofSfixed64(let v)?:
         XCTAssertEqual(i, 10)
         XCTAssertEqual(v, 60)
-      case .oneofFloat(let v):
+      case .oneofFloat(let v)?:
         XCTAssertEqual(i, 11)
         XCTAssertEqual(v, 61.0)
-      case .oneofDouble(let v):
+      case .oneofDouble(let v)?:
         XCTAssertEqual(i, 12)
         XCTAssertEqual(v, 62.0)
-      case .oneofBool(let v):
+      case .oneofBool(let v)?:
         XCTAssertEqual(i, 13)
         XCTAssertEqual(v, true)
-      case .oneofString(let v):
+      case .oneofString(let v)?:
         XCTAssertEqual(i, 14)
         XCTAssertEqual(v, "64")
-      case .oneofBytes(let v):
+      case .oneofBytes(let v)?:
         XCTAssertEqual(i, 15)
         XCTAssertEqual(v, Data([65]))
       // No group.
-      case .oneofMessage(let v):
+      case .oneofMessage(let v)?:
         XCTAssertEqual(i, 17)
         XCTAssertEqual(v.optionalInt32, 68)
-      case .oneofEnum(let v):
+      case .oneofEnum(let v)?:
         XCTAssertEqual(i, 18)
         XCTAssertEqual(v, .bar)
       }

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -147,44 +147,34 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
   ]
 
 
-  enum OneOf_Payload: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Payload: SwiftProtobuf.OneofEnum {
     case protobufPayload(Data)
     case jsonPayload(String)
-    case None
 
     static func ==(lhs: Conformance_ConformanceRequest.OneOf_Payload, rhs: Conformance_ConformanceRequest.OneOf_Payload) -> Bool {
       switch (lhs, rhs) {
       case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
       case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .protobufPayload(value)
+        return
       case 2:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .jsonPayload(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -197,15 +187,13 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
         if start <= 2 && 2 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 2)
         }
-      case .None:
-        break
       }
     }
   }
 
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v) = payload {
+      if case .protobufPayload(let v)? = payload {
         return v
       }
       return Data()
@@ -215,11 +203,11 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
     }
   }
 
-  var payload: Conformance_ConformanceRequest.OneOf_Payload = .None
+  var payload: Conformance_ConformanceRequest.OneOf_Payload? = nil
 
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v) = payload {
+      if case .jsonPayload(let v)? = payload {
         return v
       }
       return ""
@@ -240,14 +228,18 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message, SwiftProtobuf.Prot
 
   mutating func _protoc_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2: try payload.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 1, 2:
+      if payload != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      payload = try Conformance_ConformanceRequest.OneOf_Payload(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     case 3: try decoder.decodeSingularEnumField(value: &requestedOutputFormat)
     default: break
     }
   }
 
   func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
-    try payload.traverse(visitor: visitor, start: 1, end: 3)
+    try payload?.traverse(visitor: visitor, start: 1, end: 3)
     if requestedOutputFormat != Conformance_WireFormat.unspecified {
       try visitor.visitSingularEnumField(value: requestedOutputFormat, fieldNumber: 3)
     }
@@ -274,14 +266,13 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ]
 
 
-  enum OneOf_Result: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Result: SwiftProtobuf.OneofEnum {
     case parseError(String)
     case serializeError(String)
     case runtimeError(String)
     case protobufPayload(Data)
     case jsonPayload(String)
     case skipped(String)
-    case None
 
     static func ==(lhs: Conformance_ConformanceResponse.OneOf_Result, rhs: Conformance_ConformanceResponse.OneOf_Result) -> Bool {
       switch (lhs, rhs) {
@@ -291,51 +282,46 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
       case (.protobufPayload(let l), .protobufPayload(let r)): return l == r
       case (.jsonPayload(let l), .jsonPayload(let r)): return l == r
       case (.skipped(let l), .skipped(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .parseError(value)
+        return
       case 2:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .runtimeError(value)
+        return
       case 3:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .protobufPayload(value)
+        return
       case 4:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .jsonPayload(value)
+        return
       case 5:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .skipped(value)
+        return
       case 6:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .serializeError(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -364,8 +350,6 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
         if start <= 6 && 6 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 6)
         }
-      case .None:
-        break
       }
     }
   }
@@ -377,7 +361,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   test.  Some of the test cases are intentionally invalid input.
   var parseError: String {
     get {
-      if case .parseError(let v) = result {
+      if case .parseError(let v)? = result {
         return v
       }
       return ""
@@ -387,14 +371,14 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
     }
   }
 
-  var result: Conformance_ConformanceResponse.OneOf_Result = .None
+  var result: Conformance_ConformanceResponse.OneOf_Result? = nil
 
   ///   If the input was successfully parsed but errors occurred when
   ///   serializing it to the requested output format, set the error message in
   ///   this field.
   var serializeError: String {
     get {
-      if case .serializeError(let v) = result {
+      if case .serializeError(let v)? = result {
         return v
       }
       return ""
@@ -409,7 +393,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   about the failure.
   var runtimeError: String {
     get {
-      if case .runtimeError(let v) = result {
+      if case .runtimeError(let v)? = result {
         return v
       }
       return ""
@@ -423,7 +407,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   protobuf, serialize it to protobuf and set it in this field.
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v) = result {
+      if case .protobufPayload(let v)? = result {
         return v
       }
       return Data()
@@ -437,7 +421,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   serialize to JSON and set it in this field.
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v) = result {
+      if case .jsonPayload(let v)? = result {
         return v
       }
       return ""
@@ -451,7 +435,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ///   wasn't supported, like JSON input/output.
   var skipped: String {
     get {
-      if case .skipped(let v) = result {
+      if case .skipped(let v)? = result {
         return v
       }
       return ""
@@ -469,13 +453,17 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message, SwiftProtobuf.Pro
 
   mutating func _protoc_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 6, 2, 3, 4, 5: try result.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 1, 6, 2, 3, 4, 5:
+      if result != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      result = try Conformance_ConformanceResponse.OneOf_Result(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     default: break
     }
   }
 
   func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
-    try result.traverse(visitor: visitor, start: 1, end: 7)
+    try result?.traverse(visitor: visitor, start: 1, end: 7)
   }
 
   func _protoc_generated_isEqualTo(other: Conformance_ConformanceResponse) -> Bool {

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -315,7 +315,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     var _mapStringForeignMessage: Dictionary<String,ProtobufTestMessages_Proto3_ForeignMessage> = [:]
     var _mapStringNestedEnum: Dictionary<String,ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum> = [:]
     var _mapStringForeignEnum: Dictionary<String,ProtobufTestMessages_Proto3_ForeignEnum> = [:]
-    var _oneofField = ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField()
+    var _oneofField: ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField?
     var _optionalBoolWrapper: Google_Protobuf_BoolValue? = nil
     var _optionalInt32Wrapper: Google_Protobuf_Int32Value? = nil
     var _optionalInt64Wrapper: Google_Protobuf_Int64Value? = nil
@@ -435,7 +435,11 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignMessage>.self, value: &_mapStringForeignMessage)
       case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum>.self, value: &_mapStringNestedEnum)
       case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: &_mapStringForeignEnum)
-      case 111, 112, 113, 114, 115, 116, 117, 118, 119: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114, 115, 116, 117, 118, 119:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 201: try decoder.decodeSingularMessageField(value: &_optionalBoolWrapper)
       case 202: try decoder.decodeSingularMessageField(value: &_optionalInt32Wrapper)
       case 203: try decoder.decodeSingularMessageField(value: &_optionalInt64Wrapper)
@@ -675,7 +679,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       if !_mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: _mapStringForeignEnum, fieldNumber: 74)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 120)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 120)
       if let v = _optionalBoolWrapper {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 201)
       }
@@ -1057,7 +1061,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage)
     case oneofString(String)
@@ -1067,7 +1071,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     case oneofFloat(Float)
     case oneofDouble(Double)
     case oneofEnum(ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum)
-    case None
 
     static func ==(lhs: ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField, rhs: ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -1080,65 +1083,63 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
       case (.oneofFloat(let l), .oneofFloat(let r)): return l == r
       case (.oneofDouble(let l), .oneofDouble(let r)): return l == r
       case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 112:
         var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 114:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .oneofBytes(value)
+        return
       case 115:
         var value = Bool()
         try decoder.decodeSingularBoolField(value: &value)
         self = .oneofBool(value)
+        return
       case 116:
         var value = UInt64()
         try decoder.decodeSingularUInt64Field(value: &value)
         self = .oneofUint64(value)
+        return
       case 117:
         var value = Float()
         try decoder.decodeSingularFloatField(value: &value)
         self = .oneofFloat(value)
+        return
       case 118:
         var value = Double()
         try decoder.decodeSingularDoubleField(value: &value)
         self = .oneofDouble(value)
+        return
       case 119:
         var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofEnum(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -1179,8 +1180,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
         if start <= 119 && 119 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1683,7 +1682,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1695,7 +1694,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofNestedMessage: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage()
@@ -1707,7 +1706,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1719,7 +1718,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1731,7 +1730,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v) = _storage._oneofField {
+      if case .oneofBool(let v)? = _storage._oneofField {
         return v
       }
       return false
@@ -1743,7 +1742,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v) = _storage._oneofField {
+      if case .oneofUint64(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1755,7 +1754,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v) = _storage._oneofField {
+      if case .oneofFloat(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1767,7 +1766,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v) = _storage._oneofField {
+      if case .oneofDouble(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1779,7 +1778,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
   var oneofEnum: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum {
     get {
-      if case .oneofEnum(let v) = _storage._oneofField {
+      if case .oneofEnum(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum.foo
@@ -2122,7 +2121,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     set {_uniqueStorage()._fieldName18__ = newValue}
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -431,7 +431,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
     var _defaultImportEnum: ProtobufUnittestImport_ImportEnum? = nil
     var _defaultStringPiece: String? = nil
     var _defaultCord: String? = nil
-    var _oneofField = ProtobufUnittest_TestAllTypes.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_TestAllTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -512,7 +512,11 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
       case 83: try decoder.decodeSingularEnumField(value: &_defaultImportEnum)
       case 84: try decoder.decodeSingularStringField(value: &_defaultStringPiece)
       case 85: try decoder.decodeSingularStringField(value: &_defaultCord)
-      case 111, 112, 113, 114: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -731,7 +735,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
       if let v = _defaultCord {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 85)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 115)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 115)
       unknown.traverse(visitor: visitor)
     }
 
@@ -898,12 +902,11 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -911,51 +914,44 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
       case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 112:
         var value: ProtobufUnittest_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 114:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -976,8 +972,6 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
         if start <= 114 && 114 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 114)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1835,7 +1829,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1847,7 +1841,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
 
   var oneofNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllTypes.NestedMessage()
@@ -1859,7 +1853,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1871,7 +1865,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1881,7 +1875,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue
@@ -5970,7 +5964,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
   private class _StorageClass {
     typealias ExtendedMessage = ProtobufUnittest_TestOneof
     var unknown = SwiftProtobuf.UnknownStorage()
-    var _foo = ProtobufUnittest_TestOneof.OneOf_Foo()
+    var _foo: ProtobufUnittest_TestOneof.OneOf_Foo?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -5980,13 +5974,17 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
     func decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
       switch fieldNumber {
-      case 1, 2, 3, 4: try _foo.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 1, 2, 3, 4:
+        if _foo != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _foo = try ProtobufUnittest_TestOneof.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      try _foo.traverse(visitor: visitor, start: 1, end: 5)
+      try _foo?.traverse(visitor: visitor, start: 1, end: 5)
       unknown.traverse(visitor: visitor)
     }
 
@@ -6011,12 +6009,11 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_Foo: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Foo: SwiftProtobuf.OneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestAllTypes)
     case fooGroup(ProtobufUnittest_TestOneof.FooGroup)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestOneof.OneOf_Foo, rhs: ProtobufUnittest_TestOneof.OneOf_Foo) -> Bool {
       switch (lhs, rhs) {
@@ -6024,51 +6021,44 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
       case (.fooString(let l), .fooString(let r)): return l == r
       case (.fooMessage(let l), .fooMessage(let r)): return l == r
       case (.fooGroup(let l), .fooGroup(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .fooInt(value)
+          return
         }
       case 2:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .fooString(value)
+          return
         }
       case 3:
         var value: ProtobufUnittest_TestAllTypes?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .fooMessage(value)
+          return
         }
       case 4:
         var value: ProtobufUnittest_TestOneof.FooGroup?
         try decoder.decodeSingularGroupField(value: &value)
         if let value = value {
           self = .fooGroup(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -6089,8 +6079,6 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
         if start <= 4 && 4 < end {
           try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
         }
-      case .None:
-        break
       }
     }
   }
@@ -6163,7 +6151,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v) = _storage._foo {
+      if case .fooInt(let v)? = _storage._foo {
         return v
       }
       return 0
@@ -6175,7 +6163,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
   var fooString: String {
     get {
-      if case .fooString(let v) = _storage._foo {
+      if case .fooString(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -6187,7 +6175,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
   var fooMessage: ProtobufUnittest_TestAllTypes {
     get {
-      if case .fooMessage(let v) = _storage._foo {
+      if case .fooMessage(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestAllTypes()
@@ -6199,7 +6187,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
   var fooGroup: ProtobufUnittest_TestOneof.FooGroup {
     get {
-      if case .fooGroup(let v) = _storage._foo {
+      if case .fooGroup(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestOneof.FooGroup()
@@ -6209,7 +6197,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
     }
   }
 
-  var foo: OneOf_Foo {
+  var foo: OneOf_Foo? {
     get {return _storage._foo}
     set {
       _uniqueStorage()._foo = newValue
@@ -6477,8 +6465,8 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
   private class _StorageClass {
     typealias ExtendedMessage = ProtobufUnittest_TestOneof2
     var unknown = SwiftProtobuf.UnknownStorage()
-    var _foo = ProtobufUnittest_TestOneof2.OneOf_Foo()
-    var _bar = ProtobufUnittest_TestOneof2.OneOf_Bar()
+    var _foo: ProtobufUnittest_TestOneof2.OneOf_Foo?
+    var _bar: ProtobufUnittest_TestOneof2.OneOf_Bar?
     var _bazInt: Int32? = nil
     var _bazString: String? = nil
 
@@ -6490,8 +6478,16 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
     func decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
       switch fieldNumber {
-      case 1, 2, 3, 4, 5, 6, 7, 8, 11: try _foo.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
-      case 12, 13, 14, 15, 16, 17: try _bar.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 1, 2, 3, 4, 5, 6, 7, 8, 11:
+        if _foo != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _foo = try ProtobufUnittest_TestOneof2.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
+      case 12, 13, 14, 15, 16, 17:
+        if _bar != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _bar = try ProtobufUnittest_TestOneof2.OneOf_Bar(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 18: try decoder.decodeSingularInt32Field(value: &_bazInt)
       case 19: try decoder.decodeSingularStringField(value: &_bazString)
       default: break
@@ -6499,8 +6495,8 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      try _foo.traverse(visitor: visitor, start: 1, end: 12)
-      try _bar.traverse(visitor: visitor, start: 12, end: 18)
+      try _foo?.traverse(visitor: visitor, start: 1, end: 12)
+      try _bar?.traverse(visitor: visitor, start: 12, end: 18)
       if let v = _bazInt {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt32.self, value: v, fieldNumber: 18)
       }
@@ -6537,7 +6533,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_Foo: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Foo: SwiftProtobuf.OneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooCord(String)
@@ -6547,7 +6543,6 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     case fooMessage(ProtobufUnittest_TestOneof2.NestedMessage)
     case fooGroup(ProtobufUnittest_TestOneof2.FooGroup)
     case fooLazyMessage(ProtobufUnittest_TestOneof2.NestedMessage)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Foo, rhs: ProtobufUnittest_TestOneof2.OneOf_Foo) -> Bool {
       switch (lhs, rhs) {
@@ -6560,81 +6555,79 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
       case (.fooMessage(let l), .fooMessage(let r)): return l == r
       case (.fooGroup(let l), .fooGroup(let r)): return l == r
       case (.fooLazyMessage(let l), .fooLazyMessage(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .fooInt(value)
+          return
         }
       case 2:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .fooString(value)
+          return
         }
       case 3:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .fooCord(value)
+          return
         }
       case 4:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .fooStringPiece(value)
+          return
         }
       case 5:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .fooBytes(value)
+          return
         }
       case 6:
         var value: ProtobufUnittest_TestOneof2.NestedEnum?
         try decoder.decodeSingularEnumField(value: &value)
         if let value = value {
           self = .fooEnum(value)
+          return
         }
       case 7:
         var value: ProtobufUnittest_TestOneof2.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .fooMessage(value)
+          return
         }
       case 8:
         var value: ProtobufUnittest_TestOneof2.FooGroup?
         try decoder.decodeSingularGroupField(value: &value)
         if let value = value {
           self = .fooGroup(value)
+          return
         }
       case 11:
         var value: ProtobufUnittest_TestOneof2.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .fooLazyMessage(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -6675,20 +6668,17 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
         if start <= 11 && 11 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
         }
-      case .None:
-        break
       }
     }
   }
 
-  enum OneOf_Bar: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Bar: SwiftProtobuf.OneofEnum {
     case barInt(Int32)
     case barString(String)
     case barCord(String)
     case barStringPiece(String)
     case barBytes(Data)
     case barEnum(ProtobufUnittest_TestOneof2.NestedEnum)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestOneof2.OneOf_Bar, rhs: ProtobufUnittest_TestOneof2.OneOf_Bar) -> Bool {
       switch (lhs, rhs) {
@@ -6698,63 +6688,58 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
       case (.barStringPiece(let l), .barStringPiece(let r)): return l == r
       case (.barBytes(let l), .barBytes(let r)): return l == r
       case (.barEnum(let l), .barEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 12:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .barInt(value)
+          return
         }
       case 13:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .barString(value)
+          return
         }
       case 14:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .barCord(value)
+          return
         }
       case 15:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .barStringPiece(value)
+          return
         }
       case 16:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .barBytes(value)
+          return
         }
       case 17:
         var value: ProtobufUnittest_TestOneof2.NestedEnum?
         try decoder.decodeSingularEnumField(value: &value)
         if let value = value {
           self = .barEnum(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -6783,8 +6768,6 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
         if start <= 17 && 17 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
         }
-      case .None:
-        break
       }
     }
   }
@@ -6974,7 +6957,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v) = _storage._foo {
+      if case .fooInt(let v)? = _storage._foo {
         return v
       }
       return 0
@@ -6986,7 +6969,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooString: String {
     get {
-      if case .fooString(let v) = _storage._foo {
+      if case .fooString(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -6998,7 +6981,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooCord: String {
     get {
-      if case .fooCord(let v) = _storage._foo {
+      if case .fooCord(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -7010,7 +6993,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooStringPiece: String {
     get {
-      if case .fooStringPiece(let v) = _storage._foo {
+      if case .fooStringPiece(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -7022,7 +7005,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooBytes: Data {
     get {
-      if case .fooBytes(let v) = _storage._foo {
+      if case .fooBytes(let v)? = _storage._foo {
         return v
       }
       return Data()
@@ -7034,7 +7017,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .fooEnum(let v) = _storage._foo {
+      if case .fooEnum(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestOneof2.NestedEnum.foo
@@ -7046,7 +7029,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooMessage(let v) = _storage._foo {
+      if case .fooMessage(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestOneof2.NestedMessage()
@@ -7058,7 +7041,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooGroup: ProtobufUnittest_TestOneof2.FooGroup {
     get {
-      if case .fooGroup(let v) = _storage._foo {
+      if case .fooGroup(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestOneof2.FooGroup()
@@ -7070,7 +7053,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var fooLazyMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooLazyMessage(let v) = _storage._foo {
+      if case .fooLazyMessage(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestOneof2.NestedMessage()
@@ -7082,7 +7065,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barInt: Int32 {
     get {
-      if case .barInt(let v) = _storage._bar {
+      if case .barInt(let v)? = _storage._bar {
         return v
       }
       return 5
@@ -7094,7 +7077,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barString: String {
     get {
-      if case .barString(let v) = _storage._bar {
+      if case .barString(let v)? = _storage._bar {
         return v
       }
       return "STRING"
@@ -7106,7 +7089,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barCord: String {
     get {
-      if case .barCord(let v) = _storage._bar {
+      if case .barCord(let v)? = _storage._bar {
         return v
       }
       return "CORD"
@@ -7118,7 +7101,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barStringPiece: String {
     get {
-      if case .barStringPiece(let v) = _storage._bar {
+      if case .barStringPiece(let v)? = _storage._bar {
         return v
       }
       return "SPIECE"
@@ -7130,7 +7113,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barBytes: Data {
     get {
-      if case .barBytes(let v) = _storage._bar {
+      if case .barBytes(let v)? = _storage._bar {
         return v
       }
       return Data(bytes: [66, 89, 84, 69, 83])
@@ -7142,7 +7125,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
 
   var barEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .barEnum(let v) = _storage._bar {
+      if case .barEnum(let v)? = _storage._bar {
         return v
       }
       return ProtobufUnittest_TestOneof2.NestedEnum.bar
@@ -7174,14 +7157,14 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
     return _storage._bazString = nil
   }
 
-  var foo: OneOf_Foo {
+  var foo: OneOf_Foo? {
     get {return _storage._foo}
     set {
       _uniqueStorage()._foo = newValue
     }
   }
 
-  var bar: OneOf_Bar {
+  var bar: OneOf_Bar? {
     get {return _storage._bar}
     set {
       _uniqueStorage()._bar = newValue
@@ -7224,14 +7207,12 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
   private class _StorageClass {
     typealias ExtendedMessage = ProtobufUnittest_TestRequiredOneof
     var unknown = SwiftProtobuf.UnknownStorage()
-    var _foo = ProtobufUnittest_TestRequiredOneof.OneOf_Foo()
+    var _foo: ProtobufUnittest_TestRequiredOneof.OneOf_Foo?
 
     var isInitialized: Bool {
       switch _foo {
-      case .fooMessage(let v):
+      case .fooMessage(let v)?:
         if !v.isInitialized {return false}
-      case .None:
-        break
       default:
         break
       }
@@ -7246,13 +7227,17 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
 
     func decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
       switch fieldNumber {
-      case 1, 2, 3: try _foo.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 1, 2, 3:
+        if _foo != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _foo = try ProtobufUnittest_TestRequiredOneof.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      try _foo.traverse(visitor: visitor, start: 1, end: 4)
+      try _foo?.traverse(visitor: visitor, start: 1, end: 4)
       unknown.traverse(visitor: visitor)
     }
 
@@ -7277,56 +7262,47 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_Foo: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Foo: SwiftProtobuf.OneofEnum {
     case fooInt(Int32)
     case fooString(String)
     case fooMessage(ProtobufUnittest_TestRequiredOneof.NestedMessage)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo, rhs: ProtobufUnittest_TestRequiredOneof.OneOf_Foo) -> Bool {
       switch (lhs, rhs) {
       case (.fooInt(let l), .fooInt(let r)): return l == r
       case (.fooString(let l), .fooString(let r)): return l == r
       case (.fooMessage(let l), .fooMessage(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .fooInt(value)
+          return
         }
       case 2:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .fooString(value)
+          return
         }
       case 3:
         var value: ProtobufUnittest_TestRequiredOneof.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .fooMessage(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -7343,8 +7319,6 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
         if start <= 3 && 3 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
         }
-      case .None:
-        break
       }
     }
   }
@@ -7404,7 +7378,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v) = _storage._foo {
+      if case .fooInt(let v)? = _storage._foo {
         return v
       }
       return 0
@@ -7416,7 +7390,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
 
   var fooString: String {
     get {
-      if case .fooString(let v) = _storage._foo {
+      if case .fooString(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -7428,7 +7402,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
 
   var fooMessage: ProtobufUnittest_TestRequiredOneof.NestedMessage {
     get {
-      if case .fooMessage(let v) = _storage._foo {
+      if case .fooMessage(let v)? = _storage._foo {
         return v
       }
       return ProtobufUnittest_TestRequiredOneof.NestedMessage()
@@ -7438,7 +7412,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
     }
   }
 
-  var foo: OneOf_Foo {
+  var foo: OneOf_Foo? {
     get {return _storage._foo}
     set {
       _uniqueStorage()._foo = newValue
@@ -9292,7 +9266,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
     var _optionalMessage: ProtobufUnittest_ForeignMessage? = nil
     var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbers.OptionalGroup? = nil
     var _stringStringMap: Dictionary<String,String> = [:]
-    var _oneofField = ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField?
 
     var isInitialized: Bool {
       if !extensionFieldValues.isInitialized {return false}
@@ -9317,7 +9291,11 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       case 536870007: try decoder.decodeSingularMessageField(value: &_optionalMessage)
       case 536870008: try decoder.decodeSingularGroupField(value: &_optionalGroup)
       case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_stringStringMap)
-      case 536870011, 536870012, 536870013, 536870014: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 536870011, 536870012, 536870013, 536870014:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: if (536860000 <= fieldNumber && fieldNumber < 536870000) {
           try decoder.decodeExtensionField(values: &extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber)
         }
@@ -9356,7 +9334,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       if !_stringStringMap.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _stringStringMap, fieldNumber: 536870010)
       }
-      try _oneofField.traverse(visitor: visitor, start: 536870011, end: 536870015)
+      try _oneofField?.traverse(visitor: visitor, start: 536870011, end: 536870015)
       unknown.traverse(visitor: visitor)
     }
 
@@ -9403,12 +9381,11 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofTestAllTypes(ProtobufUnittest_TestAllTypes)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -9416,51 +9393,44 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 536870011:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 536870012:
         var value: ProtobufUnittest_TestAllTypes?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofTestAllTypes(value)
+          return
         }
       case 536870013:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 536870014:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -9481,8 +9451,6 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
         if start <= 536870014 && 536870014 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 536870014)
         }
-      case .None:
-        break
       }
     }
   }
@@ -9629,7 +9597,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -9641,7 +9609,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypes {
     get {
-      if case .oneofTestAllTypes(let v) = _storage._oneofField {
+      if case .oneofTestAllTypes(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllTypes()
@@ -9653,7 +9621,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -9665,7 +9633,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -9675,7 +9643,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -376,7 +376,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
     var _defaultImportEnum: ProtobufUnittestImport_ImportEnumLite? = nil
     var _defaultStringPiece: String? = nil
     var _defaultCord: String? = nil
-    var _oneofField = ProtobufUnittest_TestAllTypesLite.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField?
     var _deceptivelyNamedList: Int32? = nil
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -458,7 +458,11 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
       case 83: try decoder.decodeSingularEnumField(value: &_defaultImportEnum)
       case 84: try decoder.decodeSingularStringField(value: &_defaultStringPiece)
       case 85: try decoder.decodeSingularStringField(value: &_defaultCord)
-      case 111, 112, 113, 114, 115: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114, 115:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_TestAllTypesLite.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 116: try decoder.decodeSingularInt32Field(value: &_deceptivelyNamedList)
       default: break
       }
@@ -678,7 +682,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
       if let v = _defaultCord {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 85)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 116)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 116)
       if let v = _deceptivelyNamedList {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt32.self, value: v, fieldNumber: 116)
       }
@@ -850,13 +854,12 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllTypesLite.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
     case oneofLazyNestedMessage(ProtobufUnittest_TestAllTypesLite.NestedMessage)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField, rhs: ProtobufUnittest_TestAllTypesLite.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -865,57 +868,51 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
       case (.oneofLazyNestedMessage(let l), .oneofLazyNestedMessage(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 112:
         var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 114:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       case 115:
         var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofLazyNestedMessage(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -940,8 +937,6 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
         if start <= 115 && 115 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1806,7 +1801,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1818,7 +1813,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllTypesLite.NestedMessage()
@@ -1830,7 +1825,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1842,7 +1837,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1854,7 +1849,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofLazyNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
-      if case .oneofLazyNestedMessage(let v) = _storage._oneofField {
+      if case .oneofLazyNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllTypesLite.NestedMessage()
@@ -1876,7 +1871,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
     return _storage._deceptivelyNamedList = nil
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue
@@ -3304,7 +3299,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
     var _optionalMessage: ProtobufUnittest_ForeignMessageLite? = nil
     var _optionalGroup: ProtobufUnittest_TestHugeFieldNumbersLite.OptionalGroup? = nil
     var _stringStringMap: Dictionary<String,String> = [:]
-    var _oneofField = ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField?
 
     var isInitialized: Bool {
       if !extensionFieldValues.isInitialized {return false}
@@ -3329,7 +3324,11 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       case 536870007: try decoder.decodeSingularMessageField(value: &_optionalMessage)
       case 536870008: try decoder.decodeSingularGroupField(value: &_optionalGroup)
       case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_stringStringMap)
-      case 536870011, 536870012, 536870013, 536870014: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 536870011, 536870012, 536870013, 536870014:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: if (536860000 <= fieldNumber && fieldNumber < 536870000) {
           try decoder.decodeExtensionField(values: &extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber)
         }
@@ -3368,7 +3367,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       if !_stringStringMap.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _stringStringMap, fieldNumber: 536870010)
       }
-      try _oneofField.traverse(visitor: visitor, start: 536870011, end: 536870015)
+      try _oneofField?.traverse(visitor: visitor, start: 536870011, end: 536870015)
       unknown.traverse(visitor: visitor)
     }
 
@@ -3415,12 +3414,11 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofTestAllTypes(ProtobufUnittest_TestAllTypesLite)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField, rhs: ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -3428,51 +3426,44 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       case (.oneofTestAllTypes(let l), .oneofTestAllTypes(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 536870011:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 536870012:
         var value: ProtobufUnittest_TestAllTypesLite?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofTestAllTypes(value)
+          return
         }
       case 536870013:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 536870014:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -3493,8 +3484,6 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
         if start <= 536870014 && 536870014 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 536870014)
         }
-      case .None:
-        break
       }
     }
   }
@@ -3641,7 +3630,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -3653,7 +3642,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypesLite {
     get {
-      if case .oneofTestAllTypes(let v) = _storage._oneofField {
+      if case .oneofTestAllTypes(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllTypesLite()
@@ -3665,7 +3654,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -3677,7 +3666,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -3687,7 +3676,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -276,7 +276,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     var _defaultImportEnum: ProtobufUnittestImport_ImportEnum? = nil
     var _defaultStringPiece: String? = nil
     var _defaultCord: String? = nil
-    var _oneofField = ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField()
+    var _oneofField: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -357,7 +357,11 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
       case 83: try decoder.decodeSingularEnumField(value: &_defaultImportEnum)
       case 84: try decoder.decodeSingularStringField(value: &_defaultStringPiece)
       case 85: try decoder.decodeSingularStringField(value: &_defaultCord)
-      case 111, 112, 113, 114, 115: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114, 115:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -576,7 +580,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
       if let v = _defaultCord {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 85)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 116)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 116)
       unknown.traverse(visitor: visitor)
     }
 
@@ -743,13 +747,12 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittestNoArena_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
     case lazyOneofNestedMessage(ProtobufUnittestNoArena_TestAllTypes.NestedMessage)
-    case None
 
     static func ==(lhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField, rhs: ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -758,57 +761,51 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
       case (.lazyOneofNestedMessage(let l), .lazyOneofNestedMessage(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 112:
         var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 114:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       case 115:
         var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .lazyOneofNestedMessage(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -833,8 +830,6 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
         if start <= 115 && 115 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1692,7 +1687,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1704,7 +1699,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittestNoArena_TestAllTypes.NestedMessage()
@@ -1716,7 +1711,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1728,7 +1723,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1740,7 +1735,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var lazyOneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
-      if case .lazyOneofNestedMessage(let v) = _storage._oneofField {
+      if case .lazyOneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittestNoArena_TestAllTypes.NestedMessage()
@@ -1750,7 +1745,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -221,7 +221,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
     var _repeatedLazyMessage: [Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage] = []
-    var _oneofField = Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField()
+    var _oneofField: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -277,7 +277,11 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
       case 54: try decoder.decodeRepeatedStringField(value: &_repeatedStringPiece)
       case 55: try decoder.decodeRepeatedStringField(value: &_repeatedCord)
       case 57: try decoder.decodeRepeatedMessageField(value: &_repeatedLazyMessage)
-      case 111, 112, 113, 114: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -421,7 +425,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
       if !_repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _repeatedLazyMessage, fieldNumber: 57)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 115)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 115)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -531,12 +535,11 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofEnum(Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum)
-    case None
 
     static func ==(lhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -544,45 +547,38 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
       case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 112:
         var value: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 114:
         var value = Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofEnum(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -603,8 +599,6 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
         if start <= 114 && 114 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
         }
-      case .None:
-        break
       }
     }
   }
@@ -971,7 +965,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -983,7 +977,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
 
   var oneofNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage()
@@ -995,7 +989,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1007,7 +1001,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
 
   var oneofEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
     get {
-      if case .oneofEnum(let v) = _storage._oneofField {
+      if case .oneofEnum(let v)? = _storage._oneofField {
         return v
       }
       return Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum.foo
@@ -1017,7 +1011,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -71,7 +71,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     var unknown = SwiftProtobuf.UnknownStorage()
     var _i: Int32? = nil
     var _msg: ProtobufUnittest_ForeignMessage? = nil
-    var _foo = ProtobufUnittest_TestOptimizedForSize.OneOf_Foo()
+    var _foo: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo?
 
     var isInitialized: Bool {
       if !extensionFieldValues.isInitialized {return false}
@@ -88,7 +88,11 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
       switch fieldNumber {
       case 1: try decoder.decodeSingularInt32Field(value: &_i)
       case 19: try decoder.decodeSingularMessageField(value: &_msg)
-      case 2, 3: try _foo.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 2, 3:
+        if _foo != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _foo = try ProtobufUnittest_TestOptimizedForSize.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
           try decoder.decodeExtensionField(values: &extensionFieldValues, messageType: ProtobufUnittest_TestOptimizedForSize.self, fieldNumber: fieldNumber)
         }
@@ -99,7 +103,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
       if let v = _i {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt32.self, value: v, fieldNumber: 1)
       }
-      try _foo.traverse(visitor: visitor, start: 2, end: 4)
+      try _foo?.traverse(visitor: visitor, start: 2, end: 4)
       if let v = _msg {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 19)
       }
@@ -134,48 +138,38 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_Foo: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Foo: SwiftProtobuf.OneofEnum {
     case integerField(Int32)
     case stringField(String)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo, rhs: ProtobufUnittest_TestOptimizedForSize.OneOf_Foo) -> Bool {
       switch (lhs, rhs) {
       case (.integerField(let l), .integerField(let r)): return l == r
       case (.stringField(let l), .stringField(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 2:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .integerField(value)
+          return
         }
       case 3:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .stringField(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -188,8 +182,6 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
         if start <= 3 && 3 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 3)
         }
-      case .None:
-        break
       }
     }
   }
@@ -233,7 +225,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
 
   var integerField: Int32 {
     get {
-      if case .integerField(let v) = _storage._foo {
+      if case .integerField(let v)? = _storage._foo {
         return v
       }
       return 0
@@ -245,7 +237,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
 
   var stringField: String {
     get {
-      if case .stringField(let v) = _storage._foo {
+      if case .stringField(let v)? = _storage._foo {
         return v
       }
       return ""
@@ -255,7 +247,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     }
   }
 
-  var foo: OneOf_Foo {
+  var foo: OneOf_Foo? {
     get {return _storage._foo}
     set {
       _uniqueStorage()._foo = newValue

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -196,44 +196,34 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
   ]
 
 
-  enum OneOf_O: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_O: SwiftProtobuf.OneofEnum {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnum)
-    case None
 
     static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
       switch (lhs, rhs) {
       case (.oneofE1(let l), .oneofE1(let r)): return l == r
       case (.oneofE2(let l), .oneofE2(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 5:
         var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofE1(value)
+        return
       case 6:
         var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofE2(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -246,8 +236,6 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
         if start <= 6 && 6 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
         }
-      case .None:
-        break
       }
     }
   }
@@ -263,7 +251,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
 
   var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE1(let v) = o {
+      if case .oneofE1(let v)? = o {
         return v
       }
       return Proto3PreserveUnknownEnumUnittest_MyEnum.foo
@@ -273,11 +261,11 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     }
   }
 
-  var o: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O = .None
+  var o: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O? = nil
 
   var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE2(let v) = o {
+      if case .oneofE2(let v)? = o {
         return v
       }
       return Proto3PreserveUnknownEnumUnittest_MyEnum.foo
@@ -299,7 +287,11 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     case 2: try decoder.decodeRepeatedEnumField(value: &repeatedE)
     case 3: try decoder.decodeRepeatedEnumField(value: &repeatedPackedE)
     case 4: try decoder.decodeRepeatedEnumField(value: &repeatedPackedUnexpectedE)
-    case 5, 6: try o.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 5, 6:
+      if o != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      o = try Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     default: break
     }
   }
@@ -317,7 +309,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     if !repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitPackedEnumField(value: repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try o.traverse(visitor: visitor, start: 5, end: 7)
+    try o?.traverse(visitor: visitor, start: 5, end: 7)
   }
 
   func _protoc_generated_isEqualTo(other: Proto3PreserveUnknownEnumUnittest_MyMessage) -> Bool {
@@ -343,44 +335,34 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
   ]
 
 
-  enum OneOf_O: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_O: SwiftProtobuf.OneofEnum {
     case oneofE1(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
     case oneofE2(Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra)
-    case None
 
     static func ==(lhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O, rhs: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O) -> Bool {
       switch (lhs, rhs) {
       case (.oneofE1(let l), .oneofE1(let r)): return l == r
       case (.oneofE2(let l), .oneofE2(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 5:
         var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofE1(value)
+        return
       case 6:
         var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofE2(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -393,8 +375,6 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
         if start <= 6 && 6 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
         }
-      case .None:
-        break
       }
     }
   }
@@ -409,7 +389,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
 
   var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
-      if case .oneofE1(let v) = o {
+      if case .oneofE1(let v)? = o {
         return v
       }
       return Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
@@ -419,11 +399,11 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     }
   }
 
-  var o: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O = .None
+  var o: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O? = nil
 
   var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
-      if case .oneofE2(let v) = o {
+      if case .oneofE2(let v)? = o {
         return v
       }
       return Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
@@ -445,7 +425,11 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     case 2: try decoder.decodeRepeatedEnumField(value: &repeatedE)
     case 3: try decoder.decodeRepeatedEnumField(value: &repeatedPackedE)
     case 4: try decoder.decodeRepeatedEnumField(value: &repeatedPackedUnexpectedE)
-    case 5, 6: try o.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 5, 6:
+      if o != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      o = try Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     default: break
     }
   }
@@ -463,7 +447,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     if !repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitPackedEnumField(value: repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try o.traverse(visitor: visitor, start: 5, end: 7)
+    try o?.traverse(visitor: visitor, start: 5, end: 7)
   }
 
   func _protoc_generated_isEqualTo(other: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra) -> Bool {

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -124,48 +124,38 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
 
   var unknown = SwiftProtobuf.UnknownStorage()
 
-  enum OneOf_O: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_O: SwiftProtobuf.OneofEnum {
     case oneofE1(Proto2PreserveUnknownEnumUnittest_MyEnum)
     case oneofE2(Proto2PreserveUnknownEnumUnittest_MyEnum)
-    case None
 
     static func ==(lhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O, rhs: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O) -> Bool {
       switch (lhs, rhs) {
       case (.oneofE1(let l), .oneofE1(let r)): return l == r
       case (.oneofE2(let l), .oneofE2(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 5:
         var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &value)
         if let value = value {
           self = .oneofE1(value)
+          return
         }
       case 6:
         var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
         try decoder.decodeSingularEnumField(value: &value)
         if let value = value {
           self = .oneofE2(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -178,8 +168,6 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
         if start <= 6 && 6 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
         }
-      case .None:
-        break
       }
     }
   }
@@ -205,7 +193,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
 
   var oneofE1: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE1(let v) = o {
+      if case .oneofE1(let v)? = o {
         return v
       }
       return Proto2PreserveUnknownEnumUnittest_MyEnum.foo
@@ -215,11 +203,11 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     }
   }
 
-  var o: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O = .None
+  var o: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O? = nil
 
   var oneofE2: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE2(let v) = o {
+      if case .oneofE2(let v)? = o {
         return v
       }
       return Proto2PreserveUnknownEnumUnittest_MyEnum.foo
@@ -241,7 +229,11 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     case 2: try decoder.decodeRepeatedEnumField(value: &repeatedE)
     case 3: try decoder.decodeRepeatedEnumField(value: &repeatedPackedE)
     case 4: try decoder.decodeRepeatedEnumField(value: &repeatedPackedUnexpectedE)
-    case 5, 6: try o.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    case 5, 6:
+      if o != nil {
+        try decoder.handleConflictingOneOf()
+      }
+      o = try Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     default: break
     }
   }
@@ -259,7 +251,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message, Swift
     if !repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitRepeatedEnumField(value: repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try o.traverse(visitor: visitor, start: 5, end: 7)
+    try o?.traverse(visitor: visitor, start: 5, end: 7)
     unknown.traverse(visitor: visitor)
   }
 

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -227,7 +227,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
     var _repeatedStringPiece: [String] = []
     var _repeatedCord: [String] = []
     var _repeatedLazyMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] = []
-    var _oneofField = Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField()
+    var _oneofField: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -284,7 +284,11 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
       case 54: try decoder.decodeRepeatedStringField(value: &_repeatedStringPiece)
       case 55: try decoder.decodeRepeatedStringField(value: &_repeatedCord)
       case 57: try decoder.decodeRepeatedMessageField(value: &_repeatedLazyMessage)
-      case 111, 112, 113, 114: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -431,7 +435,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
       if !_repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _repeatedLazyMessage, fieldNumber: 57)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 115)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 115)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -543,12 +547,11 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(Proto3ArenaUnittest_TestAllTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField, rhs: Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -556,45 +559,38 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
       case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 112:
         var value: Proto3ArenaUnittest_TestAllTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 114:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .oneofBytes(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -615,8 +611,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
         if start <= 114 && 114 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 114)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1027,7 +1021,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1039,7 +1033,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
 
   var oneofNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return Proto3ArenaUnittest_TestAllTypes.NestedMessage()
@@ -1051,7 +1045,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1063,7 +1057,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1073,7 +1067,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -156,7 +156,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
     var _defaultImportEnum: ProtobufUnittestImport_ImportEnum? = nil
     var _defaultStringPiece: String? = nil
     var _defaultCord: String? = nil
-    var _oneofField = ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField?
 
     var isInitialized: Bool {
       if _requiredInt32 == nil {return false}
@@ -209,10 +209,8 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
       if let v = _requiredNestedMessage, !v.isInitialized {return false}
       if let v = _requiredLazyMessage, !v.isInitialized {return false}
       switch _oneofField {
-      case .oneofNestedMessage(let v):
+      case .oneofNestedMessage(let v)?:
         if !v.isInitialized {return false}
-      case .None:
-        break
       default:
         break
       }
@@ -273,7 +271,11 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
       case 83: try decoder.decodeSingularEnumField(value: &_defaultImportEnum)
       case 84: try decoder.decodeSingularStringField(value: &_defaultStringPiece)
       case 85: try decoder.decodeSingularStringField(value: &_defaultCord)
-      case 111, 112, 113, 114: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 111, 112, 113, 114:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
@@ -417,7 +419,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
       if let v = _defaultCord {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 85)
       }
-      try _oneofField.traverse(visitor: visitor, start: 111, end: 115)
+      try _oneofField?.traverse(visitor: visitor, start: 111, end: 115)
       unknown.traverse(visitor: visitor)
     }
 
@@ -534,12 +536,11 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case oneofUint32(UInt32)
     case oneofNestedMessage(ProtobufUnittest_TestAllRequiredTypes.NestedMessage)
     case oneofString(String)
     case oneofBytes(Data)
-    case None
 
     static func ==(lhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField, rhs: ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -547,51 +548,44 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
       case (.oneofNestedMessage(let l), .oneofNestedMessage(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 111:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 112:
         var value: ProtobufUnittest_TestAllRequiredTypes.NestedMessage?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofNestedMessage(value)
+          return
         }
       case 113:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 114:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -612,8 +606,6 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
         if start <= 114 && 114 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufBytes.self, value: v, fieldNumber: 114)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1307,7 +1299,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._oneofField {
+      if case .oneofUint32(let v)? = _storage._oneofField {
         return v
       }
       return 0
@@ -1319,7 +1311,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
 
   var oneofNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v) = _storage._oneofField {
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {
         return v
       }
       return ProtobufUnittest_TestAllRequiredTypes.NestedMessage()
@@ -1331,7 +1323,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._oneofField {
+      if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
       return ""
@@ -1343,7 +1335,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._oneofField {
+      if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
       return Data()
@@ -1353,7 +1345,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -56,7 +56,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
     var _myString: String? = nil
     var _myInt: Int64? = nil
     var _myFloat: Float? = nil
-    var _options = Swift_Protobuf_TestFieldOrderings.OneOf_Options()
+    var _options: Swift_Protobuf_TestFieldOrderings.OneOf_Options?
     var _optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage? = nil
 
     var isInitialized: Bool {
@@ -75,7 +75,11 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
       case 11: try decoder.decodeSingularStringField(value: &_myString)
       case 1: try decoder.decodeSingularInt64Field(value: &_myInt)
       case 101: try decoder.decodeSingularFloatField(value: &_myFloat)
-      case 60, 9, 150, 10: try _options.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 60, 9, 150, 10:
+        if _options != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _options = try Swift_Protobuf_TestFieldOrderings.OneOf_Options(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 200: try decoder.decodeSingularMessageField(value: &_optionalNestedMessage)
       default: if (2 <= fieldNumber && fieldNumber < 9) || (12 <= fieldNumber && fieldNumber < 56) {
           try decoder.decodeExtensionField(values: &extensionFieldValues, messageType: Swift_Protobuf_TestFieldOrderings.self, fieldNumber: fieldNumber)
@@ -88,16 +92,16 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt64.self, value: v, fieldNumber: 1)
       }
       try visitor.visitExtensionFields(fields: extensionFieldValues, start: 2, end: 9)
-      try _options.traverse(visitor: visitor, start: 9, end: 11)
+      try _options?.traverse(visitor: visitor, start: 9, end: 11)
       if let v = _myString {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 11)
       }
       try visitor.visitExtensionFields(fields: extensionFieldValues, start: 12, end: 56)
-      try _options.traverse(visitor: visitor, start: 60, end: 61)
+      try _options?.traverse(visitor: visitor, start: 60, end: 61)
       if let v = _myFloat {
         try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufFloat.self, value: v, fieldNumber: 101)
       }
-      try _options.traverse(visitor: visitor, start: 150, end: 151)
+      try _options?.traverse(visitor: visitor, start: 150, end: 151)
       if let v = _optionalNestedMessage {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
       }
@@ -135,12 +139,11 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_Options: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_Options: SwiftProtobuf.OneofEnum {
     case oneofInt64(Int64)
     case oneofBool(Bool)
     case oneofString(String)
     case oneofInt32(Int32)
-    case None
 
     static func ==(lhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options, rhs: Swift_Protobuf_TestFieldOrderings.OneOf_Options) -> Bool {
       switch (lhs, rhs) {
@@ -148,51 +151,44 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
       case (.oneofBool(let l), .oneofBool(let r)): return l == r
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofInt32(let l), .oneofInt32(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 9:
         var value: Bool?
         try decoder.decodeSingularBoolField(value: &value)
         if let value = value {
           self = .oneofBool(value)
+          return
         }
       case 10:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .oneofInt32(value)
+          return
         }
       case 60:
         var value: Int64?
         try decoder.decodeSingularInt64Field(value: &value)
         if let value = value {
           self = .oneofInt64(value)
+          return
         }
       case 150:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -213,8 +209,6 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
         if start <= 150 && 150 < end {
           try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufString.self, value: v, fieldNumber: 150)
         }
-      case .None:
-        break
       }
     }
   }
@@ -320,7 +314,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v) = _storage._options {
+      if case .oneofInt64(let v)? = _storage._options {
         return v
       }
       return 0
@@ -332,7 +326,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v) = _storage._options {
+      if case .oneofBool(let v)? = _storage._options {
         return v
       }
       return false
@@ -344,7 +338,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._options {
+      if case .oneofString(let v)? = _storage._options {
         return v
       }
       return ""
@@ -356,7 +350,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v) = _storage._options {
+      if case .oneofInt32(let v)? = _storage._options {
         return v
       }
       return 0
@@ -377,7 +371,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
     return _storage._optionalNestedMessage = nil
   }
 
-  var options: OneOf_Options {
+  var options: OneOf_Options? {
     get {return _storage._options}
     set {
       _uniqueStorage()._options = newValue

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -166,7 +166,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
     var _repeatedGroup: [ProtobufUnittest_Message2.RepeatedGroup] = []
     var _repeatedMessage: [ProtobufUnittest_Message2] = []
     var _repeatedEnum: [ProtobufUnittest_Message2.Enum] = []
-    var _o = ProtobufUnittest_Message2.OneOf_O()
+    var _o: ProtobufUnittest_Message2.OneOf_O?
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -231,7 +231,11 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
       case 46: try decoder.decodeRepeatedGroupField(value: &_repeatedGroup)
       case 48: try decoder.decodeRepeatedMessageField(value: &_repeatedMessage)
       case 49: try decoder.decodeRepeatedEnumField(value: &_repeatedEnum)
-      case 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 68, 69: try _o.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 68, 69:
+        if _o != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _o = try ProtobufUnittest_Message2.OneOf_O(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 70: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: &_mapInt32Int32)
       case 71: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt64,SwiftProtobuf.ProtobufInt64>.self, value: &_mapInt64Int64)
       case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufUInt32,SwiftProtobuf.ProtobufUInt32>.self, value: &_mapUint32Uint32)
@@ -364,7 +368,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
       if !_repeatedEnum.isEmpty {
         try visitor.visitRepeatedEnumField(value: _repeatedEnum, fieldNumber: 49)
       }
-      try _o.traverse(visitor: visitor, start: 51, end: 70)
+      try _o?.traverse(visitor: visitor, start: 51, end: 70)
       if !_mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _mapInt32Int32, fieldNumber: 70)
       }
@@ -556,7 +560,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
     set {_storage.unknown = newValue}
   }
 
-  enum OneOf_O: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_O: SwiftProtobuf.OneofEnum {
     case oneofInt32(Int32)
     case oneofInt64(Int64)
     case oneofUint32(UInt32)
@@ -575,7 +579,6 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
     case oneofGroup(ProtobufUnittest_Message2.OneofGroup)
     case oneofMessage(ProtobufUnittest_Message2)
     case oneofEnum(ProtobufUnittest_Message2.Enum)
-    case None
 
     static func ==(lhs: ProtobufUnittest_Message2.OneOf_O, rhs: ProtobufUnittest_Message2.OneOf_O) -> Bool {
       switch (lhs, rhs) {
@@ -597,135 +600,142 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
       case (.oneofGroup(let l), .oneofGroup(let r)): return l == r
       case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
       case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 51:
         var value: Int32?
         try decoder.decodeSingularInt32Field(value: &value)
         if let value = value {
           self = .oneofInt32(value)
+          return
         }
       case 52:
         var value: Int64?
         try decoder.decodeSingularInt64Field(value: &value)
         if let value = value {
           self = .oneofInt64(value)
+          return
         }
       case 53:
         var value: UInt32?
         try decoder.decodeSingularUInt32Field(value: &value)
         if let value = value {
           self = .oneofUint32(value)
+          return
         }
       case 54:
         var value: UInt64?
         try decoder.decodeSingularUInt64Field(value: &value)
         if let value = value {
           self = .oneofUint64(value)
+          return
         }
       case 55:
         var value: Int32?
         try decoder.decodeSingularSInt32Field(value: &value)
         if let value = value {
           self = .oneofSint32(value)
+          return
         }
       case 56:
         var value: Int64?
         try decoder.decodeSingularSInt64Field(value: &value)
         if let value = value {
           self = .oneofSint64(value)
+          return
         }
       case 57:
         var value: UInt32?
         try decoder.decodeSingularFixed32Field(value: &value)
         if let value = value {
           self = .oneofFixed32(value)
+          return
         }
       case 58:
         var value: UInt64?
         try decoder.decodeSingularFixed64Field(value: &value)
         if let value = value {
           self = .oneofFixed64(value)
+          return
         }
       case 59:
         var value: Int32?
         try decoder.decodeSingularSFixed32Field(value: &value)
         if let value = value {
           self = .oneofSfixed32(value)
+          return
         }
       case 60:
         var value: Int64?
         try decoder.decodeSingularSFixed64Field(value: &value)
         if let value = value {
           self = .oneofSfixed64(value)
+          return
         }
       case 61:
         var value: Float?
         try decoder.decodeSingularFloatField(value: &value)
         if let value = value {
           self = .oneofFloat(value)
+          return
         }
       case 62:
         var value: Double?
         try decoder.decodeSingularDoubleField(value: &value)
         if let value = value {
           self = .oneofDouble(value)
+          return
         }
       case 63:
         var value: Bool?
         try decoder.decodeSingularBoolField(value: &value)
         if let value = value {
           self = .oneofBool(value)
+          return
         }
       case 64:
         var value: String?
         try decoder.decodeSingularStringField(value: &value)
         if let value = value {
           self = .oneofString(value)
+          return
         }
       case 65:
         var value: Data?
         try decoder.decodeSingularBytesField(value: &value)
         if let value = value {
           self = .oneofBytes(value)
+          return
         }
       case 66:
         var value: ProtobufUnittest_Message2.OneofGroup?
         try decoder.decodeSingularGroupField(value: &value)
         if let value = value {
           self = .oneofGroup(value)
+          return
         }
       case 68:
         var value: ProtobufUnittest_Message2?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofMessage(value)
+          return
         }
       case 69:
         var value: ProtobufUnittest_Message2.Enum?
         try decoder.decodeSingularEnumField(value: &value)
         if let value = value {
           self = .oneofEnum(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -802,8 +812,6 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
         if start <= 69 && 69 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
         }
-      case .None:
-        break
       }
     }
   }
@@ -1327,7 +1335,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v) = _storage._o {
+      if case .oneofInt32(let v)? = _storage._o {
         return v
       }
       return 100
@@ -1339,7 +1347,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v) = _storage._o {
+      if case .oneofInt64(let v)? = _storage._o {
         return v
       }
       return 101
@@ -1351,7 +1359,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._o {
+      if case .oneofUint32(let v)? = _storage._o {
         return v
       }
       return 102
@@ -1363,7 +1371,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v) = _storage._o {
+      if case .oneofUint64(let v)? = _storage._o {
         return v
       }
       return 103
@@ -1375,7 +1383,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofSint32: Int32 {
     get {
-      if case .oneofSint32(let v) = _storage._o {
+      if case .oneofSint32(let v)? = _storage._o {
         return v
       }
       return 104
@@ -1387,7 +1395,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofSint64: Int64 {
     get {
-      if case .oneofSint64(let v) = _storage._o {
+      if case .oneofSint64(let v)? = _storage._o {
         return v
       }
       return 105
@@ -1399,7 +1407,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofFixed32: UInt32 {
     get {
-      if case .oneofFixed32(let v) = _storage._o {
+      if case .oneofFixed32(let v)? = _storage._o {
         return v
       }
       return 106
@@ -1411,7 +1419,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofFixed64: UInt64 {
     get {
-      if case .oneofFixed64(let v) = _storage._o {
+      if case .oneofFixed64(let v)? = _storage._o {
         return v
       }
       return 107
@@ -1423,7 +1431,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofSfixed32: Int32 {
     get {
-      if case .oneofSfixed32(let v) = _storage._o {
+      if case .oneofSfixed32(let v)? = _storage._o {
         return v
       }
       return 108
@@ -1435,7 +1443,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofSfixed64: Int64 {
     get {
-      if case .oneofSfixed64(let v) = _storage._o {
+      if case .oneofSfixed64(let v)? = _storage._o {
         return v
       }
       return 109
@@ -1447,7 +1455,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v) = _storage._o {
+      if case .oneofFloat(let v)? = _storage._o {
         return v
       }
       return 110
@@ -1459,7 +1467,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v) = _storage._o {
+      if case .oneofDouble(let v)? = _storage._o {
         return v
       }
       return 111
@@ -1471,7 +1479,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v) = _storage._o {
+      if case .oneofBool(let v)? = _storage._o {
         return v
       }
       return true
@@ -1483,7 +1491,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._o {
+      if case .oneofString(let v)? = _storage._o {
         return v
       }
       return "string"
@@ -1495,7 +1503,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._o {
+      if case .oneofBytes(let v)? = _storage._o {
         return v
       }
       return Data(bytes: [100, 97, 116, 97])
@@ -1507,7 +1515,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofGroup: ProtobufUnittest_Message2.OneofGroup {
     get {
-      if case .oneofGroup(let v) = _storage._o {
+      if case .oneofGroup(let v)? = _storage._o {
         return v
       }
       return ProtobufUnittest_Message2.OneofGroup()
@@ -1519,7 +1527,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofMessage: ProtobufUnittest_Message2 {
     get {
-      if case .oneofMessage(let v) = _storage._o {
+      if case .oneofMessage(let v)? = _storage._o {
         return v
       }
       return ProtobufUnittest_Message2()
@@ -1531,7 +1539,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
 
   var oneofEnum: ProtobufUnittest_Message2.Enum {
     get {
-      if case .oneofEnum(let v) = _storage._o {
+      if case .oneofEnum(let v)? = _storage._o {
         return v
       }
       return ProtobufUnittest_Message2.Enum.baz
@@ -1637,7 +1645,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
     set {_uniqueStorage()._mapInt32Message = newValue}
   }
 
-  var o: OneOf_O {
+  var o: OneOf_O? {
     get {return _storage._o}
     set {
       _uniqueStorage()._o = newValue

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -160,7 +160,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
     var _repeatedBytes: [Data] = []
     var _repeatedMessage: [ProtobufUnittest_Message3] = []
     var _repeatedEnum: [ProtobufUnittest_Message3.Enum] = []
-    var _o = ProtobufUnittest_Message3.OneOf_O()
+    var _o: ProtobufUnittest_Message3.OneOf_O?
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -223,7 +223,11 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
       case 45: try decoder.decodeRepeatedBytesField(value: &_repeatedBytes)
       case 48: try decoder.decodeRepeatedMessageField(value: &_repeatedMessage)
       case 49: try decoder.decodeRepeatedEnumField(value: &_repeatedEnum)
-      case 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 68, 69: try _o.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 68, 69:
+        if _o != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _o = try ProtobufUnittest_Message3.OneOf_O(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       case 70: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: &_mapInt32Int32)
       case 71: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt64,SwiftProtobuf.ProtobufInt64>.self, value: &_mapInt64Int64)
       case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufUInt32,SwiftProtobuf.ProtobufUInt32>.self, value: &_mapUint32Uint32)
@@ -350,7 +354,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
       if !_repeatedEnum.isEmpty {
         try visitor.visitPackedEnumField(value: _repeatedEnum, fieldNumber: 49)
       }
-      try _o.traverse(visitor: visitor, start: 51, end: 70)
+      try _o?.traverse(visitor: visitor, start: 51, end: 70)
       if !_mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf.ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _mapInt32Int32, fieldNumber: 70)
       }
@@ -531,7 +535,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
   private var _storage = _StorageClass()
 
 
-  enum OneOf_O: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_O: SwiftProtobuf.OneofEnum {
     case oneofInt32(Int32)
     case oneofInt64(Int64)
     case oneofUint32(UInt32)
@@ -549,7 +553,6 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
     case oneofBytes(Data)
     case oneofMessage(ProtobufUnittest_Message3)
     case oneofEnum(ProtobufUnittest_Message3.Enum)
-    case None
 
     static func ==(lhs: ProtobufUnittest_Message3.OneOf_O, rhs: ProtobufUnittest_Message3.OneOf_O) -> Bool {
       switch (lhs, rhs) {
@@ -570,97 +573,103 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
       case (.oneofMessage(let l), .oneofMessage(let r)): return l == r
       case (.oneofEnum(let l), .oneofEnum(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 51:
         var value = Int32()
         try decoder.decodeSingularInt32Field(value: &value)
         self = .oneofInt32(value)
+        return
       case 52:
         var value = Int64()
         try decoder.decodeSingularInt64Field(value: &value)
         self = .oneofInt64(value)
+        return
       case 53:
         var value = UInt32()
         try decoder.decodeSingularUInt32Field(value: &value)
         self = .oneofUint32(value)
+        return
       case 54:
         var value = UInt64()
         try decoder.decodeSingularUInt64Field(value: &value)
         self = .oneofUint64(value)
+        return
       case 55:
         var value = Int32()
         try decoder.decodeSingularSInt32Field(value: &value)
         self = .oneofSint32(value)
+        return
       case 56:
         var value = Int64()
         try decoder.decodeSingularSInt64Field(value: &value)
         self = .oneofSint64(value)
+        return
       case 57:
         var value = UInt32()
         try decoder.decodeSingularFixed32Field(value: &value)
         self = .oneofFixed32(value)
+        return
       case 58:
         var value = UInt64()
         try decoder.decodeSingularFixed64Field(value: &value)
         self = .oneofFixed64(value)
+        return
       case 59:
         var value = Int32()
         try decoder.decodeSingularSFixed32Field(value: &value)
         self = .oneofSfixed32(value)
+        return
       case 60:
         var value = Int64()
         try decoder.decodeSingularSFixed64Field(value: &value)
         self = .oneofSfixed64(value)
+        return
       case 61:
         var value = Float()
         try decoder.decodeSingularFloatField(value: &value)
         self = .oneofFloat(value)
+        return
       case 62:
         var value = Double()
         try decoder.decodeSingularDoubleField(value: &value)
         self = .oneofDouble(value)
+        return
       case 63:
         var value = Bool()
         try decoder.decodeSingularBoolField(value: &value)
         self = .oneofBool(value)
+        return
       case 64:
         var value = String()
         try decoder.decodeSingularStringField(value: &value)
         self = .oneofString(value)
+        return
       case 65:
         var value = Data()
         try decoder.decodeSingularBytesField(value: &value)
         self = .oneofBytes(value)
+        return
       case 68:
         var value: ProtobufUnittest_Message3?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .oneofMessage(value)
+          return
         }
       case 69:
         var value = ProtobufUnittest_Message3.Enum()
         try decoder.decodeSingularEnumField(value: &value)
         self = .oneofEnum(value)
+        return
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -733,8 +742,6 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
         if start <= 69 && 69 < end {
           try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
         }
-      case .None:
-        break
       }
     }
   }
@@ -989,7 +996,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v) = _storage._o {
+      if case .oneofInt32(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1001,7 +1008,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v) = _storage._o {
+      if case .oneofInt64(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1013,7 +1020,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v) = _storage._o {
+      if case .oneofUint32(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1025,7 +1032,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v) = _storage._o {
+      if case .oneofUint64(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1037,7 +1044,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofSint32: Int32 {
     get {
-      if case .oneofSint32(let v) = _storage._o {
+      if case .oneofSint32(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1049,7 +1056,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofSint64: Int64 {
     get {
-      if case .oneofSint64(let v) = _storage._o {
+      if case .oneofSint64(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1061,7 +1068,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofFixed32: UInt32 {
     get {
-      if case .oneofFixed32(let v) = _storage._o {
+      if case .oneofFixed32(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1073,7 +1080,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofFixed64: UInt64 {
     get {
-      if case .oneofFixed64(let v) = _storage._o {
+      if case .oneofFixed64(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1085,7 +1092,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofSfixed32: Int32 {
     get {
-      if case .oneofSfixed32(let v) = _storage._o {
+      if case .oneofSfixed32(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1097,7 +1104,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofSfixed64: Int64 {
     get {
-      if case .oneofSfixed64(let v) = _storage._o {
+      if case .oneofSfixed64(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1109,7 +1116,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v) = _storage._o {
+      if case .oneofFloat(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1121,7 +1128,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v) = _storage._o {
+      if case .oneofDouble(let v)? = _storage._o {
         return v
       }
       return 0
@@ -1133,7 +1140,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v) = _storage._o {
+      if case .oneofBool(let v)? = _storage._o {
         return v
       }
       return false
@@ -1145,7 +1152,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofString: String {
     get {
-      if case .oneofString(let v) = _storage._o {
+      if case .oneofString(let v)? = _storage._o {
         return v
       }
       return ""
@@ -1157,7 +1164,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v) = _storage._o {
+      if case .oneofBytes(let v)? = _storage._o {
         return v
       }
       return Data()
@@ -1170,7 +1177,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
   ///   No 'group' in proto3.
   var oneofMessage: ProtobufUnittest_Message3 {
     get {
-      if case .oneofMessage(let v) = _storage._o {
+      if case .oneofMessage(let v)? = _storage._o {
         return v
       }
       return ProtobufUnittest_Message3()
@@ -1182,7 +1189,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
 
   var oneofEnum: ProtobufUnittest_Message3.Enum {
     get {
-      if case .oneofEnum(let v) = _storage._o {
+      if case .oneofEnum(let v)? = _storage._o {
         return v
       }
       return ProtobufUnittest_Message3.Enum.foo
@@ -1288,7 +1295,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
     set {_uniqueStorage()._mapInt32Message = newValue}
   }
 
-  var o: OneOf_O {
+  var o: OneOf_O? {
     get {return _storage._o}
     set {
       _uniqueStorage()._o = newValue

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -768,7 +768,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   private class _StorageClass {
     typealias ExtendedMessage = ProtobufUnittest_OneofWellKnownTypes
-    var _oneofField = ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField()
+    var _oneofField: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
       while let fieldNumber = try decoder.nextFieldNumber() {
@@ -778,13 +778,17 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
     func decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
       switch fieldNumber {
-      case 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18: try _oneofField.decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+      case 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18:
+        if _oneofField != nil {
+          try decoder.handleConflictingOneOf()
+        }
+        _oneofField = try ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
       default: break
       }
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      try _oneofField.traverse(visitor: visitor, start: 1, end: 19)
+      try _oneofField?.traverse(visitor: visitor, start: 1, end: 19)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -802,7 +806,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
   private var _storage = _StorageClass()
 
 
-  enum OneOf_OneofField: ExpressibleByNilLiteral, SwiftProtobuf.OneofEnum {
+  enum OneOf_OneofField: SwiftProtobuf.OneofEnum {
     case anyField(Google_Protobuf_Any)
     case apiField(Google_Protobuf_Api)
     case durationField(Google_Protobuf_Duration)
@@ -821,7 +825,6 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
     case boolField(Google_Protobuf_BoolValue)
     case stringField(Google_Protobuf_StringValue)
     case bytesField(Google_Protobuf_BytesValue)
-    case None
 
     static func ==(lhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField, rhs: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField) -> Bool {
       switch (lhs, rhs) {
@@ -843,135 +846,142 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
       case (.boolField(let l), .boolField(let r)): return l == r
       case (.stringField(let l), .stringField(let r)): return l == r
       case (.bytesField(let l), .bytesField(let r)): return l == r
-      case (.None, .None): return true
       default: return false
       }
     }
 
-    init(nilLiteral: ()) {
-      self = .None
-    }
-
-    init() {
-      self = .None
-    }
-
-    mutating func decodeField<T: SwiftProtobuf.Decoder>(decoder: inout T, fieldNumber: Int) throws {
-      if self != .None {
-        try decoder.handleConflictingOneOf()
-      }
+    init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
       switch fieldNumber {
       case 1:
         var value: Google_Protobuf_Any?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .anyField(value)
+          return
         }
       case 2:
         var value: Google_Protobuf_Api?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .apiField(value)
+          return
         }
       case 3:
         var value: Google_Protobuf_Duration?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .durationField(value)
+          return
         }
       case 4:
         var value: Google_Protobuf_Empty?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .emptyField(value)
+          return
         }
       case 5:
         var value: Google_Protobuf_FieldMask?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .fieldMaskField(value)
+          return
         }
       case 6:
         var value: Google_Protobuf_SourceContext?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .sourceContextField(value)
+          return
         }
       case 7:
         var value: Google_Protobuf_Struct?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .structField(value)
+          return
         }
       case 8:
         var value: Google_Protobuf_Timestamp?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .timestampField(value)
+          return
         }
       case 9:
         var value: Google_Protobuf_Type?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .typeField(value)
+          return
         }
       case 10:
         var value: Google_Protobuf_DoubleValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .doubleField(value)
+          return
         }
       case 11:
         var value: Google_Protobuf_FloatValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .floatField(value)
+          return
         }
       case 12:
         var value: Google_Protobuf_Int64Value?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .int64Field(value)
+          return
         }
       case 13:
         var value: Google_Protobuf_UInt64Value?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .uint64Field(value)
+          return
         }
       case 14:
         var value: Google_Protobuf_Int32Value?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .int32Field(value)
+          return
         }
       case 15:
         var value: Google_Protobuf_UInt32Value?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .uint32Field(value)
+          return
         }
       case 16:
         var value: Google_Protobuf_BoolValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .boolField(value)
+          return
         }
       case 17:
         var value: Google_Protobuf_StringValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .stringField(value)
+          return
         }
       case 18:
         var value: Google_Protobuf_BytesValue?
         try decoder.decodeSingularMessageField(value: &value)
         if let value = value {
           self = .bytesField(value)
+          return
         }
       default:
-        self = .None
+        break
       }
+      return nil
     }
 
     func traverse(visitor: SwiftProtobuf.Visitor, start: Int, end: Int) throws {
@@ -1048,15 +1058,13 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
         if start <= 18 && 18 < end {
           try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
         }
-      case .None:
-        break
       }
     }
   }
 
   var anyField: Google_Protobuf_Any {
     get {
-      if case .anyField(let v) = _storage._oneofField {
+      if case .anyField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Any()
@@ -1068,7 +1076,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var apiField: Google_Protobuf_Api {
     get {
-      if case .apiField(let v) = _storage._oneofField {
+      if case .apiField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Api()
@@ -1080,7 +1088,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var durationField: Google_Protobuf_Duration {
     get {
-      if case .durationField(let v) = _storage._oneofField {
+      if case .durationField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Duration()
@@ -1092,7 +1100,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var emptyField: Google_Protobuf_Empty {
     get {
-      if case .emptyField(let v) = _storage._oneofField {
+      if case .emptyField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Empty()
@@ -1104,7 +1112,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var fieldMaskField: Google_Protobuf_FieldMask {
     get {
-      if case .fieldMaskField(let v) = _storage._oneofField {
+      if case .fieldMaskField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_FieldMask()
@@ -1116,7 +1124,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var sourceContextField: Google_Protobuf_SourceContext {
     get {
-      if case .sourceContextField(let v) = _storage._oneofField {
+      if case .sourceContextField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_SourceContext()
@@ -1128,7 +1136,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var structField: Google_Protobuf_Struct {
     get {
-      if case .structField(let v) = _storage._oneofField {
+      if case .structField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Struct()
@@ -1140,7 +1148,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var timestampField: Google_Protobuf_Timestamp {
     get {
-      if case .timestampField(let v) = _storage._oneofField {
+      if case .timestampField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Timestamp()
@@ -1152,7 +1160,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var typeField: Google_Protobuf_Type {
     get {
-      if case .typeField(let v) = _storage._oneofField {
+      if case .typeField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Type()
@@ -1164,7 +1172,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var doubleField: Google_Protobuf_DoubleValue {
     get {
-      if case .doubleField(let v) = _storage._oneofField {
+      if case .doubleField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_DoubleValue()
@@ -1176,7 +1184,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var floatField: Google_Protobuf_FloatValue {
     get {
-      if case .floatField(let v) = _storage._oneofField {
+      if case .floatField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_FloatValue()
@@ -1188,7 +1196,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var int64Field: Google_Protobuf_Int64Value {
     get {
-      if case .int64Field(let v) = _storage._oneofField {
+      if case .int64Field(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Int64Value()
@@ -1200,7 +1208,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var uint64Field: Google_Protobuf_UInt64Value {
     get {
-      if case .uint64Field(let v) = _storage._oneofField {
+      if case .uint64Field(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_UInt64Value()
@@ -1212,7 +1220,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var int32Field: Google_Protobuf_Int32Value {
     get {
-      if case .int32Field(let v) = _storage._oneofField {
+      if case .int32Field(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_Int32Value()
@@ -1224,7 +1232,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var uint32Field: Google_Protobuf_UInt32Value {
     get {
-      if case .uint32Field(let v) = _storage._oneofField {
+      if case .uint32Field(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_UInt32Value()
@@ -1236,7 +1244,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var boolField: Google_Protobuf_BoolValue {
     get {
-      if case .boolField(let v) = _storage._oneofField {
+      if case .boolField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_BoolValue()
@@ -1248,7 +1256,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var stringField: Google_Protobuf_StringValue {
     get {
-      if case .stringField(let v) = _storage._oneofField {
+      if case .stringField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_StringValue()
@@ -1260,7 +1268,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
 
   var bytesField: Google_Protobuf_BytesValue {
     get {
-      if case .bytesField(let v) = _storage._oneofField {
+      if case .bytesField(let v)? = _storage._oneofField {
         return v
       }
       return Google_Protobuf_BytesValue()
@@ -1270,7 +1278,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
     }
   }
 
-  var oneofField: OneOf_OneofField {
+  var oneofField: OneOf_OneofField? {
     get {return _storage._oneofField}
     set {
       _uniqueStorage()._oneofField = newValue


### PR DESCRIPTION
This removes the `.None` case from generated `oneof` enums and goes a bit further by making the property itself optional. This provides nice cohesion with Swift optionals that isn't possible with other fields—since a `oneof` itself doesn't have a default value (its individual fields do), we can take advantage of Swift's own `Optional` type here to convey the difference between a `oneof` that has a value and one for which none of its fields is present.

This allows users to clear the `oneof` by setting it to `nil` (or `.none`). It also necessitates a change in the patterns used in `case` clauses. The former `case .foo(let bar)` now must be written `case .foo(let bar)?` (note the terminal question mark) if one wishes to not manually unwrap it first.

Implementation-wise, the most significant part of this change is the removal of `ExpressibleByNilLiteral` from `OneofEnum` and changing the decode method into an initializer. The latter was required because the decoder logic previously assumed that a (possibly `.None`) value was always present, which is no longer the case when the value is optional and `nil` when unset.

Fixes #133.