### PR TITLE
Issue #222: Duration range truncation

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration_Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration_Extensions.swift
@@ -99,13 +99,13 @@ private func formatDuration(seconds: Int64, nanos: Int32) -> String? {
     }
 
     if nanos == 0 {
-        return String(format: "%ds", seconds)
+        return String(format: "%lds", seconds)
     } else if nanos % 1000000 == 0 {
-        return String(format: "%d.%03ds", seconds, abs(nanos) / 1000000)
+        return String(format: "%ld.%03ds", seconds, abs(nanos) / 1000000)
     } else if nanos % 1000 == 0 {
-        return String(format: "%d.%06ds", seconds, abs(nanos) / 1000)
+        return String(format: "%ld.%06ds", seconds, abs(nanos) / 1000)
     } else {
-        return String(format: "%d.%09ds", seconds, abs(nanos))
+        return String(format: "%ld.%09ds", seconds, abs(nanos))
     }
 }
 

--- a/failure_list_swift.txt
+++ b/failure_list_swift.txt
@@ -1,4 +1,2 @@
-Required.JsonInput.DurationMaxValue.JsonOutput
-Required.JsonInput.DurationMinValue.JsonOutput
 Required.ProtobufInput.RepeatedScalarSelectsLast.DOUBLE.JsonOutput
 Required.ProtobufInput.ValidDataRepeated.DOUBLE.JsonOutput


### PR DESCRIPTION
`String(format:)` treats `%d` as a 32-bit integer, truncating
the 64-bit seconds value used in `Google_Protobuf_Duration`.
Change to `%ld` to preserve the 64-bit value.