### PR TITLE
Fix reserved word handing on field names for proto2.

### DIFF
--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -307,10 +307,10 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message, SwiftProtobuf.
     get {return _isInitialized_p ?? ""}
     set {_isInitialized_p = newValue}
   }
-  var hasIsInitialized: Bool {
+  var hasIsInitialized_p: Bool {
     return _isInitialized_p != nil
   }
-  mutating func clearIsInitialized() {
+  mutating func clearIsInitialized_p() {
     return _isInitialized_p = nil
   }
 
@@ -319,10 +319,10 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message, SwiftProtobuf.
     get {return _hashValue_p ?? ""}
     set {_hashValue_p = newValue}
   }
-  var hasHashValue: Bool {
+  var hasHashValue_p: Bool {
     return _hashValue_p != nil
   }
-  mutating func clearHashValue() {
+  mutating func clearHashValue_p() {
     return _hashValue_p = nil
   }
 
@@ -331,10 +331,10 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message, SwiftProtobuf.
     get {return _debugDescription_p ?? 0}
     set {_debugDescription_p = newValue}
   }
-  var hasDebugDescription: Bool {
+  var hasDebugDescription_p: Bool {
     return _debugDescription_p != nil
   }
-  mutating func clearDebugDescription() {
+  mutating func clearDebugDescription_p() {
     return _debugDescription_p = nil
   }
 

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -263,13 +263,17 @@ struct MessageFieldGenerator {
         self.jsonName = descriptor.jsonName
         if descriptor.type == .group {
             let g = context.getMessageForPath(path: descriptor.typeName)!
-            self.swiftName = sanitizeFieldName(toLowerCamelCase(g.name))
-            self.swiftHasName = sanitizeFieldName("has" + toUpperCamelCase(g.name))
-            self.swiftClearName = sanitizeFieldName("clear" + toUpperCamelCase(g.name))
+            let lowerName = toLowerCamelCase(g.name)
+            self.swiftName = sanitizeFieldName(lowerName)
+            let sanitizedUpper = sanitizeFieldName(toUpperCamelCase(g.name), basedOn: lowerName)
+            self.swiftHasName = "has" + sanitizedUpper
+            self.swiftClearName = "clear" + sanitizedUpper
         } else {
-            self.swiftName = sanitizeFieldName(toLowerCamelCase(descriptor.name))
-            self.swiftHasName = sanitizeFieldName("has" + toUpperCamelCase(descriptor.name))
-            self.swiftClearName = sanitizeFieldName("clear" + toUpperCamelCase(descriptor.name))
+            let lowerName = toLowerCamelCase(descriptor.name)
+            self.swiftName = sanitizeFieldName(lowerName)
+            let sanitizedUpper = sanitizeFieldName(toUpperCamelCase(descriptor.name), basedOn: lowerName)
+            self.swiftHasName = "has" + sanitizedUpper
+            self.swiftClearName = "clear" + sanitizedUpper
         }
         if descriptor.hasOneofIndex {
             self.oneof = messageDescriptor.oneofDecl[Int(descriptor.oneofIndex)]

--- a/Sources/protoc-gen-swift/ReservedWords.swift
+++ b/Sources/protoc-gen-swift/ReservedWords.swift
@@ -193,15 +193,20 @@ private let reservedFieldNames: Set<String> = [
 /// this before going into the source code.
 /// It appends "_p" to any name that can't be
 /// used as a field name in Swift source code.
-func sanitizeFieldName(_ s: String) -> String {
-    if reservedFieldNames.contains(s) {
+func sanitizeFieldName(_ s: String, basedOn: String) -> String {
+    if reservedFieldNames.contains(basedOn) {
         return s + "_p"
-    } else if isAllUnderscore(s) {
+    } else if isAllUnderscore(basedOn) {
         return s + "__"
     } else {
         return s
     }
 }
+
+func sanitizeFieldName(_ s: String) -> String {
+  return sanitizeFieldName(s, basedOn: s)
+}
+
 
 /*
  * Many Swift reserved words can be used as enum cases if we put

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -307,10 +307,10 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message, SwiftProtobuf.
     get {return _isInitialized_p ?? ""}
     set {_isInitialized_p = newValue}
   }
-  var hasIsInitialized: Bool {
+  var hasIsInitialized_p: Bool {
     return _isInitialized_p != nil
   }
-  mutating func clearIsInitialized() {
+  mutating func clearIsInitialized_p() {
     return _isInitialized_p = nil
   }
 
@@ -319,10 +319,10 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message, SwiftProtobuf.
     get {return _hashValue_p ?? ""}
     set {_hashValue_p = newValue}
   }
-  var hasHashValue: Bool {
+  var hasHashValue_p: Bool {
     return _hashValue_p != nil
   }
-  mutating func clearHashValue() {
+  mutating func clearHashValue_p() {
     return _hashValue_p = nil
   }
 
@@ -331,10 +331,10 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message, SwiftProtobuf.
     get {return _debugDescription_p ?? 0}
     set {_debugDescription_p = newValue}
   }
-  var hasDebugDescription: Bool {
+  var hasDebugDescription_p: Bool {
     return _debugDescription_p != nil
   }
-  mutating func clearDebugDescription() {
+  mutating func clearDebugDescription_p() {
     return _debugDescription_p = nil
   }
 


### PR DESCRIPTION
We were checks for reserved words after adding has/clear, but we should
make the naming consistent with the property name, so added a helper to
to the sanitize based on another word so we can do this correct.