### PR TITLE
Avoid extension collisions because of Swifty naming.

### DIFF
--- a/Protos/unittest_swift_extension.proto
+++ b/Protos/unittest_swift_extension.proto
@@ -40,3 +40,21 @@ extend Foo.Bar.Baz.C {
    optional bool d = 12;
 }
 */
+
+// If this compiles then it means we deal with unique proto names that
+// could end up with naming collisions when remapped to Swifty names.
+
+message Msg1 {
+  extensions 1 to 1000;
+}
+message Msg2 {
+  extensions 1 to 1000;
+}
+
+extend Msg1 {
+  optional int32 a_b = 1;
+}
+
+extend Msg2 {
+  optional int32 aB = 1;
+}

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -2336,7 +2336,7 @@ struct ProtobufUnittest_TestNestedExtension: SwiftProtobuf.Message, SwiftProtobu
 
     ///   Used to test if generated extension name is correct when there are
     ///   underscores.
-    static let nestedStringExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
       fieldNumber: 1003,
       fieldNames: .same(proto: "protobuf_unittest.TestNestedExtension.nested_string_extension"),
       defaultValue: ""
@@ -8773,13 +8773,13 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
 
   struct Extensions {
 
-    static let optionalExt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
+    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
       fieldNumber: 1000,
       fieldNames: .same(proto: "protobuf_unittest.TestParsingMerge.optional_ext"),
       defaultValue: ProtobufUnittest_TestAllTypes()
     )
 
-    static let repeatedExt = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
+    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
       fieldNumber: 1001,
       fieldNames: .same(proto: "protobuf_unittest.TestParsingMerge.repeated_ext"),
       defaultValue: []
@@ -9686,640 +9686,640 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 }
 
 ///   Singular
-let ProtobufUnittest_Extensions_optionalInt32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 1,
   fieldNames: .same(proto: "protobuf_unittest.optional_int32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalInt64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 2,
   fieldNames: .same(proto: "protobuf_unittest.optional_int64_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalUint32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 3,
   fieldNames: .same(proto: "protobuf_unittest.optional_uint32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalUint64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 4,
   fieldNames: .same(proto: "protobuf_unittest.optional_uint64_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSint32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 5,
   fieldNames: .same(proto: "protobuf_unittest.optional_sint32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSint64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 6,
   fieldNames: .same(proto: "protobuf_unittest.optional_sint64_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFixed32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 7,
   fieldNames: .same(proto: "protobuf_unittest.optional_fixed32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFixed64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 8,
   fieldNames: .same(proto: "protobuf_unittest.optional_fixed64_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSfixed32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 9,
   fieldNames: .same(proto: "protobuf_unittest.optional_sfixed32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSfixed64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 10,
   fieldNames: .same(proto: "protobuf_unittest.optional_sfixed64_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFloatExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 11,
   fieldNames: .same(proto: "protobuf_unittest.optional_float_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalDoubleExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 12,
   fieldNames: .same(proto: "protobuf_unittest.optional_double_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalBoolExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 13,
   fieldNames: .same(proto: "protobuf_unittest.optional_bool_extension"),
   defaultValue: false
 )
 
-let ProtobufUnittest_Extensions_optionalStringExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 14,
   fieldNames: .same(proto: "protobuf_unittest.optional_string_extension"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalBytesExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 15,
   fieldNames: .same(proto: "protobuf_unittest.optional_bytes_extension"),
   defaultValue: Data()
 )
 
-let ProtobufUnittest_Extensions_optionalGroupExtension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_OptionalGroup_extension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 16,
   fieldNames: .same(proto: "protobuf_unittest.OptionalGroup_extension"),
   defaultValue: ProtobufUnittest_OptionalGroup_extension()
 )
 
-let ProtobufUnittest_Extensions_optionalNestedMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 18,
   fieldNames: .same(proto: "protobuf_unittest.optional_nested_message_extension"),
   defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
 )
 
-let ProtobufUnittest_Extensions_optionalForeignMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_foreign_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 19,
   fieldNames: .same(proto: "protobuf_unittest.optional_foreign_message_extension"),
   defaultValue: ProtobufUnittest_ForeignMessage()
 )
 
-let ProtobufUnittest_Extensions_optionalImportMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 20,
   fieldNames: .same(proto: "protobuf_unittest.optional_import_message_extension"),
   defaultValue: ProtobufUnittestImport_ImportMessage()
 )
 
-let ProtobufUnittest_Extensions_optionalNestedEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 21,
   fieldNames: .same(proto: "protobuf_unittest.optional_nested_enum_extension"),
   defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.foo
 )
 
-let ProtobufUnittest_Extensions_optionalForeignEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 22,
   fieldNames: .same(proto: "protobuf_unittest.optional_foreign_enum_extension"),
   defaultValue: ProtobufUnittest_ForeignEnum.foreignFoo
 )
 
-let ProtobufUnittest_Extensions_optionalImportEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 23,
   fieldNames: .same(proto: "protobuf_unittest.optional_import_enum_extension"),
   defaultValue: ProtobufUnittestImport_ImportEnum.importFoo
 )
 
-let ProtobufUnittest_Extensions_optionalStringPieceExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 24,
   fieldNames: .same(proto: "protobuf_unittest.optional_string_piece_extension"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalCordExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 25,
   fieldNames: .same(proto: "protobuf_unittest.optional_cord_extension"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalPublicImportMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_public_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 26,
   fieldNames: .same(proto: "protobuf_unittest.optional_public_import_message_extension"),
   defaultValue: ProtobufUnittestImport_PublicImportMessage()
 )
 
-let ProtobufUnittest_Extensions_optionalLazyMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_lazy_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 27,
   fieldNames: .same(proto: "protobuf_unittest.optional_lazy_message_extension"),
   defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
 )
 
 ///   Repeated
-let ProtobufUnittest_Extensions_repeatedInt32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 31,
   fieldNames: .same(proto: "protobuf_unittest.repeated_int32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedInt64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 32,
   fieldNames: .same(proto: "protobuf_unittest.repeated_int64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedUint32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 33,
   fieldNames: .same(proto: "protobuf_unittest.repeated_uint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedUint64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 34,
   fieldNames: .same(proto: "protobuf_unittest.repeated_uint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSint32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 35,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSint64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 36,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFixed32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 37,
   fieldNames: .same(proto: "protobuf_unittest.repeated_fixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFixed64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 38,
   fieldNames: .same(proto: "protobuf_unittest.repeated_fixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSfixed32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 39,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sfixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSfixed64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 40,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sfixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFloatExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 41,
   fieldNames: .same(proto: "protobuf_unittest.repeated_float_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedDoubleExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 42,
   fieldNames: .same(proto: "protobuf_unittest.repeated_double_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedBoolExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 43,
   fieldNames: .same(proto: "protobuf_unittest.repeated_bool_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedStringExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_string_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 44,
   fieldNames: .same(proto: "protobuf_unittest.repeated_string_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedBytesExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_bytes_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 45,
   fieldNames: .same(proto: "protobuf_unittest.repeated_bytes_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedGroupExtension = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_RepeatedGroup_extension = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 46,
   fieldNames: .same(proto: "protobuf_unittest.RepeatedGroup_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedNestedMessageExtension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_nested_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 48,
   fieldNames: .same(proto: "protobuf_unittest.repeated_nested_message_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedForeignMessageExtension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_foreign_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 49,
   fieldNames: .same(proto: "protobuf_unittest.repeated_foreign_message_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedImportMessageExtension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_import_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 50,
   fieldNames: .same(proto: "protobuf_unittest.repeated_import_message_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedNestedEnumExtension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_nested_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 51,
   fieldNames: .same(proto: "protobuf_unittest.repeated_nested_enum_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedForeignEnumExtension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_foreign_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 52,
   fieldNames: .same(proto: "protobuf_unittest.repeated_foreign_enum_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedImportEnumExtension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_import_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 53,
   fieldNames: .same(proto: "protobuf_unittest.repeated_import_enum_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedStringPieceExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_string_piece_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 54,
   fieldNames: .same(proto: "protobuf_unittest.repeated_string_piece_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedCordExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_cord_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 55,
   fieldNames: .same(proto: "protobuf_unittest.repeated_cord_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedLazyMessageExtension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_lazy_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 57,
   fieldNames: .same(proto: "protobuf_unittest.repeated_lazy_message_extension"),
   defaultValue: []
 )
 
 ///   Singular with defaults
-let ProtobufUnittest_Extensions_defaultInt32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 61,
   fieldNames: .same(proto: "protobuf_unittest.default_int32_extension"),
   defaultValue: 41
 )
 
-let ProtobufUnittest_Extensions_defaultInt64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 62,
   fieldNames: .same(proto: "protobuf_unittest.default_int64_extension"),
   defaultValue: 42
 )
 
-let ProtobufUnittest_Extensions_defaultUint32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 63,
   fieldNames: .same(proto: "protobuf_unittest.default_uint32_extension"),
   defaultValue: 43
 )
 
-let ProtobufUnittest_Extensions_defaultUint64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 64,
   fieldNames: .same(proto: "protobuf_unittest.default_uint64_extension"),
   defaultValue: 44
 )
 
-let ProtobufUnittest_Extensions_defaultSint32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 65,
   fieldNames: .same(proto: "protobuf_unittest.default_sint32_extension"),
   defaultValue: -45
 )
 
-let ProtobufUnittest_Extensions_defaultSint64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 66,
   fieldNames: .same(proto: "protobuf_unittest.default_sint64_extension"),
   defaultValue: 46
 )
 
-let ProtobufUnittest_Extensions_defaultFixed32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 67,
   fieldNames: .same(proto: "protobuf_unittest.default_fixed32_extension"),
   defaultValue: 47
 )
 
-let ProtobufUnittest_Extensions_defaultFixed64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 68,
   fieldNames: .same(proto: "protobuf_unittest.default_fixed64_extension"),
   defaultValue: 48
 )
 
-let ProtobufUnittest_Extensions_defaultSfixed32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 69,
   fieldNames: .same(proto: "protobuf_unittest.default_sfixed32_extension"),
   defaultValue: 49
 )
 
-let ProtobufUnittest_Extensions_defaultSfixed64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 70,
   fieldNames: .same(proto: "protobuf_unittest.default_sfixed64_extension"),
   defaultValue: -50
 )
 
-let ProtobufUnittest_Extensions_defaultFloatExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 71,
   fieldNames: .same(proto: "protobuf_unittest.default_float_extension"),
   defaultValue: 51.5
 )
 
-let ProtobufUnittest_Extensions_defaultDoubleExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 72,
   fieldNames: .same(proto: "protobuf_unittest.default_double_extension"),
   defaultValue: 52000
 )
 
-let ProtobufUnittest_Extensions_defaultBoolExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 73,
   fieldNames: .same(proto: "protobuf_unittest.default_bool_extension"),
   defaultValue: true
 )
 
-let ProtobufUnittest_Extensions_defaultStringExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 74,
   fieldNames: .same(proto: "protobuf_unittest.default_string_extension"),
   defaultValue: "hello"
 )
 
-let ProtobufUnittest_Extensions_defaultBytesExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 75,
   fieldNames: .same(proto: "protobuf_unittest.default_bytes_extension"),
   defaultValue: Data(bytes: [119, 111, 114, 108, 100])
 )
 
-let ProtobufUnittest_Extensions_defaultNestedEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 81,
   fieldNames: .same(proto: "protobuf_unittest.default_nested_enum_extension"),
   defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.bar
 )
 
-let ProtobufUnittest_Extensions_defaultForeignEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 82,
   fieldNames: .same(proto: "protobuf_unittest.default_foreign_enum_extension"),
   defaultValue: ProtobufUnittest_ForeignEnum.foreignBar
 )
 
-let ProtobufUnittest_Extensions_defaultImportEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 83,
   fieldNames: .same(proto: "protobuf_unittest.default_import_enum_extension"),
   defaultValue: ProtobufUnittestImport_ImportEnum.importBar
 )
 
-let ProtobufUnittest_Extensions_defaultStringPieceExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 84,
   fieldNames: .same(proto: "protobuf_unittest.default_string_piece_extension"),
   defaultValue: "abc"
 )
 
-let ProtobufUnittest_Extensions_defaultCordExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 85,
   fieldNames: .same(proto: "protobuf_unittest.default_cord_extension"),
   defaultValue: "123"
 )
 
 ///   For oneof test
-let ProtobufUnittest_Extensions_oneofUint32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_oneof_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 111,
   fieldNames: .same(proto: "protobuf_unittest.oneof_uint32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_oneofNestedMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_oneof_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 112,
   fieldNames: .same(proto: "protobuf_unittest.oneof_nested_message_extension"),
   defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
 )
 
-let ProtobufUnittest_Extensions_oneofStringExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_oneof_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 113,
   fieldNames: .same(proto: "protobuf_unittest.oneof_string_extension"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_oneofBytesExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_oneof_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 114,
   fieldNames: .same(proto: "protobuf_unittest.oneof_bytes_extension"),
   defaultValue: Data()
 )
 
-let ProtobufUnittest_Extensions_myExtensionString = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestFieldOrderings>(
+let ProtobufUnittest_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestFieldOrderings>(
   fieldNumber: 50,
   fieldNames: .same(proto: "protobuf_unittest.my_extension_string"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_myExtensionInt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestFieldOrderings>(
+let ProtobufUnittest_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestFieldOrderings>(
   fieldNumber: 5,
   fieldNames: .same(proto: "protobuf_unittest.my_extension_int"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_packedInt32Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_int32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 90,
   fieldNames: .same(proto: "protobuf_unittest.packed_int32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedInt64Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_int64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 91,
   fieldNames: .same(proto: "protobuf_unittest.packed_int64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedUint32Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_uint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 92,
   fieldNames: .same(proto: "protobuf_unittest.packed_uint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedUint64Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_uint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 93,
   fieldNames: .same(proto: "protobuf_unittest.packed_uint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSint32Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_sint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 94,
   fieldNames: .same(proto: "protobuf_unittest.packed_sint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSint64Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_sint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 95,
   fieldNames: .same(proto: "protobuf_unittest.packed_sint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFixed32Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_fixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 96,
   fieldNames: .same(proto: "protobuf_unittest.packed_fixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFixed64Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_fixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 97,
   fieldNames: .same(proto: "protobuf_unittest.packed_fixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSfixed32Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_sfixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 98,
   fieldNames: .same(proto: "protobuf_unittest.packed_sfixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSfixed64Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_sfixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 99,
   fieldNames: .same(proto: "protobuf_unittest.packed_sfixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFloatExtension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_float_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 100,
   fieldNames: .same(proto: "protobuf_unittest.packed_float_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedDoubleExtension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_double_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 101,
   fieldNames: .same(proto: "protobuf_unittest.packed_double_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedBoolExtension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_bool_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 102,
   fieldNames: .same(proto: "protobuf_unittest.packed_bool_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedEnumExtension = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_enum_extension = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 103,
   fieldNames: .same(proto: "protobuf_unittest.packed_enum_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedInt32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 90,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_int32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedInt64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 91,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_int64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedUint32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 92,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_uint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedUint64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 93,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_uint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedSint32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 94,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_sint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedSint64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 95,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_sint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedFixed32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 96,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_fixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedFixed64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 97,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_fixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedSfixed32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 98,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_sfixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedSfixed64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 99,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_sfixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedFloatExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 100,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_float_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedDoubleExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 101,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_double_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedBoolExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 102,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_bool_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedEnumExtension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 103,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_enum_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_testAllTypes = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestHugeFieldNumbers>(
+let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestHugeFieldNumbers>(
   fieldNumber: 536860000,
   fieldNames: .same(proto: "protobuf_unittest.test_all_types"),
   defaultValue: ProtobufUnittest_TestAllTypes()
@@ -10344,14 +10344,14 @@ extension ProtobufUnittest_TestAllExtensions {
   ///   Used to test if generated extension name is correct when there are
   ///   underscores.
   var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nestedStringExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nestedStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nestedStringExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
   }
   mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nestedStringExtension)
+    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
   }
 }
 
@@ -10383,1523 +10383,1523 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestParsingMerge {
   var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optionalExt) ?? ProtobufUnittest_TestAllTypes()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optionalExt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypes()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext, value: newValue)}
   }
   var hasProtobufUnittest_TestParsingMerge_optionalExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optionalExt)
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
   }
   mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optionalExt)
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
   }
 }
 
 extension ProtobufUnittest_TestParsingMerge {
   var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt)}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext, value: newValue)}
   }
   var hasProtobufUnittest_TestParsingMerge_repeatedExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt)
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
   }
   mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt)
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Singular
   var ProtobufUnittest_optionalInt32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension)
   }
   mutating func clearProtobufUnittest_optionalInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalInt64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension)
   }
   mutating func clearProtobufUnittest_optionalInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalUint32Extension: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension)
   }
   mutating func clearProtobufUnittest_optionalUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalUint64Extension: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension)
   }
   mutating func clearProtobufUnittest_optionalUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSint32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension)
   }
   mutating func clearProtobufUnittest_optionalSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSint64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension)
   }
   mutating func clearProtobufUnittest_optionalSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFixed32Extension: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension)
   }
   mutating func clearProtobufUnittest_optionalFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFixed64Extension: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension)
   }
   mutating func clearProtobufUnittest_optionalFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSfixed32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension)
   }
   mutating func clearProtobufUnittest_optionalSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSfixed64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension)
   }
   mutating func clearProtobufUnittest_optionalSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFloatExtension: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension)
   }
   mutating func clearProtobufUnittest_optionalFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalDoubleExtension: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension)
   }
   mutating func clearProtobufUnittest_optionalDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalBoolExtension: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtension) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension)
   }
   mutating func clearProtobufUnittest_optionalBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension)
   }
   mutating func clearProtobufUnittest_optionalStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalBytesExtension: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtension) ?? Data()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension) ?? Data()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalBytesExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension)
   }
   mutating func clearProtobufUnittest_optionalBytesExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalGroupExtension: ProtobufUnittest_OptionalGroup_extension {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtension) ?? ProtobufUnittest_OptionalGroup_extension()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension) ?? ProtobufUnittest_OptionalGroup_extension()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalGroupExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension)
   }
   mutating func clearProtobufUnittest_optionalGroupExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalNestedMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension)
   }
   mutating func clearProtobufUnittest_optionalNestedMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalForeignMessageExtension: ProtobufUnittest_ForeignMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtension) ?? ProtobufUnittest_ForeignMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension) ?? ProtobufUnittest_ForeignMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalForeignMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension)
   }
   mutating func clearProtobufUnittest_optionalForeignMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalImportMessageExtension: ProtobufUnittestImport_ImportMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtension) ?? ProtobufUnittestImport_ImportMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension) ?? ProtobufUnittestImport_ImportMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalImportMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension)
   }
   mutating func clearProtobufUnittest_optionalImportMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.foo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.foo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalNestedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension)
   }
   mutating func clearProtobufUnittest_optionalNestedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalForeignEnumExtension: ProtobufUnittest_ForeignEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtension) ?? ProtobufUnittest_ForeignEnum.foreignFoo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension) ?? ProtobufUnittest_ForeignEnum.foreignFoo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalForeignEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension)
   }
   mutating func clearProtobufUnittest_optionalForeignEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalImportEnumExtension: ProtobufUnittestImport_ImportEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtension) ?? ProtobufUnittestImport_ImportEnum.importFoo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension) ?? ProtobufUnittestImport_ImportEnum.importFoo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalImportEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension)
   }
   mutating func clearProtobufUnittest_optionalImportEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringPieceExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringPieceExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension)
   }
   mutating func clearProtobufUnittest_optionalStringPieceExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalCordExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalCordExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension)
   }
   mutating func clearProtobufUnittest_optionalCordExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalPublicImportMessageExtension: ProtobufUnittestImport_PublicImportMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtension) ?? ProtobufUnittestImport_PublicImportMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension) ?? ProtobufUnittestImport_PublicImportMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalPublicImportMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension)
   }
   mutating func clearProtobufUnittest_optionalPublicImportMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalLazyMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalLazyMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension)
   }
   mutating func clearProtobufUnittest_optionalLazyMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Repeated
   var ProtobufUnittest_repeatedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension)
   }
   mutating func clearProtobufUnittest_repeatedInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedInt64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension)
   }
   mutating func clearProtobufUnittest_repeatedInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedUint32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension)
   }
   mutating func clearProtobufUnittest_repeatedUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedUint64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension)
   }
   mutating func clearProtobufUnittest_repeatedUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSint32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension)
   }
   mutating func clearProtobufUnittest_repeatedSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSint64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension)
   }
   mutating func clearProtobufUnittest_repeatedSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFixed32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension)
   }
   mutating func clearProtobufUnittest_repeatedFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFixed64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension)
   }
   mutating func clearProtobufUnittest_repeatedFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSfixed32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension)
   }
   mutating func clearProtobufUnittest_repeatedSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSfixed64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension)
   }
   mutating func clearProtobufUnittest_repeatedSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFloatExtension: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension)
   }
   mutating func clearProtobufUnittest_repeatedFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedDoubleExtension: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension)
   }
   mutating func clearProtobufUnittest_repeatedDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedBoolExtension: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension)
   }
   mutating func clearProtobufUnittest_repeatedBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedStringExtension: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension)
   }
   mutating func clearProtobufUnittest_repeatedStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedBytesExtension: [Data] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedBytesExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension)
   }
   mutating func clearProtobufUnittest_repeatedBytesExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedGroupExtension: [ProtobufUnittest_RepeatedGroup_extension] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedGroupExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension)
   }
   mutating func clearProtobufUnittest_repeatedGroupExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedNestedMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedNestedMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension)
   }
   mutating func clearProtobufUnittest_repeatedNestedMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedForeignMessageExtension: [ProtobufUnittest_ForeignMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedForeignMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension)
   }
   mutating func clearProtobufUnittest_repeatedForeignMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedImportMessageExtension: [ProtobufUnittestImport_ImportMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedImportMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension)
   }
   mutating func clearProtobufUnittest_repeatedImportMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedNestedEnumExtension: [ProtobufUnittest_TestAllTypes.NestedEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedNestedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension)
   }
   mutating func clearProtobufUnittest_repeatedNestedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedForeignEnumExtension: [ProtobufUnittest_ForeignEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedForeignEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension)
   }
   mutating func clearProtobufUnittest_repeatedForeignEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedImportEnumExtension: [ProtobufUnittestImport_ImportEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedImportEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension)
   }
   mutating func clearProtobufUnittest_repeatedImportEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedStringPieceExtension: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedStringPieceExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension)
   }
   mutating func clearProtobufUnittest_repeatedStringPieceExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedCordExtension: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedCordExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension)
   }
   mutating func clearProtobufUnittest_repeatedCordExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedLazyMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedLazyMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension)
   }
   mutating func clearProtobufUnittest_repeatedLazyMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Singular with defaults
   var ProtobufUnittest_defaultInt32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32Extension) ?? 41}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension) ?? 41}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension)
   }
   mutating func clearProtobufUnittest_defaultInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultInt64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64Extension) ?? 42}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension) ?? 42}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension)
   }
   mutating func clearProtobufUnittest_defaultInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultUint32Extension: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32Extension) ?? 43}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension) ?? 43}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension)
   }
   mutating func clearProtobufUnittest_defaultUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultUint64Extension: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64Extension) ?? 44}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension) ?? 44}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension)
   }
   mutating func clearProtobufUnittest_defaultUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSint32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32Extension) ?? -45}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension) ?? -45}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension)
   }
   mutating func clearProtobufUnittest_defaultSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSint64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64Extension) ?? 46}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension) ?? 46}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension)
   }
   mutating func clearProtobufUnittest_defaultSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFixed32Extension: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32Extension) ?? 47}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension) ?? 47}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension)
   }
   mutating func clearProtobufUnittest_defaultFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFixed64Extension: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64Extension) ?? 48}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension) ?? 48}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension)
   }
   mutating func clearProtobufUnittest_defaultFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSfixed32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32Extension) ?? 49}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension) ?? 49}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension)
   }
   mutating func clearProtobufUnittest_defaultSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSfixed64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64Extension) ?? -50}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension) ?? -50}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension)
   }
   mutating func clearProtobufUnittest_defaultSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFloatExtension: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtension) ?? 51.5}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension) ?? 51.5}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension)
   }
   mutating func clearProtobufUnittest_defaultFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultDoubleExtension: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtension) ?? 52000}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension) ?? 52000}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension)
   }
   mutating func clearProtobufUnittest_defaultDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultBoolExtension: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtension) ?? true}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension) ?? true}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension)
   }
   mutating func clearProtobufUnittest_defaultBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtension) ?? "hello"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension) ?? "hello"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension)
   }
   mutating func clearProtobufUnittest_defaultStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultBytesExtension: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtension) ?? Data(bytes: [119, 111, 114, 108, 100])}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension) ?? Data(bytes: [119, 111, 114, 108, 100])}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultBytesExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension)
   }
   mutating func clearProtobufUnittest_defaultBytesExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.bar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.bar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultNestedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension)
   }
   mutating func clearProtobufUnittest_defaultNestedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultForeignEnumExtension: ProtobufUnittest_ForeignEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtension) ?? ProtobufUnittest_ForeignEnum.foreignBar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension) ?? ProtobufUnittest_ForeignEnum.foreignBar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultForeignEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension)
   }
   mutating func clearProtobufUnittest_defaultForeignEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultImportEnumExtension: ProtobufUnittestImport_ImportEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtension) ?? ProtobufUnittestImport_ImportEnum.importBar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension) ?? ProtobufUnittestImport_ImportEnum.importBar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultImportEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension)
   }
   mutating func clearProtobufUnittest_defaultImportEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultStringPieceExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtension) ?? "abc"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension) ?? "abc"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultStringPieceExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension)
   }
   mutating func clearProtobufUnittest_defaultStringPieceExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultCordExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtension) ?? "123"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension) ?? "123"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultCordExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension)
   }
   mutating func clearProtobufUnittest_defaultCordExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   For oneof test
   var ProtobufUnittest_oneofUint32Extension: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension)
   }
   mutating func clearProtobufUnittest_oneofUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofNestedMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension)
   }
   mutating func clearProtobufUnittest_oneofNestedMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension)
   }
   mutating func clearProtobufUnittest_oneofStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofBytesExtension: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtension) ?? Data()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension) ?? Data()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofBytesExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension)
   }
   mutating func clearProtobufUnittest_oneofBytesExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension)
   }
 }
 
 extension ProtobufUnittest_TestFieldOrderings {
   var ProtobufUnittest_myExtensionString: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionString) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionString, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string, value: newValue)}
   }
   var hasProtobufUnittest_myExtensionString: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionString)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
   }
   mutating func clearProtobufUnittest_myExtensionString() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionString)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
   }
 }
 
 extension ProtobufUnittest_TestFieldOrderings {
   var ProtobufUnittest_myExtensionInt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionInt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionInt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int, value: newValue)}
   }
   var hasProtobufUnittest_myExtensionInt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionInt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
   }
   mutating func clearProtobufUnittest_myExtensionInt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionInt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
   }
   mutating func clearProtobufUnittest_packedInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedInt64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
   }
   mutating func clearProtobufUnittest_packedInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedUint32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
   }
   mutating func clearProtobufUnittest_packedUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedUint64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
   }
   mutating func clearProtobufUnittest_packedUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedSint32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
   }
   mutating func clearProtobufUnittest_packedSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedSint64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
   }
   mutating func clearProtobufUnittest_packedSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedFixed32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
   }
   mutating func clearProtobufUnittest_packedFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedFixed64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
   }
   mutating func clearProtobufUnittest_packedFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedSfixed32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
   }
   mutating func clearProtobufUnittest_packedSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedSfixed64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
   }
   mutating func clearProtobufUnittest_packedSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedFloatExtension: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
   }
   mutating func clearProtobufUnittest_packedFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedDoubleExtension: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
   }
   mutating func clearProtobufUnittest_packedDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedBoolExtension: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
   }
   mutating func clearProtobufUnittest_packedBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedEnumExtension: [ProtobufUnittest_ForeignEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
   }
   mutating func clearProtobufUnittest_packedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
   }
   mutating func clearProtobufUnittest_unpackedInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedInt64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
   }
   mutating func clearProtobufUnittest_unpackedInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedUint32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
   }
   mutating func clearProtobufUnittest_unpackedUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedUint64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
   }
   mutating func clearProtobufUnittest_unpackedUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedSint32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
   }
   mutating func clearProtobufUnittest_unpackedSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedSint64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
   }
   mutating func clearProtobufUnittest_unpackedSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedFixed32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
   }
   mutating func clearProtobufUnittest_unpackedFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedFixed64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
   }
   mutating func clearProtobufUnittest_unpackedFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedSfixed32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
   }
   mutating func clearProtobufUnittest_unpackedSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedSfixed64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
   }
   mutating func clearProtobufUnittest_unpackedSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedFloatExtension: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFloatExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFloatExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFloatExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
   }
   mutating func clearProtobufUnittest_unpackedFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFloatExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedDoubleExtension: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedDoubleExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedDoubleExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedDoubleExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
   }
   mutating func clearProtobufUnittest_unpackedDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedDoubleExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedBoolExtension: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedBoolExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedBoolExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedBoolExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
   }
   mutating func clearProtobufUnittest_unpackedBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedBoolExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedEnumExtension: [ProtobufUnittest_ForeignEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedEnumExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
   }
   mutating func clearProtobufUnittest_unpackedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestHugeFieldNumbers {
   var ProtobufUnittest_testAllTypes: ProtobufUnittest_TestAllTypes {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypes) ?? ProtobufUnittest_TestAllTypes()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypes, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types) ?? ProtobufUnittest_TestAllTypes()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types, value: newValue)}
   }
   var hasProtobufUnittest_testAllTypes: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypes)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
   }
   mutating func clearProtobufUnittest_testAllTypes() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypes)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
   }
 }
 
 let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_Extensions_optionalInt32Extension,
-  ProtobufUnittest_Extensions_optionalInt64Extension,
-  ProtobufUnittest_Extensions_optionalUint32Extension,
-  ProtobufUnittest_Extensions_optionalUint64Extension,
-  ProtobufUnittest_Extensions_optionalSint32Extension,
-  ProtobufUnittest_Extensions_optionalSint64Extension,
-  ProtobufUnittest_Extensions_optionalFixed32Extension,
-  ProtobufUnittest_Extensions_optionalFixed64Extension,
-  ProtobufUnittest_Extensions_optionalSfixed32Extension,
-  ProtobufUnittest_Extensions_optionalSfixed64Extension,
-  ProtobufUnittest_Extensions_optionalFloatExtension,
-  ProtobufUnittest_Extensions_optionalDoubleExtension,
-  ProtobufUnittest_Extensions_optionalBoolExtension,
-  ProtobufUnittest_Extensions_optionalStringExtension,
-  ProtobufUnittest_Extensions_optionalBytesExtension,
-  ProtobufUnittest_Extensions_optionalGroupExtension,
-  ProtobufUnittest_Extensions_optionalNestedMessageExtension,
-  ProtobufUnittest_Extensions_optionalForeignMessageExtension,
-  ProtobufUnittest_Extensions_optionalImportMessageExtension,
-  ProtobufUnittest_Extensions_optionalNestedEnumExtension,
-  ProtobufUnittest_Extensions_optionalForeignEnumExtension,
-  ProtobufUnittest_Extensions_optionalImportEnumExtension,
-  ProtobufUnittest_Extensions_optionalStringPieceExtension,
-  ProtobufUnittest_Extensions_optionalCordExtension,
-  ProtobufUnittest_Extensions_optionalPublicImportMessageExtension,
-  ProtobufUnittest_Extensions_optionalLazyMessageExtension,
-  ProtobufUnittest_Extensions_repeatedInt32Extension,
-  ProtobufUnittest_Extensions_repeatedInt64Extension,
-  ProtobufUnittest_Extensions_repeatedUint32Extension,
-  ProtobufUnittest_Extensions_repeatedUint64Extension,
-  ProtobufUnittest_Extensions_repeatedSint32Extension,
-  ProtobufUnittest_Extensions_repeatedSint64Extension,
-  ProtobufUnittest_Extensions_repeatedFixed32Extension,
-  ProtobufUnittest_Extensions_repeatedFixed64Extension,
-  ProtobufUnittest_Extensions_repeatedSfixed32Extension,
-  ProtobufUnittest_Extensions_repeatedSfixed64Extension,
-  ProtobufUnittest_Extensions_repeatedFloatExtension,
-  ProtobufUnittest_Extensions_repeatedDoubleExtension,
-  ProtobufUnittest_Extensions_repeatedBoolExtension,
-  ProtobufUnittest_Extensions_repeatedStringExtension,
-  ProtobufUnittest_Extensions_repeatedBytesExtension,
-  ProtobufUnittest_Extensions_repeatedGroupExtension,
-  ProtobufUnittest_Extensions_repeatedNestedMessageExtension,
-  ProtobufUnittest_Extensions_repeatedForeignMessageExtension,
-  ProtobufUnittest_Extensions_repeatedImportMessageExtension,
-  ProtobufUnittest_Extensions_repeatedNestedEnumExtension,
-  ProtobufUnittest_Extensions_repeatedForeignEnumExtension,
-  ProtobufUnittest_Extensions_repeatedImportEnumExtension,
-  ProtobufUnittest_Extensions_repeatedStringPieceExtension,
-  ProtobufUnittest_Extensions_repeatedCordExtension,
-  ProtobufUnittest_Extensions_repeatedLazyMessageExtension,
-  ProtobufUnittest_Extensions_defaultInt32Extension,
-  ProtobufUnittest_Extensions_defaultInt64Extension,
-  ProtobufUnittest_Extensions_defaultUint32Extension,
-  ProtobufUnittest_Extensions_defaultUint64Extension,
-  ProtobufUnittest_Extensions_defaultSint32Extension,
-  ProtobufUnittest_Extensions_defaultSint64Extension,
-  ProtobufUnittest_Extensions_defaultFixed32Extension,
-  ProtobufUnittest_Extensions_defaultFixed64Extension,
-  ProtobufUnittest_Extensions_defaultSfixed32Extension,
-  ProtobufUnittest_Extensions_defaultSfixed64Extension,
-  ProtobufUnittest_Extensions_defaultFloatExtension,
-  ProtobufUnittest_Extensions_defaultDoubleExtension,
-  ProtobufUnittest_Extensions_defaultBoolExtension,
-  ProtobufUnittest_Extensions_defaultStringExtension,
-  ProtobufUnittest_Extensions_defaultBytesExtension,
-  ProtobufUnittest_Extensions_defaultNestedEnumExtension,
-  ProtobufUnittest_Extensions_defaultForeignEnumExtension,
-  ProtobufUnittest_Extensions_defaultImportEnumExtension,
-  ProtobufUnittest_Extensions_defaultStringPieceExtension,
-  ProtobufUnittest_Extensions_defaultCordExtension,
-  ProtobufUnittest_Extensions_oneofUint32Extension,
-  ProtobufUnittest_Extensions_oneofNestedMessageExtension,
-  ProtobufUnittest_Extensions_oneofStringExtension,
-  ProtobufUnittest_Extensions_oneofBytesExtension,
-  ProtobufUnittest_Extensions_myExtensionString,
-  ProtobufUnittest_Extensions_myExtensionInt,
-  ProtobufUnittest_Extensions_packedInt32Extension,
-  ProtobufUnittest_Extensions_packedInt64Extension,
-  ProtobufUnittest_Extensions_packedUint32Extension,
-  ProtobufUnittest_Extensions_packedUint64Extension,
-  ProtobufUnittest_Extensions_packedSint32Extension,
-  ProtobufUnittest_Extensions_packedSint64Extension,
-  ProtobufUnittest_Extensions_packedFixed32Extension,
-  ProtobufUnittest_Extensions_packedFixed64Extension,
-  ProtobufUnittest_Extensions_packedSfixed32Extension,
-  ProtobufUnittest_Extensions_packedSfixed64Extension,
-  ProtobufUnittest_Extensions_packedFloatExtension,
-  ProtobufUnittest_Extensions_packedDoubleExtension,
-  ProtobufUnittest_Extensions_packedBoolExtension,
-  ProtobufUnittest_Extensions_packedEnumExtension,
-  ProtobufUnittest_Extensions_unpackedInt32Extension,
-  ProtobufUnittest_Extensions_unpackedInt64Extension,
-  ProtobufUnittest_Extensions_unpackedUint32Extension,
-  ProtobufUnittest_Extensions_unpackedUint64Extension,
-  ProtobufUnittest_Extensions_unpackedSint32Extension,
-  ProtobufUnittest_Extensions_unpackedSint64Extension,
-  ProtobufUnittest_Extensions_unpackedFixed32Extension,
-  ProtobufUnittest_Extensions_unpackedFixed64Extension,
-  ProtobufUnittest_Extensions_unpackedSfixed32Extension,
-  ProtobufUnittest_Extensions_unpackedSfixed64Extension,
-  ProtobufUnittest_Extensions_unpackedFloatExtension,
-  ProtobufUnittest_Extensions_unpackedDoubleExtension,
-  ProtobufUnittest_Extensions_unpackedBoolExtension,
-  ProtobufUnittest_Extensions_unpackedEnumExtension,
-  ProtobufUnittest_Extensions_testAllTypes,
+  ProtobufUnittest_Extensions_optional_int32_extension,
+  ProtobufUnittest_Extensions_optional_int64_extension,
+  ProtobufUnittest_Extensions_optional_uint32_extension,
+  ProtobufUnittest_Extensions_optional_uint64_extension,
+  ProtobufUnittest_Extensions_optional_sint32_extension,
+  ProtobufUnittest_Extensions_optional_sint64_extension,
+  ProtobufUnittest_Extensions_optional_fixed32_extension,
+  ProtobufUnittest_Extensions_optional_fixed64_extension,
+  ProtobufUnittest_Extensions_optional_sfixed32_extension,
+  ProtobufUnittest_Extensions_optional_sfixed64_extension,
+  ProtobufUnittest_Extensions_optional_float_extension,
+  ProtobufUnittest_Extensions_optional_double_extension,
+  ProtobufUnittest_Extensions_optional_bool_extension,
+  ProtobufUnittest_Extensions_optional_string_extension,
+  ProtobufUnittest_Extensions_optional_bytes_extension,
+  ProtobufUnittest_Extensions_OptionalGroup_extension,
+  ProtobufUnittest_Extensions_optional_nested_message_extension,
+  ProtobufUnittest_Extensions_optional_foreign_message_extension,
+  ProtobufUnittest_Extensions_optional_import_message_extension,
+  ProtobufUnittest_Extensions_optional_nested_enum_extension,
+  ProtobufUnittest_Extensions_optional_foreign_enum_extension,
+  ProtobufUnittest_Extensions_optional_import_enum_extension,
+  ProtobufUnittest_Extensions_optional_string_piece_extension,
+  ProtobufUnittest_Extensions_optional_cord_extension,
+  ProtobufUnittest_Extensions_optional_public_import_message_extension,
+  ProtobufUnittest_Extensions_optional_lazy_message_extension,
+  ProtobufUnittest_Extensions_repeated_int32_extension,
+  ProtobufUnittest_Extensions_repeated_int64_extension,
+  ProtobufUnittest_Extensions_repeated_uint32_extension,
+  ProtobufUnittest_Extensions_repeated_uint64_extension,
+  ProtobufUnittest_Extensions_repeated_sint32_extension,
+  ProtobufUnittest_Extensions_repeated_sint64_extension,
+  ProtobufUnittest_Extensions_repeated_fixed32_extension,
+  ProtobufUnittest_Extensions_repeated_fixed64_extension,
+  ProtobufUnittest_Extensions_repeated_sfixed32_extension,
+  ProtobufUnittest_Extensions_repeated_sfixed64_extension,
+  ProtobufUnittest_Extensions_repeated_float_extension,
+  ProtobufUnittest_Extensions_repeated_double_extension,
+  ProtobufUnittest_Extensions_repeated_bool_extension,
+  ProtobufUnittest_Extensions_repeated_string_extension,
+  ProtobufUnittest_Extensions_repeated_bytes_extension,
+  ProtobufUnittest_Extensions_RepeatedGroup_extension,
+  ProtobufUnittest_Extensions_repeated_nested_message_extension,
+  ProtobufUnittest_Extensions_repeated_foreign_message_extension,
+  ProtobufUnittest_Extensions_repeated_import_message_extension,
+  ProtobufUnittest_Extensions_repeated_nested_enum_extension,
+  ProtobufUnittest_Extensions_repeated_foreign_enum_extension,
+  ProtobufUnittest_Extensions_repeated_import_enum_extension,
+  ProtobufUnittest_Extensions_repeated_string_piece_extension,
+  ProtobufUnittest_Extensions_repeated_cord_extension,
+  ProtobufUnittest_Extensions_repeated_lazy_message_extension,
+  ProtobufUnittest_Extensions_default_int32_extension,
+  ProtobufUnittest_Extensions_default_int64_extension,
+  ProtobufUnittest_Extensions_default_uint32_extension,
+  ProtobufUnittest_Extensions_default_uint64_extension,
+  ProtobufUnittest_Extensions_default_sint32_extension,
+  ProtobufUnittest_Extensions_default_sint64_extension,
+  ProtobufUnittest_Extensions_default_fixed32_extension,
+  ProtobufUnittest_Extensions_default_fixed64_extension,
+  ProtobufUnittest_Extensions_default_sfixed32_extension,
+  ProtobufUnittest_Extensions_default_sfixed64_extension,
+  ProtobufUnittest_Extensions_default_float_extension,
+  ProtobufUnittest_Extensions_default_double_extension,
+  ProtobufUnittest_Extensions_default_bool_extension,
+  ProtobufUnittest_Extensions_default_string_extension,
+  ProtobufUnittest_Extensions_default_bytes_extension,
+  ProtobufUnittest_Extensions_default_nested_enum_extension,
+  ProtobufUnittest_Extensions_default_foreign_enum_extension,
+  ProtobufUnittest_Extensions_default_import_enum_extension,
+  ProtobufUnittest_Extensions_default_string_piece_extension,
+  ProtobufUnittest_Extensions_default_cord_extension,
+  ProtobufUnittest_Extensions_oneof_uint32_extension,
+  ProtobufUnittest_Extensions_oneof_nested_message_extension,
+  ProtobufUnittest_Extensions_oneof_string_extension,
+  ProtobufUnittest_Extensions_oneof_bytes_extension,
+  ProtobufUnittest_Extensions_my_extension_string,
+  ProtobufUnittest_Extensions_my_extension_int,
+  ProtobufUnittest_Extensions_packed_int32_extension,
+  ProtobufUnittest_Extensions_packed_int64_extension,
+  ProtobufUnittest_Extensions_packed_uint32_extension,
+  ProtobufUnittest_Extensions_packed_uint64_extension,
+  ProtobufUnittest_Extensions_packed_sint32_extension,
+  ProtobufUnittest_Extensions_packed_sint64_extension,
+  ProtobufUnittest_Extensions_packed_fixed32_extension,
+  ProtobufUnittest_Extensions_packed_fixed64_extension,
+  ProtobufUnittest_Extensions_packed_sfixed32_extension,
+  ProtobufUnittest_Extensions_packed_sfixed64_extension,
+  ProtobufUnittest_Extensions_packed_float_extension,
+  ProtobufUnittest_Extensions_packed_double_extension,
+  ProtobufUnittest_Extensions_packed_bool_extension,
+  ProtobufUnittest_Extensions_packed_enum_extension,
+  ProtobufUnittest_Extensions_unpacked_int32_extension,
+  ProtobufUnittest_Extensions_unpacked_int64_extension,
+  ProtobufUnittest_Extensions_unpacked_uint32_extension,
+  ProtobufUnittest_Extensions_unpacked_uint64_extension,
+  ProtobufUnittest_Extensions_unpacked_sint32_extension,
+  ProtobufUnittest_Extensions_unpacked_sint64_extension,
+  ProtobufUnittest_Extensions_unpacked_fixed32_extension,
+  ProtobufUnittest_Extensions_unpacked_fixed64_extension,
+  ProtobufUnittest_Extensions_unpacked_sfixed32_extension,
+  ProtobufUnittest_Extensions_unpacked_sfixed64_extension,
+  ProtobufUnittest_Extensions_unpacked_float_extension,
+  ProtobufUnittest_Extensions_unpacked_double_extension,
+  ProtobufUnittest_Extensions_unpacked_bool_extension,
+  ProtobufUnittest_Extensions_unpacked_enum_extension,
+  ProtobufUnittest_Extensions_test_all_types,
   ProtobufUnittest_TestNestedExtension.Extensions.test,
-  ProtobufUnittest_TestNestedExtension.Extensions.nestedStringExtension,
+  ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension,
   ProtobufUnittest_TestRequired.Extensions.single,
   ProtobufUnittest_TestRequired.Extensions.multi,
-  ProtobufUnittest_TestParsingMerge.Extensions.optionalExt,
-  ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt
+  ProtobufUnittest_TestParsingMerge.Extensions.optional_ext,
+  ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext
 ]

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -885,7 +885,7 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.Message, SwiftProtobuf
 
     struct Extensions {
 
-      static let complexOpt4 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2.ComplexOptionType4>, Google_Protobuf_MessageOptions>(
+      static let complex_opt4 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2.ComplexOptionType4>, Google_Protobuf_MessageOptions>(
         fieldNumber: 7633546,
         fieldNames: .same(proto: "protobuf_unittest.ComplexOptionType2.ComplexOptionType4.complex_opt4"),
         defaultValue: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()
@@ -1321,7 +1321,7 @@ struct ProtobufUnittest_AggregateMessageSetElement: SwiftProtobuf.Message, Swift
 
   struct Extensions {
 
-    static let messageSetExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_AggregateMessageSetElement>, ProtobufUnittest_AggregateMessageSet>(
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_AggregateMessageSetElement>, ProtobufUnittest_AggregateMessageSet>(
       fieldNumber: 15447542,
       fieldNames: .same(proto: "protobuf_unittest.AggregateMessageSetElement.message_set_extension"),
       defaultValue: ProtobufUnittest_AggregateMessageSetElement()
@@ -1708,7 +1708,7 @@ struct ProtobufUnittest_NestedOptionType: SwiftProtobuf.Message, SwiftProtobuf.P
 
   struct Extensions {
 
-    static let nestedExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FileOptions>(
+    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FileOptions>(
       fieldNumber: 7912573,
       fieldNames: .same(proto: "protobuf_unittest.NestedOptionType.nested_extension"),
       defaultValue: 0
@@ -1970,19 +1970,19 @@ struct ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf.Message
   }
 }
 
-let ProtobufUnittest_Extensions_fileOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_FileOptions>(
+let ProtobufUnittest_Extensions_file_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_FileOptions>(
   fieldNumber: 7736974,
   fieldNames: .same(proto: "protobuf_unittest.file_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_messageOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_message_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7739036,
   fieldNames: .same(proto: "protobuf_unittest.message_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_fieldOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_FieldOptions>(
+let ProtobufUnittest_Extensions_field_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_FieldOptions>(
   fieldNumber: 7740936,
   fieldNames: .same(proto: "protobuf_unittest.field_opt1"),
   defaultValue: 0
@@ -1990,139 +1990,139 @@ let ProtobufUnittest_Extensions_fieldOpt1 = SwiftProtobuf.MessageExtension<Optio
 
 ///   This is useful for testing that we correctly register default values for
 ///   extension options.
-let ProtobufUnittest_Extensions_fieldOpt2 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FieldOptions>(
+let ProtobufUnittest_Extensions_field_opt2 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FieldOptions>(
   fieldNumber: 7753913,
   fieldNames: .same(proto: "protobuf_unittest.field_opt2"),
   defaultValue: 42
 )
 
-let ProtobufUnittest_Extensions_oneofOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_OneofOptions>(
+let ProtobufUnittest_Extensions_oneof_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_OneofOptions>(
   fieldNumber: 7740111,
   fieldNames: .same(proto: "protobuf_unittest.oneof_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_enumOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_EnumOptions>(
+let ProtobufUnittest_Extensions_enum_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_EnumOptions>(
   fieldNumber: 7753576,
   fieldNames: .same(proto: "protobuf_unittest.enum_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_enumValueOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_EnumValueOptions>(
+let ProtobufUnittest_Extensions_enum_value_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_EnumValueOptions>(
   fieldNumber: 1560678,
   fieldNames: .same(proto: "protobuf_unittest.enum_value_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_serviceOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_ServiceOptions>(
+let ProtobufUnittest_Extensions_service_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_ServiceOptions>(
   fieldNumber: 7887650,
   fieldNames: .same(proto: "protobuf_unittest.service_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_methodOpt1 = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_MethodOpt1>, Google_Protobuf_MethodOptions>(
+let ProtobufUnittest_Extensions_method_opt1 = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_MethodOpt1>, Google_Protobuf_MethodOptions>(
   fieldNumber: 7890860,
   fieldNames: .same(proto: "protobuf_unittest.method_opt1"),
   defaultValue: ProtobufUnittest_MethodOpt1.val1
 )
 
-let ProtobufUnittest_Extensions_boolOpt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_bool_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7706090,
   fieldNames: .same(proto: "protobuf_unittest.bool_opt"),
   defaultValue: false
 )
 
-let ProtobufUnittest_Extensions_int32Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_int32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7705709,
   fieldNames: .same(proto: "protobuf_unittest.int32_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_int64Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_int64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7705542,
   fieldNames: .same(proto: "protobuf_unittest.int64_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_uint32Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_uint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7704880,
   fieldNames: .same(proto: "protobuf_unittest.uint32_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_uint64Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_uint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7702367,
   fieldNames: .same(proto: "protobuf_unittest.uint64_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_sint32Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_sint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7701568,
   fieldNames: .same(proto: "protobuf_unittest.sint32_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_sint64Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_sint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7700863,
   fieldNames: .same(proto: "protobuf_unittest.sint64_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_fixed32Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_fixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7700307,
   fieldNames: .same(proto: "protobuf_unittest.fixed32_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_fixed64Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_fixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7700194,
   fieldNames: .same(proto: "protobuf_unittest.fixed64_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_sfixed32Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_sfixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7698645,
   fieldNames: .same(proto: "protobuf_unittest.sfixed32_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_sfixed64Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_sfixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7685475,
   fieldNames: .same(proto: "protobuf_unittest.sfixed64_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_floatOpt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_float_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7675390,
   fieldNames: .same(proto: "protobuf_unittest.float_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_doubleOpt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_double_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7673293,
   fieldNames: .same(proto: "protobuf_unittest.double_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_stringOpt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_string_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7673285,
   fieldNames: .same(proto: "protobuf_unittest.string_opt"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_bytesOpt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_bytes_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7673238,
   fieldNames: .same(proto: "protobuf_unittest.bytes_opt"),
   defaultValue: Data()
 )
 
-let ProtobufUnittest_Extensions_enumOpt = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_DummyMessageContainingEnum.TestEnumType>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_enum_opt = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_DummyMessageContainingEnum.TestEnumType>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7673233,
   fieldNames: .same(proto: "protobuf_unittest.enum_opt"),
   defaultValue: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1
 )
 
-let ProtobufUnittest_Extensions_messageTypeOpt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_DummyMessageInvalidAsOptionType>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_message_type_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_DummyMessageInvalidAsOptionType>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7665967,
   fieldNames: .same(proto: "protobuf_unittest.message_type_opt"),
   defaultValue: ProtobufUnittest_DummyMessageInvalidAsOptionType()
@@ -2152,25 +2152,25 @@ let ProtobufUnittest_Extensions_garply = SwiftProtobuf.MessageExtension<Optional
   defaultValue: ProtobufUnittest_ComplexOptionType1()
 )
 
-let ProtobufUnittest_Extensions_complexOpt1 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_complex_opt1 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7646756,
   fieldNames: .same(proto: "protobuf_unittest.complex_opt1"),
   defaultValue: ProtobufUnittest_ComplexOptionType1()
 )
 
-let ProtobufUnittest_Extensions_complexOpt2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_complex_opt2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7636949,
   fieldNames: .same(proto: "protobuf_unittest.complex_opt2"),
   defaultValue: ProtobufUnittest_ComplexOptionType2()
 )
 
-let ProtobufUnittest_Extensions_complexOpt3 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_complex_opt3 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7636463,
   fieldNames: .same(proto: "protobuf_unittest.complex_opt3"),
   defaultValue: ProtobufUnittest_ComplexOptionType3()
 )
 
-let ProtobufUnittest_Extensions_complexOpt6 = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_ComplexOpt6>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_ComplexOpt6 = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_ComplexOpt6>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7595468,
   fieldNames: .same(proto: "protobuf_unittest.ComplexOpt6"),
   defaultValue: ProtobufUnittest_ComplexOpt6()
@@ -2218,7 +2218,7 @@ let ProtobufUnittest_Extensions_methodopt = SwiftProtobuf.MessageExtension<Optio
   defaultValue: ProtobufUnittest_Aggregate()
 )
 
-let ProtobufUnittest_Extensions_requiredEnumOpt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_required_enum_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(
   fieldNumber: 106161807,
   fieldNames: .same(proto: "protobuf_unittest.required_enum_opt"),
   defaultValue: ProtobufUnittest_OldOptionType()
@@ -2226,27 +2226,27 @@ let ProtobufUnittest_Extensions_requiredEnumOpt = SwiftProtobuf.MessageExtension
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
-    get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complexOpt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
-    set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complexOpt4, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
+    set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4, value: newValue)}
   }
   var hasProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complexOpt4)
+    return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
   }
   mutating func clearProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4() {
-    clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complexOpt4)
+    clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
   }
 }
 
 extension ProtobufUnittest_AggregateMessageSet {
   var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
-    get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.messageSetExtension) ?? ProtobufUnittest_AggregateMessageSetElement()}
-    set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.messageSetExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension) ?? ProtobufUnittest_AggregateMessageSetElement()}
+    set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension, value: newValue)}
   }
   var hasProtobufUnittest_AggregateMessageSetElement_messageSetExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.messageSetExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
   }
   mutating func clearProtobufUnittest_AggregateMessageSetElement_messageSetExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.messageSetExtension)
+    clearExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
   }
 }
 
@@ -2265,53 +2265,53 @@ extension Google_Protobuf_FileOptions {
 
 extension Google_Protobuf_FileOptions {
   var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nestedExtension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nestedExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension, value: newValue)}
   }
   var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nestedExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
   }
   mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nestedExtension)
+    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
   }
 }
 
 extension Google_Protobuf_FileOptions {
   var ProtobufUnittest_fileOpt1: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fileOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fileOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1, value: newValue)}
   }
   var hasProtobufUnittest_fileOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fileOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
   }
   mutating func clearProtobufUnittest_fileOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fileOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_messageOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_messageOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_messageOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1, value: newValue)}
   }
   var hasProtobufUnittest_messageOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_messageOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
   }
   mutating func clearProtobufUnittest_messageOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_messageOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
   }
 }
 
 extension Google_Protobuf_FieldOptions {
   var ProtobufUnittest_fieldOpt1: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1, value: newValue)}
   }
   var hasProtobufUnittest_fieldOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
   }
   mutating func clearProtobufUnittest_fieldOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
   }
 }
 
@@ -2319,300 +2319,300 @@ extension Google_Protobuf_FieldOptions {
   ///   This is useful for testing that we correctly register default values for
   ///   extension options.
   var ProtobufUnittest_fieldOpt2: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt2) ?? 42}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt2, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2) ?? 42}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2, value: newValue)}
   }
   var hasProtobufUnittest_fieldOpt2: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt2)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
   }
   mutating func clearProtobufUnittest_fieldOpt2() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt2)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
   }
 }
 
 extension Google_Protobuf_OneofOptions {
   var ProtobufUnittest_oneofOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1, value: newValue)}
   }
   var hasProtobufUnittest_oneofOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
   }
   mutating func clearProtobufUnittest_oneofOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
   }
 }
 
 extension Google_Protobuf_EnumOptions {
   var ProtobufUnittest_enumOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1, value: newValue)}
   }
   var hasProtobufUnittest_enumOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1)
   }
   mutating func clearProtobufUnittest_enumOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1)
   }
 }
 
 extension Google_Protobuf_EnumValueOptions {
   var ProtobufUnittest_enumValueOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enumValueOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enumValueOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1, value: newValue)}
   }
   var hasProtobufUnittest_enumValueOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enumValueOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
   }
   mutating func clearProtobufUnittest_enumValueOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_enumValueOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
   }
 }
 
 extension Google_Protobuf_ServiceOptions {
   var ProtobufUnittest_serviceOpt1: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_serviceOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_serviceOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1, value: newValue)}
   }
   var hasProtobufUnittest_serviceOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_serviceOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
   }
   mutating func clearProtobufUnittest_serviceOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_serviceOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
   }
 }
 
 extension Google_Protobuf_MethodOptions {
   var ProtobufUnittest_methodOpt1: ProtobufUnittest_MethodOpt1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_methodOpt1) ?? ProtobufUnittest_MethodOpt1.val1}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_methodOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1) ?? ProtobufUnittest_MethodOpt1.val1}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1, value: newValue)}
   }
   var hasProtobufUnittest_methodOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_methodOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
   }
   mutating func clearProtobufUnittest_methodOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_methodOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_boolOpt: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_boolOpt) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_boolOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt, value: newValue)}
   }
   var hasProtobufUnittest_boolOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_boolOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
   }
   mutating func clearProtobufUnittest_boolOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_boolOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_int32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int32Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int32Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt, value: newValue)}
   }
   var hasProtobufUnittest_int32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int32Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
   }
   mutating func clearProtobufUnittest_int32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_int32Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_int64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int64Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int64Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt, value: newValue)}
   }
   var hasProtobufUnittest_int64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int64Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
   }
   mutating func clearProtobufUnittest_int64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_int64Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_uint32Opt: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint32Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint32Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt, value: newValue)}
   }
   var hasProtobufUnittest_uint32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint32Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
   }
   mutating func clearProtobufUnittest_uint32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint32Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_uint64Opt: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint64Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint64Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt, value: newValue)}
   }
   var hasProtobufUnittest_uint64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint64Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
   }
   mutating func clearProtobufUnittest_uint64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint64Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_sint32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint32Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint32Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt, value: newValue)}
   }
   var hasProtobufUnittest_sint32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint32Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
   }
   mutating func clearProtobufUnittest_sint32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint32Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_sint64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint64Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint64Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt, value: newValue)}
   }
   var hasProtobufUnittest_sint64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint64Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
   }
   mutating func clearProtobufUnittest_sint64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint64Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_fixed32Opt: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed32Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed32Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt, value: newValue)}
   }
   var hasProtobufUnittest_fixed32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed32Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
   }
   mutating func clearProtobufUnittest_fixed32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed32Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_fixed64Opt: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed64Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed64Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt, value: newValue)}
   }
   var hasProtobufUnittest_fixed64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed64Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
   }
   mutating func clearProtobufUnittest_fixed64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed64Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_sfixed32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt, value: newValue)}
   }
   var hasProtobufUnittest_sfixed32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
   }
   mutating func clearProtobufUnittest_sfixed32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_sfixed64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt, value: newValue)}
   }
   var hasProtobufUnittest_sfixed64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
   }
   mutating func clearProtobufUnittest_sfixed64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_floatOpt: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_floatOpt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_floatOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_float_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_float_opt, value: newValue)}
   }
   var hasProtobufUnittest_floatOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_floatOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
   }
   mutating func clearProtobufUnittest_floatOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_floatOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_doubleOpt: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_doubleOpt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_doubleOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_double_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_double_opt, value: newValue)}
   }
   var hasProtobufUnittest_doubleOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_doubleOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
   }
   mutating func clearProtobufUnittest_doubleOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_doubleOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_stringOpt: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_stringOpt) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_stringOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_string_opt) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_string_opt, value: newValue)}
   }
   var hasProtobufUnittest_stringOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_stringOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
   }
   mutating func clearProtobufUnittest_stringOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_stringOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_bytesOpt: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytesOpt) ?? Data()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bytesOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt) ?? Data()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt, value: newValue)}
   }
   var hasProtobufUnittest_bytesOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bytesOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
   }
   mutating func clearProtobufUnittest_bytesOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_bytesOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_enumOpt: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt) ?? ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt) ?? ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt, value: newValue)}
   }
   var hasProtobufUnittest_enumOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
   }
   mutating func clearProtobufUnittest_enumOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_messageTypeOpt: ProtobufUnittest_DummyMessageInvalidAsOptionType {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_messageTypeOpt) ?? ProtobufUnittest_DummyMessageInvalidAsOptionType()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_messageTypeOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt) ?? ProtobufUnittest_DummyMessageInvalidAsOptionType()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt, value: newValue)}
   }
   var hasProtobufUnittest_messageTypeOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_messageTypeOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
   }
   mutating func clearProtobufUnittest_messageTypeOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_messageTypeOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
   }
 }
 
@@ -2670,53 +2670,53 @@ extension ProtobufUnittest_ComplexOptionType2 {
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_complexOpt1: ProtobufUnittest_ComplexOptionType1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt1) ?? ProtobufUnittest_ComplexOptionType1()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1) ?? ProtobufUnittest_ComplexOptionType1()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1, value: newValue)}
   }
   var hasProtobufUnittest_complexOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
   }
   mutating func clearProtobufUnittest_complexOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_complexOpt2: ProtobufUnittest_ComplexOptionType2 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt2) ?? ProtobufUnittest_ComplexOptionType2()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt2, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2) ?? ProtobufUnittest_ComplexOptionType2()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2, value: newValue)}
   }
   var hasProtobufUnittest_complexOpt2: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt2)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
   }
   mutating func clearProtobufUnittest_complexOpt2() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt2)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_complexOpt3: ProtobufUnittest_ComplexOptionType3 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt3) ?? ProtobufUnittest_ComplexOptionType3()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt3, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3) ?? ProtobufUnittest_ComplexOptionType3()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3, value: newValue)}
   }
   var hasProtobufUnittest_complexOpt3: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt3)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
   }
   mutating func clearProtobufUnittest_complexOpt3() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt3)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_complexOpt6: ProtobufUnittest_ComplexOpt6 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt6) ?? ProtobufUnittest_ComplexOpt6()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt6, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6) ?? ProtobufUnittest_ComplexOpt6()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6, value: newValue)}
   }
   var hasProtobufUnittest_complexOpt6: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt6)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
   }
   mutating func clearProtobufUnittest_complexOpt6() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt6)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
   }
 }
 
@@ -2813,52 +2813,52 @@ extension Google_Protobuf_MethodOptions {
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_requiredEnumOpt: ProtobufUnittest_OldOptionType {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_requiredEnumOpt) ?? ProtobufUnittest_OldOptionType()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_requiredEnumOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt) ?? ProtobufUnittest_OldOptionType()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt, value: newValue)}
   }
   var hasProtobufUnittest_requiredEnumOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_requiredEnumOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt)
   }
   mutating func clearProtobufUnittest_requiredEnumOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_requiredEnumOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt)
   }
 }
 
 let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_Extensions_fileOpt1,
-  ProtobufUnittest_Extensions_messageOpt1,
-  ProtobufUnittest_Extensions_fieldOpt1,
-  ProtobufUnittest_Extensions_fieldOpt2,
-  ProtobufUnittest_Extensions_oneofOpt1,
-  ProtobufUnittest_Extensions_enumOpt1,
-  ProtobufUnittest_Extensions_enumValueOpt1,
-  ProtobufUnittest_Extensions_serviceOpt1,
-  ProtobufUnittest_Extensions_methodOpt1,
-  ProtobufUnittest_Extensions_boolOpt,
-  ProtobufUnittest_Extensions_int32Opt,
-  ProtobufUnittest_Extensions_int64Opt,
-  ProtobufUnittest_Extensions_uint32Opt,
-  ProtobufUnittest_Extensions_uint64Opt,
-  ProtobufUnittest_Extensions_sint32Opt,
-  ProtobufUnittest_Extensions_sint64Opt,
-  ProtobufUnittest_Extensions_fixed32Opt,
-  ProtobufUnittest_Extensions_fixed64Opt,
-  ProtobufUnittest_Extensions_sfixed32Opt,
-  ProtobufUnittest_Extensions_sfixed64Opt,
-  ProtobufUnittest_Extensions_floatOpt,
-  ProtobufUnittest_Extensions_doubleOpt,
-  ProtobufUnittest_Extensions_stringOpt,
-  ProtobufUnittest_Extensions_bytesOpt,
-  ProtobufUnittest_Extensions_enumOpt,
-  ProtobufUnittest_Extensions_messageTypeOpt,
+  ProtobufUnittest_Extensions_file_opt1,
+  ProtobufUnittest_Extensions_message_opt1,
+  ProtobufUnittest_Extensions_field_opt1,
+  ProtobufUnittest_Extensions_field_opt2,
+  ProtobufUnittest_Extensions_oneof_opt1,
+  ProtobufUnittest_Extensions_enum_opt1,
+  ProtobufUnittest_Extensions_enum_value_opt1,
+  ProtobufUnittest_Extensions_service_opt1,
+  ProtobufUnittest_Extensions_method_opt1,
+  ProtobufUnittest_Extensions_bool_opt,
+  ProtobufUnittest_Extensions_int32_opt,
+  ProtobufUnittest_Extensions_int64_opt,
+  ProtobufUnittest_Extensions_uint32_opt,
+  ProtobufUnittest_Extensions_uint64_opt,
+  ProtobufUnittest_Extensions_sint32_opt,
+  ProtobufUnittest_Extensions_sint64_opt,
+  ProtobufUnittest_Extensions_fixed32_opt,
+  ProtobufUnittest_Extensions_fixed64_opt,
+  ProtobufUnittest_Extensions_sfixed32_opt,
+  ProtobufUnittest_Extensions_sfixed64_opt,
+  ProtobufUnittest_Extensions_float_opt,
+  ProtobufUnittest_Extensions_double_opt,
+  ProtobufUnittest_Extensions_string_opt,
+  ProtobufUnittest_Extensions_bytes_opt,
+  ProtobufUnittest_Extensions_enum_opt,
+  ProtobufUnittest_Extensions_message_type_opt,
   ProtobufUnittest_Extensions_quux,
   ProtobufUnittest_Extensions_corge,
   ProtobufUnittest_Extensions_grault,
   ProtobufUnittest_Extensions_garply,
-  ProtobufUnittest_Extensions_complexOpt1,
-  ProtobufUnittest_Extensions_complexOpt2,
-  ProtobufUnittest_Extensions_complexOpt3,
-  ProtobufUnittest_Extensions_complexOpt6,
+  ProtobufUnittest_Extensions_complex_opt1,
+  ProtobufUnittest_Extensions_complex_opt2,
+  ProtobufUnittest_Extensions_complex_opt3,
+  ProtobufUnittest_Extensions_ComplexOpt6,
   ProtobufUnittest_Extensions_fileopt,
   ProtobufUnittest_Extensions_msgopt,
   ProtobufUnittest_Extensions_fieldopt,
@@ -2866,9 +2866,9 @@ let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.ExtensionSe
   ProtobufUnittest_Extensions_enumvalopt,
   ProtobufUnittest_Extensions_serviceopt,
   ProtobufUnittest_Extensions_methodopt,
-  ProtobufUnittest_Extensions_requiredEnumOpt,
-  ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complexOpt4,
-  ProtobufUnittest_AggregateMessageSetElement.Extensions.messageSetExtension,
+  ProtobufUnittest_Extensions_required_enum_opt,
+  ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4,
+  ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension,
   ProtobufUnittest_Aggregate.Extensions.nested,
-  ProtobufUnittest_NestedOptionType.Extensions.nestedExtension
+  ProtobufUnittest_NestedOptionType.Extensions.nested_extension
 ]

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -2309,7 +2309,7 @@ struct ProtobufUnittest_TestNestedExtensionLite: SwiftProtobuf.Message, SwiftPro
 
   struct Extensions {
 
-    static let nestedExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
       fieldNumber: 12345,
       fieldNames: .same(proto: "protobuf_unittest.TestNestedExtensionLite.nested_extension"),
       defaultValue: 0
@@ -2923,13 +2923,13 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
 
   struct Extensions {
 
-    static let optionalExt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
+    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
       fieldNumber: 1000,
       fieldNames: .same(proto: "protobuf_unittest.TestParsingMergeLite.optional_ext"),
       defaultValue: ProtobufUnittest_TestAllTypesLite()
     )
 
-    static let repeatedExt = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
+    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
       fieldNumber: 1001,
       fieldNames: .same(proto: "protobuf_unittest.TestParsingMergeLite.repeated_ext"),
       defaultValue: []
@@ -3723,544 +3723,544 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 }
 
 ///   Singular
-let ProtobufUnittest_Extensions_optionalInt32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 1,
   fieldNames: .same(proto: "protobuf_unittest.optional_int32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalInt64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 2,
   fieldNames: .same(proto: "protobuf_unittest.optional_int64_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalUint32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 3,
   fieldNames: .same(proto: "protobuf_unittest.optional_uint32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalUint64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 4,
   fieldNames: .same(proto: "protobuf_unittest.optional_uint64_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSint32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 5,
   fieldNames: .same(proto: "protobuf_unittest.optional_sint32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSint64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 6,
   fieldNames: .same(proto: "protobuf_unittest.optional_sint64_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFixed32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 7,
   fieldNames: .same(proto: "protobuf_unittest.optional_fixed32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFixed64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 8,
   fieldNames: .same(proto: "protobuf_unittest.optional_fixed64_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 9,
   fieldNames: .same(proto: "protobuf_unittest.optional_sfixed32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 10,
   fieldNames: .same(proto: "protobuf_unittest.optional_sfixed64_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFloatExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 11,
   fieldNames: .same(proto: "protobuf_unittest.optional_float_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalDoubleExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 12,
   fieldNames: .same(proto: "protobuf_unittest.optional_double_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalBoolExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 13,
   fieldNames: .same(proto: "protobuf_unittest.optional_bool_extension_lite"),
   defaultValue: false
 )
 
-let ProtobufUnittest_Extensions_optionalStringExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 14,
   fieldNames: .same(proto: "protobuf_unittest.optional_string_extension_lite"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalBytesExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 15,
   fieldNames: .same(proto: "protobuf_unittest.optional_bytes_extension_lite"),
   defaultValue: Data()
 )
 
-let ProtobufUnittest_Extensions_optionalGroupExtensionLite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_OptionalGroup_extension_lite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 16,
   fieldNames: .same(proto: "protobuf_unittest.OptionalGroup_extension_lite"),
   defaultValue: ProtobufUnittest_OptionalGroup_extension_lite()
 )
 
-let ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 18,
   fieldNames: .same(proto: "protobuf_unittest.optional_nested_message_extension_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
 )
 
-let ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 19,
   fieldNames: .same(proto: "protobuf_unittest.optional_foreign_message_extension_lite"),
   defaultValue: ProtobufUnittest_ForeignMessageLite()
 )
 
-let ProtobufUnittest_Extensions_optionalImportMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 20,
   fieldNames: .same(proto: "protobuf_unittest.optional_import_message_extension_lite"),
   defaultValue: ProtobufUnittestImport_ImportMessageLite()
 )
 
-let ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 21,
   fieldNames: .same(proto: "protobuf_unittest.optional_nested_enum_extension_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.foo
 )
 
-let ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 22,
   fieldNames: .same(proto: "protobuf_unittest.optional_foreign_enum_extension_lite"),
   defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteFoo
 )
 
-let ProtobufUnittest_Extensions_optionalImportEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 23,
   fieldNames: .same(proto: "protobuf_unittest.optional_import_enum_extension_lite"),
   defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteFoo
 )
 
-let ProtobufUnittest_Extensions_optionalStringPieceExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 24,
   fieldNames: .same(proto: "protobuf_unittest.optional_string_piece_extension_lite"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalCordExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 25,
   fieldNames: .same(proto: "protobuf_unittest.optional_cord_extension_lite"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_public_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 26,
   fieldNames: .same(proto: "protobuf_unittest.optional_public_import_message_extension_lite"),
   defaultValue: ProtobufUnittestImport_PublicImportMessageLite()
 )
 
-let ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 27,
   fieldNames: .same(proto: "protobuf_unittest.optional_lazy_message_extension_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
 )
 
 ///   Repeated
-let ProtobufUnittest_Extensions_repeatedInt32ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_int32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 31,
   fieldNames: .same(proto: "protobuf_unittest.repeated_int32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedInt64ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_int64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 32,
   fieldNames: .same(proto: "protobuf_unittest.repeated_int64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedUint32ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_uint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 33,
   fieldNames: .same(proto: "protobuf_unittest.repeated_uint32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedUint64ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_uint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 34,
   fieldNames: .same(proto: "protobuf_unittest.repeated_uint64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSint32ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_sint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 35,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sint32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSint64ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_sint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 36,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sint64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_fixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 37,
   fieldNames: .same(proto: "protobuf_unittest.repeated_fixed32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_fixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 38,
   fieldNames: .same(proto: "protobuf_unittest.repeated_fixed64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 39,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sfixed32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 40,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sfixed64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFloatExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_float_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 41,
   fieldNames: .same(proto: "protobuf_unittest.repeated_float_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedDoubleExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_double_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 42,
   fieldNames: .same(proto: "protobuf_unittest.repeated_double_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedBoolExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_bool_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 43,
   fieldNames: .same(proto: "protobuf_unittest.repeated_bool_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedStringExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_string_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 44,
   fieldNames: .same(proto: "protobuf_unittest.repeated_string_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedBytesExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_bytes_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 45,
   fieldNames: .same(proto: "protobuf_unittest.repeated_bytes_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedGroupExtensionLite = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_RepeatedGroup_extension_lite = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 46,
   fieldNames: .same(proto: "protobuf_unittest.RepeatedGroup_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_nested_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 48,
   fieldNames: .same(proto: "protobuf_unittest.repeated_nested_message_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 49,
   fieldNames: .same(proto: "protobuf_unittest.repeated_foreign_message_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_import_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 50,
   fieldNames: .same(proto: "protobuf_unittest.repeated_import_message_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 51,
   fieldNames: .same(proto: "protobuf_unittest.repeated_nested_enum_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 52,
   fieldNames: .same(proto: "protobuf_unittest.repeated_foreign_enum_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_import_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 53,
   fieldNames: .same(proto: "protobuf_unittest.repeated_import_enum_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_string_piece_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 54,
   fieldNames: .same(proto: "protobuf_unittest.repeated_string_piece_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedCordExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_cord_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 55,
   fieldNames: .same(proto: "protobuf_unittest.repeated_cord_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 57,
   fieldNames: .same(proto: "protobuf_unittest.repeated_lazy_message_extension_lite"),
   defaultValue: []
 )
 
 ///   Singular with defaults
-let ProtobufUnittest_Extensions_defaultInt32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 61,
   fieldNames: .same(proto: "protobuf_unittest.default_int32_extension_lite"),
   defaultValue: 41
 )
 
-let ProtobufUnittest_Extensions_defaultInt64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 62,
   fieldNames: .same(proto: "protobuf_unittest.default_int64_extension_lite"),
   defaultValue: 42
 )
 
-let ProtobufUnittest_Extensions_defaultUint32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 63,
   fieldNames: .same(proto: "protobuf_unittest.default_uint32_extension_lite"),
   defaultValue: 43
 )
 
-let ProtobufUnittest_Extensions_defaultUint64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 64,
   fieldNames: .same(proto: "protobuf_unittest.default_uint64_extension_lite"),
   defaultValue: 44
 )
 
-let ProtobufUnittest_Extensions_defaultSint32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 65,
   fieldNames: .same(proto: "protobuf_unittest.default_sint32_extension_lite"),
   defaultValue: -45
 )
 
-let ProtobufUnittest_Extensions_defaultSint64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 66,
   fieldNames: .same(proto: "protobuf_unittest.default_sint64_extension_lite"),
   defaultValue: 46
 )
 
-let ProtobufUnittest_Extensions_defaultFixed32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 67,
   fieldNames: .same(proto: "protobuf_unittest.default_fixed32_extension_lite"),
   defaultValue: 47
 )
 
-let ProtobufUnittest_Extensions_defaultFixed64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 68,
   fieldNames: .same(proto: "protobuf_unittest.default_fixed64_extension_lite"),
   defaultValue: 48
 )
 
-let ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 69,
   fieldNames: .same(proto: "protobuf_unittest.default_sfixed32_extension_lite"),
   defaultValue: 49
 )
 
-let ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 70,
   fieldNames: .same(proto: "protobuf_unittest.default_sfixed64_extension_lite"),
   defaultValue: -50
 )
 
-let ProtobufUnittest_Extensions_defaultFloatExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 71,
   fieldNames: .same(proto: "protobuf_unittest.default_float_extension_lite"),
   defaultValue: 51.5
 )
 
-let ProtobufUnittest_Extensions_defaultDoubleExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 72,
   fieldNames: .same(proto: "protobuf_unittest.default_double_extension_lite"),
   defaultValue: 52000
 )
 
-let ProtobufUnittest_Extensions_defaultBoolExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 73,
   fieldNames: .same(proto: "protobuf_unittest.default_bool_extension_lite"),
   defaultValue: true
 )
 
-let ProtobufUnittest_Extensions_defaultStringExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 74,
   fieldNames: .same(proto: "protobuf_unittest.default_string_extension_lite"),
   defaultValue: "hello"
 )
 
-let ProtobufUnittest_Extensions_defaultBytesExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 75,
   fieldNames: .same(proto: "protobuf_unittest.default_bytes_extension_lite"),
   defaultValue: Data(bytes: [119, 111, 114, 108, 100])
 )
 
-let ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 81,
   fieldNames: .same(proto: "protobuf_unittest.default_nested_enum_extension_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.bar
 )
 
-let ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 82,
   fieldNames: .same(proto: "protobuf_unittest.default_foreign_enum_extension_lite"),
   defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteBar
 )
 
-let ProtobufUnittest_Extensions_defaultImportEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 83,
   fieldNames: .same(proto: "protobuf_unittest.default_import_enum_extension_lite"),
   defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteBar
 )
 
-let ProtobufUnittest_Extensions_defaultStringPieceExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 84,
   fieldNames: .same(proto: "protobuf_unittest.default_string_piece_extension_lite"),
   defaultValue: "abc"
 )
 
-let ProtobufUnittest_Extensions_defaultCordExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 85,
   fieldNames: .same(proto: "protobuf_unittest.default_cord_extension_lite"),
   defaultValue: "123"
 )
 
 ///   For oneof test
-let ProtobufUnittest_Extensions_oneofUint32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_oneof_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 111,
   fieldNames: .same(proto: "protobuf_unittest.oneof_uint32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_oneof_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 112,
   fieldNames: .same(proto: "protobuf_unittest.oneof_nested_message_extension_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
 )
 
-let ProtobufUnittest_Extensions_oneofStringExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_oneof_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 113,
   fieldNames: .same(proto: "protobuf_unittest.oneof_string_extension_lite"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_oneofBytesExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_oneof_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 114,
   fieldNames: .same(proto: "protobuf_unittest.oneof_bytes_extension_lite"),
   defaultValue: Data()
 )
 
-let ProtobufUnittest_Extensions_packedInt32ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_int32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 90,
   fieldNames: .same(proto: "protobuf_unittest.packed_int32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedInt64ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_int64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 91,
   fieldNames: .same(proto: "protobuf_unittest.packed_int64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedUint32ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_uint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 92,
   fieldNames: .same(proto: "protobuf_unittest.packed_uint32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedUint64ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_uint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 93,
   fieldNames: .same(proto: "protobuf_unittest.packed_uint64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSint32ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_sint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 94,
   fieldNames: .same(proto: "protobuf_unittest.packed_sint32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSint64ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_sint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 95,
   fieldNames: .same(proto: "protobuf_unittest.packed_sint64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFixed32ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_fixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 96,
   fieldNames: .same(proto: "protobuf_unittest.packed_fixed32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFixed64ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_fixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 97,
   fieldNames: .same(proto: "protobuf_unittest.packed_fixed64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSfixed32ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 98,
   fieldNames: .same(proto: "protobuf_unittest.packed_sfixed32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSfixed64ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 99,
   fieldNames: .same(proto: "protobuf_unittest.packed_sfixed64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFloatExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_float_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 100,
   fieldNames: .same(proto: "protobuf_unittest.packed_float_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedDoubleExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_double_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 101,
   fieldNames: .same(proto: "protobuf_unittest.packed_double_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedBoolExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_bool_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 102,
   fieldNames: .same(proto: "protobuf_unittest.packed_bool_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedEnumExtensionLite = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_enum_extension_lite = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 103,
   fieldNames: .same(proto: "protobuf_unittest.packed_enum_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_testAllTypesLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestHugeFieldNumbersLite>(
+let ProtobufUnittest_Extensions_test_all_types_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestHugeFieldNumbersLite>(
   fieldNumber: 536860000,
   fieldNames: .same(proto: "protobuf_unittest.test_all_types_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite()
@@ -4268,1309 +4268,1309 @@ let ProtobufUnittest_Extensions_testAllTypesLite = SwiftProtobuf.MessageExtensio
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestNestedExtensionLite_nestedExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
   }
   mutating func clearProtobufUnittest_TestNestedExtensionLite_nestedExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension)
+    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
   }
 }
 
 extension ProtobufUnittest_TestParsingMergeLite {
   var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optionalExt) ?? ProtobufUnittest_TestAllTypesLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optionalExt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypesLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext, value: newValue)}
   }
   var hasProtobufUnittest_TestParsingMergeLite_optionalExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optionalExt)
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
   }
   mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optionalExt)
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
   }
 }
 
 extension ProtobufUnittest_TestParsingMergeLite {
   var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt)}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext, value: newValue)}
   }
   var hasProtobufUnittest_TestParsingMergeLite_repeatedExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt)
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
   }
   mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt)
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Singular
   var ProtobufUnittest_optionalInt32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalInt32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalInt32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalInt64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalInt64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalInt64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalUint32ExtensionLite: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalUint64ExtensionLite: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalUint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalUint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSint32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalSint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalSint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSint64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalSint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalSint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFixed32ExtensionLite: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalFixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalFixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFixed64ExtensionLite: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalFixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalFixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSfixed32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalSfixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalSfixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSfixed64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalSfixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalSfixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFloatExtensionLite: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalFloatExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalFloatExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalDoubleExtensionLite: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalDoubleExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalDoubleExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalBoolExtensionLite: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtensionLite) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalBoolExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalBoolExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtensionLite) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalStringExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalBytesExtensionLite: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtensionLite) ?? Data()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite) ?? Data()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalBytesExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalBytesExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalGroupExtensionLite: ProtobufUnittest_OptionalGroup_extension_lite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtensionLite) ?? ProtobufUnittest_OptionalGroup_extension_lite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite) ?? ProtobufUnittest_OptionalGroup_extension_lite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalGroupExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalGroupExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalNestedMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalNestedMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalForeignMessageExtensionLite: ProtobufUnittest_ForeignMessageLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite) ?? ProtobufUnittest_ForeignMessageLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite) ?? ProtobufUnittest_ForeignMessageLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalForeignMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalForeignMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalImportMessageExtensionLite: ProtobufUnittestImport_ImportMessageLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtensionLite) ?? ProtobufUnittestImport_ImportMessageLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite) ?? ProtobufUnittestImport_ImportMessageLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalImportMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalImportMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.foo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.foo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalNestedEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalNestedEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteFoo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteFoo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalForeignEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalForeignEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtensionLite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteFoo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteFoo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalImportEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalImportEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringPieceExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtensionLite) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringPieceExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalStringPieceExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalCordExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtensionLite) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalCordExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalCordExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalPublicImportMessageExtensionLite: ProtobufUnittestImport_PublicImportMessageLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite) ?? ProtobufUnittestImport_PublicImportMessageLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite) ?? ProtobufUnittestImport_PublicImportMessageLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalPublicImportMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalPublicImportMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalLazyMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalLazyMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalLazyMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Repeated
   var ProtobufUnittest_repeatedInt32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedInt32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedInt32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedInt64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedInt64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedInt64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedUint32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedUint64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedUint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedUint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSint32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedSint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSint64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedSint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFixed32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedFixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFixed64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedFixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSfixed32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSfixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedSfixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSfixed64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSfixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedSfixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFloatExtensionLite: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFloatExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedFloatExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedDoubleExtensionLite: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedDoubleExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedDoubleExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedBoolExtensionLite: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedBoolExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedBoolExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedStringExtensionLite: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedStringExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedStringExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedBytesExtensionLite: [Data] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedBytesExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedBytesExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedGroupExtensionLite: [ProtobufUnittest_RepeatedGroup_extension_lite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedGroupExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedGroupExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedNestedMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedNestedMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedNestedMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedForeignMessageExtensionLite: [ProtobufUnittest_ForeignMessageLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedForeignMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedForeignMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedImportMessageExtensionLite: [ProtobufUnittestImport_ImportMessageLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedImportMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedImportMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedNestedEnumExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedNestedEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedNestedEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedForeignEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedForeignEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedForeignEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedImportEnumExtensionLite: [ProtobufUnittestImport_ImportEnumLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedImportEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedImportEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedStringPieceExtensionLite: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedStringPieceExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedStringPieceExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedCordExtensionLite: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedCordExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedCordExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedLazyMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedLazyMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedLazyMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Singular with defaults
   var ProtobufUnittest_defaultInt32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32ExtensionLite) ?? 41}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite) ?? 41}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultInt32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultInt32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultInt64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64ExtensionLite) ?? 42}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite) ?? 42}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultInt64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultInt64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultUint32ExtensionLite: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32ExtensionLite) ?? 43}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite) ?? 43}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultUint64ExtensionLite: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64ExtensionLite) ?? 44}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite) ?? 44}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultUint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultUint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSint32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32ExtensionLite) ?? -45}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite) ?? -45}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultSint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultSint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSint64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64ExtensionLite) ?? 46}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite) ?? 46}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultSint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultSint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFixed32ExtensionLite: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32ExtensionLite) ?? 47}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite) ?? 47}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultFixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultFixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFixed64ExtensionLite: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64ExtensionLite) ?? 48}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite) ?? 48}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultFixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultFixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSfixed32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite) ?? 49}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite) ?? 49}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultSfixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultSfixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSfixed64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite) ?? -50}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite) ?? -50}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultSfixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultSfixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFloatExtensionLite: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtensionLite) ?? 51.5}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite) ?? 51.5}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultFloatExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultFloatExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultDoubleExtensionLite: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtensionLite) ?? 52000}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite) ?? 52000}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultDoubleExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultDoubleExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultBoolExtensionLite: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtensionLite) ?? true}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite) ?? true}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultBoolExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultBoolExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultStringExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtensionLite) ?? "hello"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite) ?? "hello"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultStringExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultStringExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultBytesExtensionLite: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtensionLite) ?? Data(bytes: [119, 111, 114, 108, 100])}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite) ?? Data(bytes: [119, 111, 114, 108, 100])}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultBytesExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultBytesExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.bar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.bar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultNestedEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultNestedEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteBar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteBar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultForeignEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultForeignEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtensionLite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteBar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteBar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultImportEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultImportEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultStringPieceExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtensionLite) ?? "abc"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite) ?? "abc"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultStringPieceExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultStringPieceExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultCordExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtensionLite) ?? "123"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite) ?? "123"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultCordExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultCordExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   For oneof test
   var ProtobufUnittest_oneofUint32ExtensionLite: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite)
   }
   mutating func clearProtobufUnittest_oneofUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofNestedMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite)
   }
   mutating func clearProtobufUnittest_oneofNestedMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofStringExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtensionLite) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofStringExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite)
   }
   mutating func clearProtobufUnittest_oneofStringExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofBytesExtensionLite: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtensionLite) ?? Data()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite) ?? Data()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofBytesExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite)
   }
   mutating func clearProtobufUnittest_oneofBytesExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedInt32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedInt32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
   }
   mutating func clearProtobufUnittest_packedInt32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedInt64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedInt64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
   }
   mutating func clearProtobufUnittest_packedInt64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedUint32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
   }
   mutating func clearProtobufUnittest_packedUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedUint64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedUint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
   }
   mutating func clearProtobufUnittest_packedUint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedSint32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedSint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
   }
   mutating func clearProtobufUnittest_packedSint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedSint64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedSint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
   }
   mutating func clearProtobufUnittest_packedSint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedFixed32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedFixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_packedFixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedFixed64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedFixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_packedFixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedSfixed32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedSfixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_packedSfixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedSfixed64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedSfixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_packedSfixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedFloatExtensionLite: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedFloatExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
   }
   mutating func clearProtobufUnittest_packedFloatExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedDoubleExtensionLite: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedDoubleExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
   }
   mutating func clearProtobufUnittest_packedDoubleExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedBoolExtensionLite: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedBoolExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
   }
   mutating func clearProtobufUnittest_packedBoolExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_packedEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestHugeFieldNumbersLite {
   var ProtobufUnittest_testAllTypesLite: ProtobufUnittest_TestAllTypesLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypesLite) ?? ProtobufUnittest_TestAllTypesLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypesLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite) ?? ProtobufUnittest_TestAllTypesLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite, value: newValue)}
   }
   var hasProtobufUnittest_testAllTypesLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypesLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
   }
   mutating func clearProtobufUnittest_testAllTypesLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypesLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
   }
 }
 
 let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_Extensions_optionalInt32ExtensionLite,
-  ProtobufUnittest_Extensions_optionalInt64ExtensionLite,
-  ProtobufUnittest_Extensions_optionalUint32ExtensionLite,
-  ProtobufUnittest_Extensions_optionalUint64ExtensionLite,
-  ProtobufUnittest_Extensions_optionalSint32ExtensionLite,
-  ProtobufUnittest_Extensions_optionalSint64ExtensionLite,
-  ProtobufUnittest_Extensions_optionalFixed32ExtensionLite,
-  ProtobufUnittest_Extensions_optionalFixed64ExtensionLite,
-  ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite,
-  ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite,
-  ProtobufUnittest_Extensions_optionalFloatExtensionLite,
-  ProtobufUnittest_Extensions_optionalDoubleExtensionLite,
-  ProtobufUnittest_Extensions_optionalBoolExtensionLite,
-  ProtobufUnittest_Extensions_optionalStringExtensionLite,
-  ProtobufUnittest_Extensions_optionalBytesExtensionLite,
-  ProtobufUnittest_Extensions_optionalGroupExtensionLite,
-  ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite,
-  ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite,
-  ProtobufUnittest_Extensions_optionalImportMessageExtensionLite,
-  ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite,
-  ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite,
-  ProtobufUnittest_Extensions_optionalImportEnumExtensionLite,
-  ProtobufUnittest_Extensions_optionalStringPieceExtensionLite,
-  ProtobufUnittest_Extensions_optionalCordExtensionLite,
-  ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite,
-  ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite,
-  ProtobufUnittest_Extensions_repeatedInt32ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedInt64ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedUint32ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedUint64ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedSint32ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedSint64ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedFloatExtensionLite,
-  ProtobufUnittest_Extensions_repeatedDoubleExtensionLite,
-  ProtobufUnittest_Extensions_repeatedBoolExtensionLite,
-  ProtobufUnittest_Extensions_repeatedStringExtensionLite,
-  ProtobufUnittest_Extensions_repeatedBytesExtensionLite,
-  ProtobufUnittest_Extensions_repeatedGroupExtensionLite,
-  ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite,
-  ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite,
-  ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite,
-  ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite,
-  ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite,
-  ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite,
-  ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite,
-  ProtobufUnittest_Extensions_repeatedCordExtensionLite,
-  ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite,
-  ProtobufUnittest_Extensions_defaultInt32ExtensionLite,
-  ProtobufUnittest_Extensions_defaultInt64ExtensionLite,
-  ProtobufUnittest_Extensions_defaultUint32ExtensionLite,
-  ProtobufUnittest_Extensions_defaultUint64ExtensionLite,
-  ProtobufUnittest_Extensions_defaultSint32ExtensionLite,
-  ProtobufUnittest_Extensions_defaultSint64ExtensionLite,
-  ProtobufUnittest_Extensions_defaultFixed32ExtensionLite,
-  ProtobufUnittest_Extensions_defaultFixed64ExtensionLite,
-  ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite,
-  ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite,
-  ProtobufUnittest_Extensions_defaultFloatExtensionLite,
-  ProtobufUnittest_Extensions_defaultDoubleExtensionLite,
-  ProtobufUnittest_Extensions_defaultBoolExtensionLite,
-  ProtobufUnittest_Extensions_defaultStringExtensionLite,
-  ProtobufUnittest_Extensions_defaultBytesExtensionLite,
-  ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite,
-  ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite,
-  ProtobufUnittest_Extensions_defaultImportEnumExtensionLite,
-  ProtobufUnittest_Extensions_defaultStringPieceExtensionLite,
-  ProtobufUnittest_Extensions_defaultCordExtensionLite,
-  ProtobufUnittest_Extensions_oneofUint32ExtensionLite,
-  ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite,
-  ProtobufUnittest_Extensions_oneofStringExtensionLite,
-  ProtobufUnittest_Extensions_oneofBytesExtensionLite,
-  ProtobufUnittest_Extensions_packedInt32ExtensionLite,
-  ProtobufUnittest_Extensions_packedInt64ExtensionLite,
-  ProtobufUnittest_Extensions_packedUint32ExtensionLite,
-  ProtobufUnittest_Extensions_packedUint64ExtensionLite,
-  ProtobufUnittest_Extensions_packedSint32ExtensionLite,
-  ProtobufUnittest_Extensions_packedSint64ExtensionLite,
-  ProtobufUnittest_Extensions_packedFixed32ExtensionLite,
-  ProtobufUnittest_Extensions_packedFixed64ExtensionLite,
-  ProtobufUnittest_Extensions_packedSfixed32ExtensionLite,
-  ProtobufUnittest_Extensions_packedSfixed64ExtensionLite,
-  ProtobufUnittest_Extensions_packedFloatExtensionLite,
-  ProtobufUnittest_Extensions_packedDoubleExtensionLite,
-  ProtobufUnittest_Extensions_packedBoolExtensionLite,
-  ProtobufUnittest_Extensions_packedEnumExtensionLite,
-  ProtobufUnittest_Extensions_testAllTypesLite,
-  ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension,
-  ProtobufUnittest_TestParsingMergeLite.Extensions.optionalExt,
-  ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt
+  ProtobufUnittest_Extensions_optional_int32_extension_lite,
+  ProtobufUnittest_Extensions_optional_int64_extension_lite,
+  ProtobufUnittest_Extensions_optional_uint32_extension_lite,
+  ProtobufUnittest_Extensions_optional_uint64_extension_lite,
+  ProtobufUnittest_Extensions_optional_sint32_extension_lite,
+  ProtobufUnittest_Extensions_optional_sint64_extension_lite,
+  ProtobufUnittest_Extensions_optional_fixed32_extension_lite,
+  ProtobufUnittest_Extensions_optional_fixed64_extension_lite,
+  ProtobufUnittest_Extensions_optional_sfixed32_extension_lite,
+  ProtobufUnittest_Extensions_optional_sfixed64_extension_lite,
+  ProtobufUnittest_Extensions_optional_float_extension_lite,
+  ProtobufUnittest_Extensions_optional_double_extension_lite,
+  ProtobufUnittest_Extensions_optional_bool_extension_lite,
+  ProtobufUnittest_Extensions_optional_string_extension_lite,
+  ProtobufUnittest_Extensions_optional_bytes_extension_lite,
+  ProtobufUnittest_Extensions_OptionalGroup_extension_lite,
+  ProtobufUnittest_Extensions_optional_nested_message_extension_lite,
+  ProtobufUnittest_Extensions_optional_foreign_message_extension_lite,
+  ProtobufUnittest_Extensions_optional_import_message_extension_lite,
+  ProtobufUnittest_Extensions_optional_nested_enum_extension_lite,
+  ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite,
+  ProtobufUnittest_Extensions_optional_import_enum_extension_lite,
+  ProtobufUnittest_Extensions_optional_string_piece_extension_lite,
+  ProtobufUnittest_Extensions_optional_cord_extension_lite,
+  ProtobufUnittest_Extensions_optional_public_import_message_extension_lite,
+  ProtobufUnittest_Extensions_optional_lazy_message_extension_lite,
+  ProtobufUnittest_Extensions_repeated_int32_extension_lite,
+  ProtobufUnittest_Extensions_repeated_int64_extension_lite,
+  ProtobufUnittest_Extensions_repeated_uint32_extension_lite,
+  ProtobufUnittest_Extensions_repeated_uint64_extension_lite,
+  ProtobufUnittest_Extensions_repeated_sint32_extension_lite,
+  ProtobufUnittest_Extensions_repeated_sint64_extension_lite,
+  ProtobufUnittest_Extensions_repeated_fixed32_extension_lite,
+  ProtobufUnittest_Extensions_repeated_fixed64_extension_lite,
+  ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite,
+  ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite,
+  ProtobufUnittest_Extensions_repeated_float_extension_lite,
+  ProtobufUnittest_Extensions_repeated_double_extension_lite,
+  ProtobufUnittest_Extensions_repeated_bool_extension_lite,
+  ProtobufUnittest_Extensions_repeated_string_extension_lite,
+  ProtobufUnittest_Extensions_repeated_bytes_extension_lite,
+  ProtobufUnittest_Extensions_RepeatedGroup_extension_lite,
+  ProtobufUnittest_Extensions_repeated_nested_message_extension_lite,
+  ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite,
+  ProtobufUnittest_Extensions_repeated_import_message_extension_lite,
+  ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite,
+  ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite,
+  ProtobufUnittest_Extensions_repeated_import_enum_extension_lite,
+  ProtobufUnittest_Extensions_repeated_string_piece_extension_lite,
+  ProtobufUnittest_Extensions_repeated_cord_extension_lite,
+  ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite,
+  ProtobufUnittest_Extensions_default_int32_extension_lite,
+  ProtobufUnittest_Extensions_default_int64_extension_lite,
+  ProtobufUnittest_Extensions_default_uint32_extension_lite,
+  ProtobufUnittest_Extensions_default_uint64_extension_lite,
+  ProtobufUnittest_Extensions_default_sint32_extension_lite,
+  ProtobufUnittest_Extensions_default_sint64_extension_lite,
+  ProtobufUnittest_Extensions_default_fixed32_extension_lite,
+  ProtobufUnittest_Extensions_default_fixed64_extension_lite,
+  ProtobufUnittest_Extensions_default_sfixed32_extension_lite,
+  ProtobufUnittest_Extensions_default_sfixed64_extension_lite,
+  ProtobufUnittest_Extensions_default_float_extension_lite,
+  ProtobufUnittest_Extensions_default_double_extension_lite,
+  ProtobufUnittest_Extensions_default_bool_extension_lite,
+  ProtobufUnittest_Extensions_default_string_extension_lite,
+  ProtobufUnittest_Extensions_default_bytes_extension_lite,
+  ProtobufUnittest_Extensions_default_nested_enum_extension_lite,
+  ProtobufUnittest_Extensions_default_foreign_enum_extension_lite,
+  ProtobufUnittest_Extensions_default_import_enum_extension_lite,
+  ProtobufUnittest_Extensions_default_string_piece_extension_lite,
+  ProtobufUnittest_Extensions_default_cord_extension_lite,
+  ProtobufUnittest_Extensions_oneof_uint32_extension_lite,
+  ProtobufUnittest_Extensions_oneof_nested_message_extension_lite,
+  ProtobufUnittest_Extensions_oneof_string_extension_lite,
+  ProtobufUnittest_Extensions_oneof_bytes_extension_lite,
+  ProtobufUnittest_Extensions_packed_int32_extension_lite,
+  ProtobufUnittest_Extensions_packed_int64_extension_lite,
+  ProtobufUnittest_Extensions_packed_uint32_extension_lite,
+  ProtobufUnittest_Extensions_packed_uint64_extension_lite,
+  ProtobufUnittest_Extensions_packed_sint32_extension_lite,
+  ProtobufUnittest_Extensions_packed_sint64_extension_lite,
+  ProtobufUnittest_Extensions_packed_fixed32_extension_lite,
+  ProtobufUnittest_Extensions_packed_fixed64_extension_lite,
+  ProtobufUnittest_Extensions_packed_sfixed32_extension_lite,
+  ProtobufUnittest_Extensions_packed_sfixed64_extension_lite,
+  ProtobufUnittest_Extensions_packed_float_extension_lite,
+  ProtobufUnittest_Extensions_packed_double_extension_lite,
+  ProtobufUnittest_Extensions_packed_bool_extension_lite,
+  ProtobufUnittest_Extensions_packed_enum_extension_lite,
+  ProtobufUnittest_Extensions_test_all_types_lite,
+  ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension,
+  ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext,
+  ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext
 ]

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -164,7 +164,7 @@ struct ProtobufUnittest_TestMessageSetExtension1: SwiftProtobuf.Message, SwiftPr
 
   struct Extensions {
 
-    static let messageSetExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension1>, Proto2WireformatUnittest_TestMessageSet>(
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension1>, Proto2WireformatUnittest_TestMessageSet>(
       fieldNumber: 1545008,
       fieldNames: .same(proto: "protobuf_unittest.TestMessageSetExtension1.message_set_extension"),
       defaultValue: ProtobufUnittest_TestMessageSetExtension1()
@@ -221,7 +221,7 @@ struct ProtobufUnittest_TestMessageSetExtension2: SwiftProtobuf.Message, SwiftPr
 
   struct Extensions {
 
-    static let messageSetExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension2>, Proto2WireformatUnittest_TestMessageSet>(
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension2>, Proto2WireformatUnittest_TestMessageSet>(
       fieldNumber: 1547769,
       fieldNames: .same(proto: "protobuf_unittest.TestMessageSetExtension2.message_set_extension"),
       defaultValue: ProtobufUnittest_TestMessageSetExtension2()
@@ -396,31 +396,31 @@ struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message, SwiftProtobuf.Prot
 
 extension Proto2WireformatUnittest_TestMessageSet {
   var ProtobufUnittest_TestMessageSetExtension1_messageSetExtension: ProtobufUnittest_TestMessageSetExtension1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.messageSetExtension) ?? ProtobufUnittest_TestMessageSetExtension1()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.messageSetExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension) ?? ProtobufUnittest_TestMessageSetExtension1()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestMessageSetExtension1_messageSetExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.messageSetExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension)
   }
   mutating func clearProtobufUnittest_TestMessageSetExtension1_messageSetExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.messageSetExtension)
+    clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension)
   }
 }
 
 extension Proto2WireformatUnittest_TestMessageSet {
   var ProtobufUnittest_TestMessageSetExtension2_messageSetExtension: ProtobufUnittest_TestMessageSetExtension2 {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.messageSetExtension) ?? ProtobufUnittest_TestMessageSetExtension2()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.messageSetExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension) ?? ProtobufUnittest_TestMessageSetExtension2()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestMessageSetExtension2_messageSetExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.messageSetExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension)
   }
   mutating func clearProtobufUnittest_TestMessageSetExtension2_messageSetExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.messageSetExtension)
+    clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension)
   }
 }
 
 let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_TestMessageSetExtension1.Extensions.messageSetExtension,
-  ProtobufUnittest_TestMessageSetExtension2.Extensions.messageSetExtension
+  ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension,
+  ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension
 ]

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -181,7 +181,7 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf.Message,
   }
 }
 
-let Google_Protobuf_NoGenericServicesTest_Extensions_testExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_NoGenericServicesTest_TestMessage>(
+let Google_Protobuf_NoGenericServicesTest_Extensions_test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_NoGenericServicesTest_TestMessage>(
   fieldNumber: 1000,
   fieldNames: .same(proto: "google.protobuf.no_generic_services_test.test_extension"),
   defaultValue: 0
@@ -189,17 +189,17 @@ let Google_Protobuf_NoGenericServicesTest_Extensions_testExtension = SwiftProtob
 
 extension Google_Protobuf_NoGenericServicesTest_TestMessage {
   var Google_Protobuf_NoGenericServicesTest_testExtension: Int32 {
-    get {return getExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_testExtension) ?? 0}
-    set {setExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_testExtension, value: newValue)}
+    get {return getExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension) ?? 0}
+    set {setExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension, value: newValue)}
   }
   var hasGoogle_Protobuf_NoGenericServicesTest_testExtension: Bool {
-    return hasExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_testExtension)
+    return hasExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension)
   }
   mutating func clearGoogle_Protobuf_NoGenericServicesTest_testExtension() {
-    clearExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_testExtension)
+    clearExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension)
   }
 }
 
 let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.ExtensionSet = [
-  Google_Protobuf_NoGenericServicesTest_Extensions_testExtension
+  Google_Protobuf_NoGenericServicesTest_Extensions_test_extension
 ]

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -188,13 +188,13 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
 
   struct Extensions {
 
-    static let testExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestOptimizedForSize>(
+    static let test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestOptimizedForSize>(
       fieldNumber: 1234,
       fieldNames: .same(proto: "protobuf_unittest.TestOptimizedForSize.test_extension"),
       defaultValue: 0
     )
 
-    static let testExtension2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequiredOptimizedForSize>, ProtobufUnittest_TestOptimizedForSize>(
+    static let test_extension2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequiredOptimizedForSize>, ProtobufUnittest_TestOptimizedForSize>(
       fieldNumber: 1235,
       fieldNames: .same(proto: "protobuf_unittest.TestOptimizedForSize.test_extension2"),
       defaultValue: ProtobufUnittest_TestRequiredOptimizedForSize()
@@ -453,31 +453,31 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message, Swi
 
 extension ProtobufUnittest_TestOptimizedForSize {
   var ProtobufUnittest_TestOptimizedForSize_testExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestOptimizedForSize_testExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension)
   }
   mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension)
+    clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension)
   }
 }
 
 extension ProtobufUnittest_TestOptimizedForSize {
   var ProtobufUnittest_TestOptimizedForSize_testExtension2: ProtobufUnittest_TestRequiredOptimizedForSize {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension2) ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension2, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2) ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2, value: newValue)}
   }
   var hasProtobufUnittest_TestOptimizedForSize_testExtension2: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension2)
+    return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2)
   }
   mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension2() {
-    clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension2)
+    clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2)
   }
 }
 
 let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension,
-  ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension2
+  ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension,
+  ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2
 ]

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -217,16 +217,156 @@ struct ProtobufUnittest_Extend_C: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
   }
 }
 
+// 
+// extend Foo.Bar.Baz.C {
+// optional bool d = 12;
+// }
+
+//  If this compiles then it means we deal with unique proto names that
+//  could end up with naming collisions when remapped to Swifty names.
+
+struct ProtobufUnittest_Extend_Msg1: SwiftProtobuf.Message, SwiftProtobuf.Proto2Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf.ProtoNameProviding {
+  static let protoMessageName: String = "Msg1"
+  static let protoPackageName: String = "protobuf_unittest.extend"
+  static let _protobuf_fieldNames = FieldNameMap()
+
+  var unknown = SwiftProtobuf.UnknownStorage()
+
+  public var isInitialized: Bool {
+    if !_extensionFieldValues.isInitialized {return false}
+    return true
+  }
+
+  mutating func _protoc_generated_decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      try decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    }
+  }
+
+  mutating func _protoc_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
+    if (1 <= fieldNumber && fieldNumber < 1001) {
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_Msg1.self, fieldNumber: fieldNumber)
+    }
+  }
+
+  func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
+    try visitor.visitExtensionFields(fields: _extensionFieldValues, start: 1, end: 1001)
+    unknown.traverse(visitor: visitor)
+  }
+
+  func _protoc_generated_isEqualTo(other: ProtobufUnittest_Extend_Msg1) -> Bool {
+    if unknown != other.unknown {return false}
+    if _extensionFieldValues != other._extensionFieldValues {return false}
+    return true
+  }
+
+  private var _extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
+
+  mutating func setExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg1>, value: F.ValueType) {
+    _extensionFieldValues[ext.fieldNumber] = ext.set(value: value)
+  }
+
+  mutating func clearExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg1>) {
+    _extensionFieldValues[ext.fieldNumber] = nil
+  }
+
+  func getExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg1>) -> F.ValueType {
+    if let fieldValue = _extensionFieldValues[ext.fieldNumber] as? F {
+      return fieldValue.value
+    }
+    return ext.defaultValue
+  }
+
+  func hasExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg1>) -> Bool {
+    return _extensionFieldValues[ext.fieldNumber] is F
+  }
+  func _protobuf_fieldNames(for number: Int) -> FieldNameMap.Names? {
+    return ProtobufUnittest_Extend_Msg1._protobuf_fieldNames.fieldNames(for: number) ?? _extensionFieldValues.fieldNames(for: number)
+  }
+}
+
+struct ProtobufUnittest_Extend_Msg2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf.ProtoNameProviding {
+  static let protoMessageName: String = "Msg2"
+  static let protoPackageName: String = "protobuf_unittest.extend"
+  static let _protobuf_fieldNames = FieldNameMap()
+
+  var unknown = SwiftProtobuf.UnknownStorage()
+
+  public var isInitialized: Bool {
+    if !_extensionFieldValues.isInitialized {return false}
+    return true
+  }
+
+  mutating func _protoc_generated_decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      try decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    }
+  }
+
+  mutating func _protoc_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
+    if (1 <= fieldNumber && fieldNumber < 1001) {
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_Msg2.self, fieldNumber: fieldNumber)
+    }
+  }
+
+  func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
+    try visitor.visitExtensionFields(fields: _extensionFieldValues, start: 1, end: 1001)
+    unknown.traverse(visitor: visitor)
+  }
+
+  func _protoc_generated_isEqualTo(other: ProtobufUnittest_Extend_Msg2) -> Bool {
+    if unknown != other.unknown {return false}
+    if _extensionFieldValues != other._extensionFieldValues {return false}
+    return true
+  }
+
+  private var _extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
+
+  mutating func setExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg2>, value: F.ValueType) {
+    _extensionFieldValues[ext.fieldNumber] = ext.set(value: value)
+  }
+
+  mutating func clearExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg2>) {
+    _extensionFieldValues[ext.fieldNumber] = nil
+  }
+
+  func getExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg2>) -> F.ValueType {
+    if let fieldValue = _extensionFieldValues[ext.fieldNumber] as? F {
+      return fieldValue.value
+    }
+    return ext.defaultValue
+  }
+
+  func hasExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg2>) -> Bool {
+    return _extensionFieldValues[ext.fieldNumber] is F
+  }
+  func _protobuf_fieldNames(for number: Int) -> FieldNameMap.Names? {
+    return ProtobufUnittest_Extend_Msg2._protobuf_fieldNames.fieldNames(for: number) ?? _extensionFieldValues.fieldNames(for: number)
+  }
+}
+
 let ProtobufUnittest_Extend_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   fieldNumber: 100,
   fieldNames: .same(proto: "protobuf_unittest.extend.b"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extend_Extensions_c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+let ProtobufUnittest_Extend_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   fieldNumber: 101,
   fieldNames: .same(proto: "protobuf_unittest.extend.C"),
   defaultValue: ProtobufUnittest_Extend_C()
+)
+
+let ProtobufUnittest_Extend_Extensions_a_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg1>(
+  fieldNumber: 1,
+  fieldNames: .same(proto: "protobuf_unittest.extend.a_b"),
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_aB = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg2>(
+  fieldNumber: 1,
+  fieldNames: .same(proto: "protobuf_unittest.extend.aB"),
+  defaultValue: 0
 )
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
@@ -244,18 +384,46 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend_c: ProtobufUnittest_Extend_C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_c) ?? ProtobufUnittest_Extend_C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_c, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C) ?? ProtobufUnittest_Extend_C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C, value: newValue)}
   }
   var hasProtobufUnittest_Extend_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend_Extensions_c)
+    return hasExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C)
   }
   mutating func clearProtobufUnittest_Extend_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_c)
+    clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C)
+  }
+}
+
+extension ProtobufUnittest_Extend_Msg1 {
+  var ProtobufUnittest_Extend_aB: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend_aB: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b)
+  }
+  mutating func clearProtobufUnittest_Extend_aB() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b)
+  }
+}
+
+extension ProtobufUnittest_Extend_Msg2 {
+  var ProtobufUnittest_Extend_aB: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend_aB: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB)
+  }
+  mutating func clearProtobufUnittest_Extend_aB() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB)
   }
 }
 
 let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: SwiftProtobuf.ExtensionSet = [
   ProtobufUnittest_Extend_Extensions_b,
-  ProtobufUnittest_Extend_Extensions_c
+  ProtobufUnittest_Extend_Extensions_C,
+  ProtobufUnittest_Extend_Extensions_a_b,
+  ProtobufUnittest_Extend_Extensions_aB
 ]

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -100,7 +100,7 @@ struct ProtobufUnittest_Extend2_MyMessage: SwiftProtobuf.Message, SwiftProtobuf.
       defaultValue: ""
     )
 
-    static let c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       fieldNumber: 211,
       fieldNames: .same(proto: "protobuf_unittest.extend2.MyMessage.C"),
       defaultValue: ProtobufUnittest_Extend2_MyMessage.C()
@@ -180,7 +180,7 @@ let ProtobufUnittest_Extend2_Extensions_b = SwiftProtobuf.MessageExtension<Optio
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extend2_Extensions_c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   fieldNumber: 221,
   fieldNames: .same(proto: "protobuf_unittest.extend2.C"),
   defaultValue: ProtobufUnittest_Extend2_C()
@@ -201,14 +201,14 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_MyMessage_c: ProtobufUnittest_Extend2_MyMessage.C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.c) ?? ProtobufUnittest_Extend2_MyMessage.C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.c, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend2_MyMessage.C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C, value: newValue)}
   }
   var hasProtobufUnittest_Extend2_MyMessage_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.c)
+    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
   }
   mutating func clearProtobufUnittest_Extend2_MyMessage_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.c)
+    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
   }
 }
 
@@ -227,20 +227,20 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_c: ProtobufUnittest_Extend2_C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_c) ?? ProtobufUnittest_Extend2_C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_c, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C) ?? ProtobufUnittest_Extend2_C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C, value: newValue)}
   }
   var hasProtobufUnittest_Extend2_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_c)
+    return hasExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C)
   }
   mutating func clearProtobufUnittest_Extend2_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_c)
+    clearExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C)
   }
 }
 
 let ProtobufUnittest_Extend2_UnittestSwiftExtension2_Extensions: SwiftProtobuf.ExtensionSet = [
   ProtobufUnittest_Extend2_Extensions_b,
-  ProtobufUnittest_Extend2_Extensions_c,
+  ProtobufUnittest_Extend2_Extensions_C,
   ProtobufUnittest_Extend2_MyMessage.Extensions.b,
-  ProtobufUnittest_Extend2_MyMessage.Extensions.c
+  ProtobufUnittest_Extend2_MyMessage.Extensions.C
 ]

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -100,7 +100,7 @@ struct ProtobufUnittest_Extend3_MyMessage: SwiftProtobuf.Message, SwiftProtobuf.
       defaultValue: ""
     )
 
-    static let c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       fieldNumber: 311,
       fieldNames: .same(proto: "protobuf_unittest.extend3.MyMessage.C"),
       defaultValue: ProtobufUnittest_Extend3_MyMessage.C()
@@ -180,7 +180,7 @@ let ProtobufUnittest_Extend3_Extensions_b = SwiftProtobuf.MessageExtension<Optio
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extend3_Extensions_c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   fieldNumber: 321,
   fieldNames: .same(proto: "protobuf_unittest.extend3.C"),
   defaultValue: ProtobufUnittest_Extend3_C()
@@ -201,14 +201,14 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_MyMessage_c: ProtobufUnittest_Extend3_MyMessage.C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.c) ?? ProtobufUnittest_Extend3_MyMessage.C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.c, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend3_MyMessage.C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C, value: newValue)}
   }
   var hasProtobufUnittest_Extend3_MyMessage_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.c)
+    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
   }
   mutating func clearProtobufUnittest_Extend3_MyMessage_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.c)
+    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
   }
 }
 
@@ -227,20 +227,20 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_c: ProtobufUnittest_Extend3_C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_c) ?? ProtobufUnittest_Extend3_C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_c, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C) ?? ProtobufUnittest_Extend3_C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C, value: newValue)}
   }
   var hasProtobufUnittest_Extend3_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_c)
+    return hasExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C)
   }
   mutating func clearProtobufUnittest_Extend3_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_c)
+    clearExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C)
   }
 }
 
 let ProtobufUnittest_Extend3_UnittestSwiftExtension3_Extensions: SwiftProtobuf.ExtensionSet = [
   ProtobufUnittest_Extend3_Extensions_b,
-  ProtobufUnittest_Extend3_Extensions_c,
+  ProtobufUnittest_Extend3_Extensions_C,
   ProtobufUnittest_Extend3_MyMessage.Extensions.b,
-  ProtobufUnittest_Extend3_MyMessage.Extensions.c
+  ProtobufUnittest_Extend3_MyMessage.Extensions.C
 ]

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -100,7 +100,7 @@ struct Ext4MyMessage: SwiftProtobuf.Message, SwiftProtobuf.Proto2Message, SwiftP
       defaultValue: ""
     )
 
-    static let c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       fieldNumber: 411,
       fieldNames: .same(proto: "protobuf_unittest.extend4.MyMessage.C"),
       defaultValue: Ext4MyMessage.C()
@@ -180,7 +180,7 @@ let Ext4Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<Swi
   defaultValue: ""
 )
 
-let Ext4Extensions_c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   fieldNumber: 421,
   fieldNames: .same(proto: "protobuf_unittest.extend4.C"),
   defaultValue: Ext4C()
@@ -201,14 +201,14 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4MyMessage_c: Ext4MyMessage.C {
-    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.c) ?? Ext4MyMessage.C()}
-    set {setExtensionValue(ext: Ext4MyMessage.Extensions.c, value: newValue)}
+    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.C) ?? Ext4MyMessage.C()}
+    set {setExtensionValue(ext: Ext4MyMessage.Extensions.C, value: newValue)}
   }
   var hasExt4MyMessage_c: Bool {
-    return hasExtensionValue(ext: Ext4MyMessage.Extensions.c)
+    return hasExtensionValue(ext: Ext4MyMessage.Extensions.C)
   }
   mutating func clearExt4MyMessage_c() {
-    clearExtensionValue(ext: Ext4MyMessage.Extensions.c)
+    clearExtensionValue(ext: Ext4MyMessage.Extensions.C)
   }
 }
 
@@ -227,20 +227,20 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4c: Ext4C {
-    get {return getExtensionValue(ext: Ext4Extensions_c) ?? Ext4C()}
-    set {setExtensionValue(ext: Ext4Extensions_c, value: newValue)}
+    get {return getExtensionValue(ext: Ext4Extensions_C) ?? Ext4C()}
+    set {setExtensionValue(ext: Ext4Extensions_C, value: newValue)}
   }
   var hasExt4c: Bool {
-    return hasExtensionValue(ext: Ext4Extensions_c)
+    return hasExtensionValue(ext: Ext4Extensions_C)
   }
   mutating func clearExt4c() {
-    clearExtensionValue(ext: Ext4Extensions_c)
+    clearExtensionValue(ext: Ext4Extensions_C)
   }
 }
 
 let Ext4UnittestSwiftExtension4_Extensions: SwiftProtobuf.ExtensionSet = [
   Ext4Extensions_b,
-  Ext4Extensions_c,
+  Ext4Extensions_C,
   Ext4MyMessage.Extensions.b,
-  Ext4MyMessage.Extensions.c
+  Ext4MyMessage.Extensions.C
 ]

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -425,13 +425,13 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
   }
 }
 
-let Swift_Protobuf_Extensions_myExtensionString = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(
+let Swift_Protobuf_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(
   fieldNumber: 50,
   fieldNames: .same(proto: "swift.protobuf.my_extension_string"),
   defaultValue: ""
 )
 
-let Swift_Protobuf_Extensions_myExtensionInt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(
+let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(
   fieldNumber: 5,
   fieldNames: .same(proto: "swift.protobuf.my_extension_int"),
   defaultValue: 0
@@ -439,31 +439,31 @@ let Swift_Protobuf_Extensions_myExtensionInt = SwiftProtobuf.MessageExtension<Op
 
 extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionString: String {
-    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionString) ?? ""}
-    set {setExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionString, value: newValue)}
+    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string) ?? ""}
+    set {setExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string, value: newValue)}
   }
   var hasSwift_Protobuf_myExtensionString: Bool {
-    return hasExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionString)
+    return hasExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string)
   }
   mutating func clearSwift_Protobuf_myExtensionString() {
-    clearExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionString)
+    clearExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string)
   }
 }
 
 extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionInt: Int32 {
-    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionInt) ?? 0}
-    set {setExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionInt, value: newValue)}
+    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int) ?? 0}
+    set {setExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int, value: newValue)}
   }
   var hasSwift_Protobuf_myExtensionInt: Bool {
-    return hasExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionInt)
+    return hasExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int)
   }
   mutating func clearSwift_Protobuf_myExtensionInt() {
-    clearExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionInt)
+    clearExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int)
   }
 }
 
 let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: SwiftProtobuf.ExtensionSet = [
-  Swift_Protobuf_Extensions_myExtensionString,
-  Swift_Protobuf_Extensions_myExtensionInt
+  Swift_Protobuf_Extensions_my_extension_string,
+  Swift_Protobuf_Extensions_my_extension_int
 ]

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -275,13 +275,13 @@ struct SwiftTestGroupUnextended: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mess
   }
 }
 
-let Extensions_extensionGroup = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ExtensionGroup>, SwiftTestGroupExtensions>(
+let Extensions_ExtensionGroup = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ExtensionGroup>, SwiftTestGroupExtensions>(
   fieldNumber: 2,
   fieldNames: .same(proto: "ExtensionGroup"),
   defaultValue: ExtensionGroup()
 )
 
-let Extensions_repeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(
+let Extensions_RepeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(
   fieldNumber: 3,
   fieldNames: .same(proto: "RepeatedExtensionGroup"),
   defaultValue: []
@@ -289,31 +289,31 @@ let Extensions_repeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedG
 
 extension SwiftTestGroupExtensions {
   var extensionGroup: ExtensionGroup {
-    get {return getExtensionValue(ext: Extensions_extensionGroup) ?? ExtensionGroup()}
-    set {setExtensionValue(ext: Extensions_extensionGroup, value: newValue)}
+    get {return getExtensionValue(ext: Extensions_ExtensionGroup) ?? ExtensionGroup()}
+    set {setExtensionValue(ext: Extensions_ExtensionGroup, value: newValue)}
   }
   var hasExtensionGroup: Bool {
-    return hasExtensionValue(ext: Extensions_extensionGroup)
+    return hasExtensionValue(ext: Extensions_ExtensionGroup)
   }
   mutating func clearExtensionGroup() {
-    clearExtensionValue(ext: Extensions_extensionGroup)
+    clearExtensionValue(ext: Extensions_ExtensionGroup)
   }
 }
 
 extension SwiftTestGroupExtensions {
   var repeatedExtensionGroup: [RepeatedExtensionGroup] {
-    get {return getExtensionValue(ext: Extensions_repeatedExtensionGroup)}
-    set {setExtensionValue(ext: Extensions_repeatedExtensionGroup, value: newValue)}
+    get {return getExtensionValue(ext: Extensions_RepeatedExtensionGroup)}
+    set {setExtensionValue(ext: Extensions_RepeatedExtensionGroup, value: newValue)}
   }
   var hasRepeatedExtensionGroup: Bool {
-    return hasExtensionValue(ext: Extensions_repeatedExtensionGroup)
+    return hasExtensionValue(ext: Extensions_RepeatedExtensionGroup)
   }
   mutating func clearRepeatedExtensionGroup() {
-    clearExtensionValue(ext: Extensions_repeatedExtensionGroup)
+    clearExtensionValue(ext: Extensions_RepeatedExtensionGroup)
   }
 }
 
 let UnittestSwiftGroups_Extensions: SwiftProtobuf.ExtensionSet = [
-  Extensions_extensionGroup,
-  Extensions_repeatedExtensionGroup
+  Extensions_ExtensionGroup,
+  Extensions_RepeatedExtensionGroup
 ]

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -26175,19 +26175,19 @@ struct SwiftUnittest_Names_Lowers: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
       defaultValue: 0
     )
 
-    static let httpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 2,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.http_request"),
       defaultValue: 0
     )
 
-    static let theHTTPRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 3,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_http_request"),
       defaultValue: 0
     )
 
-    static let theHTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 4,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_http"),
       defaultValue: 0
@@ -26199,19 +26199,19 @@ struct SwiftUnittest_Names_Lowers: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
       defaultValue: 0
     )
 
-    static let httpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 12,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.https_request"),
       defaultValue: 0
     )
 
-    static let theHTTPSRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 13,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_https_request"),
       defaultValue: 0
     )
 
-    static let theHTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 14,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_https"),
       defaultValue: 0
@@ -26223,25 +26223,25 @@ struct SwiftUnittest_Names_Lowers: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
       defaultValue: 0
     )
 
-    static let urlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 22,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.url_value"),
       defaultValue: 0
     )
 
-    static let theURLValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 23,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_url_value"),
       defaultValue: 0
     )
 
-    static let theURL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 24,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_url"),
       defaultValue: 0
     )
 
-    static let aBC = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 31,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.a_b_c"),
       defaultValue: 0
@@ -26276,73 +26276,73 @@ struct SwiftUnittest_Names_Uppers: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
   struct Extensions {
 
-    static let http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 101,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.HTTP"),
       defaultValue: 0
     )
 
-    static let httpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 102,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.HTTP_request"),
       defaultValue: 0
     )
 
-    static let theHTTPRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 103,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_HTTP_request"),
       defaultValue: 0
     )
 
-    static let theHTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 104,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_HTTP"),
       defaultValue: 0
     )
 
-    static let https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 111,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.HTTPS"),
       defaultValue: 0
     )
 
-    static let httpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 112,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.HTTPS_request"),
       defaultValue: 0
     )
 
-    static let theHTTPSRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 113,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_HTTPS_request"),
       defaultValue: 0
     )
 
-    static let theHTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 114,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_HTTPS"),
       defaultValue: 0
     )
 
-    static let url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 121,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.URL"),
       defaultValue: 0
     )
 
-    static let urlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 122,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.URL_value"),
       defaultValue: 0
     )
 
-    static let theURLValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 123,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_URL_value"),
       defaultValue: 0
     )
 
-    static let theURL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 124,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_URL"),
       defaultValue: 0
@@ -26377,73 +26377,73 @@ struct SwiftUnittest_Names_WordCase: SwiftProtobuf.Message, SwiftProtobuf.Proto2
 
   struct Extensions {
 
-    static let http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 201,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.Http"),
       defaultValue: 0
     )
 
-    static let httpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 202,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.HttpRequest"),
       defaultValue: 0
     )
 
-    static let theHTTPRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 203,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheHttpRequest"),
       defaultValue: 0
     )
 
-    static let theHTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 204,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheHttp"),
       defaultValue: 0
     )
 
-    static let https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 211,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.Https"),
       defaultValue: 0
     )
 
-    static let httpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 212,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.HttpsRequest"),
       defaultValue: 0
     )
 
-    static let theHTTPSRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 213,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheHttpsRequest"),
       defaultValue: 0
     )
 
-    static let theHTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 214,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheHttps"),
       defaultValue: 0
     )
 
-    static let url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 221,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.Url"),
       defaultValue: 0
     )
 
-    static let urlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 222,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.UrlValue"),
       defaultValue: 0
     )
 
-    static let theURLValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 223,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheUrlValue"),
       defaultValue: 0
     )
 
-    static let theURL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 224,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheUrl"),
       defaultValue: 0
@@ -26484,40 +26484,40 @@ extension SwiftUnittest_Names_ExtensionNamingInitials {
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
   }
   mutating func clearSwiftUnittest_Names_Lowers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTP, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTP)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTP)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
   }
 }
 
@@ -26536,40 +26536,40 @@ extension SwiftUnittest_Names_ExtensionNamingInitials {
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpsRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpsRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
   }
   mutating func clearSwiftUnittest_Names_Lowers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpsRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPSRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPSRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPSRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPSRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPS, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPS)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPS)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
   }
 }
 
@@ -26588,404 +26588,404 @@ extension SwiftUnittest_Names_ExtensionNamingInitials {
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.urlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.urlValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.urlValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
   }
   mutating func clearSwiftUnittest_Names_Lowers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.urlValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURLValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURLValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURLValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURLValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURL, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURL)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURL)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_aBC: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.aBC) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.aBC, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_aBC: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.aBC)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
   }
   mutating func clearSwiftUnittest_Names_Lowers_aBC() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.aBC)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.http, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.http)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
   }
   mutating func clearSwiftUnittest_Names_Uppers_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.http)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
   }
   mutating func clearSwiftUnittest_Names_Uppers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTP, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTP)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTP)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.https, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.https)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
   }
   mutating func clearSwiftUnittest_Names_Uppers_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.https)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpsRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpsRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
   }
   mutating func clearSwiftUnittest_Names_Uppers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpsRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPSRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPSRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPSRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPSRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPS, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPS)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPS)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.url, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.url)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
   }
   mutating func clearSwiftUnittest_Names_Uppers_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.url)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.urlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.urlValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.urlValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
   }
   mutating func clearSwiftUnittest_Names_Uppers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.urlValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURLValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURLValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURLValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURLValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURL, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURL)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURL)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.http, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.http)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
   }
   mutating func clearSwiftUnittest_Names_WordCase_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.http)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
   }
   mutating func clearSwiftUnittest_Names_WordCase_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTP, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTP)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTP)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.https, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.https)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
   }
   mutating func clearSwiftUnittest_Names_WordCase_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.https)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpsRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpsRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
   }
   mutating func clearSwiftUnittest_Names_WordCase_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpsRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPSRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPSRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPSRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPSRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPS, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPS)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPS)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.url, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.url)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
   }
   mutating func clearSwiftUnittest_Names_WordCase_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.url)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.urlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.urlValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.urlValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
   }
   mutating func clearSwiftUnittest_Names_WordCase_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.urlValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURLValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURLValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURLValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURLValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURL, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURL)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURL)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
   }
 }
 
 let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.ExtensionSet = [
   SwiftUnittest_Names_Lowers.Extensions.http,
-  SwiftUnittest_Names_Lowers.Extensions.httpRequest,
-  SwiftUnittest_Names_Lowers.Extensions.theHTTPRequest,
-  SwiftUnittest_Names_Lowers.Extensions.theHTTP,
+  SwiftUnittest_Names_Lowers.Extensions.http_request,
+  SwiftUnittest_Names_Lowers.Extensions.the_http_request,
+  SwiftUnittest_Names_Lowers.Extensions.the_http,
   SwiftUnittest_Names_Lowers.Extensions.https,
-  SwiftUnittest_Names_Lowers.Extensions.httpsRequest,
-  SwiftUnittest_Names_Lowers.Extensions.theHTTPSRequest,
-  SwiftUnittest_Names_Lowers.Extensions.theHTTPS,
+  SwiftUnittest_Names_Lowers.Extensions.https_request,
+  SwiftUnittest_Names_Lowers.Extensions.the_https_request,
+  SwiftUnittest_Names_Lowers.Extensions.the_https,
   SwiftUnittest_Names_Lowers.Extensions.url,
-  SwiftUnittest_Names_Lowers.Extensions.urlValue,
-  SwiftUnittest_Names_Lowers.Extensions.theURLValue,
-  SwiftUnittest_Names_Lowers.Extensions.theURL,
-  SwiftUnittest_Names_Lowers.Extensions.aBC,
-  SwiftUnittest_Names_Uppers.Extensions.http,
-  SwiftUnittest_Names_Uppers.Extensions.httpRequest,
-  SwiftUnittest_Names_Uppers.Extensions.theHTTPRequest,
-  SwiftUnittest_Names_Uppers.Extensions.theHTTP,
-  SwiftUnittest_Names_Uppers.Extensions.https,
-  SwiftUnittest_Names_Uppers.Extensions.httpsRequest,
-  SwiftUnittest_Names_Uppers.Extensions.theHTTPSRequest,
-  SwiftUnittest_Names_Uppers.Extensions.theHTTPS,
-  SwiftUnittest_Names_Uppers.Extensions.url,
-  SwiftUnittest_Names_Uppers.Extensions.urlValue,
-  SwiftUnittest_Names_Uppers.Extensions.theURLValue,
-  SwiftUnittest_Names_Uppers.Extensions.theURL,
-  SwiftUnittest_Names_WordCase.Extensions.http,
-  SwiftUnittest_Names_WordCase.Extensions.httpRequest,
-  SwiftUnittest_Names_WordCase.Extensions.theHTTPRequest,
-  SwiftUnittest_Names_WordCase.Extensions.theHTTP,
-  SwiftUnittest_Names_WordCase.Extensions.https,
-  SwiftUnittest_Names_WordCase.Extensions.httpsRequest,
-  SwiftUnittest_Names_WordCase.Extensions.theHTTPSRequest,
-  SwiftUnittest_Names_WordCase.Extensions.theHTTPS,
-  SwiftUnittest_Names_WordCase.Extensions.url,
-  SwiftUnittest_Names_WordCase.Extensions.urlValue,
-  SwiftUnittest_Names_WordCase.Extensions.theURLValue,
-  SwiftUnittest_Names_WordCase.Extensions.theURL
+  SwiftUnittest_Names_Lowers.Extensions.url_value,
+  SwiftUnittest_Names_Lowers.Extensions.the_url_value,
+  SwiftUnittest_Names_Lowers.Extensions.the_url,
+  SwiftUnittest_Names_Lowers.Extensions.a_b_c,
+  SwiftUnittest_Names_Uppers.Extensions.HTTP,
+  SwiftUnittest_Names_Uppers.Extensions.HTTP_request,
+  SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request,
+  SwiftUnittest_Names_Uppers.Extensions.the_HTTP,
+  SwiftUnittest_Names_Uppers.Extensions.HTTPS,
+  SwiftUnittest_Names_Uppers.Extensions.HTTPS_request,
+  SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request,
+  SwiftUnittest_Names_Uppers.Extensions.the_HTTPS,
+  SwiftUnittest_Names_Uppers.Extensions.URL,
+  SwiftUnittest_Names_Uppers.Extensions.URL_value,
+  SwiftUnittest_Names_Uppers.Extensions.the_URL_value,
+  SwiftUnittest_Names_Uppers.Extensions.the_URL,
+  SwiftUnittest_Names_WordCase.Extensions.Http,
+  SwiftUnittest_Names_WordCase.Extensions.HttpRequest,
+  SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest,
+  SwiftUnittest_Names_WordCase.Extensions.TheHttp,
+  SwiftUnittest_Names_WordCase.Extensions.Https,
+  SwiftUnittest_Names_WordCase.Extensions.HttpsRequest,
+  SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest,
+  SwiftUnittest_Names_WordCase.Extensions.TheHttps,
+  SwiftUnittest_Names_WordCase.Extensions.Url,
+  SwiftUnittest_Names_WordCase.Extensions.UrlValue,
+  SwiftUnittest_Names_WordCase.Extensions.TheUrlValue,
+  SwiftUnittest_Names_WordCase.Extensions.TheUrl
 ]

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -441,7 +441,7 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message, SwiftProtob
     ///   Even though it is a raw name in the Extensions struct for the
     ///   Message (SwiftReservedTestExt), the generation controls what
     ///   that struct has to conform to, so collisions there don't matter.
-    static let hashValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+    static let hash_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
       fieldNumber: 1001,
       fieldNames: .same(proto: "protobuf_unittest.SwiftReservedTestExt.hash_value"),
       defaultValue: false
@@ -468,7 +468,7 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message, SwiftProtob
 }
 
 ///   Won't get _p added because it is fully qualified.
-let ProtobufUnittest_Extensions_debugDescription = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+let ProtobufUnittest_Extensions_debug_description = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
   fieldNumber: 1000,
   fieldNames: .same(proto: "protobuf_unittest.debug_description"),
   defaultValue: false
@@ -479,32 +479,32 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   ///   Message (SwiftReservedTestExt), the generation controls what
   ///   that struct has to conform to, so collisions there don't matter.
   var ProtobufUnittest_SwiftReservedTestExt_hashValue: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hashValue) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hashValue, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value, value: newValue)}
   }
   var hasProtobufUnittest_SwiftReservedTestExt_hashValue: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hashValue)
+    return hasExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value)
   }
   mutating func clearProtobufUnittest_SwiftReservedTestExt_hashValue() {
-    clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hashValue)
+    clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value)
   }
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
   ///   Won't get _p added because it is fully qualified.
   var ProtobufUnittest_debugDescription: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debugDescription) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_debugDescription, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debug_description) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_debug_description, value: newValue)}
   }
   var hasProtobufUnittest_debugDescription: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_debugDescription)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
   }
   mutating func clearProtobufUnittest_debugDescription() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_debugDescription)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
   }
 }
 
 let ProtobufUnittest_UnittestSwiftReserved_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_Extensions_debugDescription,
-  ProtobufUnittest_SwiftReservedTestExt.Extensions.hashValue
+  ProtobufUnittest_Extensions_debug_description,
+  ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value
 ]

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -118,7 +118,7 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message, SwiftP
 
   struct Extensions {
 
-    static let nestedStringExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
       fieldNumber: 3,
       fieldNames: .same(proto: "protobuf_objc_unittest.TestObjCStartupNested.nested_string_extension"),
       defaultValue: ""
@@ -145,13 +145,13 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message, SwiftP
 }
 
 ///   Singular
-let ProtobufObjcUnittest_Extensions_optionalInt32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+let ProtobufObjcUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
   fieldNumber: 1,
   fieldNames: .same(proto: "protobuf_objc_unittest.optional_int32_extension"),
   defaultValue: 0
 )
 
-let ProtobufObjcUnittest_Extensions_repeatedInt32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
   fieldNumber: 2,
   fieldNames: .same(proto: "protobuf_objc_unittest.repeated_int32_extension"),
   defaultValue: []
@@ -159,46 +159,46 @@ let ProtobufObjcUnittest_Extensions_repeatedInt32Extension = SwiftProtobuf.Messa
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nestedStringExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nestedStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension, value: newValue)}
   }
   var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nestedStringExtension)
+    return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
   }
   mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
-    clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nestedStringExtension)
+    clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
   }
 }
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   ///   Singular
   var ProtobufObjcUnittest_optionalInt32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_optionalInt32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_optionalInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension, value: newValue)}
   }
   var hasProtobufObjcUnittest_optionalInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufObjcUnittest_Extensions_optionalInt32Extension)
+    return hasExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension)
   }
   mutating func clearProtobufObjcUnittest_optionalInt32Extension() {
-    clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_optionalInt32Extension)
+    clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension)
   }
 }
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_repeatedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeatedInt32Extension)}
-    set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeatedInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension)}
+    set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension, value: newValue)}
   }
   var hasProtobufObjcUnittest_repeatedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeatedInt32Extension)
+    return hasExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension)
   }
   mutating func clearProtobufObjcUnittest_repeatedInt32Extension() {
-    clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeatedInt32Extension)
+    clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension)
   }
 }
 
 let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufObjcUnittest_Extensions_optionalInt32Extension,
-  ProtobufObjcUnittest_Extensions_repeatedInt32Extension,
-  ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nestedStringExtension
+  ProtobufObjcUnittest_Extensions_optional_int32_extension,
+  ProtobufObjcUnittest_Extensions_repeated_int32_extension,
+  ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension
 ]

--- a/Sources/protoc-gen-swift/ExtensionGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionGenerator.swift
@@ -81,21 +81,22 @@ struct ExtensionGenerator {
             self.protoPath = fieldName
         }
 
-        let fieldBaseName: String
+        let baseName: String
         if descriptor.type == .group {
             let g = context.getMessageForPath(path: descriptor.typeName)!
-            fieldBaseName = toLowerCamelCase(g.name)
+            baseName = g.name
         } else {
-            fieldBaseName = toLowerCamelCase(descriptor.name)
+            baseName = descriptor.name
         }
+        let fieldBaseName = toLowerCamelCase(baseName)
 
         if let msg = swiftDeclaringMessageName {
-            self.swiftRelativeExtensionName = fieldBaseName
-            self.swiftFullExtensionName = msg + ".Extensions." + fieldBaseName
+            self.swiftRelativeExtensionName = baseName
+            self.swiftFullExtensionName = msg + ".Extensions." + baseName
             self.swiftFieldName = periodsToUnderscores(msg + "_" + fieldBaseName)
         } else {
             let swiftPrefix = file.swiftPrefix
-            self.swiftRelativeExtensionName = swiftPrefix + "Extensions_" + fieldBaseName
+            self.swiftRelativeExtensionName = swiftPrefix + "Extensions_" + baseName
             self.swiftFullExtensionName = self.swiftRelativeExtensionName
             self.swiftFieldName = periodsToUnderscores(swiftPrefix + fieldBaseName)
         }

--- a/Tests/SwiftProtobufTests/Test_Extensions.swift
+++ b/Tests/SwiftProtobufTests/Test_Extensions.swift
@@ -78,8 +78,8 @@ class Test_Extensions: XCTestCase, PBTestHelpers {
         // Append an array of extensions
         extensions.insert(contentsOf:
             [
-                Extensions_repeatedExtensionGroup,
-                Extensions_extensionGroup
+                Extensions_RepeatedExtensionGroup,
+                Extensions_ExtensionGroup
             ]
         )
     }
@@ -123,8 +123,8 @@ class Test_Extensions: XCTestCase, PBTestHelpers {
         // An extension set with two extensions for field #5, but for
         // different messages and with different types
         var extensions = ExtensionSet()
-        extensions.insert(ProtobufUnittest_Extensions_optionalSint32Extension)
-        extensions.insert(ProtobufUnittest_Extensions_myExtensionInt)
+        extensions.insert(ProtobufUnittest_Extensions_optional_sint32_extension)
+        extensions.insert(ProtobufUnittest_Extensions_my_extension_int)
 
         // This should decode with optionalSint32Extension
         let m1 = try ProtobufUnittest_TestAllExtensions(serializedData: Data(bytes: [40, 1]), extensions: extensions)

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -2336,7 +2336,7 @@ struct ProtobufUnittest_TestNestedExtension: SwiftProtobuf.Message, SwiftProtobu
 
     ///   Used to test if generated extension name is correct when there are
     ///   underscores.
-    static let nestedStringExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
       fieldNumber: 1003,
       fieldNames: .same(proto: "protobuf_unittest.TestNestedExtension.nested_string_extension"),
       defaultValue: ""
@@ -8773,13 +8773,13 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
 
   struct Extensions {
 
-    static let optionalExt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
+    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
       fieldNumber: 1000,
       fieldNames: .same(proto: "protobuf_unittest.TestParsingMerge.optional_ext"),
       defaultValue: ProtobufUnittest_TestAllTypes()
     )
 
-    static let repeatedExt = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
+    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
       fieldNumber: 1001,
       fieldNames: .same(proto: "protobuf_unittest.TestParsingMerge.repeated_ext"),
       defaultValue: []
@@ -9686,640 +9686,640 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 }
 
 ///   Singular
-let ProtobufUnittest_Extensions_optionalInt32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 1,
   fieldNames: .same(proto: "protobuf_unittest.optional_int32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalInt64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 2,
   fieldNames: .same(proto: "protobuf_unittest.optional_int64_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalUint32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 3,
   fieldNames: .same(proto: "protobuf_unittest.optional_uint32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalUint64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 4,
   fieldNames: .same(proto: "protobuf_unittest.optional_uint64_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSint32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 5,
   fieldNames: .same(proto: "protobuf_unittest.optional_sint32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSint64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 6,
   fieldNames: .same(proto: "protobuf_unittest.optional_sint64_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFixed32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 7,
   fieldNames: .same(proto: "protobuf_unittest.optional_fixed32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFixed64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 8,
   fieldNames: .same(proto: "protobuf_unittest.optional_fixed64_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSfixed32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 9,
   fieldNames: .same(proto: "protobuf_unittest.optional_sfixed32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSfixed64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 10,
   fieldNames: .same(proto: "protobuf_unittest.optional_sfixed64_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFloatExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 11,
   fieldNames: .same(proto: "protobuf_unittest.optional_float_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalDoubleExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 12,
   fieldNames: .same(proto: "protobuf_unittest.optional_double_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalBoolExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 13,
   fieldNames: .same(proto: "protobuf_unittest.optional_bool_extension"),
   defaultValue: false
 )
 
-let ProtobufUnittest_Extensions_optionalStringExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 14,
   fieldNames: .same(proto: "protobuf_unittest.optional_string_extension"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalBytesExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 15,
   fieldNames: .same(proto: "protobuf_unittest.optional_bytes_extension"),
   defaultValue: Data()
 )
 
-let ProtobufUnittest_Extensions_optionalGroupExtension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_OptionalGroup_extension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 16,
   fieldNames: .same(proto: "protobuf_unittest.OptionalGroup_extension"),
   defaultValue: ProtobufUnittest_OptionalGroup_extension()
 )
 
-let ProtobufUnittest_Extensions_optionalNestedMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 18,
   fieldNames: .same(proto: "protobuf_unittest.optional_nested_message_extension"),
   defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
 )
 
-let ProtobufUnittest_Extensions_optionalForeignMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_foreign_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 19,
   fieldNames: .same(proto: "protobuf_unittest.optional_foreign_message_extension"),
   defaultValue: ProtobufUnittest_ForeignMessage()
 )
 
-let ProtobufUnittest_Extensions_optionalImportMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 20,
   fieldNames: .same(proto: "protobuf_unittest.optional_import_message_extension"),
   defaultValue: ProtobufUnittestImport_ImportMessage()
 )
 
-let ProtobufUnittest_Extensions_optionalNestedEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 21,
   fieldNames: .same(proto: "protobuf_unittest.optional_nested_enum_extension"),
   defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.foo
 )
 
-let ProtobufUnittest_Extensions_optionalForeignEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 22,
   fieldNames: .same(proto: "protobuf_unittest.optional_foreign_enum_extension"),
   defaultValue: ProtobufUnittest_ForeignEnum.foreignFoo
 )
 
-let ProtobufUnittest_Extensions_optionalImportEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 23,
   fieldNames: .same(proto: "protobuf_unittest.optional_import_enum_extension"),
   defaultValue: ProtobufUnittestImport_ImportEnum.importFoo
 )
 
-let ProtobufUnittest_Extensions_optionalStringPieceExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 24,
   fieldNames: .same(proto: "protobuf_unittest.optional_string_piece_extension"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalCordExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 25,
   fieldNames: .same(proto: "protobuf_unittest.optional_cord_extension"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalPublicImportMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_public_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 26,
   fieldNames: .same(proto: "protobuf_unittest.optional_public_import_message_extension"),
   defaultValue: ProtobufUnittestImport_PublicImportMessage()
 )
 
-let ProtobufUnittest_Extensions_optionalLazyMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_optional_lazy_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 27,
   fieldNames: .same(proto: "protobuf_unittest.optional_lazy_message_extension"),
   defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
 )
 
 ///   Repeated
-let ProtobufUnittest_Extensions_repeatedInt32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 31,
   fieldNames: .same(proto: "protobuf_unittest.repeated_int32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedInt64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 32,
   fieldNames: .same(proto: "protobuf_unittest.repeated_int64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedUint32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 33,
   fieldNames: .same(proto: "protobuf_unittest.repeated_uint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedUint64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 34,
   fieldNames: .same(proto: "protobuf_unittest.repeated_uint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSint32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 35,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSint64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 36,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFixed32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 37,
   fieldNames: .same(proto: "protobuf_unittest.repeated_fixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFixed64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 38,
   fieldNames: .same(proto: "protobuf_unittest.repeated_fixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSfixed32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 39,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sfixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSfixed64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 40,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sfixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFloatExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 41,
   fieldNames: .same(proto: "protobuf_unittest.repeated_float_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedDoubleExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 42,
   fieldNames: .same(proto: "protobuf_unittest.repeated_double_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedBoolExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 43,
   fieldNames: .same(proto: "protobuf_unittest.repeated_bool_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedStringExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_string_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 44,
   fieldNames: .same(proto: "protobuf_unittest.repeated_string_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedBytesExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_bytes_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 45,
   fieldNames: .same(proto: "protobuf_unittest.repeated_bytes_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedGroupExtension = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_RepeatedGroup_extension = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 46,
   fieldNames: .same(proto: "protobuf_unittest.RepeatedGroup_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedNestedMessageExtension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_nested_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 48,
   fieldNames: .same(proto: "protobuf_unittest.repeated_nested_message_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedForeignMessageExtension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_foreign_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 49,
   fieldNames: .same(proto: "protobuf_unittest.repeated_foreign_message_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedImportMessageExtension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_import_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 50,
   fieldNames: .same(proto: "protobuf_unittest.repeated_import_message_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedNestedEnumExtension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_nested_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 51,
   fieldNames: .same(proto: "protobuf_unittest.repeated_nested_enum_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedForeignEnumExtension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_foreign_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 52,
   fieldNames: .same(proto: "protobuf_unittest.repeated_foreign_enum_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedImportEnumExtension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_import_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 53,
   fieldNames: .same(proto: "protobuf_unittest.repeated_import_enum_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedStringPieceExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_string_piece_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 54,
   fieldNames: .same(proto: "protobuf_unittest.repeated_string_piece_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedCordExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_cord_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 55,
   fieldNames: .same(proto: "protobuf_unittest.repeated_cord_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedLazyMessageExtension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_repeated_lazy_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 57,
   fieldNames: .same(proto: "protobuf_unittest.repeated_lazy_message_extension"),
   defaultValue: []
 )
 
 ///   Singular with defaults
-let ProtobufUnittest_Extensions_defaultInt32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 61,
   fieldNames: .same(proto: "protobuf_unittest.default_int32_extension"),
   defaultValue: 41
 )
 
-let ProtobufUnittest_Extensions_defaultInt64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 62,
   fieldNames: .same(proto: "protobuf_unittest.default_int64_extension"),
   defaultValue: 42
 )
 
-let ProtobufUnittest_Extensions_defaultUint32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 63,
   fieldNames: .same(proto: "protobuf_unittest.default_uint32_extension"),
   defaultValue: 43
 )
 
-let ProtobufUnittest_Extensions_defaultUint64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 64,
   fieldNames: .same(proto: "protobuf_unittest.default_uint64_extension"),
   defaultValue: 44
 )
 
-let ProtobufUnittest_Extensions_defaultSint32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 65,
   fieldNames: .same(proto: "protobuf_unittest.default_sint32_extension"),
   defaultValue: -45
 )
 
-let ProtobufUnittest_Extensions_defaultSint64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 66,
   fieldNames: .same(proto: "protobuf_unittest.default_sint64_extension"),
   defaultValue: 46
 )
 
-let ProtobufUnittest_Extensions_defaultFixed32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 67,
   fieldNames: .same(proto: "protobuf_unittest.default_fixed32_extension"),
   defaultValue: 47
 )
 
-let ProtobufUnittest_Extensions_defaultFixed64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 68,
   fieldNames: .same(proto: "protobuf_unittest.default_fixed64_extension"),
   defaultValue: 48
 )
 
-let ProtobufUnittest_Extensions_defaultSfixed32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 69,
   fieldNames: .same(proto: "protobuf_unittest.default_sfixed32_extension"),
   defaultValue: 49
 )
 
-let ProtobufUnittest_Extensions_defaultSfixed64Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 70,
   fieldNames: .same(proto: "protobuf_unittest.default_sfixed64_extension"),
   defaultValue: -50
 )
 
-let ProtobufUnittest_Extensions_defaultFloatExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 71,
   fieldNames: .same(proto: "protobuf_unittest.default_float_extension"),
   defaultValue: 51.5
 )
 
-let ProtobufUnittest_Extensions_defaultDoubleExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 72,
   fieldNames: .same(proto: "protobuf_unittest.default_double_extension"),
   defaultValue: 52000
 )
 
-let ProtobufUnittest_Extensions_defaultBoolExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 73,
   fieldNames: .same(proto: "protobuf_unittest.default_bool_extension"),
   defaultValue: true
 )
 
-let ProtobufUnittest_Extensions_defaultStringExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 74,
   fieldNames: .same(proto: "protobuf_unittest.default_string_extension"),
   defaultValue: "hello"
 )
 
-let ProtobufUnittest_Extensions_defaultBytesExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 75,
   fieldNames: .same(proto: "protobuf_unittest.default_bytes_extension"),
   defaultValue: Data(bytes: [119, 111, 114, 108, 100])
 )
 
-let ProtobufUnittest_Extensions_defaultNestedEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 81,
   fieldNames: .same(proto: "protobuf_unittest.default_nested_enum_extension"),
   defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.bar
 )
 
-let ProtobufUnittest_Extensions_defaultForeignEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 82,
   fieldNames: .same(proto: "protobuf_unittest.default_foreign_enum_extension"),
   defaultValue: ProtobufUnittest_ForeignEnum.foreignBar
 )
 
-let ProtobufUnittest_Extensions_defaultImportEnumExtension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 83,
   fieldNames: .same(proto: "protobuf_unittest.default_import_enum_extension"),
   defaultValue: ProtobufUnittestImport_ImportEnum.importBar
 )
 
-let ProtobufUnittest_Extensions_defaultStringPieceExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 84,
   fieldNames: .same(proto: "protobuf_unittest.default_string_piece_extension"),
   defaultValue: "abc"
 )
 
-let ProtobufUnittest_Extensions_defaultCordExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_default_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 85,
   fieldNames: .same(proto: "protobuf_unittest.default_cord_extension"),
   defaultValue: "123"
 )
 
 ///   For oneof test
-let ProtobufUnittest_Extensions_oneofUint32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_oneof_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 111,
   fieldNames: .same(proto: "protobuf_unittest.oneof_uint32_extension"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_oneofNestedMessageExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_oneof_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 112,
   fieldNames: .same(proto: "protobuf_unittest.oneof_nested_message_extension"),
   defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
 )
 
-let ProtobufUnittest_Extensions_oneofStringExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_oneof_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 113,
   fieldNames: .same(proto: "protobuf_unittest.oneof_string_extension"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_oneofBytesExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+let ProtobufUnittest_Extensions_oneof_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   fieldNumber: 114,
   fieldNames: .same(proto: "protobuf_unittest.oneof_bytes_extension"),
   defaultValue: Data()
 )
 
-let ProtobufUnittest_Extensions_myExtensionString = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestFieldOrderings>(
+let ProtobufUnittest_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestFieldOrderings>(
   fieldNumber: 50,
   fieldNames: .same(proto: "protobuf_unittest.my_extension_string"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_myExtensionInt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestFieldOrderings>(
+let ProtobufUnittest_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestFieldOrderings>(
   fieldNumber: 5,
   fieldNames: .same(proto: "protobuf_unittest.my_extension_int"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_packedInt32Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_int32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 90,
   fieldNames: .same(proto: "protobuf_unittest.packed_int32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedInt64Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_int64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 91,
   fieldNames: .same(proto: "protobuf_unittest.packed_int64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedUint32Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_uint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 92,
   fieldNames: .same(proto: "protobuf_unittest.packed_uint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedUint64Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_uint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 93,
   fieldNames: .same(proto: "protobuf_unittest.packed_uint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSint32Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_sint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 94,
   fieldNames: .same(proto: "protobuf_unittest.packed_sint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSint64Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_sint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 95,
   fieldNames: .same(proto: "protobuf_unittest.packed_sint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFixed32Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_fixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 96,
   fieldNames: .same(proto: "protobuf_unittest.packed_fixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFixed64Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_fixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 97,
   fieldNames: .same(proto: "protobuf_unittest.packed_fixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSfixed32Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_sfixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 98,
   fieldNames: .same(proto: "protobuf_unittest.packed_sfixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSfixed64Extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_sfixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 99,
   fieldNames: .same(proto: "protobuf_unittest.packed_sfixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFloatExtension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_float_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 100,
   fieldNames: .same(proto: "protobuf_unittest.packed_float_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedDoubleExtension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_double_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 101,
   fieldNames: .same(proto: "protobuf_unittest.packed_double_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedBoolExtension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_bool_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 102,
   fieldNames: .same(proto: "protobuf_unittest.packed_bool_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedEnumExtension = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestPackedExtensions>(
+let ProtobufUnittest_Extensions_packed_enum_extension = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestPackedExtensions>(
   fieldNumber: 103,
   fieldNames: .same(proto: "protobuf_unittest.packed_enum_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedInt32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 90,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_int32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedInt64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 91,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_int64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedUint32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 92,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_uint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedUint64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 93,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_uint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedSint32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 94,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_sint32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedSint64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 95,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_sint64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedFixed32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 96,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_fixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedFixed64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 97,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_fixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedSfixed32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 98,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_sfixed32_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedSfixed64Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 99,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_sfixed64_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedFloatExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 100,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_float_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedDoubleExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 101,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_double_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedBoolExtension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 102,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_bool_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_unpackedEnumExtension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestUnpackedExtensions>(
+let ProtobufUnittest_Extensions_unpacked_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestUnpackedExtensions>(
   fieldNumber: 103,
   fieldNames: .same(proto: "protobuf_unittest.unpacked_enum_extension"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_testAllTypes = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestHugeFieldNumbers>(
+let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestHugeFieldNumbers>(
   fieldNumber: 536860000,
   fieldNames: .same(proto: "protobuf_unittest.test_all_types"),
   defaultValue: ProtobufUnittest_TestAllTypes()
@@ -10344,14 +10344,14 @@ extension ProtobufUnittest_TestAllExtensions {
   ///   Used to test if generated extension name is correct when there are
   ///   underscores.
   var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nestedStringExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nestedStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nestedStringExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
   }
   mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nestedStringExtension)
+    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
   }
 }
 
@@ -10383,1523 +10383,1523 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestParsingMerge {
   var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optionalExt) ?? ProtobufUnittest_TestAllTypes()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optionalExt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypes()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext, value: newValue)}
   }
   var hasProtobufUnittest_TestParsingMerge_optionalExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optionalExt)
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
   }
   mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optionalExt)
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
   }
 }
 
 extension ProtobufUnittest_TestParsingMerge {
   var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt)}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext, value: newValue)}
   }
   var hasProtobufUnittest_TestParsingMerge_repeatedExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt)
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
   }
   mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt)
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Singular
   var ProtobufUnittest_optionalInt32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension)
   }
   mutating func clearProtobufUnittest_optionalInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalInt64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension)
   }
   mutating func clearProtobufUnittest_optionalInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalUint32Extension: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension)
   }
   mutating func clearProtobufUnittest_optionalUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalUint64Extension: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension)
   }
   mutating func clearProtobufUnittest_optionalUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSint32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension)
   }
   mutating func clearProtobufUnittest_optionalSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSint64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension)
   }
   mutating func clearProtobufUnittest_optionalSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFixed32Extension: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension)
   }
   mutating func clearProtobufUnittest_optionalFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFixed64Extension: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension)
   }
   mutating func clearProtobufUnittest_optionalFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSfixed32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension)
   }
   mutating func clearProtobufUnittest_optionalSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSfixed64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension)
   }
   mutating func clearProtobufUnittest_optionalSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFloatExtension: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension)
   }
   mutating func clearProtobufUnittest_optionalFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalDoubleExtension: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension)
   }
   mutating func clearProtobufUnittest_optionalDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalBoolExtension: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtension) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension)
   }
   mutating func clearProtobufUnittest_optionalBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension)
   }
   mutating func clearProtobufUnittest_optionalStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalBytesExtension: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtension) ?? Data()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension) ?? Data()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalBytesExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension)
   }
   mutating func clearProtobufUnittest_optionalBytesExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalGroupExtension: ProtobufUnittest_OptionalGroup_extension {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtension) ?? ProtobufUnittest_OptionalGroup_extension()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension) ?? ProtobufUnittest_OptionalGroup_extension()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalGroupExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension)
   }
   mutating func clearProtobufUnittest_optionalGroupExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalNestedMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension)
   }
   mutating func clearProtobufUnittest_optionalNestedMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalForeignMessageExtension: ProtobufUnittest_ForeignMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtension) ?? ProtobufUnittest_ForeignMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension) ?? ProtobufUnittest_ForeignMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalForeignMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension)
   }
   mutating func clearProtobufUnittest_optionalForeignMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalImportMessageExtension: ProtobufUnittestImport_ImportMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtension) ?? ProtobufUnittestImport_ImportMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension) ?? ProtobufUnittestImport_ImportMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalImportMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension)
   }
   mutating func clearProtobufUnittest_optionalImportMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.foo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.foo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalNestedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension)
   }
   mutating func clearProtobufUnittest_optionalNestedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalForeignEnumExtension: ProtobufUnittest_ForeignEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtension) ?? ProtobufUnittest_ForeignEnum.foreignFoo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension) ?? ProtobufUnittest_ForeignEnum.foreignFoo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalForeignEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension)
   }
   mutating func clearProtobufUnittest_optionalForeignEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalImportEnumExtension: ProtobufUnittestImport_ImportEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtension) ?? ProtobufUnittestImport_ImportEnum.importFoo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension) ?? ProtobufUnittestImport_ImportEnum.importFoo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalImportEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension)
   }
   mutating func clearProtobufUnittest_optionalImportEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringPieceExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringPieceExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension)
   }
   mutating func clearProtobufUnittest_optionalStringPieceExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalCordExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalCordExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension)
   }
   mutating func clearProtobufUnittest_optionalCordExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalPublicImportMessageExtension: ProtobufUnittestImport_PublicImportMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtension) ?? ProtobufUnittestImport_PublicImportMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension) ?? ProtobufUnittestImport_PublicImportMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalPublicImportMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension)
   }
   mutating func clearProtobufUnittest_optionalPublicImportMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalLazyMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalLazyMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension)
   }
   mutating func clearProtobufUnittest_optionalLazyMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Repeated
   var ProtobufUnittest_repeatedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension)
   }
   mutating func clearProtobufUnittest_repeatedInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedInt64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension)
   }
   mutating func clearProtobufUnittest_repeatedInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedUint32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension)
   }
   mutating func clearProtobufUnittest_repeatedUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedUint64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension)
   }
   mutating func clearProtobufUnittest_repeatedUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSint32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension)
   }
   mutating func clearProtobufUnittest_repeatedSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSint64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension)
   }
   mutating func clearProtobufUnittest_repeatedSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFixed32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension)
   }
   mutating func clearProtobufUnittest_repeatedFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFixed64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension)
   }
   mutating func clearProtobufUnittest_repeatedFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSfixed32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension)
   }
   mutating func clearProtobufUnittest_repeatedSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSfixed64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension)
   }
   mutating func clearProtobufUnittest_repeatedSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFloatExtension: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension)
   }
   mutating func clearProtobufUnittest_repeatedFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedDoubleExtension: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension)
   }
   mutating func clearProtobufUnittest_repeatedDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedBoolExtension: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension)
   }
   mutating func clearProtobufUnittest_repeatedBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedStringExtension: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension)
   }
   mutating func clearProtobufUnittest_repeatedStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedBytesExtension: [Data] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedBytesExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension)
   }
   mutating func clearProtobufUnittest_repeatedBytesExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedGroupExtension: [ProtobufUnittest_RepeatedGroup_extension] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedGroupExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension)
   }
   mutating func clearProtobufUnittest_repeatedGroupExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedNestedMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedNestedMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension)
   }
   mutating func clearProtobufUnittest_repeatedNestedMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedForeignMessageExtension: [ProtobufUnittest_ForeignMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedForeignMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension)
   }
   mutating func clearProtobufUnittest_repeatedForeignMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedImportMessageExtension: [ProtobufUnittestImport_ImportMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedImportMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension)
   }
   mutating func clearProtobufUnittest_repeatedImportMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedNestedEnumExtension: [ProtobufUnittest_TestAllTypes.NestedEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedNestedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension)
   }
   mutating func clearProtobufUnittest_repeatedNestedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedForeignEnumExtension: [ProtobufUnittest_ForeignEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedForeignEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension)
   }
   mutating func clearProtobufUnittest_repeatedForeignEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedImportEnumExtension: [ProtobufUnittestImport_ImportEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedImportEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension)
   }
   mutating func clearProtobufUnittest_repeatedImportEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedStringPieceExtension: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedStringPieceExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension)
   }
   mutating func clearProtobufUnittest_repeatedStringPieceExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedCordExtension: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedCordExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension)
   }
   mutating func clearProtobufUnittest_repeatedCordExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedLazyMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_repeatedLazyMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension)
   }
   mutating func clearProtobufUnittest_repeatedLazyMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   Singular with defaults
   var ProtobufUnittest_defaultInt32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32Extension) ?? 41}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension) ?? 41}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension)
   }
   mutating func clearProtobufUnittest_defaultInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultInt64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64Extension) ?? 42}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension) ?? 42}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension)
   }
   mutating func clearProtobufUnittest_defaultInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultUint32Extension: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32Extension) ?? 43}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension) ?? 43}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension)
   }
   mutating func clearProtobufUnittest_defaultUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultUint64Extension: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64Extension) ?? 44}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension) ?? 44}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension)
   }
   mutating func clearProtobufUnittest_defaultUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSint32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32Extension) ?? -45}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension) ?? -45}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension)
   }
   mutating func clearProtobufUnittest_defaultSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSint64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64Extension) ?? 46}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension) ?? 46}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension)
   }
   mutating func clearProtobufUnittest_defaultSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFixed32Extension: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32Extension) ?? 47}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension) ?? 47}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension)
   }
   mutating func clearProtobufUnittest_defaultFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFixed64Extension: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64Extension) ?? 48}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension) ?? 48}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension)
   }
   mutating func clearProtobufUnittest_defaultFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSfixed32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32Extension) ?? 49}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension) ?? 49}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension)
   }
   mutating func clearProtobufUnittest_defaultSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSfixed64Extension: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64Extension) ?? -50}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension) ?? -50}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension)
   }
   mutating func clearProtobufUnittest_defaultSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFloatExtension: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtension) ?? 51.5}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension) ?? 51.5}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension)
   }
   mutating func clearProtobufUnittest_defaultFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultDoubleExtension: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtension) ?? 52000}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension) ?? 52000}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension)
   }
   mutating func clearProtobufUnittest_defaultDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultBoolExtension: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtension) ?? true}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension) ?? true}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension)
   }
   mutating func clearProtobufUnittest_defaultBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtension) ?? "hello"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension) ?? "hello"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension)
   }
   mutating func clearProtobufUnittest_defaultStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultBytesExtension: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtension) ?? Data(bytes: [119, 111, 114, 108, 100])}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension) ?? Data(bytes: [119, 111, 114, 108, 100])}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultBytesExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension)
   }
   mutating func clearProtobufUnittest_defaultBytesExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.bar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension) ?? ProtobufUnittest_TestAllTypes.NestedEnum.bar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultNestedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension)
   }
   mutating func clearProtobufUnittest_defaultNestedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultForeignEnumExtension: ProtobufUnittest_ForeignEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtension) ?? ProtobufUnittest_ForeignEnum.foreignBar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension) ?? ProtobufUnittest_ForeignEnum.foreignBar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultForeignEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension)
   }
   mutating func clearProtobufUnittest_defaultForeignEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultImportEnumExtension: ProtobufUnittestImport_ImportEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtension) ?? ProtobufUnittestImport_ImportEnum.importBar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension) ?? ProtobufUnittestImport_ImportEnum.importBar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultImportEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension)
   }
   mutating func clearProtobufUnittest_defaultImportEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultStringPieceExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtension) ?? "abc"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension) ?? "abc"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultStringPieceExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension)
   }
   mutating func clearProtobufUnittest_defaultStringPieceExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultCordExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtension) ?? "123"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension) ?? "123"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension, value: newValue)}
   }
   var hasProtobufUnittest_defaultCordExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension)
   }
   mutating func clearProtobufUnittest_defaultCordExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   ///   For oneof test
   var ProtobufUnittest_oneofUint32Extension: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension)
   }
   mutating func clearProtobufUnittest_oneofUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofNestedMessageExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension)
   }
   mutating func clearProtobufUnittest_oneofNestedMessageExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension)
   }
   mutating func clearProtobufUnittest_oneofStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofBytesExtension: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtension) ?? Data()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension) ?? Data()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofBytesExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension)
   }
   mutating func clearProtobufUnittest_oneofBytesExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension)
   }
 }
 
 extension ProtobufUnittest_TestFieldOrderings {
   var ProtobufUnittest_myExtensionString: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionString) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionString, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string, value: newValue)}
   }
   var hasProtobufUnittest_myExtensionString: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionString)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
   }
   mutating func clearProtobufUnittest_myExtensionString() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionString)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
   }
 }
 
 extension ProtobufUnittest_TestFieldOrderings {
   var ProtobufUnittest_myExtensionInt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionInt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionInt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int, value: newValue)}
   }
   var hasProtobufUnittest_myExtensionInt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionInt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
   }
   mutating func clearProtobufUnittest_myExtensionInt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_myExtensionInt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
   }
   mutating func clearProtobufUnittest_packedInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedInt64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
   }
   mutating func clearProtobufUnittest_packedInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedUint32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
   }
   mutating func clearProtobufUnittest_packedUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedUint64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
   }
   mutating func clearProtobufUnittest_packedUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedSint32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
   }
   mutating func clearProtobufUnittest_packedSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedSint64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
   }
   mutating func clearProtobufUnittest_packedSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedFixed32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
   }
   mutating func clearProtobufUnittest_packedFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedFixed64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
   }
   mutating func clearProtobufUnittest_packedFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedSfixed32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
   }
   mutating func clearProtobufUnittest_packedSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedSfixed64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
   }
   mutating func clearProtobufUnittest_packedSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedFloatExtension: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
   }
   mutating func clearProtobufUnittest_packedFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedDoubleExtension: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
   }
   mutating func clearProtobufUnittest_packedDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedBoolExtension: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
   }
   mutating func clearProtobufUnittest_packedBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensions {
   var ProtobufUnittest_packedEnumExtension: [ProtobufUnittest_ForeignEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_packedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
   }
   mutating func clearProtobufUnittest_packedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
   }
   mutating func clearProtobufUnittest_unpackedInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedInt64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
   }
   mutating func clearProtobufUnittest_unpackedInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedInt64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedUint32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
   }
   mutating func clearProtobufUnittest_unpackedUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedUint64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
   }
   mutating func clearProtobufUnittest_unpackedUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedUint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedSint32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
   }
   mutating func clearProtobufUnittest_unpackedSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedSint64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
   }
   mutating func clearProtobufUnittest_unpackedSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSint64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedFixed32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
   }
   mutating func clearProtobufUnittest_unpackedFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedFixed64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
   }
   mutating func clearProtobufUnittest_unpackedFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedSfixed32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed32Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed32Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
   }
   mutating func clearProtobufUnittest_unpackedSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed32Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedSfixed64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed64Extension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed64Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed64Extension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
   }
   mutating func clearProtobufUnittest_unpackedSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedSfixed64Extension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedFloatExtension: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFloatExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFloatExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFloatExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
   }
   mutating func clearProtobufUnittest_unpackedFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedFloatExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedDoubleExtension: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedDoubleExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedDoubleExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedDoubleExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
   }
   mutating func clearProtobufUnittest_unpackedDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedDoubleExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedBoolExtension: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedBoolExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedBoolExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedBoolExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
   }
   mutating func clearProtobufUnittest_unpackedBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedBoolExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
   }
 }
 
 extension ProtobufUnittest_TestUnpackedExtensions {
   var ProtobufUnittest_unpackedEnumExtension: [ProtobufUnittest_ForeignEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpackedEnumExtension)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpackedEnumExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension, value: newValue)}
   }
   var hasProtobufUnittest_unpackedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpackedEnumExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
   }
   mutating func clearProtobufUnittest_unpackedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpackedEnumExtension)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
   }
 }
 
 extension ProtobufUnittest_TestHugeFieldNumbers {
   var ProtobufUnittest_testAllTypes: ProtobufUnittest_TestAllTypes {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypes) ?? ProtobufUnittest_TestAllTypes()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypes, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types) ?? ProtobufUnittest_TestAllTypes()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types, value: newValue)}
   }
   var hasProtobufUnittest_testAllTypes: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypes)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
   }
   mutating func clearProtobufUnittest_testAllTypes() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypes)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
   }
 }
 
 let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_Extensions_optionalInt32Extension,
-  ProtobufUnittest_Extensions_optionalInt64Extension,
-  ProtobufUnittest_Extensions_optionalUint32Extension,
-  ProtobufUnittest_Extensions_optionalUint64Extension,
-  ProtobufUnittest_Extensions_optionalSint32Extension,
-  ProtobufUnittest_Extensions_optionalSint64Extension,
-  ProtobufUnittest_Extensions_optionalFixed32Extension,
-  ProtobufUnittest_Extensions_optionalFixed64Extension,
-  ProtobufUnittest_Extensions_optionalSfixed32Extension,
-  ProtobufUnittest_Extensions_optionalSfixed64Extension,
-  ProtobufUnittest_Extensions_optionalFloatExtension,
-  ProtobufUnittest_Extensions_optionalDoubleExtension,
-  ProtobufUnittest_Extensions_optionalBoolExtension,
-  ProtobufUnittest_Extensions_optionalStringExtension,
-  ProtobufUnittest_Extensions_optionalBytesExtension,
-  ProtobufUnittest_Extensions_optionalGroupExtension,
-  ProtobufUnittest_Extensions_optionalNestedMessageExtension,
-  ProtobufUnittest_Extensions_optionalForeignMessageExtension,
-  ProtobufUnittest_Extensions_optionalImportMessageExtension,
-  ProtobufUnittest_Extensions_optionalNestedEnumExtension,
-  ProtobufUnittest_Extensions_optionalForeignEnumExtension,
-  ProtobufUnittest_Extensions_optionalImportEnumExtension,
-  ProtobufUnittest_Extensions_optionalStringPieceExtension,
-  ProtobufUnittest_Extensions_optionalCordExtension,
-  ProtobufUnittest_Extensions_optionalPublicImportMessageExtension,
-  ProtobufUnittest_Extensions_optionalLazyMessageExtension,
-  ProtobufUnittest_Extensions_repeatedInt32Extension,
-  ProtobufUnittest_Extensions_repeatedInt64Extension,
-  ProtobufUnittest_Extensions_repeatedUint32Extension,
-  ProtobufUnittest_Extensions_repeatedUint64Extension,
-  ProtobufUnittest_Extensions_repeatedSint32Extension,
-  ProtobufUnittest_Extensions_repeatedSint64Extension,
-  ProtobufUnittest_Extensions_repeatedFixed32Extension,
-  ProtobufUnittest_Extensions_repeatedFixed64Extension,
-  ProtobufUnittest_Extensions_repeatedSfixed32Extension,
-  ProtobufUnittest_Extensions_repeatedSfixed64Extension,
-  ProtobufUnittest_Extensions_repeatedFloatExtension,
-  ProtobufUnittest_Extensions_repeatedDoubleExtension,
-  ProtobufUnittest_Extensions_repeatedBoolExtension,
-  ProtobufUnittest_Extensions_repeatedStringExtension,
-  ProtobufUnittest_Extensions_repeatedBytesExtension,
-  ProtobufUnittest_Extensions_repeatedGroupExtension,
-  ProtobufUnittest_Extensions_repeatedNestedMessageExtension,
-  ProtobufUnittest_Extensions_repeatedForeignMessageExtension,
-  ProtobufUnittest_Extensions_repeatedImportMessageExtension,
-  ProtobufUnittest_Extensions_repeatedNestedEnumExtension,
-  ProtobufUnittest_Extensions_repeatedForeignEnumExtension,
-  ProtobufUnittest_Extensions_repeatedImportEnumExtension,
-  ProtobufUnittest_Extensions_repeatedStringPieceExtension,
-  ProtobufUnittest_Extensions_repeatedCordExtension,
-  ProtobufUnittest_Extensions_repeatedLazyMessageExtension,
-  ProtobufUnittest_Extensions_defaultInt32Extension,
-  ProtobufUnittest_Extensions_defaultInt64Extension,
-  ProtobufUnittest_Extensions_defaultUint32Extension,
-  ProtobufUnittest_Extensions_defaultUint64Extension,
-  ProtobufUnittest_Extensions_defaultSint32Extension,
-  ProtobufUnittest_Extensions_defaultSint64Extension,
-  ProtobufUnittest_Extensions_defaultFixed32Extension,
-  ProtobufUnittest_Extensions_defaultFixed64Extension,
-  ProtobufUnittest_Extensions_defaultSfixed32Extension,
-  ProtobufUnittest_Extensions_defaultSfixed64Extension,
-  ProtobufUnittest_Extensions_defaultFloatExtension,
-  ProtobufUnittest_Extensions_defaultDoubleExtension,
-  ProtobufUnittest_Extensions_defaultBoolExtension,
-  ProtobufUnittest_Extensions_defaultStringExtension,
-  ProtobufUnittest_Extensions_defaultBytesExtension,
-  ProtobufUnittest_Extensions_defaultNestedEnumExtension,
-  ProtobufUnittest_Extensions_defaultForeignEnumExtension,
-  ProtobufUnittest_Extensions_defaultImportEnumExtension,
-  ProtobufUnittest_Extensions_defaultStringPieceExtension,
-  ProtobufUnittest_Extensions_defaultCordExtension,
-  ProtobufUnittest_Extensions_oneofUint32Extension,
-  ProtobufUnittest_Extensions_oneofNestedMessageExtension,
-  ProtobufUnittest_Extensions_oneofStringExtension,
-  ProtobufUnittest_Extensions_oneofBytesExtension,
-  ProtobufUnittest_Extensions_myExtensionString,
-  ProtobufUnittest_Extensions_myExtensionInt,
-  ProtobufUnittest_Extensions_packedInt32Extension,
-  ProtobufUnittest_Extensions_packedInt64Extension,
-  ProtobufUnittest_Extensions_packedUint32Extension,
-  ProtobufUnittest_Extensions_packedUint64Extension,
-  ProtobufUnittest_Extensions_packedSint32Extension,
-  ProtobufUnittest_Extensions_packedSint64Extension,
-  ProtobufUnittest_Extensions_packedFixed32Extension,
-  ProtobufUnittest_Extensions_packedFixed64Extension,
-  ProtobufUnittest_Extensions_packedSfixed32Extension,
-  ProtobufUnittest_Extensions_packedSfixed64Extension,
-  ProtobufUnittest_Extensions_packedFloatExtension,
-  ProtobufUnittest_Extensions_packedDoubleExtension,
-  ProtobufUnittest_Extensions_packedBoolExtension,
-  ProtobufUnittest_Extensions_packedEnumExtension,
-  ProtobufUnittest_Extensions_unpackedInt32Extension,
-  ProtobufUnittest_Extensions_unpackedInt64Extension,
-  ProtobufUnittest_Extensions_unpackedUint32Extension,
-  ProtobufUnittest_Extensions_unpackedUint64Extension,
-  ProtobufUnittest_Extensions_unpackedSint32Extension,
-  ProtobufUnittest_Extensions_unpackedSint64Extension,
-  ProtobufUnittest_Extensions_unpackedFixed32Extension,
-  ProtobufUnittest_Extensions_unpackedFixed64Extension,
-  ProtobufUnittest_Extensions_unpackedSfixed32Extension,
-  ProtobufUnittest_Extensions_unpackedSfixed64Extension,
-  ProtobufUnittest_Extensions_unpackedFloatExtension,
-  ProtobufUnittest_Extensions_unpackedDoubleExtension,
-  ProtobufUnittest_Extensions_unpackedBoolExtension,
-  ProtobufUnittest_Extensions_unpackedEnumExtension,
-  ProtobufUnittest_Extensions_testAllTypes,
+  ProtobufUnittest_Extensions_optional_int32_extension,
+  ProtobufUnittest_Extensions_optional_int64_extension,
+  ProtobufUnittest_Extensions_optional_uint32_extension,
+  ProtobufUnittest_Extensions_optional_uint64_extension,
+  ProtobufUnittest_Extensions_optional_sint32_extension,
+  ProtobufUnittest_Extensions_optional_sint64_extension,
+  ProtobufUnittest_Extensions_optional_fixed32_extension,
+  ProtobufUnittest_Extensions_optional_fixed64_extension,
+  ProtobufUnittest_Extensions_optional_sfixed32_extension,
+  ProtobufUnittest_Extensions_optional_sfixed64_extension,
+  ProtobufUnittest_Extensions_optional_float_extension,
+  ProtobufUnittest_Extensions_optional_double_extension,
+  ProtobufUnittest_Extensions_optional_bool_extension,
+  ProtobufUnittest_Extensions_optional_string_extension,
+  ProtobufUnittest_Extensions_optional_bytes_extension,
+  ProtobufUnittest_Extensions_OptionalGroup_extension,
+  ProtobufUnittest_Extensions_optional_nested_message_extension,
+  ProtobufUnittest_Extensions_optional_foreign_message_extension,
+  ProtobufUnittest_Extensions_optional_import_message_extension,
+  ProtobufUnittest_Extensions_optional_nested_enum_extension,
+  ProtobufUnittest_Extensions_optional_foreign_enum_extension,
+  ProtobufUnittest_Extensions_optional_import_enum_extension,
+  ProtobufUnittest_Extensions_optional_string_piece_extension,
+  ProtobufUnittest_Extensions_optional_cord_extension,
+  ProtobufUnittest_Extensions_optional_public_import_message_extension,
+  ProtobufUnittest_Extensions_optional_lazy_message_extension,
+  ProtobufUnittest_Extensions_repeated_int32_extension,
+  ProtobufUnittest_Extensions_repeated_int64_extension,
+  ProtobufUnittest_Extensions_repeated_uint32_extension,
+  ProtobufUnittest_Extensions_repeated_uint64_extension,
+  ProtobufUnittest_Extensions_repeated_sint32_extension,
+  ProtobufUnittest_Extensions_repeated_sint64_extension,
+  ProtobufUnittest_Extensions_repeated_fixed32_extension,
+  ProtobufUnittest_Extensions_repeated_fixed64_extension,
+  ProtobufUnittest_Extensions_repeated_sfixed32_extension,
+  ProtobufUnittest_Extensions_repeated_sfixed64_extension,
+  ProtobufUnittest_Extensions_repeated_float_extension,
+  ProtobufUnittest_Extensions_repeated_double_extension,
+  ProtobufUnittest_Extensions_repeated_bool_extension,
+  ProtobufUnittest_Extensions_repeated_string_extension,
+  ProtobufUnittest_Extensions_repeated_bytes_extension,
+  ProtobufUnittest_Extensions_RepeatedGroup_extension,
+  ProtobufUnittest_Extensions_repeated_nested_message_extension,
+  ProtobufUnittest_Extensions_repeated_foreign_message_extension,
+  ProtobufUnittest_Extensions_repeated_import_message_extension,
+  ProtobufUnittest_Extensions_repeated_nested_enum_extension,
+  ProtobufUnittest_Extensions_repeated_foreign_enum_extension,
+  ProtobufUnittest_Extensions_repeated_import_enum_extension,
+  ProtobufUnittest_Extensions_repeated_string_piece_extension,
+  ProtobufUnittest_Extensions_repeated_cord_extension,
+  ProtobufUnittest_Extensions_repeated_lazy_message_extension,
+  ProtobufUnittest_Extensions_default_int32_extension,
+  ProtobufUnittest_Extensions_default_int64_extension,
+  ProtobufUnittest_Extensions_default_uint32_extension,
+  ProtobufUnittest_Extensions_default_uint64_extension,
+  ProtobufUnittest_Extensions_default_sint32_extension,
+  ProtobufUnittest_Extensions_default_sint64_extension,
+  ProtobufUnittest_Extensions_default_fixed32_extension,
+  ProtobufUnittest_Extensions_default_fixed64_extension,
+  ProtobufUnittest_Extensions_default_sfixed32_extension,
+  ProtobufUnittest_Extensions_default_sfixed64_extension,
+  ProtobufUnittest_Extensions_default_float_extension,
+  ProtobufUnittest_Extensions_default_double_extension,
+  ProtobufUnittest_Extensions_default_bool_extension,
+  ProtobufUnittest_Extensions_default_string_extension,
+  ProtobufUnittest_Extensions_default_bytes_extension,
+  ProtobufUnittest_Extensions_default_nested_enum_extension,
+  ProtobufUnittest_Extensions_default_foreign_enum_extension,
+  ProtobufUnittest_Extensions_default_import_enum_extension,
+  ProtobufUnittest_Extensions_default_string_piece_extension,
+  ProtobufUnittest_Extensions_default_cord_extension,
+  ProtobufUnittest_Extensions_oneof_uint32_extension,
+  ProtobufUnittest_Extensions_oneof_nested_message_extension,
+  ProtobufUnittest_Extensions_oneof_string_extension,
+  ProtobufUnittest_Extensions_oneof_bytes_extension,
+  ProtobufUnittest_Extensions_my_extension_string,
+  ProtobufUnittest_Extensions_my_extension_int,
+  ProtobufUnittest_Extensions_packed_int32_extension,
+  ProtobufUnittest_Extensions_packed_int64_extension,
+  ProtobufUnittest_Extensions_packed_uint32_extension,
+  ProtobufUnittest_Extensions_packed_uint64_extension,
+  ProtobufUnittest_Extensions_packed_sint32_extension,
+  ProtobufUnittest_Extensions_packed_sint64_extension,
+  ProtobufUnittest_Extensions_packed_fixed32_extension,
+  ProtobufUnittest_Extensions_packed_fixed64_extension,
+  ProtobufUnittest_Extensions_packed_sfixed32_extension,
+  ProtobufUnittest_Extensions_packed_sfixed64_extension,
+  ProtobufUnittest_Extensions_packed_float_extension,
+  ProtobufUnittest_Extensions_packed_double_extension,
+  ProtobufUnittest_Extensions_packed_bool_extension,
+  ProtobufUnittest_Extensions_packed_enum_extension,
+  ProtobufUnittest_Extensions_unpacked_int32_extension,
+  ProtobufUnittest_Extensions_unpacked_int64_extension,
+  ProtobufUnittest_Extensions_unpacked_uint32_extension,
+  ProtobufUnittest_Extensions_unpacked_uint64_extension,
+  ProtobufUnittest_Extensions_unpacked_sint32_extension,
+  ProtobufUnittest_Extensions_unpacked_sint64_extension,
+  ProtobufUnittest_Extensions_unpacked_fixed32_extension,
+  ProtobufUnittest_Extensions_unpacked_fixed64_extension,
+  ProtobufUnittest_Extensions_unpacked_sfixed32_extension,
+  ProtobufUnittest_Extensions_unpacked_sfixed64_extension,
+  ProtobufUnittest_Extensions_unpacked_float_extension,
+  ProtobufUnittest_Extensions_unpacked_double_extension,
+  ProtobufUnittest_Extensions_unpacked_bool_extension,
+  ProtobufUnittest_Extensions_unpacked_enum_extension,
+  ProtobufUnittest_Extensions_test_all_types,
   ProtobufUnittest_TestNestedExtension.Extensions.test,
-  ProtobufUnittest_TestNestedExtension.Extensions.nestedStringExtension,
+  ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension,
   ProtobufUnittest_TestRequired.Extensions.single,
   ProtobufUnittest_TestRequired.Extensions.multi,
-  ProtobufUnittest_TestParsingMerge.Extensions.optionalExt,
-  ProtobufUnittest_TestParsingMerge.Extensions.repeatedExt
+  ProtobufUnittest_TestParsingMerge.Extensions.optional_ext,
+  ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext
 ]

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -885,7 +885,7 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.Message, SwiftProtobuf
 
     struct Extensions {
 
-      static let complexOpt4 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2.ComplexOptionType4>, Google_Protobuf_MessageOptions>(
+      static let complex_opt4 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2.ComplexOptionType4>, Google_Protobuf_MessageOptions>(
         fieldNumber: 7633546,
         fieldNames: .same(proto: "protobuf_unittest.ComplexOptionType2.ComplexOptionType4.complex_opt4"),
         defaultValue: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()
@@ -1321,7 +1321,7 @@ struct ProtobufUnittest_AggregateMessageSetElement: SwiftProtobuf.Message, Swift
 
   struct Extensions {
 
-    static let messageSetExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_AggregateMessageSetElement>, ProtobufUnittest_AggregateMessageSet>(
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_AggregateMessageSetElement>, ProtobufUnittest_AggregateMessageSet>(
       fieldNumber: 15447542,
       fieldNames: .same(proto: "protobuf_unittest.AggregateMessageSetElement.message_set_extension"),
       defaultValue: ProtobufUnittest_AggregateMessageSetElement()
@@ -1708,7 +1708,7 @@ struct ProtobufUnittest_NestedOptionType: SwiftProtobuf.Message, SwiftProtobuf.P
 
   struct Extensions {
 
-    static let nestedExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FileOptions>(
+    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FileOptions>(
       fieldNumber: 7912573,
       fieldNames: .same(proto: "protobuf_unittest.NestedOptionType.nested_extension"),
       defaultValue: 0
@@ -1970,19 +1970,19 @@ struct ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf.Message
   }
 }
 
-let ProtobufUnittest_Extensions_fileOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_FileOptions>(
+let ProtobufUnittest_Extensions_file_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_FileOptions>(
   fieldNumber: 7736974,
   fieldNames: .same(proto: "protobuf_unittest.file_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_messageOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_message_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7739036,
   fieldNames: .same(proto: "protobuf_unittest.message_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_fieldOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_FieldOptions>(
+let ProtobufUnittest_Extensions_field_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_FieldOptions>(
   fieldNumber: 7740936,
   fieldNames: .same(proto: "protobuf_unittest.field_opt1"),
   defaultValue: 0
@@ -1990,139 +1990,139 @@ let ProtobufUnittest_Extensions_fieldOpt1 = SwiftProtobuf.MessageExtension<Optio
 
 ///   This is useful for testing that we correctly register default values for
 ///   extension options.
-let ProtobufUnittest_Extensions_fieldOpt2 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FieldOptions>(
+let ProtobufUnittest_Extensions_field_opt2 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FieldOptions>(
   fieldNumber: 7753913,
   fieldNames: .same(proto: "protobuf_unittest.field_opt2"),
   defaultValue: 42
 )
 
-let ProtobufUnittest_Extensions_oneofOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_OneofOptions>(
+let ProtobufUnittest_Extensions_oneof_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_OneofOptions>(
   fieldNumber: 7740111,
   fieldNames: .same(proto: "protobuf_unittest.oneof_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_enumOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_EnumOptions>(
+let ProtobufUnittest_Extensions_enum_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_EnumOptions>(
   fieldNumber: 7753576,
   fieldNames: .same(proto: "protobuf_unittest.enum_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_enumValueOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_EnumValueOptions>(
+let ProtobufUnittest_Extensions_enum_value_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_EnumValueOptions>(
   fieldNumber: 1560678,
   fieldNames: .same(proto: "protobuf_unittest.enum_value_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_serviceOpt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_ServiceOptions>(
+let ProtobufUnittest_Extensions_service_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_ServiceOptions>(
   fieldNumber: 7887650,
   fieldNames: .same(proto: "protobuf_unittest.service_opt1"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_methodOpt1 = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_MethodOpt1>, Google_Protobuf_MethodOptions>(
+let ProtobufUnittest_Extensions_method_opt1 = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_MethodOpt1>, Google_Protobuf_MethodOptions>(
   fieldNumber: 7890860,
   fieldNames: .same(proto: "protobuf_unittest.method_opt1"),
   defaultValue: ProtobufUnittest_MethodOpt1.val1
 )
 
-let ProtobufUnittest_Extensions_boolOpt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_bool_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7706090,
   fieldNames: .same(proto: "protobuf_unittest.bool_opt"),
   defaultValue: false
 )
 
-let ProtobufUnittest_Extensions_int32Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_int32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7705709,
   fieldNames: .same(proto: "protobuf_unittest.int32_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_int64Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_int64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7705542,
   fieldNames: .same(proto: "protobuf_unittest.int64_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_uint32Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_uint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7704880,
   fieldNames: .same(proto: "protobuf_unittest.uint32_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_uint64Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_uint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7702367,
   fieldNames: .same(proto: "protobuf_unittest.uint64_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_sint32Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_sint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7701568,
   fieldNames: .same(proto: "protobuf_unittest.sint32_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_sint64Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_sint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7700863,
   fieldNames: .same(proto: "protobuf_unittest.sint64_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_fixed32Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_fixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7700307,
   fieldNames: .same(proto: "protobuf_unittest.fixed32_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_fixed64Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_fixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7700194,
   fieldNames: .same(proto: "protobuf_unittest.fixed64_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_sfixed32Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_sfixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7698645,
   fieldNames: .same(proto: "protobuf_unittest.sfixed32_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_sfixed64Opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_sfixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7685475,
   fieldNames: .same(proto: "protobuf_unittest.sfixed64_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_floatOpt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_float_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7675390,
   fieldNames: .same(proto: "protobuf_unittest.float_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_doubleOpt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_double_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7673293,
   fieldNames: .same(proto: "protobuf_unittest.double_opt"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_stringOpt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_string_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7673285,
   fieldNames: .same(proto: "protobuf_unittest.string_opt"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_bytesOpt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_bytes_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7673238,
   fieldNames: .same(proto: "protobuf_unittest.bytes_opt"),
   defaultValue: Data()
 )
 
-let ProtobufUnittest_Extensions_enumOpt = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_DummyMessageContainingEnum.TestEnumType>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_enum_opt = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_DummyMessageContainingEnum.TestEnumType>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7673233,
   fieldNames: .same(proto: "protobuf_unittest.enum_opt"),
   defaultValue: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1
 )
 
-let ProtobufUnittest_Extensions_messageTypeOpt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_DummyMessageInvalidAsOptionType>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_message_type_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_DummyMessageInvalidAsOptionType>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7665967,
   fieldNames: .same(proto: "protobuf_unittest.message_type_opt"),
   defaultValue: ProtobufUnittest_DummyMessageInvalidAsOptionType()
@@ -2152,25 +2152,25 @@ let ProtobufUnittest_Extensions_garply = SwiftProtobuf.MessageExtension<Optional
   defaultValue: ProtobufUnittest_ComplexOptionType1()
 )
 
-let ProtobufUnittest_Extensions_complexOpt1 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_complex_opt1 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7646756,
   fieldNames: .same(proto: "protobuf_unittest.complex_opt1"),
   defaultValue: ProtobufUnittest_ComplexOptionType1()
 )
 
-let ProtobufUnittest_Extensions_complexOpt2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_complex_opt2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7636949,
   fieldNames: .same(proto: "protobuf_unittest.complex_opt2"),
   defaultValue: ProtobufUnittest_ComplexOptionType2()
 )
 
-let ProtobufUnittest_Extensions_complexOpt3 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_complex_opt3 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7636463,
   fieldNames: .same(proto: "protobuf_unittest.complex_opt3"),
   defaultValue: ProtobufUnittest_ComplexOptionType3()
 )
 
-let ProtobufUnittest_Extensions_complexOpt6 = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_ComplexOpt6>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_ComplexOpt6 = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_ComplexOpt6>, Google_Protobuf_MessageOptions>(
   fieldNumber: 7595468,
   fieldNames: .same(proto: "protobuf_unittest.ComplexOpt6"),
   defaultValue: ProtobufUnittest_ComplexOpt6()
@@ -2218,7 +2218,7 @@ let ProtobufUnittest_Extensions_methodopt = SwiftProtobuf.MessageExtension<Optio
   defaultValue: ProtobufUnittest_Aggregate()
 )
 
-let ProtobufUnittest_Extensions_requiredEnumOpt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(
+let ProtobufUnittest_Extensions_required_enum_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(
   fieldNumber: 106161807,
   fieldNames: .same(proto: "protobuf_unittest.required_enum_opt"),
   defaultValue: ProtobufUnittest_OldOptionType()
@@ -2226,27 +2226,27 @@ let ProtobufUnittest_Extensions_requiredEnumOpt = SwiftProtobuf.MessageExtension
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
-    get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complexOpt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
-    set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complexOpt4, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
+    set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4, value: newValue)}
   }
   var hasProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complexOpt4)
+    return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
   }
   mutating func clearProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4() {
-    clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complexOpt4)
+    clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
   }
 }
 
 extension ProtobufUnittest_AggregateMessageSet {
   var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
-    get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.messageSetExtension) ?? ProtobufUnittest_AggregateMessageSetElement()}
-    set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.messageSetExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension) ?? ProtobufUnittest_AggregateMessageSetElement()}
+    set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension, value: newValue)}
   }
   var hasProtobufUnittest_AggregateMessageSetElement_messageSetExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.messageSetExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
   }
   mutating func clearProtobufUnittest_AggregateMessageSetElement_messageSetExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.messageSetExtension)
+    clearExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
   }
 }
 
@@ -2265,53 +2265,53 @@ extension Google_Protobuf_FileOptions {
 
 extension Google_Protobuf_FileOptions {
   var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nestedExtension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nestedExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension, value: newValue)}
   }
   var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nestedExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
   }
   mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nestedExtension)
+    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
   }
 }
 
 extension Google_Protobuf_FileOptions {
   var ProtobufUnittest_fileOpt1: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fileOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fileOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1, value: newValue)}
   }
   var hasProtobufUnittest_fileOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fileOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
   }
   mutating func clearProtobufUnittest_fileOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fileOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_messageOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_messageOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_messageOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1, value: newValue)}
   }
   var hasProtobufUnittest_messageOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_messageOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
   }
   mutating func clearProtobufUnittest_messageOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_messageOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
   }
 }
 
 extension Google_Protobuf_FieldOptions {
   var ProtobufUnittest_fieldOpt1: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1, value: newValue)}
   }
   var hasProtobufUnittest_fieldOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
   }
   mutating func clearProtobufUnittest_fieldOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
   }
 }
 
@@ -2319,300 +2319,300 @@ extension Google_Protobuf_FieldOptions {
   ///   This is useful for testing that we correctly register default values for
   ///   extension options.
   var ProtobufUnittest_fieldOpt2: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt2) ?? 42}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt2, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2) ?? 42}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2, value: newValue)}
   }
   var hasProtobufUnittest_fieldOpt2: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt2)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
   }
   mutating func clearProtobufUnittest_fieldOpt2() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fieldOpt2)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
   }
 }
 
 extension Google_Protobuf_OneofOptions {
   var ProtobufUnittest_oneofOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1, value: newValue)}
   }
   var hasProtobufUnittest_oneofOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
   }
   mutating func clearProtobufUnittest_oneofOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
   }
 }
 
 extension Google_Protobuf_EnumOptions {
   var ProtobufUnittest_enumOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1, value: newValue)}
   }
   var hasProtobufUnittest_enumOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1)
   }
   mutating func clearProtobufUnittest_enumOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1)
   }
 }
 
 extension Google_Protobuf_EnumValueOptions {
   var ProtobufUnittest_enumValueOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enumValueOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enumValueOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1, value: newValue)}
   }
   var hasProtobufUnittest_enumValueOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enumValueOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
   }
   mutating func clearProtobufUnittest_enumValueOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_enumValueOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
   }
 }
 
 extension Google_Protobuf_ServiceOptions {
   var ProtobufUnittest_serviceOpt1: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_serviceOpt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_serviceOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1, value: newValue)}
   }
   var hasProtobufUnittest_serviceOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_serviceOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
   }
   mutating func clearProtobufUnittest_serviceOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_serviceOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
   }
 }
 
 extension Google_Protobuf_MethodOptions {
   var ProtobufUnittest_methodOpt1: ProtobufUnittest_MethodOpt1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_methodOpt1) ?? ProtobufUnittest_MethodOpt1.val1}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_methodOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1) ?? ProtobufUnittest_MethodOpt1.val1}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1, value: newValue)}
   }
   var hasProtobufUnittest_methodOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_methodOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
   }
   mutating func clearProtobufUnittest_methodOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_methodOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_boolOpt: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_boolOpt) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_boolOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt, value: newValue)}
   }
   var hasProtobufUnittest_boolOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_boolOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
   }
   mutating func clearProtobufUnittest_boolOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_boolOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_int32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int32Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int32Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt, value: newValue)}
   }
   var hasProtobufUnittest_int32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int32Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
   }
   mutating func clearProtobufUnittest_int32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_int32Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_int64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int64Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int64Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt, value: newValue)}
   }
   var hasProtobufUnittest_int64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int64Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
   }
   mutating func clearProtobufUnittest_int64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_int64Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_uint32Opt: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint32Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint32Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt, value: newValue)}
   }
   var hasProtobufUnittest_uint32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint32Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
   }
   mutating func clearProtobufUnittest_uint32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint32Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_uint64Opt: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint64Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint64Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt, value: newValue)}
   }
   var hasProtobufUnittest_uint64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint64Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
   }
   mutating func clearProtobufUnittest_uint64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint64Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_sint32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint32Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint32Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt, value: newValue)}
   }
   var hasProtobufUnittest_sint32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint32Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
   }
   mutating func clearProtobufUnittest_sint32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint32Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_sint64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint64Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint64Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt, value: newValue)}
   }
   var hasProtobufUnittest_sint64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint64Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
   }
   mutating func clearProtobufUnittest_sint64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint64Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_fixed32Opt: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed32Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed32Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt, value: newValue)}
   }
   var hasProtobufUnittest_fixed32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed32Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
   }
   mutating func clearProtobufUnittest_fixed32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed32Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_fixed64Opt: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed64Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed64Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt, value: newValue)}
   }
   var hasProtobufUnittest_fixed64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed64Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
   }
   mutating func clearProtobufUnittest_fixed64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed64Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_sfixed32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt, value: newValue)}
   }
   var hasProtobufUnittest_sfixed32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
   }
   mutating func clearProtobufUnittest_sfixed32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_sfixed64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64Opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64Opt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt, value: newValue)}
   }
   var hasProtobufUnittest_sfixed64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64Opt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
   }
   mutating func clearProtobufUnittest_sfixed64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64Opt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_floatOpt: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_floatOpt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_floatOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_float_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_float_opt, value: newValue)}
   }
   var hasProtobufUnittest_floatOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_floatOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
   }
   mutating func clearProtobufUnittest_floatOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_floatOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_doubleOpt: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_doubleOpt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_doubleOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_double_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_double_opt, value: newValue)}
   }
   var hasProtobufUnittest_doubleOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_doubleOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
   }
   mutating func clearProtobufUnittest_doubleOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_doubleOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_stringOpt: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_stringOpt) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_stringOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_string_opt) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_string_opt, value: newValue)}
   }
   var hasProtobufUnittest_stringOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_stringOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
   }
   mutating func clearProtobufUnittest_stringOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_stringOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_bytesOpt: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytesOpt) ?? Data()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bytesOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt) ?? Data()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt, value: newValue)}
   }
   var hasProtobufUnittest_bytesOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bytesOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
   }
   mutating func clearProtobufUnittest_bytesOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_bytesOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_enumOpt: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt) ?? ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt) ?? ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt, value: newValue)}
   }
   var hasProtobufUnittest_enumOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
   }
   mutating func clearProtobufUnittest_enumOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_enumOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_messageTypeOpt: ProtobufUnittest_DummyMessageInvalidAsOptionType {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_messageTypeOpt) ?? ProtobufUnittest_DummyMessageInvalidAsOptionType()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_messageTypeOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt) ?? ProtobufUnittest_DummyMessageInvalidAsOptionType()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt, value: newValue)}
   }
   var hasProtobufUnittest_messageTypeOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_messageTypeOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
   }
   mutating func clearProtobufUnittest_messageTypeOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_messageTypeOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
   }
 }
 
@@ -2670,53 +2670,53 @@ extension ProtobufUnittest_ComplexOptionType2 {
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_complexOpt1: ProtobufUnittest_ComplexOptionType1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt1) ?? ProtobufUnittest_ComplexOptionType1()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt1, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1) ?? ProtobufUnittest_ComplexOptionType1()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1, value: newValue)}
   }
   var hasProtobufUnittest_complexOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt1)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
   }
   mutating func clearProtobufUnittest_complexOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt1)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_complexOpt2: ProtobufUnittest_ComplexOptionType2 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt2) ?? ProtobufUnittest_ComplexOptionType2()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt2, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2) ?? ProtobufUnittest_ComplexOptionType2()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2, value: newValue)}
   }
   var hasProtobufUnittest_complexOpt2: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt2)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
   }
   mutating func clearProtobufUnittest_complexOpt2() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt2)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_complexOpt3: ProtobufUnittest_ComplexOptionType3 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt3) ?? ProtobufUnittest_ComplexOptionType3()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt3, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3) ?? ProtobufUnittest_ComplexOptionType3()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3, value: newValue)}
   }
   var hasProtobufUnittest_complexOpt3: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt3)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
   }
   mutating func clearProtobufUnittest_complexOpt3() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt3)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_complexOpt6: ProtobufUnittest_ComplexOpt6 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt6) ?? ProtobufUnittest_ComplexOpt6()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt6, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6) ?? ProtobufUnittest_ComplexOpt6()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6, value: newValue)}
   }
   var hasProtobufUnittest_complexOpt6: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt6)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
   }
   mutating func clearProtobufUnittest_complexOpt6() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complexOpt6)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
   }
 }
 
@@ -2813,52 +2813,52 @@ extension Google_Protobuf_MethodOptions {
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_requiredEnumOpt: ProtobufUnittest_OldOptionType {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_requiredEnumOpt) ?? ProtobufUnittest_OldOptionType()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_requiredEnumOpt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt) ?? ProtobufUnittest_OldOptionType()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt, value: newValue)}
   }
   var hasProtobufUnittest_requiredEnumOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_requiredEnumOpt)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt)
   }
   mutating func clearProtobufUnittest_requiredEnumOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_requiredEnumOpt)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt)
   }
 }
 
 let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_Extensions_fileOpt1,
-  ProtobufUnittest_Extensions_messageOpt1,
-  ProtobufUnittest_Extensions_fieldOpt1,
-  ProtobufUnittest_Extensions_fieldOpt2,
-  ProtobufUnittest_Extensions_oneofOpt1,
-  ProtobufUnittest_Extensions_enumOpt1,
-  ProtobufUnittest_Extensions_enumValueOpt1,
-  ProtobufUnittest_Extensions_serviceOpt1,
-  ProtobufUnittest_Extensions_methodOpt1,
-  ProtobufUnittest_Extensions_boolOpt,
-  ProtobufUnittest_Extensions_int32Opt,
-  ProtobufUnittest_Extensions_int64Opt,
-  ProtobufUnittest_Extensions_uint32Opt,
-  ProtobufUnittest_Extensions_uint64Opt,
-  ProtobufUnittest_Extensions_sint32Opt,
-  ProtobufUnittest_Extensions_sint64Opt,
-  ProtobufUnittest_Extensions_fixed32Opt,
-  ProtobufUnittest_Extensions_fixed64Opt,
-  ProtobufUnittest_Extensions_sfixed32Opt,
-  ProtobufUnittest_Extensions_sfixed64Opt,
-  ProtobufUnittest_Extensions_floatOpt,
-  ProtobufUnittest_Extensions_doubleOpt,
-  ProtobufUnittest_Extensions_stringOpt,
-  ProtobufUnittest_Extensions_bytesOpt,
-  ProtobufUnittest_Extensions_enumOpt,
-  ProtobufUnittest_Extensions_messageTypeOpt,
+  ProtobufUnittest_Extensions_file_opt1,
+  ProtobufUnittest_Extensions_message_opt1,
+  ProtobufUnittest_Extensions_field_opt1,
+  ProtobufUnittest_Extensions_field_opt2,
+  ProtobufUnittest_Extensions_oneof_opt1,
+  ProtobufUnittest_Extensions_enum_opt1,
+  ProtobufUnittest_Extensions_enum_value_opt1,
+  ProtobufUnittest_Extensions_service_opt1,
+  ProtobufUnittest_Extensions_method_opt1,
+  ProtobufUnittest_Extensions_bool_opt,
+  ProtobufUnittest_Extensions_int32_opt,
+  ProtobufUnittest_Extensions_int64_opt,
+  ProtobufUnittest_Extensions_uint32_opt,
+  ProtobufUnittest_Extensions_uint64_opt,
+  ProtobufUnittest_Extensions_sint32_opt,
+  ProtobufUnittest_Extensions_sint64_opt,
+  ProtobufUnittest_Extensions_fixed32_opt,
+  ProtobufUnittest_Extensions_fixed64_opt,
+  ProtobufUnittest_Extensions_sfixed32_opt,
+  ProtobufUnittest_Extensions_sfixed64_opt,
+  ProtobufUnittest_Extensions_float_opt,
+  ProtobufUnittest_Extensions_double_opt,
+  ProtobufUnittest_Extensions_string_opt,
+  ProtobufUnittest_Extensions_bytes_opt,
+  ProtobufUnittest_Extensions_enum_opt,
+  ProtobufUnittest_Extensions_message_type_opt,
   ProtobufUnittest_Extensions_quux,
   ProtobufUnittest_Extensions_corge,
   ProtobufUnittest_Extensions_grault,
   ProtobufUnittest_Extensions_garply,
-  ProtobufUnittest_Extensions_complexOpt1,
-  ProtobufUnittest_Extensions_complexOpt2,
-  ProtobufUnittest_Extensions_complexOpt3,
-  ProtobufUnittest_Extensions_complexOpt6,
+  ProtobufUnittest_Extensions_complex_opt1,
+  ProtobufUnittest_Extensions_complex_opt2,
+  ProtobufUnittest_Extensions_complex_opt3,
+  ProtobufUnittest_Extensions_ComplexOpt6,
   ProtobufUnittest_Extensions_fileopt,
   ProtobufUnittest_Extensions_msgopt,
   ProtobufUnittest_Extensions_fieldopt,
@@ -2866,9 +2866,9 @@ let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.ExtensionSe
   ProtobufUnittest_Extensions_enumvalopt,
   ProtobufUnittest_Extensions_serviceopt,
   ProtobufUnittest_Extensions_methodopt,
-  ProtobufUnittest_Extensions_requiredEnumOpt,
-  ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complexOpt4,
-  ProtobufUnittest_AggregateMessageSetElement.Extensions.messageSetExtension,
+  ProtobufUnittest_Extensions_required_enum_opt,
+  ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4,
+  ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension,
   ProtobufUnittest_Aggregate.Extensions.nested,
-  ProtobufUnittest_NestedOptionType.Extensions.nestedExtension
+  ProtobufUnittest_NestedOptionType.Extensions.nested_extension
 ]

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -2309,7 +2309,7 @@ struct ProtobufUnittest_TestNestedExtensionLite: SwiftProtobuf.Message, SwiftPro
 
   struct Extensions {
 
-    static let nestedExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
       fieldNumber: 12345,
       fieldNames: .same(proto: "protobuf_unittest.TestNestedExtensionLite.nested_extension"),
       defaultValue: 0
@@ -2923,13 +2923,13 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
 
   struct Extensions {
 
-    static let optionalExt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
+    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
       fieldNumber: 1000,
       fieldNames: .same(proto: "protobuf_unittest.TestParsingMergeLite.optional_ext"),
       defaultValue: ProtobufUnittest_TestAllTypesLite()
     )
 
-    static let repeatedExt = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
+    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
       fieldNumber: 1001,
       fieldNames: .same(proto: "protobuf_unittest.TestParsingMergeLite.repeated_ext"),
       defaultValue: []
@@ -3723,544 +3723,544 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 }
 
 ///   Singular
-let ProtobufUnittest_Extensions_optionalInt32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 1,
   fieldNames: .same(proto: "protobuf_unittest.optional_int32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalInt64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 2,
   fieldNames: .same(proto: "protobuf_unittest.optional_int64_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalUint32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 3,
   fieldNames: .same(proto: "protobuf_unittest.optional_uint32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalUint64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 4,
   fieldNames: .same(proto: "protobuf_unittest.optional_uint64_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSint32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 5,
   fieldNames: .same(proto: "protobuf_unittest.optional_sint32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSint64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 6,
   fieldNames: .same(proto: "protobuf_unittest.optional_sint64_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFixed32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 7,
   fieldNames: .same(proto: "protobuf_unittest.optional_fixed32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFixed64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 8,
   fieldNames: .same(proto: "protobuf_unittest.optional_fixed64_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 9,
   fieldNames: .same(proto: "protobuf_unittest.optional_sfixed32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 10,
   fieldNames: .same(proto: "protobuf_unittest.optional_sfixed64_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalFloatExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 11,
   fieldNames: .same(proto: "protobuf_unittest.optional_float_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalDoubleExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 12,
   fieldNames: .same(proto: "protobuf_unittest.optional_double_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_optionalBoolExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 13,
   fieldNames: .same(proto: "protobuf_unittest.optional_bool_extension_lite"),
   defaultValue: false
 )
 
-let ProtobufUnittest_Extensions_optionalStringExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 14,
   fieldNames: .same(proto: "protobuf_unittest.optional_string_extension_lite"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalBytesExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 15,
   fieldNames: .same(proto: "protobuf_unittest.optional_bytes_extension_lite"),
   defaultValue: Data()
 )
 
-let ProtobufUnittest_Extensions_optionalGroupExtensionLite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_OptionalGroup_extension_lite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 16,
   fieldNames: .same(proto: "protobuf_unittest.OptionalGroup_extension_lite"),
   defaultValue: ProtobufUnittest_OptionalGroup_extension_lite()
 )
 
-let ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 18,
   fieldNames: .same(proto: "protobuf_unittest.optional_nested_message_extension_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
 )
 
-let ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 19,
   fieldNames: .same(proto: "protobuf_unittest.optional_foreign_message_extension_lite"),
   defaultValue: ProtobufUnittest_ForeignMessageLite()
 )
 
-let ProtobufUnittest_Extensions_optionalImportMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 20,
   fieldNames: .same(proto: "protobuf_unittest.optional_import_message_extension_lite"),
   defaultValue: ProtobufUnittestImport_ImportMessageLite()
 )
 
-let ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 21,
   fieldNames: .same(proto: "protobuf_unittest.optional_nested_enum_extension_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.foo
 )
 
-let ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 22,
   fieldNames: .same(proto: "protobuf_unittest.optional_foreign_enum_extension_lite"),
   defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteFoo
 )
 
-let ProtobufUnittest_Extensions_optionalImportEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 23,
   fieldNames: .same(proto: "protobuf_unittest.optional_import_enum_extension_lite"),
   defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteFoo
 )
 
-let ProtobufUnittest_Extensions_optionalStringPieceExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 24,
   fieldNames: .same(proto: "protobuf_unittest.optional_string_piece_extension_lite"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalCordExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 25,
   fieldNames: .same(proto: "protobuf_unittest.optional_cord_extension_lite"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_public_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 26,
   fieldNames: .same(proto: "protobuf_unittest.optional_public_import_message_extension_lite"),
   defaultValue: ProtobufUnittestImport_PublicImportMessageLite()
 )
 
-let ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_optional_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 27,
   fieldNames: .same(proto: "protobuf_unittest.optional_lazy_message_extension_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
 )
 
 ///   Repeated
-let ProtobufUnittest_Extensions_repeatedInt32ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_int32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 31,
   fieldNames: .same(proto: "protobuf_unittest.repeated_int32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedInt64ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_int64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 32,
   fieldNames: .same(proto: "protobuf_unittest.repeated_int64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedUint32ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_uint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 33,
   fieldNames: .same(proto: "protobuf_unittest.repeated_uint32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedUint64ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_uint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 34,
   fieldNames: .same(proto: "protobuf_unittest.repeated_uint64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSint32ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_sint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 35,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sint32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSint64ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_sint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 36,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sint64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_fixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 37,
   fieldNames: .same(proto: "protobuf_unittest.repeated_fixed32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_fixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 38,
   fieldNames: .same(proto: "protobuf_unittest.repeated_fixed64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 39,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sfixed32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 40,
   fieldNames: .same(proto: "protobuf_unittest.repeated_sfixed64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedFloatExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_float_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 41,
   fieldNames: .same(proto: "protobuf_unittest.repeated_float_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedDoubleExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_double_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 42,
   fieldNames: .same(proto: "protobuf_unittest.repeated_double_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedBoolExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_bool_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 43,
   fieldNames: .same(proto: "protobuf_unittest.repeated_bool_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedStringExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_string_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 44,
   fieldNames: .same(proto: "protobuf_unittest.repeated_string_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedBytesExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_bytes_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 45,
   fieldNames: .same(proto: "protobuf_unittest.repeated_bytes_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedGroupExtensionLite = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_RepeatedGroup_extension_lite = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 46,
   fieldNames: .same(proto: "protobuf_unittest.RepeatedGroup_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_nested_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 48,
   fieldNames: .same(proto: "protobuf_unittest.repeated_nested_message_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 49,
   fieldNames: .same(proto: "protobuf_unittest.repeated_foreign_message_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_import_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 50,
   fieldNames: .same(proto: "protobuf_unittest.repeated_import_message_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 51,
   fieldNames: .same(proto: "protobuf_unittest.repeated_nested_enum_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 52,
   fieldNames: .same(proto: "protobuf_unittest.repeated_foreign_enum_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_import_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 53,
   fieldNames: .same(proto: "protobuf_unittest.repeated_import_enum_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_string_piece_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 54,
   fieldNames: .same(proto: "protobuf_unittest.repeated_string_piece_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedCordExtensionLite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_cord_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 55,
   fieldNames: .same(proto: "protobuf_unittest.repeated_cord_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 57,
   fieldNames: .same(proto: "protobuf_unittest.repeated_lazy_message_extension_lite"),
   defaultValue: []
 )
 
 ///   Singular with defaults
-let ProtobufUnittest_Extensions_defaultInt32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 61,
   fieldNames: .same(proto: "protobuf_unittest.default_int32_extension_lite"),
   defaultValue: 41
 )
 
-let ProtobufUnittest_Extensions_defaultInt64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 62,
   fieldNames: .same(proto: "protobuf_unittest.default_int64_extension_lite"),
   defaultValue: 42
 )
 
-let ProtobufUnittest_Extensions_defaultUint32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 63,
   fieldNames: .same(proto: "protobuf_unittest.default_uint32_extension_lite"),
   defaultValue: 43
 )
 
-let ProtobufUnittest_Extensions_defaultUint64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 64,
   fieldNames: .same(proto: "protobuf_unittest.default_uint64_extension_lite"),
   defaultValue: 44
 )
 
-let ProtobufUnittest_Extensions_defaultSint32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 65,
   fieldNames: .same(proto: "protobuf_unittest.default_sint32_extension_lite"),
   defaultValue: -45
 )
 
-let ProtobufUnittest_Extensions_defaultSint64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 66,
   fieldNames: .same(proto: "protobuf_unittest.default_sint64_extension_lite"),
   defaultValue: 46
 )
 
-let ProtobufUnittest_Extensions_defaultFixed32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 67,
   fieldNames: .same(proto: "protobuf_unittest.default_fixed32_extension_lite"),
   defaultValue: 47
 )
 
-let ProtobufUnittest_Extensions_defaultFixed64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 68,
   fieldNames: .same(proto: "protobuf_unittest.default_fixed64_extension_lite"),
   defaultValue: 48
 )
 
-let ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 69,
   fieldNames: .same(proto: "protobuf_unittest.default_sfixed32_extension_lite"),
   defaultValue: 49
 )
 
-let ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 70,
   fieldNames: .same(proto: "protobuf_unittest.default_sfixed64_extension_lite"),
   defaultValue: -50
 )
 
-let ProtobufUnittest_Extensions_defaultFloatExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 71,
   fieldNames: .same(proto: "protobuf_unittest.default_float_extension_lite"),
   defaultValue: 51.5
 )
 
-let ProtobufUnittest_Extensions_defaultDoubleExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 72,
   fieldNames: .same(proto: "protobuf_unittest.default_double_extension_lite"),
   defaultValue: 52000
 )
 
-let ProtobufUnittest_Extensions_defaultBoolExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 73,
   fieldNames: .same(proto: "protobuf_unittest.default_bool_extension_lite"),
   defaultValue: true
 )
 
-let ProtobufUnittest_Extensions_defaultStringExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 74,
   fieldNames: .same(proto: "protobuf_unittest.default_string_extension_lite"),
   defaultValue: "hello"
 )
 
-let ProtobufUnittest_Extensions_defaultBytesExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 75,
   fieldNames: .same(proto: "protobuf_unittest.default_bytes_extension_lite"),
   defaultValue: Data(bytes: [119, 111, 114, 108, 100])
 )
 
-let ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 81,
   fieldNames: .same(proto: "protobuf_unittest.default_nested_enum_extension_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.bar
 )
 
-let ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 82,
   fieldNames: .same(proto: "protobuf_unittest.default_foreign_enum_extension_lite"),
   defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteBar
 )
 
-let ProtobufUnittest_Extensions_defaultImportEnumExtensionLite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 83,
   fieldNames: .same(proto: "protobuf_unittest.default_import_enum_extension_lite"),
   defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteBar
 )
 
-let ProtobufUnittest_Extensions_defaultStringPieceExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 84,
   fieldNames: .same(proto: "protobuf_unittest.default_string_piece_extension_lite"),
   defaultValue: "abc"
 )
 
-let ProtobufUnittest_Extensions_defaultCordExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_default_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 85,
   fieldNames: .same(proto: "protobuf_unittest.default_cord_extension_lite"),
   defaultValue: "123"
 )
 
 ///   For oneof test
-let ProtobufUnittest_Extensions_oneofUint32ExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_oneof_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 111,
   fieldNames: .same(proto: "protobuf_unittest.oneof_uint32_extension_lite"),
   defaultValue: 0
 )
 
-let ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_oneof_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 112,
   fieldNames: .same(proto: "protobuf_unittest.oneof_nested_message_extension_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
 )
 
-let ProtobufUnittest_Extensions_oneofStringExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_oneof_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 113,
   fieldNames: .same(proto: "protobuf_unittest.oneof_string_extension_lite"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extensions_oneofBytesExtensionLite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+let ProtobufUnittest_Extensions_oneof_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   fieldNumber: 114,
   fieldNames: .same(proto: "protobuf_unittest.oneof_bytes_extension_lite"),
   defaultValue: Data()
 )
 
-let ProtobufUnittest_Extensions_packedInt32ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_int32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 90,
   fieldNames: .same(proto: "protobuf_unittest.packed_int32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedInt64ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_int64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 91,
   fieldNames: .same(proto: "protobuf_unittest.packed_int64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedUint32ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_uint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 92,
   fieldNames: .same(proto: "protobuf_unittest.packed_uint32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedUint64ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_uint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 93,
   fieldNames: .same(proto: "protobuf_unittest.packed_uint64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSint32ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_sint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 94,
   fieldNames: .same(proto: "protobuf_unittest.packed_sint32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSint64ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_sint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 95,
   fieldNames: .same(proto: "protobuf_unittest.packed_sint64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFixed32ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_fixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 96,
   fieldNames: .same(proto: "protobuf_unittest.packed_fixed32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFixed64ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_fixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 97,
   fieldNames: .same(proto: "protobuf_unittest.packed_fixed64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSfixed32ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 98,
   fieldNames: .same(proto: "protobuf_unittest.packed_sfixed32_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedSfixed64ExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 99,
   fieldNames: .same(proto: "protobuf_unittest.packed_sfixed64_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedFloatExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_float_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 100,
   fieldNames: .same(proto: "protobuf_unittest.packed_float_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedDoubleExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_double_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 101,
   fieldNames: .same(proto: "protobuf_unittest.packed_double_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedBoolExtensionLite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_bool_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 102,
   fieldNames: .same(proto: "protobuf_unittest.packed_bool_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_packedEnumExtensionLite = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestPackedExtensionsLite>(
+let ProtobufUnittest_Extensions_packed_enum_extension_lite = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestPackedExtensionsLite>(
   fieldNumber: 103,
   fieldNames: .same(proto: "protobuf_unittest.packed_enum_extension_lite"),
   defaultValue: []
 )
 
-let ProtobufUnittest_Extensions_testAllTypesLite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestHugeFieldNumbersLite>(
+let ProtobufUnittest_Extensions_test_all_types_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestHugeFieldNumbersLite>(
   fieldNumber: 536860000,
   fieldNames: .same(proto: "protobuf_unittest.test_all_types_lite"),
   defaultValue: ProtobufUnittest_TestAllTypesLite()
@@ -4268,1309 +4268,1309 @@ let ProtobufUnittest_Extensions_testAllTypesLite = SwiftProtobuf.MessageExtensio
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestNestedExtensionLite_nestedExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
   }
   mutating func clearProtobufUnittest_TestNestedExtensionLite_nestedExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension)
+    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
   }
 }
 
 extension ProtobufUnittest_TestParsingMergeLite {
   var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optionalExt) ?? ProtobufUnittest_TestAllTypesLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optionalExt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypesLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext, value: newValue)}
   }
   var hasProtobufUnittest_TestParsingMergeLite_optionalExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optionalExt)
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
   }
   mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optionalExt)
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
   }
 }
 
 extension ProtobufUnittest_TestParsingMergeLite {
   var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt)}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext, value: newValue)}
   }
   var hasProtobufUnittest_TestParsingMergeLite_repeatedExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt)
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
   }
   mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt)
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Singular
   var ProtobufUnittest_optionalInt32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalInt32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalInt32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalInt64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalInt64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalInt64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalInt64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalUint32ExtensionLite: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalUint64ExtensionLite: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalUint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalUint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalUint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSint32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalSint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalSint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSint64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalSint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalSint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFixed32ExtensionLite: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalFixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalFixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFixed64ExtensionLite: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalFixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalFixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSfixed32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalSfixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalSfixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSfixed64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalSfixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalSfixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFloatExtensionLite: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalFloatExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalFloatExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalFloatExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalDoubleExtensionLite: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalDoubleExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalDoubleExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalDoubleExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalBoolExtensionLite: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtensionLite) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalBoolExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalBoolExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalBoolExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtensionLite) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalStringExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalBytesExtensionLite: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtensionLite) ?? Data()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite) ?? Data()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalBytesExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalBytesExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalBytesExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalGroupExtensionLite: ProtobufUnittest_OptionalGroup_extension_lite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtensionLite) ?? ProtobufUnittest_OptionalGroup_extension_lite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite) ?? ProtobufUnittest_OptionalGroup_extension_lite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalGroupExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalGroupExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalGroupExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalNestedMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalNestedMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalForeignMessageExtensionLite: ProtobufUnittest_ForeignMessageLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite) ?? ProtobufUnittest_ForeignMessageLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite) ?? ProtobufUnittest_ForeignMessageLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalForeignMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalForeignMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalImportMessageExtensionLite: ProtobufUnittestImport_ImportMessageLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtensionLite) ?? ProtobufUnittestImport_ImportMessageLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite) ?? ProtobufUnittestImport_ImportMessageLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalImportMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalImportMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.foo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.foo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalNestedEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalNestedEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteFoo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteFoo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalForeignEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalForeignEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtensionLite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteFoo}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteFoo}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalImportEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalImportEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalImportEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringPieceExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtensionLite) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringPieceExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalStringPieceExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalStringPieceExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalCordExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtensionLite) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalCordExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalCordExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalCordExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalPublicImportMessageExtensionLite: ProtobufUnittestImport_PublicImportMessageLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite) ?? ProtobufUnittestImport_PublicImportMessageLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite) ?? ProtobufUnittestImport_PublicImportMessageLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalPublicImportMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalPublicImportMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalLazyMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalLazyMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite)
   }
   mutating func clearProtobufUnittest_optionalLazyMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Repeated
   var ProtobufUnittest_repeatedInt32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedInt32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedInt32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedInt64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedInt64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedInt64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedInt64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedUint32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedUint64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedUint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedUint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedUint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSint32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedSint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSint64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedSint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFixed32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedFixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFixed64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedFixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSfixed32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSfixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedSfixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSfixed64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedSfixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedSfixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFloatExtensionLite: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedFloatExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedFloatExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedFloatExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedDoubleExtensionLite: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedDoubleExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedDoubleExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedDoubleExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedBoolExtensionLite: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedBoolExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedBoolExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBoolExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedStringExtensionLite: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedStringExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedStringExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedBytesExtensionLite: [Data] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedBytesExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedBytesExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedBytesExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedGroupExtensionLite: [ProtobufUnittest_RepeatedGroup_extension_lite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedGroupExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedGroupExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedGroupExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedNestedMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedNestedMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedNestedMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedForeignMessageExtensionLite: [ProtobufUnittest_ForeignMessageLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedForeignMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedForeignMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedImportMessageExtensionLite: [ProtobufUnittestImport_ImportMessageLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedImportMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedImportMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedNestedEnumExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedNestedEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedNestedEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedForeignEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedForeignEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedForeignEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedImportEnumExtensionLite: [ProtobufUnittestImport_ImportEnumLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedImportEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedImportEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedStringPieceExtensionLite: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedStringPieceExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedStringPieceExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedCordExtensionLite: [String] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedCordExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedCordExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedCordExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedLazyMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_repeatedLazyMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite)
   }
   mutating func clearProtobufUnittest_repeatedLazyMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   Singular with defaults
   var ProtobufUnittest_defaultInt32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32ExtensionLite) ?? 41}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite) ?? 41}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultInt32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultInt32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultInt64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64ExtensionLite) ?? 42}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite) ?? 42}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultInt64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultInt64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultInt64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultUint32ExtensionLite: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32ExtensionLite) ?? 43}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite) ?? 43}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultUint64ExtensionLite: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64ExtensionLite) ?? 44}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite) ?? 44}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultUint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultUint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultUint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSint32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32ExtensionLite) ?? -45}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite) ?? -45}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultSint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultSint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSint64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64ExtensionLite) ?? 46}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite) ?? 46}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultSint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultSint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFixed32ExtensionLite: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32ExtensionLite) ?? 47}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite) ?? 47}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultFixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultFixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFixed64ExtensionLite: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64ExtensionLite) ?? 48}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite) ?? 48}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultFixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultFixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSfixed32ExtensionLite: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite) ?? 49}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite) ?? 49}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultSfixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultSfixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSfixed64ExtensionLite: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite) ?? -50}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite) ?? -50}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultSfixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultSfixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFloatExtensionLite: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtensionLite) ?? 51.5}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite) ?? 51.5}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultFloatExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultFloatExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultFloatExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultDoubleExtensionLite: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtensionLite) ?? 52000}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite) ?? 52000}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultDoubleExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultDoubleExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultDoubleExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultBoolExtensionLite: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtensionLite) ?? true}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite) ?? true}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultBoolExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultBoolExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultBoolExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultStringExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtensionLite) ?? "hello"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite) ?? "hello"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultStringExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultStringExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultBytesExtensionLite: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtensionLite) ?? Data(bytes: [119, 111, 114, 108, 100])}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite) ?? Data(bytes: [119, 111, 114, 108, 100])}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultBytesExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultBytesExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultBytesExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.bar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedEnum.bar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultNestedEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultNestedEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteBar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite) ?? ProtobufUnittest_ForeignEnumLite.foreignLiteBar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultForeignEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultForeignEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtensionLite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteBar}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite) ?? ProtobufUnittestImport_ImportEnumLite.importLiteBar}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultImportEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultImportEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultImportEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultStringPieceExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtensionLite) ?? "abc"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite) ?? "abc"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultStringPieceExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultStringPieceExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultStringPieceExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultCordExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtensionLite) ?? "123"}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite) ?? "123"}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_defaultCordExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite)
   }
   mutating func clearProtobufUnittest_defaultCordExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_defaultCordExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   ///   For oneof test
   var ProtobufUnittest_oneofUint32ExtensionLite: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32ExtensionLite) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite)
   }
   mutating func clearProtobufUnittest_oneofUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofUint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofNestedMessageExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite)
   }
   mutating func clearProtobufUnittest_oneofNestedMessageExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofStringExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtensionLite) ?? ""}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite) ?? ""}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofStringExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite)
   }
   mutating func clearProtobufUnittest_oneofStringExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofStringExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofBytesExtensionLite: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtensionLite) ?? Data()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite) ?? Data()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofBytesExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite)
   }
   mutating func clearProtobufUnittest_oneofBytesExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneofBytesExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedInt32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedInt32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
   }
   mutating func clearProtobufUnittest_packedInt32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedInt32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedInt64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedInt64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
   }
   mutating func clearProtobufUnittest_packedInt64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedInt64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedUint32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
   }
   mutating func clearProtobufUnittest_packedUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedUint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedUint64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedUint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
   }
   mutating func clearProtobufUnittest_packedUint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedUint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedSint32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedSint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
   }
   mutating func clearProtobufUnittest_packedSint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSint32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedSint64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedSint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
   }
   mutating func clearProtobufUnittest_packedSint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSint64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedFixed32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedFixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_packedFixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedFixed64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedFixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_packedFixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedSfixed32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedSfixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
   }
   mutating func clearProtobufUnittest_packedSfixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed32ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedSfixed64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64ExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64ExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedSfixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64ExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
   }
   mutating func clearProtobufUnittest_packedSfixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedSfixed64ExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedFloatExtensionLite: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedFloatExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
   }
   mutating func clearProtobufUnittest_packedFloatExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedFloatExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedDoubleExtensionLite: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedDoubleExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
   }
   mutating func clearProtobufUnittest_packedDoubleExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedDoubleExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedBoolExtensionLite: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedBoolExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
   }
   mutating func clearProtobufUnittest_packedBoolExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedBoolExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestPackedExtensionsLite {
   var ProtobufUnittest_packedEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtensionLite)}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtensionLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_packedEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtensionLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
   }
   mutating func clearProtobufUnittest_packedEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packedEnumExtensionLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
   }
 }
 
 extension ProtobufUnittest_TestHugeFieldNumbersLite {
   var ProtobufUnittest_testAllTypesLite: ProtobufUnittest_TestAllTypesLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypesLite) ?? ProtobufUnittest_TestAllTypesLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypesLite, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite) ?? ProtobufUnittest_TestAllTypesLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite, value: newValue)}
   }
   var hasProtobufUnittest_testAllTypesLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypesLite)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
   }
   mutating func clearProtobufUnittest_testAllTypesLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_testAllTypesLite)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
   }
 }
 
 let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_Extensions_optionalInt32ExtensionLite,
-  ProtobufUnittest_Extensions_optionalInt64ExtensionLite,
-  ProtobufUnittest_Extensions_optionalUint32ExtensionLite,
-  ProtobufUnittest_Extensions_optionalUint64ExtensionLite,
-  ProtobufUnittest_Extensions_optionalSint32ExtensionLite,
-  ProtobufUnittest_Extensions_optionalSint64ExtensionLite,
-  ProtobufUnittest_Extensions_optionalFixed32ExtensionLite,
-  ProtobufUnittest_Extensions_optionalFixed64ExtensionLite,
-  ProtobufUnittest_Extensions_optionalSfixed32ExtensionLite,
-  ProtobufUnittest_Extensions_optionalSfixed64ExtensionLite,
-  ProtobufUnittest_Extensions_optionalFloatExtensionLite,
-  ProtobufUnittest_Extensions_optionalDoubleExtensionLite,
-  ProtobufUnittest_Extensions_optionalBoolExtensionLite,
-  ProtobufUnittest_Extensions_optionalStringExtensionLite,
-  ProtobufUnittest_Extensions_optionalBytesExtensionLite,
-  ProtobufUnittest_Extensions_optionalGroupExtensionLite,
-  ProtobufUnittest_Extensions_optionalNestedMessageExtensionLite,
-  ProtobufUnittest_Extensions_optionalForeignMessageExtensionLite,
-  ProtobufUnittest_Extensions_optionalImportMessageExtensionLite,
-  ProtobufUnittest_Extensions_optionalNestedEnumExtensionLite,
-  ProtobufUnittest_Extensions_optionalForeignEnumExtensionLite,
-  ProtobufUnittest_Extensions_optionalImportEnumExtensionLite,
-  ProtobufUnittest_Extensions_optionalStringPieceExtensionLite,
-  ProtobufUnittest_Extensions_optionalCordExtensionLite,
-  ProtobufUnittest_Extensions_optionalPublicImportMessageExtensionLite,
-  ProtobufUnittest_Extensions_optionalLazyMessageExtensionLite,
-  ProtobufUnittest_Extensions_repeatedInt32ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedInt64ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedUint32ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedUint64ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedSint32ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedSint64ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedFixed32ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedFixed64ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedSfixed32ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedSfixed64ExtensionLite,
-  ProtobufUnittest_Extensions_repeatedFloatExtensionLite,
-  ProtobufUnittest_Extensions_repeatedDoubleExtensionLite,
-  ProtobufUnittest_Extensions_repeatedBoolExtensionLite,
-  ProtobufUnittest_Extensions_repeatedStringExtensionLite,
-  ProtobufUnittest_Extensions_repeatedBytesExtensionLite,
-  ProtobufUnittest_Extensions_repeatedGroupExtensionLite,
-  ProtobufUnittest_Extensions_repeatedNestedMessageExtensionLite,
-  ProtobufUnittest_Extensions_repeatedForeignMessageExtensionLite,
-  ProtobufUnittest_Extensions_repeatedImportMessageExtensionLite,
-  ProtobufUnittest_Extensions_repeatedNestedEnumExtensionLite,
-  ProtobufUnittest_Extensions_repeatedForeignEnumExtensionLite,
-  ProtobufUnittest_Extensions_repeatedImportEnumExtensionLite,
-  ProtobufUnittest_Extensions_repeatedStringPieceExtensionLite,
-  ProtobufUnittest_Extensions_repeatedCordExtensionLite,
-  ProtobufUnittest_Extensions_repeatedLazyMessageExtensionLite,
-  ProtobufUnittest_Extensions_defaultInt32ExtensionLite,
-  ProtobufUnittest_Extensions_defaultInt64ExtensionLite,
-  ProtobufUnittest_Extensions_defaultUint32ExtensionLite,
-  ProtobufUnittest_Extensions_defaultUint64ExtensionLite,
-  ProtobufUnittest_Extensions_defaultSint32ExtensionLite,
-  ProtobufUnittest_Extensions_defaultSint64ExtensionLite,
-  ProtobufUnittest_Extensions_defaultFixed32ExtensionLite,
-  ProtobufUnittest_Extensions_defaultFixed64ExtensionLite,
-  ProtobufUnittest_Extensions_defaultSfixed32ExtensionLite,
-  ProtobufUnittest_Extensions_defaultSfixed64ExtensionLite,
-  ProtobufUnittest_Extensions_defaultFloatExtensionLite,
-  ProtobufUnittest_Extensions_defaultDoubleExtensionLite,
-  ProtobufUnittest_Extensions_defaultBoolExtensionLite,
-  ProtobufUnittest_Extensions_defaultStringExtensionLite,
-  ProtobufUnittest_Extensions_defaultBytesExtensionLite,
-  ProtobufUnittest_Extensions_defaultNestedEnumExtensionLite,
-  ProtobufUnittest_Extensions_defaultForeignEnumExtensionLite,
-  ProtobufUnittest_Extensions_defaultImportEnumExtensionLite,
-  ProtobufUnittest_Extensions_defaultStringPieceExtensionLite,
-  ProtobufUnittest_Extensions_defaultCordExtensionLite,
-  ProtobufUnittest_Extensions_oneofUint32ExtensionLite,
-  ProtobufUnittest_Extensions_oneofNestedMessageExtensionLite,
-  ProtobufUnittest_Extensions_oneofStringExtensionLite,
-  ProtobufUnittest_Extensions_oneofBytesExtensionLite,
-  ProtobufUnittest_Extensions_packedInt32ExtensionLite,
-  ProtobufUnittest_Extensions_packedInt64ExtensionLite,
-  ProtobufUnittest_Extensions_packedUint32ExtensionLite,
-  ProtobufUnittest_Extensions_packedUint64ExtensionLite,
-  ProtobufUnittest_Extensions_packedSint32ExtensionLite,
-  ProtobufUnittest_Extensions_packedSint64ExtensionLite,
-  ProtobufUnittest_Extensions_packedFixed32ExtensionLite,
-  ProtobufUnittest_Extensions_packedFixed64ExtensionLite,
-  ProtobufUnittest_Extensions_packedSfixed32ExtensionLite,
-  ProtobufUnittest_Extensions_packedSfixed64ExtensionLite,
-  ProtobufUnittest_Extensions_packedFloatExtensionLite,
-  ProtobufUnittest_Extensions_packedDoubleExtensionLite,
-  ProtobufUnittest_Extensions_packedBoolExtensionLite,
-  ProtobufUnittest_Extensions_packedEnumExtensionLite,
-  ProtobufUnittest_Extensions_testAllTypesLite,
-  ProtobufUnittest_TestNestedExtensionLite.Extensions.nestedExtension,
-  ProtobufUnittest_TestParsingMergeLite.Extensions.optionalExt,
-  ProtobufUnittest_TestParsingMergeLite.Extensions.repeatedExt
+  ProtobufUnittest_Extensions_optional_int32_extension_lite,
+  ProtobufUnittest_Extensions_optional_int64_extension_lite,
+  ProtobufUnittest_Extensions_optional_uint32_extension_lite,
+  ProtobufUnittest_Extensions_optional_uint64_extension_lite,
+  ProtobufUnittest_Extensions_optional_sint32_extension_lite,
+  ProtobufUnittest_Extensions_optional_sint64_extension_lite,
+  ProtobufUnittest_Extensions_optional_fixed32_extension_lite,
+  ProtobufUnittest_Extensions_optional_fixed64_extension_lite,
+  ProtobufUnittest_Extensions_optional_sfixed32_extension_lite,
+  ProtobufUnittest_Extensions_optional_sfixed64_extension_lite,
+  ProtobufUnittest_Extensions_optional_float_extension_lite,
+  ProtobufUnittest_Extensions_optional_double_extension_lite,
+  ProtobufUnittest_Extensions_optional_bool_extension_lite,
+  ProtobufUnittest_Extensions_optional_string_extension_lite,
+  ProtobufUnittest_Extensions_optional_bytes_extension_lite,
+  ProtobufUnittest_Extensions_OptionalGroup_extension_lite,
+  ProtobufUnittest_Extensions_optional_nested_message_extension_lite,
+  ProtobufUnittest_Extensions_optional_foreign_message_extension_lite,
+  ProtobufUnittest_Extensions_optional_import_message_extension_lite,
+  ProtobufUnittest_Extensions_optional_nested_enum_extension_lite,
+  ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite,
+  ProtobufUnittest_Extensions_optional_import_enum_extension_lite,
+  ProtobufUnittest_Extensions_optional_string_piece_extension_lite,
+  ProtobufUnittest_Extensions_optional_cord_extension_lite,
+  ProtobufUnittest_Extensions_optional_public_import_message_extension_lite,
+  ProtobufUnittest_Extensions_optional_lazy_message_extension_lite,
+  ProtobufUnittest_Extensions_repeated_int32_extension_lite,
+  ProtobufUnittest_Extensions_repeated_int64_extension_lite,
+  ProtobufUnittest_Extensions_repeated_uint32_extension_lite,
+  ProtobufUnittest_Extensions_repeated_uint64_extension_lite,
+  ProtobufUnittest_Extensions_repeated_sint32_extension_lite,
+  ProtobufUnittest_Extensions_repeated_sint64_extension_lite,
+  ProtobufUnittest_Extensions_repeated_fixed32_extension_lite,
+  ProtobufUnittest_Extensions_repeated_fixed64_extension_lite,
+  ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite,
+  ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite,
+  ProtobufUnittest_Extensions_repeated_float_extension_lite,
+  ProtobufUnittest_Extensions_repeated_double_extension_lite,
+  ProtobufUnittest_Extensions_repeated_bool_extension_lite,
+  ProtobufUnittest_Extensions_repeated_string_extension_lite,
+  ProtobufUnittest_Extensions_repeated_bytes_extension_lite,
+  ProtobufUnittest_Extensions_RepeatedGroup_extension_lite,
+  ProtobufUnittest_Extensions_repeated_nested_message_extension_lite,
+  ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite,
+  ProtobufUnittest_Extensions_repeated_import_message_extension_lite,
+  ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite,
+  ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite,
+  ProtobufUnittest_Extensions_repeated_import_enum_extension_lite,
+  ProtobufUnittest_Extensions_repeated_string_piece_extension_lite,
+  ProtobufUnittest_Extensions_repeated_cord_extension_lite,
+  ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite,
+  ProtobufUnittest_Extensions_default_int32_extension_lite,
+  ProtobufUnittest_Extensions_default_int64_extension_lite,
+  ProtobufUnittest_Extensions_default_uint32_extension_lite,
+  ProtobufUnittest_Extensions_default_uint64_extension_lite,
+  ProtobufUnittest_Extensions_default_sint32_extension_lite,
+  ProtobufUnittest_Extensions_default_sint64_extension_lite,
+  ProtobufUnittest_Extensions_default_fixed32_extension_lite,
+  ProtobufUnittest_Extensions_default_fixed64_extension_lite,
+  ProtobufUnittest_Extensions_default_sfixed32_extension_lite,
+  ProtobufUnittest_Extensions_default_sfixed64_extension_lite,
+  ProtobufUnittest_Extensions_default_float_extension_lite,
+  ProtobufUnittest_Extensions_default_double_extension_lite,
+  ProtobufUnittest_Extensions_default_bool_extension_lite,
+  ProtobufUnittest_Extensions_default_string_extension_lite,
+  ProtobufUnittest_Extensions_default_bytes_extension_lite,
+  ProtobufUnittest_Extensions_default_nested_enum_extension_lite,
+  ProtobufUnittest_Extensions_default_foreign_enum_extension_lite,
+  ProtobufUnittest_Extensions_default_import_enum_extension_lite,
+  ProtobufUnittest_Extensions_default_string_piece_extension_lite,
+  ProtobufUnittest_Extensions_default_cord_extension_lite,
+  ProtobufUnittest_Extensions_oneof_uint32_extension_lite,
+  ProtobufUnittest_Extensions_oneof_nested_message_extension_lite,
+  ProtobufUnittest_Extensions_oneof_string_extension_lite,
+  ProtobufUnittest_Extensions_oneof_bytes_extension_lite,
+  ProtobufUnittest_Extensions_packed_int32_extension_lite,
+  ProtobufUnittest_Extensions_packed_int64_extension_lite,
+  ProtobufUnittest_Extensions_packed_uint32_extension_lite,
+  ProtobufUnittest_Extensions_packed_uint64_extension_lite,
+  ProtobufUnittest_Extensions_packed_sint32_extension_lite,
+  ProtobufUnittest_Extensions_packed_sint64_extension_lite,
+  ProtobufUnittest_Extensions_packed_fixed32_extension_lite,
+  ProtobufUnittest_Extensions_packed_fixed64_extension_lite,
+  ProtobufUnittest_Extensions_packed_sfixed32_extension_lite,
+  ProtobufUnittest_Extensions_packed_sfixed64_extension_lite,
+  ProtobufUnittest_Extensions_packed_float_extension_lite,
+  ProtobufUnittest_Extensions_packed_double_extension_lite,
+  ProtobufUnittest_Extensions_packed_bool_extension_lite,
+  ProtobufUnittest_Extensions_packed_enum_extension_lite,
+  ProtobufUnittest_Extensions_test_all_types_lite,
+  ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension,
+  ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext,
+  ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext
 ]

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -164,7 +164,7 @@ struct ProtobufUnittest_TestMessageSetExtension1: SwiftProtobuf.Message, SwiftPr
 
   struct Extensions {
 
-    static let messageSetExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension1>, Proto2WireformatUnittest_TestMessageSet>(
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension1>, Proto2WireformatUnittest_TestMessageSet>(
       fieldNumber: 1545008,
       fieldNames: .same(proto: "protobuf_unittest.TestMessageSetExtension1.message_set_extension"),
       defaultValue: ProtobufUnittest_TestMessageSetExtension1()
@@ -221,7 +221,7 @@ struct ProtobufUnittest_TestMessageSetExtension2: SwiftProtobuf.Message, SwiftPr
 
   struct Extensions {
 
-    static let messageSetExtension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension2>, Proto2WireformatUnittest_TestMessageSet>(
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension2>, Proto2WireformatUnittest_TestMessageSet>(
       fieldNumber: 1547769,
       fieldNames: .same(proto: "protobuf_unittest.TestMessageSetExtension2.message_set_extension"),
       defaultValue: ProtobufUnittest_TestMessageSetExtension2()
@@ -396,31 +396,31 @@ struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message, SwiftProtobuf.Prot
 
 extension Proto2WireformatUnittest_TestMessageSet {
   var ProtobufUnittest_TestMessageSetExtension1_messageSetExtension: ProtobufUnittest_TestMessageSetExtension1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.messageSetExtension) ?? ProtobufUnittest_TestMessageSetExtension1()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.messageSetExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension) ?? ProtobufUnittest_TestMessageSetExtension1()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestMessageSetExtension1_messageSetExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.messageSetExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension)
   }
   mutating func clearProtobufUnittest_TestMessageSetExtension1_messageSetExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.messageSetExtension)
+    clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension)
   }
 }
 
 extension Proto2WireformatUnittest_TestMessageSet {
   var ProtobufUnittest_TestMessageSetExtension2_messageSetExtension: ProtobufUnittest_TestMessageSetExtension2 {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.messageSetExtension) ?? ProtobufUnittest_TestMessageSetExtension2()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.messageSetExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension) ?? ProtobufUnittest_TestMessageSetExtension2()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestMessageSetExtension2_messageSetExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.messageSetExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension)
   }
   mutating func clearProtobufUnittest_TestMessageSetExtension2_messageSetExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.messageSetExtension)
+    clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension)
   }
 }
 
 let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_TestMessageSetExtension1.Extensions.messageSetExtension,
-  ProtobufUnittest_TestMessageSetExtension2.Extensions.messageSetExtension
+  ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension,
+  ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension
 ]

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -181,7 +181,7 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf.Message,
   }
 }
 
-let Google_Protobuf_NoGenericServicesTest_Extensions_testExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_NoGenericServicesTest_TestMessage>(
+let Google_Protobuf_NoGenericServicesTest_Extensions_test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_NoGenericServicesTest_TestMessage>(
   fieldNumber: 1000,
   fieldNames: .same(proto: "google.protobuf.no_generic_services_test.test_extension"),
   defaultValue: 0
@@ -189,17 +189,17 @@ let Google_Protobuf_NoGenericServicesTest_Extensions_testExtension = SwiftProtob
 
 extension Google_Protobuf_NoGenericServicesTest_TestMessage {
   var Google_Protobuf_NoGenericServicesTest_testExtension: Int32 {
-    get {return getExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_testExtension) ?? 0}
-    set {setExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_testExtension, value: newValue)}
+    get {return getExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension) ?? 0}
+    set {setExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension, value: newValue)}
   }
   var hasGoogle_Protobuf_NoGenericServicesTest_testExtension: Bool {
-    return hasExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_testExtension)
+    return hasExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension)
   }
   mutating func clearGoogle_Protobuf_NoGenericServicesTest_testExtension() {
-    clearExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_testExtension)
+    clearExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension)
   }
 }
 
 let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.ExtensionSet = [
-  Google_Protobuf_NoGenericServicesTest_Extensions_testExtension
+  Google_Protobuf_NoGenericServicesTest_Extensions_test_extension
 ]

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -188,13 +188,13 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
 
   struct Extensions {
 
-    static let testExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestOptimizedForSize>(
+    static let test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestOptimizedForSize>(
       fieldNumber: 1234,
       fieldNames: .same(proto: "protobuf_unittest.TestOptimizedForSize.test_extension"),
       defaultValue: 0
     )
 
-    static let testExtension2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequiredOptimizedForSize>, ProtobufUnittest_TestOptimizedForSize>(
+    static let test_extension2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequiredOptimizedForSize>, ProtobufUnittest_TestOptimizedForSize>(
       fieldNumber: 1235,
       fieldNames: .same(proto: "protobuf_unittest.TestOptimizedForSize.test_extension2"),
       defaultValue: ProtobufUnittest_TestRequiredOptimizedForSize()
@@ -453,31 +453,31 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message, Swi
 
 extension ProtobufUnittest_TestOptimizedForSize {
   var ProtobufUnittest_TestOptimizedForSize_testExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestOptimizedForSize_testExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension)
+    return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension)
   }
   mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension)
+    clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension)
   }
 }
 
 extension ProtobufUnittest_TestOptimizedForSize {
   var ProtobufUnittest_TestOptimizedForSize_testExtension2: ProtobufUnittest_TestRequiredOptimizedForSize {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension2) ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension2, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2) ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2, value: newValue)}
   }
   var hasProtobufUnittest_TestOptimizedForSize_testExtension2: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension2)
+    return hasExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2)
   }
   mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension2() {
-    clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension2)
+    clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2)
   }
 }
 
 let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension,
-  ProtobufUnittest_TestOptimizedForSize.Extensions.testExtension2
+  ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension,
+  ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -217,16 +217,156 @@ struct ProtobufUnittest_Extend_C: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
   }
 }
 
+// 
+// extend Foo.Bar.Baz.C {
+// optional bool d = 12;
+// }
+
+//  If this compiles then it means we deal with unique proto names that
+//  could end up with naming collisions when remapped to Swifty names.
+
+struct ProtobufUnittest_Extend_Msg1: SwiftProtobuf.Message, SwiftProtobuf.Proto2Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf.ProtoNameProviding {
+  static let protoMessageName: String = "Msg1"
+  static let protoPackageName: String = "protobuf_unittest.extend"
+  static let _protobuf_fieldNames = FieldNameMap()
+
+  var unknown = SwiftProtobuf.UnknownStorage()
+
+  public var isInitialized: Bool {
+    if !_extensionFieldValues.isInitialized {return false}
+    return true
+  }
+
+  mutating func _protoc_generated_decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      try decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    }
+  }
+
+  mutating func _protoc_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
+    if (1 <= fieldNumber && fieldNumber < 1001) {
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_Msg1.self, fieldNumber: fieldNumber)
+    }
+  }
+
+  func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
+    try visitor.visitExtensionFields(fields: _extensionFieldValues, start: 1, end: 1001)
+    unknown.traverse(visitor: visitor)
+  }
+
+  func _protoc_generated_isEqualTo(other: ProtobufUnittest_Extend_Msg1) -> Bool {
+    if unknown != other.unknown {return false}
+    if _extensionFieldValues != other._extensionFieldValues {return false}
+    return true
+  }
+
+  private var _extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
+
+  mutating func setExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg1>, value: F.ValueType) {
+    _extensionFieldValues[ext.fieldNumber] = ext.set(value: value)
+  }
+
+  mutating func clearExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg1>) {
+    _extensionFieldValues[ext.fieldNumber] = nil
+  }
+
+  func getExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg1>) -> F.ValueType {
+    if let fieldValue = _extensionFieldValues[ext.fieldNumber] as? F {
+      return fieldValue.value
+    }
+    return ext.defaultValue
+  }
+
+  func hasExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg1>) -> Bool {
+    return _extensionFieldValues[ext.fieldNumber] is F
+  }
+  func _protobuf_fieldNames(for number: Int) -> FieldNameMap.Names? {
+    return ProtobufUnittest_Extend_Msg1._protobuf_fieldNames.fieldNames(for: number) ?? _extensionFieldValues.fieldNames(for: number)
+  }
+}
+
+struct ProtobufUnittest_Extend_Msg2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf.ProtoNameProviding {
+  static let protoMessageName: String = "Msg2"
+  static let protoPackageName: String = "protobuf_unittest.extend"
+  static let _protobuf_fieldNames = FieldNameMap()
+
+  var unknown = SwiftProtobuf.UnknownStorage()
+
+  public var isInitialized: Bool {
+    if !_extensionFieldValues.isInitialized {return false}
+    return true
+  }
+
+  mutating func _protoc_generated_decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      try decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    }
+  }
+
+  mutating func _protoc_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
+    if (1 <= fieldNumber && fieldNumber < 1001) {
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_Msg2.self, fieldNumber: fieldNumber)
+    }
+  }
+
+  func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
+    try visitor.visitExtensionFields(fields: _extensionFieldValues, start: 1, end: 1001)
+    unknown.traverse(visitor: visitor)
+  }
+
+  func _protoc_generated_isEqualTo(other: ProtobufUnittest_Extend_Msg2) -> Bool {
+    if unknown != other.unknown {return false}
+    if _extensionFieldValues != other._extensionFieldValues {return false}
+    return true
+  }
+
+  private var _extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
+
+  mutating func setExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg2>, value: F.ValueType) {
+    _extensionFieldValues[ext.fieldNumber] = ext.set(value: value)
+  }
+
+  mutating func clearExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg2>) {
+    _extensionFieldValues[ext.fieldNumber] = nil
+  }
+
+  func getExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg2>) -> F.ValueType {
+    if let fieldValue = _extensionFieldValues[ext.fieldNumber] as? F {
+      return fieldValue.value
+    }
+    return ext.defaultValue
+  }
+
+  func hasExtensionValue<F: SwiftProtobuf.ExtensionField>(ext: SwiftProtobuf.MessageExtension<F, ProtobufUnittest_Extend_Msg2>) -> Bool {
+    return _extensionFieldValues[ext.fieldNumber] is F
+  }
+  func _protobuf_fieldNames(for number: Int) -> FieldNameMap.Names? {
+    return ProtobufUnittest_Extend_Msg2._protobuf_fieldNames.fieldNames(for: number) ?? _extensionFieldValues.fieldNames(for: number)
+  }
+}
+
 let ProtobufUnittest_Extend_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   fieldNumber: 100,
   fieldNames: .same(proto: "protobuf_unittest.extend.b"),
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extend_Extensions_c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+let ProtobufUnittest_Extend_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   fieldNumber: 101,
   fieldNames: .same(proto: "protobuf_unittest.extend.C"),
   defaultValue: ProtobufUnittest_Extend_C()
+)
+
+let ProtobufUnittest_Extend_Extensions_a_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg1>(
+  fieldNumber: 1,
+  fieldNames: .same(proto: "protobuf_unittest.extend.a_b"),
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_aB = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg2>(
+  fieldNumber: 1,
+  fieldNames: .same(proto: "protobuf_unittest.extend.aB"),
+  defaultValue: 0
 )
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
@@ -244,18 +384,46 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend_c: ProtobufUnittest_Extend_C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_c) ?? ProtobufUnittest_Extend_C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_c, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C) ?? ProtobufUnittest_Extend_C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C, value: newValue)}
   }
   var hasProtobufUnittest_Extend_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend_Extensions_c)
+    return hasExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C)
   }
   mutating func clearProtobufUnittest_Extend_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_c)
+    clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C)
+  }
+}
+
+extension ProtobufUnittest_Extend_Msg1 {
+  var ProtobufUnittest_Extend_aB: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend_aB: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b)
+  }
+  mutating func clearProtobufUnittest_Extend_aB() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b)
+  }
+}
+
+extension ProtobufUnittest_Extend_Msg2 {
+  var ProtobufUnittest_Extend_aB: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend_aB: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB)
+  }
+  mutating func clearProtobufUnittest_Extend_aB() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB)
   }
 }
 
 let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: SwiftProtobuf.ExtensionSet = [
   ProtobufUnittest_Extend_Extensions_b,
-  ProtobufUnittest_Extend_Extensions_c
+  ProtobufUnittest_Extend_Extensions_C,
+  ProtobufUnittest_Extend_Extensions_a_b,
+  ProtobufUnittest_Extend_Extensions_aB
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -100,7 +100,7 @@ struct ProtobufUnittest_Extend2_MyMessage: SwiftProtobuf.Message, SwiftProtobuf.
       defaultValue: ""
     )
 
-    static let c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       fieldNumber: 211,
       fieldNames: .same(proto: "protobuf_unittest.extend2.MyMessage.C"),
       defaultValue: ProtobufUnittest_Extend2_MyMessage.C()
@@ -180,7 +180,7 @@ let ProtobufUnittest_Extend2_Extensions_b = SwiftProtobuf.MessageExtension<Optio
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extend2_Extensions_c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   fieldNumber: 221,
   fieldNames: .same(proto: "protobuf_unittest.extend2.C"),
   defaultValue: ProtobufUnittest_Extend2_C()
@@ -201,14 +201,14 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_MyMessage_c: ProtobufUnittest_Extend2_MyMessage.C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.c) ?? ProtobufUnittest_Extend2_MyMessage.C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.c, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend2_MyMessage.C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C, value: newValue)}
   }
   var hasProtobufUnittest_Extend2_MyMessage_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.c)
+    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
   }
   mutating func clearProtobufUnittest_Extend2_MyMessage_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.c)
+    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
   }
 }
 
@@ -227,20 +227,20 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_c: ProtobufUnittest_Extend2_C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_c) ?? ProtobufUnittest_Extend2_C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_c, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C) ?? ProtobufUnittest_Extend2_C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C, value: newValue)}
   }
   var hasProtobufUnittest_Extend2_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_c)
+    return hasExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C)
   }
   mutating func clearProtobufUnittest_Extend2_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_c)
+    clearExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C)
   }
 }
 
 let ProtobufUnittest_Extend2_UnittestSwiftExtension2_Extensions: SwiftProtobuf.ExtensionSet = [
   ProtobufUnittest_Extend2_Extensions_b,
-  ProtobufUnittest_Extend2_Extensions_c,
+  ProtobufUnittest_Extend2_Extensions_C,
   ProtobufUnittest_Extend2_MyMessage.Extensions.b,
-  ProtobufUnittest_Extend2_MyMessage.Extensions.c
+  ProtobufUnittest_Extend2_MyMessage.Extensions.C
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -100,7 +100,7 @@ struct ProtobufUnittest_Extend3_MyMessage: SwiftProtobuf.Message, SwiftProtobuf.
       defaultValue: ""
     )
 
-    static let c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       fieldNumber: 311,
       fieldNames: .same(proto: "protobuf_unittest.extend3.MyMessage.C"),
       defaultValue: ProtobufUnittest_Extend3_MyMessage.C()
@@ -180,7 +180,7 @@ let ProtobufUnittest_Extend3_Extensions_b = SwiftProtobuf.MessageExtension<Optio
   defaultValue: ""
 )
 
-let ProtobufUnittest_Extend3_Extensions_c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   fieldNumber: 321,
   fieldNames: .same(proto: "protobuf_unittest.extend3.C"),
   defaultValue: ProtobufUnittest_Extend3_C()
@@ -201,14 +201,14 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_MyMessage_c: ProtobufUnittest_Extend3_MyMessage.C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.c) ?? ProtobufUnittest_Extend3_MyMessage.C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.c, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend3_MyMessage.C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C, value: newValue)}
   }
   var hasProtobufUnittest_Extend3_MyMessage_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.c)
+    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
   }
   mutating func clearProtobufUnittest_Extend3_MyMessage_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.c)
+    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
   }
 }
 
@@ -227,20 +227,20 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_c: ProtobufUnittest_Extend3_C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_c) ?? ProtobufUnittest_Extend3_C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_c, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C) ?? ProtobufUnittest_Extend3_C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C, value: newValue)}
   }
   var hasProtobufUnittest_Extend3_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_c)
+    return hasExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C)
   }
   mutating func clearProtobufUnittest_Extend3_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_c)
+    clearExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C)
   }
 }
 
 let ProtobufUnittest_Extend3_UnittestSwiftExtension3_Extensions: SwiftProtobuf.ExtensionSet = [
   ProtobufUnittest_Extend3_Extensions_b,
-  ProtobufUnittest_Extend3_Extensions_c,
+  ProtobufUnittest_Extend3_Extensions_C,
   ProtobufUnittest_Extend3_MyMessage.Extensions.b,
-  ProtobufUnittest_Extend3_MyMessage.Extensions.c
+  ProtobufUnittest_Extend3_MyMessage.Extensions.C
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -100,7 +100,7 @@ struct Ext4MyMessage: SwiftProtobuf.Message, SwiftProtobuf.Proto2Message, SwiftP
       defaultValue: ""
     )
 
-    static let c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       fieldNumber: 411,
       fieldNames: .same(proto: "protobuf_unittest.extend4.MyMessage.C"),
       defaultValue: Ext4MyMessage.C()
@@ -180,7 +180,7 @@ let Ext4Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<Swi
   defaultValue: ""
 )
 
-let Ext4Extensions_c = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   fieldNumber: 421,
   fieldNames: .same(proto: "protobuf_unittest.extend4.C"),
   defaultValue: Ext4C()
@@ -201,14 +201,14 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4MyMessage_c: Ext4MyMessage.C {
-    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.c) ?? Ext4MyMessage.C()}
-    set {setExtensionValue(ext: Ext4MyMessage.Extensions.c, value: newValue)}
+    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.C) ?? Ext4MyMessage.C()}
+    set {setExtensionValue(ext: Ext4MyMessage.Extensions.C, value: newValue)}
   }
   var hasExt4MyMessage_c: Bool {
-    return hasExtensionValue(ext: Ext4MyMessage.Extensions.c)
+    return hasExtensionValue(ext: Ext4MyMessage.Extensions.C)
   }
   mutating func clearExt4MyMessage_c() {
-    clearExtensionValue(ext: Ext4MyMessage.Extensions.c)
+    clearExtensionValue(ext: Ext4MyMessage.Extensions.C)
   }
 }
 
@@ -227,20 +227,20 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4c: Ext4C {
-    get {return getExtensionValue(ext: Ext4Extensions_c) ?? Ext4C()}
-    set {setExtensionValue(ext: Ext4Extensions_c, value: newValue)}
+    get {return getExtensionValue(ext: Ext4Extensions_C) ?? Ext4C()}
+    set {setExtensionValue(ext: Ext4Extensions_C, value: newValue)}
   }
   var hasExt4c: Bool {
-    return hasExtensionValue(ext: Ext4Extensions_c)
+    return hasExtensionValue(ext: Ext4Extensions_C)
   }
   mutating func clearExt4c() {
-    clearExtensionValue(ext: Ext4Extensions_c)
+    clearExtensionValue(ext: Ext4Extensions_C)
   }
 }
 
 let Ext4UnittestSwiftExtension4_Extensions: SwiftProtobuf.ExtensionSet = [
   Ext4Extensions_b,
-  Ext4Extensions_c,
+  Ext4Extensions_C,
   Ext4MyMessage.Extensions.b,
-  Ext4MyMessage.Extensions.c
+  Ext4MyMessage.Extensions.C
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -425,13 +425,13 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
   }
 }
 
-let Swift_Protobuf_Extensions_myExtensionString = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(
+let Swift_Protobuf_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(
   fieldNumber: 50,
   fieldNames: .same(proto: "swift.protobuf.my_extension_string"),
   defaultValue: ""
 )
 
-let Swift_Protobuf_Extensions_myExtensionInt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(
+let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(
   fieldNumber: 5,
   fieldNames: .same(proto: "swift.protobuf.my_extension_int"),
   defaultValue: 0
@@ -439,31 +439,31 @@ let Swift_Protobuf_Extensions_myExtensionInt = SwiftProtobuf.MessageExtension<Op
 
 extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionString: String {
-    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionString) ?? ""}
-    set {setExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionString, value: newValue)}
+    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string) ?? ""}
+    set {setExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string, value: newValue)}
   }
   var hasSwift_Protobuf_myExtensionString: Bool {
-    return hasExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionString)
+    return hasExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string)
   }
   mutating func clearSwift_Protobuf_myExtensionString() {
-    clearExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionString)
+    clearExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string)
   }
 }
 
 extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionInt: Int32 {
-    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionInt) ?? 0}
-    set {setExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionInt, value: newValue)}
+    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int) ?? 0}
+    set {setExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int, value: newValue)}
   }
   var hasSwift_Protobuf_myExtensionInt: Bool {
-    return hasExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionInt)
+    return hasExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int)
   }
   mutating func clearSwift_Protobuf_myExtensionInt() {
-    clearExtensionValue(ext: Swift_Protobuf_Extensions_myExtensionInt)
+    clearExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int)
   }
 }
 
 let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: SwiftProtobuf.ExtensionSet = [
-  Swift_Protobuf_Extensions_myExtensionString,
-  Swift_Protobuf_Extensions_myExtensionInt
+  Swift_Protobuf_Extensions_my_extension_string,
+  Swift_Protobuf_Extensions_my_extension_int
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -275,13 +275,13 @@ struct SwiftTestGroupUnextended: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mess
   }
 }
 
-let Extensions_extensionGroup = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ExtensionGroup>, SwiftTestGroupExtensions>(
+let Extensions_ExtensionGroup = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ExtensionGroup>, SwiftTestGroupExtensions>(
   fieldNumber: 2,
   fieldNames: .same(proto: "ExtensionGroup"),
   defaultValue: ExtensionGroup()
 )
 
-let Extensions_repeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(
+let Extensions_RepeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(
   fieldNumber: 3,
   fieldNames: .same(proto: "RepeatedExtensionGroup"),
   defaultValue: []
@@ -289,31 +289,31 @@ let Extensions_repeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedG
 
 extension SwiftTestGroupExtensions {
   var extensionGroup: ExtensionGroup {
-    get {return getExtensionValue(ext: Extensions_extensionGroup) ?? ExtensionGroup()}
-    set {setExtensionValue(ext: Extensions_extensionGroup, value: newValue)}
+    get {return getExtensionValue(ext: Extensions_ExtensionGroup) ?? ExtensionGroup()}
+    set {setExtensionValue(ext: Extensions_ExtensionGroup, value: newValue)}
   }
   var hasExtensionGroup: Bool {
-    return hasExtensionValue(ext: Extensions_extensionGroup)
+    return hasExtensionValue(ext: Extensions_ExtensionGroup)
   }
   mutating func clearExtensionGroup() {
-    clearExtensionValue(ext: Extensions_extensionGroup)
+    clearExtensionValue(ext: Extensions_ExtensionGroup)
   }
 }
 
 extension SwiftTestGroupExtensions {
   var repeatedExtensionGroup: [RepeatedExtensionGroup] {
-    get {return getExtensionValue(ext: Extensions_repeatedExtensionGroup)}
-    set {setExtensionValue(ext: Extensions_repeatedExtensionGroup, value: newValue)}
+    get {return getExtensionValue(ext: Extensions_RepeatedExtensionGroup)}
+    set {setExtensionValue(ext: Extensions_RepeatedExtensionGroup, value: newValue)}
   }
   var hasRepeatedExtensionGroup: Bool {
-    return hasExtensionValue(ext: Extensions_repeatedExtensionGroup)
+    return hasExtensionValue(ext: Extensions_RepeatedExtensionGroup)
   }
   mutating func clearRepeatedExtensionGroup() {
-    clearExtensionValue(ext: Extensions_repeatedExtensionGroup)
+    clearExtensionValue(ext: Extensions_RepeatedExtensionGroup)
   }
 }
 
 let UnittestSwiftGroups_Extensions: SwiftProtobuf.ExtensionSet = [
-  Extensions_extensionGroup,
-  Extensions_repeatedExtensionGroup
+  Extensions_ExtensionGroup,
+  Extensions_RepeatedExtensionGroup
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -26175,19 +26175,19 @@ struct SwiftUnittest_Names_Lowers: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
       defaultValue: 0
     )
 
-    static let httpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 2,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.http_request"),
       defaultValue: 0
     )
 
-    static let theHTTPRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 3,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_http_request"),
       defaultValue: 0
     )
 
-    static let theHTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 4,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_http"),
       defaultValue: 0
@@ -26199,19 +26199,19 @@ struct SwiftUnittest_Names_Lowers: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
       defaultValue: 0
     )
 
-    static let httpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 12,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.https_request"),
       defaultValue: 0
     )
 
-    static let theHTTPSRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 13,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_https_request"),
       defaultValue: 0
     )
 
-    static let theHTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 14,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_https"),
       defaultValue: 0
@@ -26223,25 +26223,25 @@ struct SwiftUnittest_Names_Lowers: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
       defaultValue: 0
     )
 
-    static let urlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 22,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.url_value"),
       defaultValue: 0
     )
 
-    static let theURLValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 23,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_url_value"),
       defaultValue: 0
     )
 
-    static let theURL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 24,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.the_url"),
       defaultValue: 0
     )
 
-    static let aBC = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 31,
       fieldNames: .same(proto: "swift_unittest.names.Lowers.a_b_c"),
       defaultValue: 0
@@ -26276,73 +26276,73 @@ struct SwiftUnittest_Names_Uppers: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
 
   struct Extensions {
 
-    static let http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 101,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.HTTP"),
       defaultValue: 0
     )
 
-    static let httpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 102,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.HTTP_request"),
       defaultValue: 0
     )
 
-    static let theHTTPRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 103,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_HTTP_request"),
       defaultValue: 0
     )
 
-    static let theHTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 104,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_HTTP"),
       defaultValue: 0
     )
 
-    static let https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 111,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.HTTPS"),
       defaultValue: 0
     )
 
-    static let httpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 112,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.HTTPS_request"),
       defaultValue: 0
     )
 
-    static let theHTTPSRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 113,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_HTTPS_request"),
       defaultValue: 0
     )
 
-    static let theHTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 114,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_HTTPS"),
       defaultValue: 0
     )
 
-    static let url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 121,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.URL"),
       defaultValue: 0
     )
 
-    static let urlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 122,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.URL_value"),
       defaultValue: 0
     )
 
-    static let theURLValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 123,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_URL_value"),
       defaultValue: 0
     )
 
-    static let theURL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 124,
       fieldNames: .same(proto: "swift_unittest.names.Uppers.the_URL"),
       defaultValue: 0
@@ -26377,73 +26377,73 @@ struct SwiftUnittest_Names_WordCase: SwiftProtobuf.Message, SwiftProtobuf.Proto2
 
   struct Extensions {
 
-    static let http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 201,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.Http"),
       defaultValue: 0
     )
 
-    static let httpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 202,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.HttpRequest"),
       defaultValue: 0
     )
 
-    static let theHTTPRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 203,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheHttpRequest"),
       defaultValue: 0
     )
 
-    static let theHTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 204,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheHttp"),
       defaultValue: 0
     )
 
-    static let https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 211,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.Https"),
       defaultValue: 0
     )
 
-    static let httpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 212,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.HttpsRequest"),
       defaultValue: 0
     )
 
-    static let theHTTPSRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 213,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheHttpsRequest"),
       defaultValue: 0
     )
 
-    static let theHTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 214,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheHttps"),
       defaultValue: 0
     )
 
-    static let url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 221,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.Url"),
       defaultValue: 0
     )
 
-    static let urlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 222,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.UrlValue"),
       defaultValue: 0
     )
 
-    static let theURLValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 223,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheUrlValue"),
       defaultValue: 0
     )
 
-    static let theURL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+    static let TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       fieldNumber: 224,
       fieldNames: .same(proto: "swift_unittest.names.WordCase.TheUrl"),
       defaultValue: 0
@@ -26484,40 +26484,40 @@ extension SwiftUnittest_Names_ExtensionNamingInitials {
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
   }
   mutating func clearSwiftUnittest_Names_Lowers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTP, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTP)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTP)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
   }
 }
 
@@ -26536,40 +26536,40 @@ extension SwiftUnittest_Names_ExtensionNamingInitials {
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpsRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpsRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
   }
   mutating func clearSwiftUnittest_Names_Lowers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.httpsRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPSRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPSRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPSRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPSRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPS, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPS)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theHTTPS)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
   }
 }
 
@@ -26588,404 +26588,404 @@ extension SwiftUnittest_Names_ExtensionNamingInitials {
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.urlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.urlValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.urlValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
   }
   mutating func clearSwiftUnittest_Names_Lowers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.urlValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURLValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURLValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURLValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURLValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURL, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURL)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
   }
   mutating func clearSwiftUnittest_Names_Lowers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.theURL)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_aBC: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.aBC) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.aBC, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c, value: newValue)}
   }
   var hasSwiftUnittest_Names_Lowers_aBC: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.aBC)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
   }
   mutating func clearSwiftUnittest_Names_Lowers_aBC() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.aBC)
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.http, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.http)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
   }
   mutating func clearSwiftUnittest_Names_Uppers_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.http)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
   }
   mutating func clearSwiftUnittest_Names_Uppers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTP, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTP)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTP)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.https, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.https)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
   }
   mutating func clearSwiftUnittest_Names_Uppers_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.https)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpsRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpsRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
   }
   mutating func clearSwiftUnittest_Names_Uppers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.httpsRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPSRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPSRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPSRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPSRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPS, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPS)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theHTTPS)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.url, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.url)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
   }
   mutating func clearSwiftUnittest_Names_Uppers_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.url)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.urlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.urlValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.urlValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
   }
   mutating func clearSwiftUnittest_Names_Uppers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.urlValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURLValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURLValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURLValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURLValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Uppers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURL, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL, value: newValue)}
   }
   var hasSwiftUnittest_Names_Uppers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURL)
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
   }
   mutating func clearSwiftUnittest_Names_Uppers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.theURL)
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.http, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.http)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
   }
   mutating func clearSwiftUnittest_Names_WordCase_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.http)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
   }
   mutating func clearSwiftUnittest_Names_WordCase_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTP, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTP)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTP)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.https, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.https)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
   }
   mutating func clearSwiftUnittest_Names_WordCase_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.https)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpsRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpsRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
   }
   mutating func clearSwiftUnittest_Names_WordCase_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.httpsRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPSRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPSRequest, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPSRequest)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPSRequest)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPS, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPS)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theHTTPS)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.url, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.url)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
   }
   mutating func clearSwiftUnittest_Names_WordCase_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.url)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.urlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.urlValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.urlValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
   }
   mutating func clearSwiftUnittest_Names_WordCase_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.urlValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURLValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURLValue, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURLValue)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURLValue)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
   }
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_WordCase_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURL, value: newValue)}
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl, value: newValue)}
   }
   var hasSwiftUnittest_Names_WordCase_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURL)
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
   }
   mutating func clearSwiftUnittest_Names_WordCase_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.theURL)
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
   }
 }
 
 let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.ExtensionSet = [
   SwiftUnittest_Names_Lowers.Extensions.http,
-  SwiftUnittest_Names_Lowers.Extensions.httpRequest,
-  SwiftUnittest_Names_Lowers.Extensions.theHTTPRequest,
-  SwiftUnittest_Names_Lowers.Extensions.theHTTP,
+  SwiftUnittest_Names_Lowers.Extensions.http_request,
+  SwiftUnittest_Names_Lowers.Extensions.the_http_request,
+  SwiftUnittest_Names_Lowers.Extensions.the_http,
   SwiftUnittest_Names_Lowers.Extensions.https,
-  SwiftUnittest_Names_Lowers.Extensions.httpsRequest,
-  SwiftUnittest_Names_Lowers.Extensions.theHTTPSRequest,
-  SwiftUnittest_Names_Lowers.Extensions.theHTTPS,
+  SwiftUnittest_Names_Lowers.Extensions.https_request,
+  SwiftUnittest_Names_Lowers.Extensions.the_https_request,
+  SwiftUnittest_Names_Lowers.Extensions.the_https,
   SwiftUnittest_Names_Lowers.Extensions.url,
-  SwiftUnittest_Names_Lowers.Extensions.urlValue,
-  SwiftUnittest_Names_Lowers.Extensions.theURLValue,
-  SwiftUnittest_Names_Lowers.Extensions.theURL,
-  SwiftUnittest_Names_Lowers.Extensions.aBC,
-  SwiftUnittest_Names_Uppers.Extensions.http,
-  SwiftUnittest_Names_Uppers.Extensions.httpRequest,
-  SwiftUnittest_Names_Uppers.Extensions.theHTTPRequest,
-  SwiftUnittest_Names_Uppers.Extensions.theHTTP,
-  SwiftUnittest_Names_Uppers.Extensions.https,
-  SwiftUnittest_Names_Uppers.Extensions.httpsRequest,
-  SwiftUnittest_Names_Uppers.Extensions.theHTTPSRequest,
-  SwiftUnittest_Names_Uppers.Extensions.theHTTPS,
-  SwiftUnittest_Names_Uppers.Extensions.url,
-  SwiftUnittest_Names_Uppers.Extensions.urlValue,
-  SwiftUnittest_Names_Uppers.Extensions.theURLValue,
-  SwiftUnittest_Names_Uppers.Extensions.theURL,
-  SwiftUnittest_Names_WordCase.Extensions.http,
-  SwiftUnittest_Names_WordCase.Extensions.httpRequest,
-  SwiftUnittest_Names_WordCase.Extensions.theHTTPRequest,
-  SwiftUnittest_Names_WordCase.Extensions.theHTTP,
-  SwiftUnittest_Names_WordCase.Extensions.https,
-  SwiftUnittest_Names_WordCase.Extensions.httpsRequest,
-  SwiftUnittest_Names_WordCase.Extensions.theHTTPSRequest,
-  SwiftUnittest_Names_WordCase.Extensions.theHTTPS,
-  SwiftUnittest_Names_WordCase.Extensions.url,
-  SwiftUnittest_Names_WordCase.Extensions.urlValue,
-  SwiftUnittest_Names_WordCase.Extensions.theURLValue,
-  SwiftUnittest_Names_WordCase.Extensions.theURL
+  SwiftUnittest_Names_Lowers.Extensions.url_value,
+  SwiftUnittest_Names_Lowers.Extensions.the_url_value,
+  SwiftUnittest_Names_Lowers.Extensions.the_url,
+  SwiftUnittest_Names_Lowers.Extensions.a_b_c,
+  SwiftUnittest_Names_Uppers.Extensions.HTTP,
+  SwiftUnittest_Names_Uppers.Extensions.HTTP_request,
+  SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request,
+  SwiftUnittest_Names_Uppers.Extensions.the_HTTP,
+  SwiftUnittest_Names_Uppers.Extensions.HTTPS,
+  SwiftUnittest_Names_Uppers.Extensions.HTTPS_request,
+  SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request,
+  SwiftUnittest_Names_Uppers.Extensions.the_HTTPS,
+  SwiftUnittest_Names_Uppers.Extensions.URL,
+  SwiftUnittest_Names_Uppers.Extensions.URL_value,
+  SwiftUnittest_Names_Uppers.Extensions.the_URL_value,
+  SwiftUnittest_Names_Uppers.Extensions.the_URL,
+  SwiftUnittest_Names_WordCase.Extensions.Http,
+  SwiftUnittest_Names_WordCase.Extensions.HttpRequest,
+  SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest,
+  SwiftUnittest_Names_WordCase.Extensions.TheHttp,
+  SwiftUnittest_Names_WordCase.Extensions.Https,
+  SwiftUnittest_Names_WordCase.Extensions.HttpsRequest,
+  SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest,
+  SwiftUnittest_Names_WordCase.Extensions.TheHttps,
+  SwiftUnittest_Names_WordCase.Extensions.Url,
+  SwiftUnittest_Names_WordCase.Extensions.UrlValue,
+  SwiftUnittest_Names_WordCase.Extensions.TheUrlValue,
+  SwiftUnittest_Names_WordCase.Extensions.TheUrl
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -441,7 +441,7 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message, SwiftProtob
     ///   Even though it is a raw name in the Extensions struct for the
     ///   Message (SwiftReservedTestExt), the generation controls what
     ///   that struct has to conform to, so collisions there don't matter.
-    static let hashValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+    static let hash_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
       fieldNumber: 1001,
       fieldNames: .same(proto: "protobuf_unittest.SwiftReservedTestExt.hash_value"),
       defaultValue: false
@@ -468,7 +468,7 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message, SwiftProtob
 }
 
 ///   Won't get _p added because it is fully qualified.
-let ProtobufUnittest_Extensions_debugDescription = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+let ProtobufUnittest_Extensions_debug_description = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
   fieldNumber: 1000,
   fieldNames: .same(proto: "protobuf_unittest.debug_description"),
   defaultValue: false
@@ -479,32 +479,32 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   ///   Message (SwiftReservedTestExt), the generation controls what
   ///   that struct has to conform to, so collisions there don't matter.
   var ProtobufUnittest_SwiftReservedTestExt_hashValue: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hashValue) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hashValue, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value, value: newValue)}
   }
   var hasProtobufUnittest_SwiftReservedTestExt_hashValue: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hashValue)
+    return hasExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value)
   }
   mutating func clearProtobufUnittest_SwiftReservedTestExt_hashValue() {
-    clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hashValue)
+    clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value)
   }
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
   ///   Won't get _p added because it is fully qualified.
   var ProtobufUnittest_debugDescription: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debugDescription) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_debugDescription, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debug_description) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_debug_description, value: newValue)}
   }
   var hasProtobufUnittest_debugDescription: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_debugDescription)
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
   }
   mutating func clearProtobufUnittest_debugDescription() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_debugDescription)
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
   }
 }
 
 let ProtobufUnittest_UnittestSwiftReserved_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufUnittest_Extensions_debugDescription,
-  ProtobufUnittest_SwiftReservedTestExt.Extensions.hashValue
+  ProtobufUnittest_Extensions_debug_description,
+  ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -118,7 +118,7 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message, SwiftP
 
   struct Extensions {
 
-    static let nestedStringExtension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
       fieldNumber: 3,
       fieldNames: .same(proto: "protobuf_objc_unittest.TestObjCStartupNested.nested_string_extension"),
       defaultValue: ""
@@ -145,13 +145,13 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message, SwiftP
 }
 
 ///   Singular
-let ProtobufObjcUnittest_Extensions_optionalInt32Extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+let ProtobufObjcUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
   fieldNumber: 1,
   fieldNames: .same(proto: "protobuf_objc_unittest.optional_int32_extension"),
   defaultValue: 0
 )
 
-let ProtobufObjcUnittest_Extensions_repeatedInt32Extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
   fieldNumber: 2,
   fieldNames: .same(proto: "protobuf_objc_unittest.repeated_int32_extension"),
   defaultValue: []
@@ -159,46 +159,46 @@ let ProtobufObjcUnittest_Extensions_repeatedInt32Extension = SwiftProtobuf.Messa
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nestedStringExtension) ?? ""}
-    set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nestedStringExtension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? ""}
+    set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension, value: newValue)}
   }
   var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nestedStringExtension)
+    return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
   }
   mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
-    clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nestedStringExtension)
+    clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
   }
 }
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   ///   Singular
   var ProtobufObjcUnittest_optionalInt32Extension: Int32 {
-    get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_optionalInt32Extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_optionalInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension, value: newValue)}
   }
   var hasProtobufObjcUnittest_optionalInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufObjcUnittest_Extensions_optionalInt32Extension)
+    return hasExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension)
   }
   mutating func clearProtobufObjcUnittest_optionalInt32Extension() {
-    clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_optionalInt32Extension)
+    clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension)
   }
 }
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_repeatedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeatedInt32Extension)}
-    set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeatedInt32Extension, value: newValue)}
+    get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension)}
+    set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension, value: newValue)}
   }
   var hasProtobufObjcUnittest_repeatedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeatedInt32Extension)
+    return hasExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension)
   }
   mutating func clearProtobufObjcUnittest_repeatedInt32Extension() {
-    clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeatedInt32Extension)
+    clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension)
   }
 }
 
 let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: SwiftProtobuf.ExtensionSet = [
-  ProtobufObjcUnittest_Extensions_optionalInt32Extension,
-  ProtobufObjcUnittest_Extensions_repeatedInt32Extension,
-  ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nestedStringExtension
+  ProtobufObjcUnittest_Extensions_optional_int32_extension,
+  ProtobufObjcUnittest_Extensions_repeated_int32_extension,
+  ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension
 ]


### PR DESCRIPTION
protoc ensures extensions defined at the same scope don't have name collisions,
but because the generator remaps names to be more Swifty, there can end up
being collisions. To avoid that, only make the names added in the Message's
Swift Extension Swifty, but leave the raw static used for the extension
plumbing as is to ensure it is unique.

Fixes https://github.com/apple/swift-protobuf/issues/275