### PR TITLE
Only generate the typealias ExtendedMessage when needed.

### DIFF
--- a/Reference/google/protobuf/any_test.pb.swift
+++ b/Reference/google/protobuf/any_test.pb.swift
@@ -59,7 +59,6 @@ struct ProtobufUnittest_TestAny: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestAny
     var _int32Value: Int32 = 0
     var _anyValue: Google_Protobuf_Any? = nil
     var _repeatedAnyValue: [Google_Protobuf_Any] = []

--- a/Reference/google/protobuf/api.pb.swift
+++ b/Reference/google/protobuf/api.pb.swift
@@ -63,7 +63,6 @@ struct Google_Protobuf_Api: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, 
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Api
     var _name: String = ""
     var _methods: [Google_Protobuf_Method] = []
     var _options: [Google_Protobuf_Option] = []

--- a/Reference/google/protobuf/compiler/plugin.pb.swift
+++ b/Reference/google/protobuf/compiler/plugin.pb.swift
@@ -182,7 +182,6 @@ struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message, Swi
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Compiler_CodeGeneratorRequest
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _fileToGenerate: [String] = []
     var _parameter: String? = nil

--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -122,7 +122,6 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_FileDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _package: String? = nil
@@ -402,7 +401,6 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_DescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _field: [Google_Protobuf_FieldDescriptorProto] = []
@@ -767,7 +765,6 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_FieldDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _number: Int32? = nil
@@ -1280,7 +1277,6 @@ struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_OneofDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _options: Google_Protobuf_OneofOptions? = nil
@@ -1398,7 +1394,6 @@ struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_EnumDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _value: [Google_Protobuf_EnumValueDescriptorProto] = []
@@ -1529,7 +1524,6 @@ struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message, SwiftPro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_EnumValueDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _number: Int32? = nil
@@ -1665,7 +1659,6 @@ struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message, SwiftProto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_ServiceDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _method: [Google_Protobuf_MethodDescriptorProto] = []
@@ -1799,7 +1792,6 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_MethodDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _inputType: String? = nil

--- a/Reference/google/protobuf/map_lite_unittest.pb.swift
+++ b/Reference/google/protobuf/map_lite_unittest.pb.swift
@@ -257,7 +257,6 @@ struct ProtobufUnittest_TestMapLite: SwiftProtobuf.Message, SwiftProtobuf.Proto2
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMapLite
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
@@ -560,7 +559,6 @@ struct ProtobufUnittest_TestArenaMapLite: SwiftProtobuf.Message, SwiftProtobuf.P
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestArenaMapLite
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]

--- a/Reference/google/protobuf/map_unittest.pb.swift
+++ b/Reference/google/protobuf/map_unittest.pb.swift
@@ -137,7 +137,6 @@ struct ProtobufUnittest_TestMap: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMap
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -415,7 +414,6 @@ struct ProtobufUnittest_TestMapSubmessage: SwiftProtobuf.Message, SwiftProtobuf.
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMapSubmessage
     var _testMap: ProtobufUnittest_TestMap? = nil
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -632,7 +630,6 @@ struct ProtobufUnittest_TestArenaMap: SwiftProtobuf.Message, SwiftProtobuf.Proto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestArenaMap
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]

--- a/Reference/google/protobuf/map_unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/map_unittest_proto3.pb.swift
@@ -143,7 +143,6 @@ struct Proto3TestMap: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestMap
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -409,7 +408,6 @@ struct Proto3TestMapSubmessage: SwiftProtobuf.Message, SwiftProtobuf.Proto3Messa
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestMapSubmessage
     var _testMap: Proto3TestMap? = nil
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -167,7 +167,6 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Value
     var _kind: Google_Protobuf_Value.OneOf_Kind?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -250,7 +250,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufTestMessages_Proto3_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0
@@ -1261,7 +1260,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage
       var _a: Int32 = 0
       var _corecursive: ProtobufTestMessages_Proto3_TestAllTypes? = nil
 

--- a/Reference/google/protobuf/type.pb.swift
+++ b/Reference/google/protobuf/type.pb.swift
@@ -123,7 +123,6 @@ struct Google_Protobuf_Type: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message,
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Type
     var _name: String = ""
     var _fields: [Google_Protobuf_Field] = []
     var _oneofs: [String] = []
@@ -668,7 +667,6 @@ struct Google_Protobuf_Enum: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message,
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Enum
     var _name: String = ""
     var _enumvalue: [Google_Protobuf_EnumValue] = []
     var _options: [Google_Protobuf_Option] = []
@@ -859,7 +857,6 @@ struct Google_Protobuf_Option: SwiftProtobuf.Message, SwiftProtobuf.Proto3Messag
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Option
     var _name: String = ""
     var _value: Google_Protobuf_Any? = nil
 

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -352,7 +352,6 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestAllTypes
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalInt32: Int32? = nil
     var _optionalInt64: Int64? = nil
@@ -1909,7 +1908,6 @@ struct ProtobufUnittest_NestedTestAllTypes: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_NestedTestAllTypes
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _child: ProtobufUnittest_NestedTestAllTypes? = nil
     var _payload: ProtobufUnittest_TestAllTypes? = nil
@@ -2407,7 +2405,6 @@ struct ProtobufUnittest_TestRequired: SwiftProtobuf.Message, SwiftProtobuf.Proto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestRequired
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _a: Int32? = nil
     var _dummy2: Int32? = nil
@@ -3101,7 +3098,6 @@ struct ProtobufUnittest_TestRequiredForeign: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestRequiredForeign
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalMessage: ProtobufUnittest_TestRequired? = nil
     var _repeatedMessage: [ProtobufUnittest_TestRequired] = []
@@ -3230,7 +3226,6 @@ struct ProtobufUnittest_TestForeignNested: SwiftProtobuf.Message, SwiftProtobuf.
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestForeignNested
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage? = nil
 
@@ -3539,7 +3534,6 @@ struct ProtobufUnittest_TestRecursiveMessage: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestRecursiveMessage
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _a: ProtobufUnittest_TestRecursiveMessage? = nil
     var _i: Int32? = nil
@@ -3646,7 +3640,6 @@ struct ProtobufUnittest_TestMutualRecursionA: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMutualRecursionA
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _bb: ProtobufUnittest_TestMutualRecursionB? = nil
 
@@ -3735,7 +3728,6 @@ struct ProtobufUnittest_TestMutualRecursionB: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMutualRecursionB
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _a: ProtobufUnittest_TestMutualRecursionA? = nil
     var _optionalInt32: Int32? = nil
@@ -3847,7 +3839,6 @@ struct ProtobufUnittest_TestDupFieldNumber: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestDupFieldNumber
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _a: Int32? = nil
     var _foo: ProtobufUnittest_TestDupFieldNumber.Foo? = nil
@@ -4069,7 +4060,6 @@ struct ProtobufUnittest_TestEagerMessage: SwiftProtobuf.Message, SwiftProtobuf.P
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestEagerMessage
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _subMessage: ProtobufUnittest_TestAllTypes? = nil
 
@@ -4157,7 +4147,6 @@ struct ProtobufUnittest_TestLazyMessage: SwiftProtobuf.Message, SwiftProtobuf.Pr
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestLazyMessage
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _subMessage: ProtobufUnittest_TestAllTypes? = nil
 
@@ -4246,7 +4235,6 @@ struct ProtobufUnittest_TestNestedMessageHasBits: SwiftProtobuf.Message, SwiftPr
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestNestedMessageHasBits
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage? = nil
 
@@ -4393,7 +4381,6 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message, SwiftPro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestCamelCaseFieldNames
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _primitiveField: Int32? = nil
     var _stringField: String? = nil
@@ -4920,7 +4907,6 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message, SwiftPr
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestExtremeDefaultValues
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _escapedBytes: Data? = nil
     var _largeUint32: UInt32? = nil
@@ -5954,7 +5940,6 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestOneof
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _foo: ProtobufUnittest_TestOneof.OneOf_Foo?
 
@@ -6231,7 +6216,6 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: SwiftProtobuf.Message, Swi
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestOneofBackwardsCompatible
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _fooInt: Int32? = nil
     var _fooString: String? = nil
@@ -6455,7 +6439,6 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestOneof2
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _foo: ProtobufUnittest_TestOneof2.OneOf_Foo?
     var _bar: ProtobufUnittest_TestOneof2.OneOf_Bar?
@@ -7195,7 +7178,6 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestRequiredOneof
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _foo: ProtobufUnittest_TestRequiredOneof.OneOf_Foo?
 
@@ -7862,7 +7844,6 @@ struct ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf.Message, SwiftProto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestDynamicExtensions
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _scalarExtension: UInt32? = nil
     var _enumExtension: ProtobufUnittest_ForeignEnum? = nil
@@ -8356,7 +8337,6 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
       ]
 
       private class _StorageClass {
-        typealias ExtendedMessage = ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1
         var unknownFields = SwiftProtobuf.UnknownStorage()
         var _field1: ProtobufUnittest_TestAllTypes? = nil
 
@@ -8444,7 +8424,6 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
       ]
 
       private class _StorageClass {
-        typealias ExtendedMessage = ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2
         var unknownFields = SwiftProtobuf.UnknownStorage()
         var _field1: ProtobufUnittest_TestAllTypes? = nil
 
@@ -8603,7 +8582,6 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufUnittest_TestParsingMerge.OptionalGroup
       var unknownFields = SwiftProtobuf.UnknownStorage()
       var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
 
@@ -8691,7 +8669,6 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufUnittest_TestParsingMerge.RepeatedGroup
       var unknownFields = SwiftProtobuf.UnknownStorage()
       var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
 

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -1025,7 +1025,6 @@ struct ProtobufUnittest_ComplexOptionType3: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_ComplexOptionType3
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _qux: Int32? = nil
     var _complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5? = nil
@@ -1380,7 +1379,6 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_Aggregate
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _i: Int32? = nil
     var _s: String? = nil

--- a/Reference/google/protobuf/unittest_embed_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_embed_optimize_for.pb.swift
@@ -64,7 +64,6 @@ struct ProtobufUnittest_TestEmbedOptimizedForSize: SwiftProtobuf.Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestEmbedOptimizedForSize
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalMessage: ProtobufUnittest_TestOptimizedForSize? = nil
     var _repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] = []

--- a/Reference/google/protobuf/unittest_enormous_descriptor.pb.swift
+++ b/Reference/google/protobuf/unittest_enormous_descriptor.pb.swift
@@ -1063,7 +1063,6 @@ struct Google_Protobuf_TestEnormousDescriptor: SwiftProtobuf.Message, SwiftProto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_TestEnormousDescriptor
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong1: String? = nil
     var _longFieldNameIsLooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong2: String? = nil

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -297,7 +297,6 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestAllTypesLite
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalInt32: Int32? = nil
     var _optionalInt64: Int64? = nil
@@ -2506,7 +2505,6 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
       ]
 
       private class _StorageClass {
-        typealias ExtendedMessage = ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1
         var unknownFields = SwiftProtobuf.UnknownStorage()
         var _field1: ProtobufUnittest_TestAllTypesLite? = nil
 
@@ -2594,7 +2592,6 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
       ]
 
       private class _StorageClass {
-        typealias ExtendedMessage = ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2
         var unknownFields = SwiftProtobuf.UnknownStorage()
         var _field1: ProtobufUnittest_TestAllTypesLite? = nil
 
@@ -2753,7 +2750,6 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufUnittest_TestParsingMergeLite.OptionalGroup
       var unknownFields = SwiftProtobuf.UnknownStorage()
       var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
 
@@ -2841,7 +2837,6 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufUnittest_TestParsingMergeLite.RepeatedGroup
       var unknownFields = SwiftProtobuf.UnknownStorage()
       var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
 

--- a/Reference/google/protobuf/unittest_lite_imports_nonlite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite_imports_nonlite.pb.swift
@@ -61,7 +61,6 @@ struct ProtobufUnittest_TestLiteImportsNonlite: SwiftProtobuf.Message, SwiftProt
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestLiteImportsNonlite
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _message: ProtobufUnittest_TestAllTypes? = nil
 

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -64,7 +64,6 @@ struct ProtobufUnittest_TestMessageSetContainer: SwiftProtobuf.Message, SwiftPro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMessageSetContainer
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
 

--- a/Reference/google/protobuf/unittest_mset_wire_format.pb.swift
+++ b/Reference/google/protobuf/unittest_mset_wire_format.pb.swift
@@ -124,7 +124,6 @@ struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer: SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto2WireformatUnittest_TestMessageSetWireFormatContainer
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
 

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -201,7 +201,6 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittestNoArena_TestAllTypes
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalInt32: Int32? = nil
     var _optionalInt64: Int64? = nil
@@ -1830,7 +1829,6 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage: SwiftProtobuf.Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittestNoArena_TestNoArenaMessage
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _arenaMessage: Proto2ArenaUnittest_ArenaMessage? = nil
 

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -172,7 +172,6 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto2NofieldpresenceUnittest_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0
@@ -1046,7 +1045,6 @@ struct Proto2NofieldpresenceUnittest_TestProto2Required: SwiftProtobuf.Message, 
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto2NofieldpresenceUnittest_TestProto2Required
     var _proto2: ProtobufUnittest_TestRequired? = nil
 
     var isInitialized: Bool {

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -362,7 +362,6 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message, Swi
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestOptionalOptimizedForSize
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _o: ProtobufUnittest_TestRequiredOptimizedForSize? = nil
 

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -349,7 +349,6 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, S
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestAllTypes
     var _singleInt32: Int32 = 0
     var _singleInt64: Int64 = 0
     var _singleUint32: UInt32 = 0
@@ -1216,7 +1215,6 @@ struct Proto3NestedTestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3NestedTestAllTypes
     var _child: Proto3NestedTestAllTypes? = nil
     var _payload: Proto3TestAllTypes? = nil
     var _repeatedChild: [Proto3NestedTestAllTypes] = []
@@ -1422,7 +1420,6 @@ struct Proto3TestForeignNested: SwiftProtobuf.Message, SwiftProtobuf.Proto3Messa
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestForeignNested
     var _foreignNested: Proto3TestAllTypes.NestedMessage? = nil
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1549,7 +1546,6 @@ struct Proto3TestRecursiveMessage: SwiftProtobuf.Message, SwiftProtobuf.Proto3Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestRecursiveMessage
     var _a: Proto3TestRecursiveMessage? = nil
     var _i: Int32 = 0
 
@@ -1642,7 +1638,6 @@ struct Proto3TestMutualRecursionA: SwiftProtobuf.Message, SwiftProtobuf.Proto3Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestMutualRecursionA
     var _bb: Proto3TestMutualRecursionB? = nil
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1723,7 +1718,6 @@ struct Proto3TestMutualRecursionB: SwiftProtobuf.Message, SwiftProtobuf.Proto3Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestMutualRecursionB
     var _a: Proto3TestMutualRecursionA? = nil
     var _optionalInt32: Int32 = 0
 
@@ -1824,7 +1818,6 @@ struct Proto3TestCamelCaseFieldNames: SwiftProtobuf.Message, SwiftProtobuf.Proto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestCamelCaseFieldNames
     var _primitiveField: Int32 = 0
     var _stringField: String = ""
     var _enumField: Proto3ForeignEnum = Proto3ForeignEnum.foreignUnspecified
@@ -1993,7 +1986,6 @@ struct Proto3TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestFieldOrderings
     var _myString: String = ""
     var _myInt: Int64 = 0
     var _myFloat: Float = 0
@@ -2510,7 +2502,6 @@ struct Proto3TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, Swif
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestOneof
     var _foo: Proto3TestOneof.OneOf_Foo?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -177,7 +177,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3ArenaUnittest_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0
@@ -1385,7 +1384,6 @@ struct Proto3ArenaUnittest_NestedTestAllTypes: SwiftProtobuf.Message, SwiftProto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3ArenaUnittest_NestedTestAllTypes
     var _child: Proto3ArenaUnittest_NestedTestAllTypes? = nil
     var _payload: Proto3ArenaUnittest_TestAllTypes? = nil
 

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -177,7 +177,6 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3ArenaLiteUnittest_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0
@@ -1385,7 +1384,6 @@ struct Proto3ArenaLiteUnittest_NestedTestAllTypes: SwiftProtobuf.Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3ArenaLiteUnittest_NestedTestAllTypes
     var _child: Proto3ArenaLiteUnittest_NestedTestAllTypes? = nil
     var _payload: Proto3ArenaLiteUnittest_TestAllTypes? = nil
 

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -177,7 +177,6 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3LiteUnittest_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0
@@ -1385,7 +1384,6 @@ struct Proto3LiteUnittest_NestedTestAllTypes: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3LiteUnittest_NestedTestAllTypes
     var _child: Proto3LiteUnittest_NestedTestAllTypes? = nil
     var _payload: Proto3LiteUnittest_TestAllTypes? = nil
 

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -48,7 +48,6 @@ struct ProtobufUnittest_TestWellKnownTypes: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestWellKnownTypes
     var _anyField: Google_Protobuf_Any? = nil
     var _apiField: Google_Protobuf_Api? = nil
     var _durationField: Google_Protobuf_Duration? = nil
@@ -471,7 +470,6 @@ struct ProtobufUnittest_RepeatedWellKnownTypes: SwiftProtobuf.Message, SwiftProt
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_RepeatedWellKnownTypes
     var _anyField: [Google_Protobuf_Any] = []
     var _apiField: [Google_Protobuf_Api] = []
     var _durationField: [Google_Protobuf_Duration] = []
@@ -767,7 +765,6 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_OneofWellKnownTypes
     var _oneofField: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1337,7 +1334,6 @@ struct ProtobufUnittest_MapWellKnownTypes: SwiftProtobuf.Message, SwiftProtobuf.
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_MapWellKnownTypes
     var _anyField: Dictionary<Int32,Google_Protobuf_Any> = [:]
     var _apiField: Dictionary<Int32,Google_Protobuf_Api> = [:]
     var _durationField: Dictionary<Int32,Google_Protobuf_Duration> = [:]

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -108,7 +108,6 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestAllRequiredTypes
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _requiredInt32: Int32? = nil
     var _requiredInt64: Int64? = nil

--- a/Reference/unittest_swift_cycle.pb.swift
+++ b/Reference/unittest_swift_cycle.pb.swift
@@ -66,7 +66,6 @@ struct ProtobufUnittest_CycleFoo: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_CycleFoo
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _aFoo: ProtobufUnittest_CycleFoo? = nil
     var _aBar: ProtobufUnittest_CycleBar? = nil
@@ -192,7 +191,6 @@ struct ProtobufUnittest_CycleBar: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_CycleBar
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _aBar: ProtobufUnittest_CycleBar? = nil
     var _aBaz: ProtobufUnittest_CycleBaz? = nil
@@ -318,7 +316,6 @@ struct ProtobufUnittest_CycleBaz: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_CycleBaz
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _aBaz: ProtobufUnittest_CycleBaz? = nil
     var _aFoo: ProtobufUnittest_CycleFoo? = nil

--- a/Reference/unittest_swift_enum_optional_default.pb.swift
+++ b/Reference/unittest_swift_enum_optional_default.pb.swift
@@ -51,7 +51,6 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: SwiftProtobuf.Message, Swift
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage
       var unknownFields = SwiftProtobuf.UnknownStorage()
       var _message: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage? = nil
       var _optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage.Enum? = nil

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -1605,7 +1605,6 @@ struct SwiftUnittest_Names_FieldNames: SwiftProtobuf.Message, SwiftProtobuf.Prot
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = SwiftUnittest_Names_FieldNames
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _string: Int32? = nil
     var _int: Int32? = nil

--- a/Reference/unittest_swift_performance.pb.swift
+++ b/Reference/unittest_swift_performance.pb.swift
@@ -88,7 +88,6 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Prot
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Swift_Performance_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -128,7 +128,6 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_Message2
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalInt32: Int32? = nil
     var _optionalInt64: Int64? = nil

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -125,7 +125,6 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_Message3
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -250,7 +250,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufTestMessages_Proto3_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0
@@ -1261,7 +1260,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage
       var _a: Int32 = 0
       var _corecursive: ProtobufTestMessages_Proto3_TestAllTypes? = nil
 

--- a/Sources/PluginLibrary/descriptor.pb.swift
+++ b/Sources/PluginLibrary/descriptor.pb.swift
@@ -124,7 +124,6 @@ public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_FileDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _package: String? = nil
@@ -406,7 +405,6 @@ public struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message, SwiftProto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_DescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _field: [Google_Protobuf_FieldDescriptorProto] = []
@@ -777,7 +775,6 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message, Swift
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_FieldDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _number: Int32? = nil
@@ -1292,7 +1289,6 @@ public struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message, Swift
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_OneofDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _options: Google_Protobuf_OneofOptions? = nil
@@ -1412,7 +1408,6 @@ public struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_EnumDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _value: [Google_Protobuf_EnumValueDescriptorProto] = []
@@ -1545,7 +1540,6 @@ public struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message, S
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_EnumValueDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _number: Int32? = nil
@@ -1683,7 +1677,6 @@ public struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message, Swi
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_ServiceDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _method: [Google_Protobuf_MethodDescriptorProto] = []
@@ -1819,7 +1812,6 @@ public struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message, Swif
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_MethodDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _inputType: String? = nil

--- a/Sources/PluginLibrary/plugin.pb.swift
+++ b/Sources/PluginLibrary/plugin.pb.swift
@@ -184,7 +184,6 @@ public struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Messa
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Compiler_CodeGeneratorRequest
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _fileToGenerate: [String] = []
     var _parameter: String? = nil

--- a/Sources/SwiftProtobuf/api.pb.swift
+++ b/Sources/SwiftProtobuf/api.pb.swift
@@ -63,7 +63,6 @@ public struct Google_Protobuf_Api: SwiftProtobuf.Message, SwiftProtobuf.Proto3Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Api
     var _name: String = ""
     var _methods: [Google_Protobuf_Method] = []
     var _options: [Google_Protobuf_Option] = []

--- a/Sources/SwiftProtobuf/type.pb.swift
+++ b/Sources/SwiftProtobuf/type.pb.swift
@@ -123,7 +123,6 @@ public struct Google_Protobuf_Type: SwiftProtobuf.Message, SwiftProtobuf.Proto3M
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Type
     var _name: String = ""
     var _fields: [Google_Protobuf_Field] = []
     var _oneofs: [String] = []
@@ -672,7 +671,6 @@ public struct Google_Protobuf_Enum: SwiftProtobuf.Message, SwiftProtobuf.Proto3M
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Enum
     var _name: String = ""
     var _enumvalue: [Google_Protobuf_EnumValue] = []
     var _options: [Google_Protobuf_Option] = []
@@ -867,7 +865,6 @@ public struct Google_Protobuf_Option: SwiftProtobuf.Message, SwiftProtobuf.Proto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_Option
     var _name: String = ""
     var _value: Google_Protobuf_Any? = nil
 

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -120,8 +120,8 @@ class StorageClassGenerator {
         }
         p.indent()
 
-        p.print("typealias ExtendedMessage = \(messageSwiftName)\n")
         if isExtensible {
+            p.print("typealias ExtendedMessage = \(messageSwiftName)\n")
             p.print("var extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()\n")
         }
         if !isProto3 {

--- a/Tests/SwiftProtobufTests/any_test.pb.swift
+++ b/Tests/SwiftProtobufTests/any_test.pb.swift
@@ -59,7 +59,6 @@ struct ProtobufUnittest_TestAny: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestAny
     var _int32Value: Int32 = 0
     var _anyValue: Google_Protobuf_Any? = nil
     var _repeatedAnyValue: [Google_Protobuf_Any] = []

--- a/Tests/SwiftProtobufTests/descriptor.pb.swift
+++ b/Tests/SwiftProtobufTests/descriptor.pb.swift
@@ -122,7 +122,6 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_FileDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _package: String? = nil
@@ -402,7 +401,6 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message, SwiftProtobuf.Pro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_DescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _field: [Google_Protobuf_FieldDescriptorProto] = []
@@ -767,7 +765,6 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_FieldDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _number: Int32? = nil
@@ -1280,7 +1277,6 @@ struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_OneofDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _options: Google_Protobuf_OneofOptions? = nil
@@ -1398,7 +1394,6 @@ struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_EnumDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _value: [Google_Protobuf_EnumValueDescriptorProto] = []
@@ -1529,7 +1524,6 @@ struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message, SwiftPro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_EnumValueDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _number: Int32? = nil
@@ -1665,7 +1659,6 @@ struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message, SwiftProto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_ServiceDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _method: [Google_Protobuf_MethodDescriptorProto] = []
@@ -1799,7 +1792,6 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Google_Protobuf_MethodDescriptorProto
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _name: String? = nil
     var _inputType: String? = nil

--- a/Tests/SwiftProtobufTests/map_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest.pb.swift
@@ -137,7 +137,6 @@ struct ProtobufUnittest_TestMap: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMap
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -415,7 +414,6 @@ struct ProtobufUnittest_TestMapSubmessage: SwiftProtobuf.Message, SwiftProtobuf.
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMapSubmessage
     var _testMap: ProtobufUnittest_TestMap? = nil
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -632,7 +630,6 @@ struct ProtobufUnittest_TestArenaMap: SwiftProtobuf.Message, SwiftProtobuf.Proto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestArenaMap
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]

--- a/Tests/SwiftProtobufTests/map_unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest_proto3.pb.swift
@@ -143,7 +143,6 @@ struct Proto3TestMap: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestMap
     var _mapInt32Int32: Dictionary<Int32,Int32> = [:]
     var _mapInt64Int64: Dictionary<Int64,Int64> = [:]
     var _mapUint32Uint32: Dictionary<UInt32,UInt32> = [:]
@@ -409,7 +408,6 @@ struct Proto3TestMapSubmessage: SwiftProtobuf.Message, SwiftProtobuf.Proto3Messa
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestMapSubmessage
     var _testMap: Proto3TestMap? = nil
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -250,7 +250,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufTestMessages_Proto3_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0
@@ -1261,7 +1260,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage
       var _a: Int32 = 0
       var _corecursive: ProtobufTestMessages_Proto3_TestAllTypes? = nil
 

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -352,7 +352,6 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestAllTypes
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalInt32: Int32? = nil
     var _optionalInt64: Int64? = nil
@@ -1909,7 +1908,6 @@ struct ProtobufUnittest_NestedTestAllTypes: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_NestedTestAllTypes
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _child: ProtobufUnittest_NestedTestAllTypes? = nil
     var _payload: ProtobufUnittest_TestAllTypes? = nil
@@ -2407,7 +2405,6 @@ struct ProtobufUnittest_TestRequired: SwiftProtobuf.Message, SwiftProtobuf.Proto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestRequired
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _a: Int32? = nil
     var _dummy2: Int32? = nil
@@ -3101,7 +3098,6 @@ struct ProtobufUnittest_TestRequiredForeign: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestRequiredForeign
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalMessage: ProtobufUnittest_TestRequired? = nil
     var _repeatedMessage: [ProtobufUnittest_TestRequired] = []
@@ -3230,7 +3226,6 @@ struct ProtobufUnittest_TestForeignNested: SwiftProtobuf.Message, SwiftProtobuf.
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestForeignNested
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _foreignNested: ProtobufUnittest_TestAllTypes.NestedMessage? = nil
 
@@ -3539,7 +3534,6 @@ struct ProtobufUnittest_TestRecursiveMessage: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestRecursiveMessage
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _a: ProtobufUnittest_TestRecursiveMessage? = nil
     var _i: Int32? = nil
@@ -3646,7 +3640,6 @@ struct ProtobufUnittest_TestMutualRecursionA: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMutualRecursionA
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _bb: ProtobufUnittest_TestMutualRecursionB? = nil
 
@@ -3735,7 +3728,6 @@ struct ProtobufUnittest_TestMutualRecursionB: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMutualRecursionB
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _a: ProtobufUnittest_TestMutualRecursionA? = nil
     var _optionalInt32: Int32? = nil
@@ -3847,7 +3839,6 @@ struct ProtobufUnittest_TestDupFieldNumber: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestDupFieldNumber
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _a: Int32? = nil
     var _foo: ProtobufUnittest_TestDupFieldNumber.Foo? = nil
@@ -4069,7 +4060,6 @@ struct ProtobufUnittest_TestEagerMessage: SwiftProtobuf.Message, SwiftProtobuf.P
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestEagerMessage
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _subMessage: ProtobufUnittest_TestAllTypes? = nil
 
@@ -4157,7 +4147,6 @@ struct ProtobufUnittest_TestLazyMessage: SwiftProtobuf.Message, SwiftProtobuf.Pr
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestLazyMessage
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _subMessage: ProtobufUnittest_TestAllTypes? = nil
 
@@ -4246,7 +4235,6 @@ struct ProtobufUnittest_TestNestedMessageHasBits: SwiftProtobuf.Message, SwiftPr
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestNestedMessageHasBits
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalNestedMessage: ProtobufUnittest_TestNestedMessageHasBits.NestedMessage? = nil
 
@@ -4393,7 +4381,6 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message, SwiftPro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestCamelCaseFieldNames
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _primitiveField: Int32? = nil
     var _stringField: String? = nil
@@ -4920,7 +4907,6 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message, SwiftPr
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestExtremeDefaultValues
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _escapedBytes: Data? = nil
     var _largeUint32: UInt32? = nil
@@ -5954,7 +5940,6 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestOneof
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _foo: ProtobufUnittest_TestOneof.OneOf_Foo?
 
@@ -6231,7 +6216,6 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: SwiftProtobuf.Message, Swi
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestOneofBackwardsCompatible
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _fooInt: Int32? = nil
     var _fooString: String? = nil
@@ -6455,7 +6439,6 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message, SwiftProtobuf.Proto2M
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestOneof2
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _foo: ProtobufUnittest_TestOneof2.OneOf_Foo?
     var _bar: ProtobufUnittest_TestOneof2.OneOf_Bar?
@@ -7195,7 +7178,6 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestRequiredOneof
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _foo: ProtobufUnittest_TestRequiredOneof.OneOf_Foo?
 
@@ -7862,7 +7844,6 @@ struct ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf.Message, SwiftProto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestDynamicExtensions
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _scalarExtension: UInt32? = nil
     var _enumExtension: ProtobufUnittest_ForeignEnum? = nil
@@ -8356,7 +8337,6 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
       ]
 
       private class _StorageClass {
-        typealias ExtendedMessage = ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group1
         var unknownFields = SwiftProtobuf.UnknownStorage()
         var _field1: ProtobufUnittest_TestAllTypes? = nil
 
@@ -8444,7 +8424,6 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
       ]
 
       private class _StorageClass {
-        typealias ExtendedMessage = ProtobufUnittest_TestParsingMerge.RepeatedFieldsGenerator.Group2
         var unknownFields = SwiftProtobuf.UnknownStorage()
         var _field1: ProtobufUnittest_TestAllTypes? = nil
 
@@ -8603,7 +8582,6 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufUnittest_TestParsingMerge.OptionalGroup
       var unknownFields = SwiftProtobuf.UnknownStorage()
       var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
 
@@ -8691,7 +8669,6 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.P
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufUnittest_TestParsingMerge.RepeatedGroup
       var unknownFields = SwiftProtobuf.UnknownStorage()
       var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypes? = nil
 

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -1025,7 +1025,6 @@ struct ProtobufUnittest_ComplexOptionType3: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_ComplexOptionType3
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _qux: Int32? = nil
     var _complexOptionType5: ProtobufUnittest_ComplexOptionType3.ComplexOptionType5? = nil
@@ -1380,7 +1379,6 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message, SwiftProtobuf.Proto2Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_Aggregate
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _i: Int32? = nil
     var _s: String? = nil

--- a/Tests/SwiftProtobufTests/unittest_embed_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_embed_optimize_for.pb.swift
@@ -64,7 +64,6 @@ struct ProtobufUnittest_TestEmbedOptimizedForSize: SwiftProtobuf.Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestEmbedOptimizedForSize
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalMessage: ProtobufUnittest_TestOptimizedForSize? = nil
     var _repeatedMessage: [ProtobufUnittest_TestOptimizedForSize] = []

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -297,7 +297,6 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message, SwiftProtobuf.P
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestAllTypesLite
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalInt32: Int32? = nil
     var _optionalInt64: Int64? = nil
@@ -2506,7 +2505,6 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
       ]
 
       private class _StorageClass {
-        typealias ExtendedMessage = ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group1
         var unknownFields = SwiftProtobuf.UnknownStorage()
         var _field1: ProtobufUnittest_TestAllTypesLite? = nil
 
@@ -2594,7 +2592,6 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
       ]
 
       private class _StorageClass {
-        typealias ExtendedMessage = ProtobufUnittest_TestParsingMergeLite.RepeatedFieldsGenerator.Group2
         var unknownFields = SwiftProtobuf.UnknownStorage()
         var _field1: ProtobufUnittest_TestAllTypesLite? = nil
 
@@ -2753,7 +2750,6 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufUnittest_TestParsingMergeLite.OptionalGroup
       var unknownFields = SwiftProtobuf.UnknownStorage()
       var _optionalGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
 
@@ -2841,7 +2837,6 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufUnittest_TestParsingMergeLite.RepeatedGroup
       var unknownFields = SwiftProtobuf.UnknownStorage()
       var _repeatedGroupAllTypes: ProtobufUnittest_TestAllTypesLite? = nil
 

--- a/Tests/SwiftProtobufTests/unittest_lite_imports_nonlite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite_imports_nonlite.pb.swift
@@ -61,7 +61,6 @@ struct ProtobufUnittest_TestLiteImportsNonlite: SwiftProtobuf.Message, SwiftProt
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestLiteImportsNonlite
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _message: ProtobufUnittest_TestAllTypes? = nil
 

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -64,7 +64,6 @@ struct ProtobufUnittest_TestMessageSetContainer: SwiftProtobuf.Message, SwiftPro
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestMessageSetContainer
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
 

--- a/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
@@ -124,7 +124,6 @@ struct Proto2WireformatUnittest_TestMessageSetWireFormatContainer: SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto2WireformatUnittest_TestMessageSetWireFormatContainer
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _messageSet: Proto2WireformatUnittest_TestMessageSet? = nil
 

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -201,7 +201,6 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittestNoArena_TestAllTypes
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalInt32: Int32? = nil
     var _optionalInt64: Int64? = nil
@@ -1830,7 +1829,6 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage: SwiftProtobuf.Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittestNoArena_TestNoArenaMessage
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _arenaMessage: Proto2ArenaUnittest_ArenaMessage? = nil
 

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -172,7 +172,6 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftP
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto2NofieldpresenceUnittest_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0
@@ -1046,7 +1045,6 @@ struct Proto2NofieldpresenceUnittest_TestProto2Required: SwiftProtobuf.Message, 
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto2NofieldpresenceUnittest_TestProto2Required
     var _proto2: ProtobufUnittest_TestRequired? = nil
 
     var isInitialized: Bool {

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -362,7 +362,6 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message, Swi
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestOptionalOptimizedForSize
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _o: ProtobufUnittest_TestRequiredOptimizedForSize? = nil
 

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -349,7 +349,6 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, S
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestAllTypes
     var _singleInt32: Int32 = 0
     var _singleInt64: Int64 = 0
     var _singleUint32: UInt32 = 0
@@ -1216,7 +1215,6 @@ struct Proto3NestedTestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3NestedTestAllTypes
     var _child: Proto3NestedTestAllTypes? = nil
     var _payload: Proto3TestAllTypes? = nil
     var _repeatedChild: [Proto3NestedTestAllTypes] = []
@@ -1422,7 +1420,6 @@ struct Proto3TestForeignNested: SwiftProtobuf.Message, SwiftProtobuf.Proto3Messa
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestForeignNested
     var _foreignNested: Proto3TestAllTypes.NestedMessage? = nil
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1549,7 +1546,6 @@ struct Proto3TestRecursiveMessage: SwiftProtobuf.Message, SwiftProtobuf.Proto3Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestRecursiveMessage
     var _a: Proto3TestRecursiveMessage? = nil
     var _i: Int32 = 0
 
@@ -1642,7 +1638,6 @@ struct Proto3TestMutualRecursionA: SwiftProtobuf.Message, SwiftProtobuf.Proto3Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestMutualRecursionA
     var _bb: Proto3TestMutualRecursionB? = nil
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1723,7 +1718,6 @@ struct Proto3TestMutualRecursionB: SwiftProtobuf.Message, SwiftProtobuf.Proto3Me
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestMutualRecursionB
     var _a: Proto3TestMutualRecursionA? = nil
     var _optionalInt32: Int32 = 0
 
@@ -1824,7 +1818,6 @@ struct Proto3TestCamelCaseFieldNames: SwiftProtobuf.Message, SwiftProtobuf.Proto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestCamelCaseFieldNames
     var _primitiveField: Int32 = 0
     var _stringField: String = ""
     var _enumField: Proto3ForeignEnum = Proto3ForeignEnum.foreignUnspecified
@@ -1993,7 +1986,6 @@ struct Proto3TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mess
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestFieldOrderings
     var _myString: String = ""
     var _myInt: Int64 = 0
     var _myFloat: Float = 0
@@ -2510,7 +2502,6 @@ struct Proto3TestOneof: SwiftProtobuf.Message, SwiftProtobuf.Proto3Message, Swif
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3TestOneof
     var _foo: Proto3TestOneof.OneOf_Foo?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -177,7 +177,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Pr
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3ArenaUnittest_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0
@@ -1385,7 +1384,6 @@ struct Proto3ArenaUnittest_NestedTestAllTypes: SwiftProtobuf.Message, SwiftProto
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Proto3ArenaUnittest_NestedTestAllTypes
     var _child: Proto3ArenaUnittest_NestedTestAllTypes? = nil
     var _payload: Proto3ArenaUnittest_TestAllTypes? = nil
 

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -108,7 +108,6 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestAllRequiredTypes
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _requiredInt32: Int32? = nil
     var _requiredInt64: Int64? = nil

--- a/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
@@ -66,7 +66,6 @@ struct ProtobufUnittest_CycleFoo: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_CycleFoo
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _aFoo: ProtobufUnittest_CycleFoo? = nil
     var _aBar: ProtobufUnittest_CycleBar? = nil
@@ -192,7 +191,6 @@ struct ProtobufUnittest_CycleBar: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_CycleBar
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _aBar: ProtobufUnittest_CycleBar? = nil
     var _aBaz: ProtobufUnittest_CycleBaz? = nil
@@ -318,7 +316,6 @@ struct ProtobufUnittest_CycleBaz: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_CycleBaz
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _aBaz: ProtobufUnittest_CycleBaz? = nil
     var _aFoo: ProtobufUnittest_CycleFoo? = nil

--- a/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
@@ -51,7 +51,6 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: SwiftProtobuf.Message, Swift
     ]
 
     private class _StorageClass {
-      typealias ExtendedMessage = ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage
       var unknownFields = SwiftProtobuf.UnknownStorage()
       var _message: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage? = nil
       var _optionalEnum: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage.Enum? = nil

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -1605,7 +1605,6 @@ struct SwiftUnittest_Names_FieldNames: SwiftProtobuf.Message, SwiftProtobuf.Prot
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = SwiftUnittest_Names_FieldNames
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _string: Int32? = nil
     var _int: Int32? = nil

--- a/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
@@ -88,7 +88,6 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf.Prot
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = Swift_Performance_TestAllTypes
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -128,7 +128,6 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf.Proto2Mes
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_Message2
     var unknownFields = SwiftProtobuf.UnknownStorage()
     var _optionalInt32: Int32? = nil
     var _optionalInt64: Int64? = nil

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -125,7 +125,6 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf.Proto3Mes
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_Message3
     var _optionalInt32: Int32 = 0
     var _optionalInt64: Int64 = 0
     var _optionalUint32: UInt32 = 0

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -48,7 +48,6 @@ struct ProtobufUnittest_TestWellKnownTypes: SwiftProtobuf.Message, SwiftProtobuf
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_TestWellKnownTypes
     var _anyField: Google_Protobuf_Any? = nil
     var _apiField: Google_Protobuf_Api? = nil
     var _durationField: Google_Protobuf_Duration? = nil
@@ -471,7 +470,6 @@ struct ProtobufUnittest_RepeatedWellKnownTypes: SwiftProtobuf.Message, SwiftProt
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_RepeatedWellKnownTypes
     var _anyField: [Google_Protobuf_Any] = []
     var _apiField: [Google_Protobuf_Api] = []
     var _durationField: [Google_Protobuf_Duration] = []
@@ -767,7 +765,6 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message, SwiftProtobu
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_OneofWellKnownTypes
     var _oneofField: ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField?
 
     func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1337,7 +1334,6 @@ struct ProtobufUnittest_MapWellKnownTypes: SwiftProtobuf.Message, SwiftProtobuf.
   ]
 
   private class _StorageClass {
-    typealias ExtendedMessage = ProtobufUnittest_MapWellKnownTypes
     var _anyField: Dictionary<Int32,Google_Protobuf_Any> = [:]
     var _apiField: Dictionary<Int32,Google_Protobuf_Api> = [:]
     var _durationField: Dictionary<Int32,Google_Protobuf_Duration> = [:]


### PR DESCRIPTION
The typealias for the _StorageClass is only needed when the message
actually supports extensions, so only generate it in that case.