### PR TITLE
Update perf harness for new API names; tweak the build.

### DIFF
--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -209,9 +209,6 @@ cp "$script_dir/../.build/release/protoc-gen-swift" \
 mkdir -p "$script_dir/_generated"
 mkdir -p "$script_dir/_results"
 
-# Build a dynamic library to use in the tests
-swiftc -emit-library -o "$script_dir/_generated/libSwiftProtobufDynamic.dylib" "$script_dir/../.build/release/SwiftProtobuf.build/"*.swift.o
-
 # If the visualization results file isn't there, copy it from the template so
 # that the harnesses can populate it.
 results_js="$script_dir/_results/results.js"


### PR DESCRIPTION
Aside from the API naming changes, this updates the perf harness to build the dylib from sources instead of the .o files created by SwiftPM. This is required to build with whole module optimization on—this is what SwiftPM would do in release mode, and the compiler has to see all the sources (not object files) to make that happen.

The result is a slightly longer build for the dylib, but more accurate based on what users would have once we can put the dylib product back into Package.swift.
