### PR TITLE
Move and tweak naming of ExtensibleMessageStorage.

### DIFF
--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -4694,7 +4694,7 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf
     200: .unique(proto: "optional_nested_message", json: "optionalNestedMessage"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestFieldOrderings
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -8341,7 +8341,7 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
     20: .unique(proto: "RepeatedGroup", json: "repeatedgroup"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestParsingMerge
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -9363,7 +9363,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
     536870014: .unique(proto: "oneof_bytes", json: "oneofBytes"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestHugeFieldNumbers
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -821,7 +821,7 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.Message, SwiftProtobuf
     4: .same(proto: "barney"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_ComplexOptionType2
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -2420,7 +2420,7 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
     20: .unique(proto: "RepeatedGroup", json: "repeatedgroup"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestParsingMergeLite
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -3316,7 +3316,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
     536870014: .unique(proto: "oneof_bytes", json: "oneofBytes"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestHugeFieldNumbersLite
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -65,7 +65,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     3: .unique(proto: "string_field", json: "stringField"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestOptimizedForSize
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -450,7 +450,7 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
     2: .same(proto: "y"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_Extend_MsgUsesStorage
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -479,17 +479,6 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
           try decoder.decodeExtensionField(values: &extensionFieldValues, messageType: ProtobufUnittest_Extend_MsgUsesStorage.self, fieldNumber: fieldNumber)
         }
       }
-    }
-
-    func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      if let v = _x {
-        try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt32.self, value: v, fieldNumber: 1)
-      }
-      if let v = _y {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
-      try visitor.visitExtensionFields(fields: extensionFieldValues, start: 100, end: 201)
-      unknownFields.traverse(visitor: visitor)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -555,7 +544,16 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
   }
 
   func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
-    try _storage.traverse(visitor: visitor)
+    try withExtendedLifetime(_storage) { (storage: _StorageClass) in
+      if let v = storage._x {
+        try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt32.self, value: v, fieldNumber: 1)
+      }
+      if let v = storage._y {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      try visitor.visitExtensionFields(fields: storage.extensionFieldValues, start: 100, end: 201)
+      storage.unknownFields.traverse(visitor: visitor)
+    }
   }
 
   func _protoc_generated_isEqualTo(other: ProtobufUnittest_Extend_MsgUsesStorage) -> Bool {

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -49,7 +49,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
     200: .unique(proto: "optional_nested_message", json: "optionalNestedMessage"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = Swift_Protobuf_TestFieldOrderings
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Sources/SwiftProtobuf/ExtensibleMessage.swift
+++ b/Sources/SwiftProtobuf/ExtensibleMessage.swift
@@ -20,31 +20,34 @@ public protocol ExtensibleMessage: Message {
     mutating func clearExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, Self>)
 }
 
-// Common support for storage classes to handle extension fields
-public protocol ExtensibleMessageStorage: class {
-    associatedtype ExtendedMessage: Message
-    var extensionFieldValues: ExtensionFieldValueSet {get set}
-    func setExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, ExtendedMessage>, value: F.ValueType)
-    func getExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, ExtendedMessage>) -> F.ValueType
+
+// -----------------------------------------------------------------------------
+
+
+/// SwiftProtobuf Internal: Common support for storage classes to handle extension fields
+public protocol _ExtensibleMessageStorage: class {
+  associatedtype ExtendedMessage: Message
+  var extensionFieldValues: ExtensionFieldValueSet {get set}
 }
 
-public extension ExtensibleMessageStorage {
-    public func setExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, ExtendedMessage>, value: F.ValueType) {
-        extensionFieldValues[ext.fieldNumber] = ext.set(value: value)
-    }
+/// SwiftProtobuf Internal: Common support for storage classes to handle extension fields
+public extension _ExtensibleMessageStorage {
+  public func setExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, ExtendedMessage>, value: F.ValueType) {
+    extensionFieldValues[ext.fieldNumber] = ext.set(value: value)
+  }
 
-    public func clearExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, ExtendedMessage>) {
-        extensionFieldValues[ext.fieldNumber] = nil
-    }
+  public func clearExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, ExtendedMessage>) {
+    extensionFieldValues[ext.fieldNumber] = nil
+  }
 
-    public func getExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, ExtendedMessage>) -> F.ValueType {
-        if let fieldValue = extensionFieldValues[ext.fieldNumber] as? F {
-            return fieldValue.value
-        }
-        return ext.defaultValue
+  public func getExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, ExtendedMessage>) -> F.ValueType {
+    if let fieldValue = extensionFieldValues[ext.fieldNumber] as? F {
+      return fieldValue.value
     }
+    return ext.defaultValue
+  }
 
-    public func hasExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, ExtendedMessage>) -> Bool {
-        return extensionFieldValues[ext.fieldNumber] is F
-    }
+  public func hasExtensionValue<F: AnyExtensionField>(ext: MessageExtension<F, ExtendedMessage>) -> Bool {
+    return extensionFieldValues[ext.fieldNumber] is F
+  }
 }

--- a/Sources/SwiftProtobuf/Internal.swift
+++ b/Sources/SwiftProtobuf/Internal.swift
@@ -1,4 +1,4 @@
-// Sources/SwiftProtobuf/Message.swift - Message support
+// Sources/SwiftProtobuf/Internal.swift - Message support
 //
 // Copyright (c) 2014 - 2017 Apple Inc. and the project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -114,7 +114,7 @@ class StorageClassGenerator {
     func generateNested(printer p: inout CodePrinter) {
         p.print("\n")
         if isExtensible {
-            p.print("private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {\n")
+            p.print("private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {\n")
         } else {
             p.print("private class _StorageClass {\n")
         }

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -4694,7 +4694,7 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf
     200: .unique(proto: "optional_nested_message", json: "optionalNestedMessage"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestFieldOrderings
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -8341,7 +8341,7 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
     20: .unique(proto: "RepeatedGroup", json: "repeatedgroup"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestParsingMerge
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -9363,7 +9363,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
     536870014: .unique(proto: "oneof_bytes", json: "oneofBytes"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestHugeFieldNumbers
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -821,7 +821,7 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.Message, SwiftProtobuf
     4: .same(proto: "barney"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_ComplexOptionType2
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -2420,7 +2420,7 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
     20: .unique(proto: "RepeatedGroup", json: "repeatedgroup"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestParsingMergeLite
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -3316,7 +3316,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
     536870014: .unique(proto: "oneof_bytes", json: "oneofBytes"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestHugeFieldNumbersLite
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -65,7 +65,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     3: .unique(proto: "string_field", json: "stringField"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_TestOptimizedForSize
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -450,7 +450,7 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
     2: .same(proto: "y"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = ProtobufUnittest_Extend_MsgUsesStorage
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -479,17 +479,6 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
           try decoder.decodeExtensionField(values: &extensionFieldValues, messageType: ProtobufUnittest_Extend_MsgUsesStorage.self, fieldNumber: fieldNumber)
         }
       }
-    }
-
-    func traverse(visitor: SwiftProtobuf.Visitor) throws {
-      if let v = _x {
-        try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt32.self, value: v, fieldNumber: 1)
-      }
-      if let v = _y {
-        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-      }
-      try visitor.visitExtensionFields(fields: extensionFieldValues, start: 100, end: 201)
-      unknownFields.traverse(visitor: visitor)
     }
 
     func isEqualTo(other: _StorageClass) -> Bool {
@@ -555,7 +544,16 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
   }
 
   func _protoc_generated_traverse(visitor: SwiftProtobuf.Visitor) throws {
-    try _storage.traverse(visitor: visitor)
+    try withExtendedLifetime(_storage) { (storage: _StorageClass) in
+      if let v = storage._x {
+        try visitor.visitSingularField(fieldType: SwiftProtobuf.ProtobufInt32.self, value: v, fieldNumber: 1)
+      }
+      if let v = storage._y {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+      try visitor.visitExtensionFields(fields: storage.extensionFieldValues, start: 100, end: 201)
+      storage.unknownFields.traverse(visitor: visitor)
+    }
   }
 
   func _protoc_generated_isEqualTo(other: ProtobufUnittest_Extend_MsgUsesStorage) -> Bool {

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -49,7 +49,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.P
     200: .unique(proto: "optional_nested_message", json: "optionalNestedMessage"),
   ]
 
-  private class _StorageClass: SwiftProtobuf.ExtensibleMessageStorage {
+  private class _StorageClass: SwiftProtobuf._ExtensibleMessageStorage {
     typealias ExtendedMessage = Swift_Protobuf_TestFieldOrderings
     var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
     var unknownFields = SwiftProtobuf.UnknownStorage()


### PR DESCRIPTION
For the things that are `public` because the generated code has to be able to use them, but really are internal details to the library/runtime, does it make sense to move/name them to help call this out?  (If Swift let me stick this inside the `struct Internal` I would, but that isn't allowed.)
