### PR TITLE
Issue #205:  Split out encoding errors for each serializer

### DIFF
--- a/Sources/SwiftProtobuf/BinaryEncodingError.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingError.swift
@@ -1,0 +1,20 @@
+// Sources/SwiftProtobuf/BinaryEncodingError.swift - Error constants
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Enum constants that identify the particular error.
+///
+// -----------------------------------------------------------------------------
+
+public enum BinaryEncodingError: Error {
+    /// Any fields that were decoded from JSON cannot be re-encoded to
+    /// binary unless the object they hold is a well-known type or a
+    /// type registered with via Google_Protobuf_Any.register()
+    case anyTranscodeFailure
+}

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
@@ -460,7 +460,7 @@ public struct Google_Protobuf_Any: Message, Proto3Message, _MessageImplementatio
                 // The big problem here is fetching the type:  Types not in the executable must be fetched from somewhere; Google says we should do an HTTPS fetch against the typeURL, which assumes that everyone will publish all their types and that everyone running this code will have reliable network access.  That seems ... optimistic.
 
                 // ProtobufDynamicMessage() is non-trivial to write but desirable for other reasons.  It's a class that can be instantiated with any protobuf type or descriptor and provides access to protos of the corresponding type.  (Not to be confused with ProtobufRaw which can decode any message but does not use a type descriptor and therefore cannot provide fully-typed access to fields.)
-                throw EncodingError.anyTranscodeFailure
+                throw JSONEncodingError.anyTranscodeFailure
             } else {
                 var jsonEncoder = JSONEncoder()
                 jsonEncoder.startObject()
@@ -534,7 +534,7 @@ public struct Google_Protobuf_Any: Message, Proto3Message, _MessageImplementatio
             if let value = value {
                 try visitor.visitSingularBytesField(value: value, fieldNumber: 2)
             } else {
-                throw EncodingError.anyTranscodeFailure
+                throw BinaryEncodingError.anyTranscodeFailure
             }
         }
     }

--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration_Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration_Extensions.swift
@@ -123,7 +123,7 @@ public extension Google_Protobuf_Duration {
         if let formatted = formatDuration(seconds: seconds, nanos: nanos) {
             return "\"\(formatted)\""
         } else {
-            throw EncodingError.durationJSONRange
+            throw JSONEncodingError.durationRange
         }
     }
 

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask_Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask_Extensions.swift
@@ -137,7 +137,7 @@ public extension Google_Protobuf_FieldMask {
             if let jsonPath = ProtoToJSON(name: p) {
                 jsonPaths.append(jsonPath)
             } else {
-                throw EncodingError.fieldMaskConversion
+                throw JSONEncodingError.fieldMaskConversion
             }
         }
         return "\"" + jsonPaths.joined(separator: ",") + "\""

--- a/Sources/SwiftProtobuf/Google_Protobuf_Timestamp_Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Timestamp_Extensions.swift
@@ -210,7 +210,7 @@ public extension Google_Protobuf_Timestamp {
         if let formatted = formatTimestamp(seconds: seconds, nanos: nanos) {
             return "\"\(formatted)\""
         } else {
-            throw EncodingError.timestampJSONRange
+            throw JSONEncodingError.timestampRange
         }
     }
 

--- a/Sources/SwiftProtobuf/JSONEncodingError.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingError.swift
@@ -1,4 +1,4 @@
-// Sources/SwiftProtobuf/Errors.swift - Error constants
+// Sources/SwiftProtobuf/JSONEncodingError.swift - Error constants
 //
 // Copyright (c) 2014 - 2016 Apple Inc. and the project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
@@ -12,25 +12,20 @@
 ///
 // -----------------------------------------------------------------------------
 
-// TODO: It would be nice if coding/decoding errors could include the name
-// of the specific field where the error was detected.
-
-public enum EncodingError: Error {
-    /// An unspecified encoding failure
-    case failure
-    /// Any fields cannot be transcoded between JSON and protobuf unless
-    /// the object they hold is a well-known type or a type registered with
-    /// via Google_Protobuf_Any.register()
+public enum JSONEncodingError: Error {
+    /// Any fields that were decoded from binary format cannot be
+    /// re-encoded into JSON unless the object they hold is a
+    /// well-known type or a type registered with via
+    /// Google_Protobuf_Any.register()
     case anyTranscodeFailure
     /// Timestamp values can only be JSON encoded if they hold a value
     /// between 0001-01-01Z00:00:00 and 9999-12-31Z23:59:59.
-    case timestampJSONRange
+    case timestampRange
     /// Duration values can only be JSON encoded if they hold a value
     /// less than +/- 100 years.
-    case durationJSONRange
+    case durationRange
     /// Field masks get edited when converting between JSON and protobuf
     case fieldMaskConversion
     /// Field names were not compiled into the binary
     case missingFieldNames
-    /// TODO: More here.
 }

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -303,7 +303,7 @@ internal struct JSONEncodingVisitor: Visitor {
     if let jsonName = nameResolver(number) {
         encoder.startField(name: jsonName)
     } else {
-        throw EncodingError.missingFieldNames
+        throw JSONEncodingError.missingFieldNames
     }
   }
 }

--- a/Sources/SwiftProtobuf/TextFormatEncodingError.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingError.swift
@@ -1,0 +1,18 @@
+// Sources/SwiftProtobuf/TextFormatEncodingError.swift - Error constants
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Enum constants that identify the particular error.
+///
+// -----------------------------------------------------------------------------
+
+public enum TextFormatEncodingError: Error {
+    /// Field names were not compiled into the binary
+    case missingFieldNames
+}

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -55,7 +55,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
     if let protoName = nameResolver(number) {
       return protoName
     }
-    throw EncodingError.missingFieldNames
+    throw TextFormatEncodingError.missingFieldNames
   }
 
   private mutating func startField(name: StaticString) {

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		9C2F23861D7780D1008524F2 /* BinaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */; };
 		9C2F23871D7780D1008524F2 /* BinaryTypeAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* BinaryTypeAdditions.swift */; };
 		9C2F23891D7780D1008524F2 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
-		9C2F238A1D7780D1008524F2 /* EncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufError.swift /* EncodingError.swift */; };
 		9C2F238B1D7780D1008524F2 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
 		9C2F238C1D7780D1008524F2 /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */; };
 		9C2F238D1D7780D1008524F2 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */; };
@@ -98,6 +97,18 @@
 		9C75F8A41DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */; };
 		9C75F8A51DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */; };
 		9C75F8A61DDD44A1005CCFF2 /* ProtobufMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */; };
+		9C84E48F1E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */; };
+		9C84E4901E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */; };
+		9C84E4911E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */; };
+		9C84E4921E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */; };
+		9C84E4931E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */; };
+		9C84E4941E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */; };
+		9C84E4951E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */; };
+		9C84E4961E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */; };
+		9C84E4971E5E3ABD00513BE0 /* TextFormatEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48E1E5E3ABD00513BE0 /* TextFormatEncodingError.swift */; };
+		9C84E4981E5E3ABD00513BE0 /* TextFormatEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48E1E5E3ABD00513BE0 /* TextFormatEncodingError.swift */; };
+		9C84E4991E5E3ABD00513BE0 /* TextFormatEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48E1E5E3ABD00513BE0 /* TextFormatEncodingError.swift */; };
+		9C84E49A1E5E3ABD00513BE0 /* TextFormatEncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C84E48E1E5E3ABD00513BE0 /* TextFormatEncodingError.swift */; };
 		9C8CDA171D7A288E00E207CA /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Protobuf_iOS" /* SwiftProtobuf.framework */; };
 		9C8CDA1D1D7A28F600E207CA /* any_test.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/any_test.pb.swift /* any_test.pb.swift */; };
 		9C8CDA1E1D7A28F600E207CA /* conformance.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/ProtobufTests/conformance.pb.swift /* conformance.pb.swift */; };
@@ -261,7 +272,6 @@
 		F44F93831DAEA76700BC5B85 /* BinaryEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4AB1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift */; };
 		F44F93841DAEA76700BC5B85 /* BinaryTypeAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* BinaryTypeAdditions.swift */; };
 		F44F93861DAEA76700BC5B85 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
-		F44F93871DAEA76700BC5B85 /* EncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufError.swift /* EncodingError.swift */; };
 		F44F93881DAEA76700BC5B85 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
 		F44F93891DAEA76700BC5B85 /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */; };
 		F44F938A1DAEA76700BC5B85 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */; };
@@ -368,7 +378,6 @@
 		F44F94121DAEB23500BC5B85 /* BinaryEncodingSizeVisitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA28A4AB1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift */; };
 		F44F94131DAEB23500BC5B85 /* BinaryTypeAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* BinaryTypeAdditions.swift */; };
 		F44F94151DAEB23500BC5B85 /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
-		F44F94161DAEB23500BC5B85 /* EncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufError.swift /* EncodingError.swift */; };
 		F44F94171DAEB23500BC5B85 /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
 		F44F94181DAEB23500BC5B85 /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */; };
 		F44F94191DAEB23500BC5B85 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */; };
@@ -438,7 +447,6 @@
 		__src_cc_ref_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */; };
 		__src_cc_ref_Sources/Protobuf/ProtobufBinaryTypes.swift /* BinaryTypeAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* BinaryTypeAdditions.swift */; };
 		__src_cc_ref_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */; };
-		__src_cc_ref_Sources/Protobuf/ProtobufError.swift /* EncodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufError.swift /* EncodingError.swift */; };
 		__src_cc_ref_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */; };
 		__src_cc_ref_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */; };
 		__src_cc_ref_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */; };
@@ -574,6 +582,9 @@
 		9C75F8931DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryEncodingVisitor.swift; sourceTree = "<group>"; };
 		9C75F89D1DDD3FA3005CCFF2 /* JSONDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONDecoder.swift; sourceTree = "<group>"; };
 		9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtobufMap.swift; sourceTree = "<group>"; };
+		9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryEncodingError.swift; sourceTree = "<group>"; };
+		9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONEncodingError.swift; sourceTree = "<group>"; };
+		9C84E48E1E5E3ABD00513BE0 /* TextFormatEncodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormatEncodingError.swift; sourceTree = "<group>"; };
 		9CA424411E286D4E00C0E5B4 /* StringUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringUtils.swift; sourceTree = "<group>"; };
 		9CCD5F921E008203002D1940 /* Test_Text_WKT_proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_Text_WKT_proto3.swift; sourceTree = "<group>"; };
 		9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONScanner.swift; sourceTree = "<group>"; };
@@ -625,7 +636,6 @@
 		__PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryEncoder.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* BinaryTypeAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryTypeAdditions.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enum.swift; sourceTree = "<group>"; };
-		__PBXFileRef_Sources/Protobuf/ProtobufError.swift /* EncodingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingError.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionFields.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageExtension.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
@@ -801,13 +811,13 @@
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift */,
 				9C667A8F1E4C203D008B974F /* BinaryDecodingError.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */,
+				9C84E48C1E5E3ABD00513BE0 /* BinaryEncodingError.swift */,
 				AA28A4AB1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift */,
 				9C75F8931DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* BinaryTypeAdditions.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift */,
 				__PBXFileRef_Sources/Protobuf/duration.pb.swift /* duration.pb.swift */,
 				__PBXFileRef_Sources/Protobuf/empty.pb.swift /* empty.pb.swift */,
-				__PBXFileRef_Sources/Protobuf/ProtobufError.swift /* EncodingError.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift */,
 				9C75F88E1DDD3108005CCFF2 /* ExtensibleMessage.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */,
@@ -828,6 +838,7 @@
 				9C75F89D1DDD3FA3005CCFF2 /* JSONDecoder.swift */,
 				9C667A8E1E4C203D008B974F /* JSONDecodingError.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufJSONEncoding.swift /* JSONEncoder.swift */,
+				9C84E48D1E5E3ABD00513BE0 /* JSONEncodingError.swift */,
 				AA86F6F91E0A0F0B006CC38A /* JSONEncodingVisitor.swift */,
 				AAF2EDFE1DFB1450007B510F /* JSONIntegerConverting.swift */,
 				9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */,
@@ -844,6 +855,7 @@
 				BCCA0E661DB1210E00957D74 /* TextFormatDecoder.swift */,
 				9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */,
 				BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */,
+				9C84E48E1E5E3ABD00513BE0 /* TextFormatEncodingError.swift */,
 				9CEB0D671DF5E934002D80F0 /* TextFormatEncodingVisitor.swift */,
 				9CEB0D6B1DF5F921002D80F0 /* TextFormatScanner.swift */,
 				BCCA0E681DB1210E00957D74 /* TextFormatTypeAdditions.swift */,
@@ -1265,14 +1277,15 @@
 				9C2F23861D7780D1008524F2 /* BinaryEncoder.swift in Sources */,
 				9C2F23871D7780D1008524F2 /* BinaryTypeAdditions.swift in Sources */,
 				9C2F23891D7780D1008524F2 /* Enum.swift in Sources */,
-				9C2F238A1D7780D1008524F2 /* EncodingError.swift in Sources */,
 				9C2F238B1D7780D1008524F2 /* ExtensionFields.swift in Sources */,
 				9C75F88B1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */,
 				F4F4F11E1E5C7562006C6CAD /* MathUtils.swift in Sources */,
+				9C84E4941E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
 				AA86F6FB1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */,
 				9C2F238C1D7780D1008524F2 /* MessageExtension.swift in Sources */,
 				9C667A961E4C203D008B974F /* BinaryDecodingError.swift in Sources */,
 				9C2F238D1D7780D1008524F2 /* Decoder.swift in Sources */,
+				9C84E4981E5E3ABD00513BE0 /* TextFormatEncodingError.swift in Sources */,
 				9C2F238F1D7780D1008524F2 /* HashVisitor.swift in Sources */,
 				AAABA40C1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */,
 				AAF2ED401DEF4D94007B510F /* ProtoNameProviding.swift in Sources */,
@@ -1294,6 +1307,7 @@
 				9C5890B91DFF6389001CFC34 /* TextFormatTypeAdditions.swift in Sources */,
 				F48FDD241E4D17ED0061D5C1 /* JSONScanner.swift in Sources */,
 				9C75F8861DDD3045005CCFF2 /* ExtensionSet.swift in Sources */,
+				9C84E4901E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
 				9C75F8811DDBE0FC005CCFF2 /* Visitor.swift in Sources */,
 				AAF2ED451DEF6C48007B510F /* ProtoNameResolvers.swift in Sources */,
 				9C2F239B1D7780D1008524F2 /* source_context.pb.swift in Sources */,
@@ -1317,7 +1331,6 @@
 				__src_cc_ref_Sources/Protobuf/duration.pb.swift /* duration.pb.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/empty.pb.swift /* empty.pb.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufEnum.swift /* Enum.swift in Sources */,
-				__src_cc_ref_Sources/Protobuf/ProtobufError.swift /* EncodingError.swift in Sources */,
 				9C75F88F1DDD3108005CCFF2 /* ExtensibleMessage.swift in Sources */,
 				8DC1CA0F1E54B81400CA8A26 /* TimeUtils.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift in Sources */,
@@ -1335,10 +1348,12 @@
 				__src_cc_ref_Sources/Protobuf/Google_Protobuf_FieldMask_Extensions.swift /* Google_Protobuf_FieldMask_Extensions.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/Google_Protobuf_Timestamp_Extensions.swift /* Google_Protobuf_Timestamp_Extensions.swift in Sources */,
+				9C84E4931E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
 				8DC1CA0D1E54B80800CA8A26 /* MathUtils.swift in Sources */,
 				AAEA52721DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
 				AAABA40B1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */,
 				9C667A951E4C203D008B974F /* BinaryDecodingError.swift in Sources */,
+				9C84E4971E5E3ABD00513BE0 /* TextFormatEncodingError.swift in Sources */,
 				AA86F6FA1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufHash.swift /* HashVisitor.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufJSONEncoding.swift /* JSONEncoder.swift in Sources */,
@@ -1360,6 +1375,7 @@
 				BCCA0E6A1DB1210E00957D74 /* TextFormatEncoder.swift in Sources */,
 				9C667A991E4C203D008B974F /* TextFormatDecodingError.swift in Sources */,
 				9CE9CF371E32C9F8004FBED6 /* JSONScanner.swift in Sources */,
+				9C84E48F1E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
 				9C667A911E4C203D008B974F /* JSONDecodingError.swift in Sources */,
 				9CEB0D681DF5E934002D80F0 /* TextFormatEncodingVisitor.swift in Sources */,
 				9CEB0D6C1DF5F921002D80F0 /* TextFormatScanner.swift in Sources */,
@@ -1502,10 +1518,12 @@
 				AA86F6FC1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */,
 				AAF2ED411DEF4D94007B510F /* ProtoNameProviding.swift in Sources */,
 				AAF2ED3C1DEF3FBC007B510F /* FieldNameMap.swift in Sources */,
+				9C84E4951E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
 				F4F4F11F1E5C7563006C6CAD /* MathUtils.swift in Sources */,
 				F44F937E1DAEA76700BC5B85 /* Google_Protobuf_Struct.swift in Sources */,
 				9C667A971E4C203D008B974F /* BinaryDecodingError.swift in Sources */,
 				F44F93941DAEA76700BC5B85 /* UnknownStorage.swift in Sources */,
+				9C84E4991E5E3ABD00513BE0 /* TextFormatEncodingError.swift in Sources */,
 				9C75F8821DDBE10D005CCFF2 /* Visitor.swift in Sources */,
 				AAABA40D1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */,
 				F44F93781DAEA76700BC5B85 /* duration.pb.swift in Sources */,
@@ -1527,9 +1545,9 @@
 				9C5890B11DFF6384001CFC34 /* TextFormatScanner.swift in Sources */,
 				9C5890B31DFF6384001CFC34 /* TextFormatTypeAdditions.swift in Sources */,
 				F48FDD251E4D17EE0061D5C1 /* JSONScanner.swift in Sources */,
+				9C84E4911E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
 				F44F93931DAEA76700BC5B85 /* FieldTypes.swift in Sources */,
 				9C75F8871DDD3045005CCFF2 /* ExtensionSet.swift in Sources */,
-				F44F93871DAEA76700BC5B85 /* EncodingError.swift in Sources */,
 				F44F937D1DAEA76700BC5B85 /* Google_Protobuf_FieldMask_Extensions.swift in Sources */,
 				F44F93771DAEA76700BC5B85 /* api.pb.swift in Sources */,
 				F44F93791DAEA76700BC5B85 /* empty.pb.swift in Sources */,
@@ -1653,7 +1671,6 @@
 				F44F94071DAEB23500BC5B85 /* duration.pb.swift in Sources */,
 				F44F94081DAEB23500BC5B85 /* empty.pb.swift in Sources */,
 				F44F94151DAEB23500BC5B85 /* Enum.swift in Sources */,
-				F44F94161DAEB23500BC5B85 /* EncodingError.swift in Sources */,
 				9C75F8921DDD3108005CCFF2 /* ExtensibleMessage.swift in Sources */,
 				F44F94171DAEB23500BC5B85 /* ExtensionFields.swift in Sources */,
 				9C75F88D1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */,
@@ -1671,10 +1688,12 @@
 				ECBC5C4A1DF6ABC500F658E8 /* Google_Protobuf_Struct.swift in Sources */,
 				ECBC5C4D1DF6ABC500F658E8 /* Google_Protobuf_Timestamp_Extensions.swift in Sources */,
 				F4F4F1201E5C7565006C6CAD /* MathUtils.swift in Sources */,
+				9C84E4961E5E3ABD00513BE0 /* JSONEncodingError.swift in Sources */,
 				ECBC5C491DF6ABC500F658E8 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
 				AA86F6FD1E0A0F0B006CC38A /* JSONEncodingVisitor.swift in Sources */,
 				9C667A981E4C203D008B974F /* BinaryDecodingError.swift in Sources */,
 				F44F941A1DAEB23500BC5B85 /* HashVisitor.swift in Sources */,
+				9C84E49A1E5E3ABD00513BE0 /* TextFormatEncodingError.swift in Sources */,
 				F44F941C1DAEB23500BC5B85 /* JSONEncoder.swift in Sources */,
 				AAABA40E1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */,
 				AAF2EE021DFB1450007B510F /* JSONIntegerConverting.swift in Sources */,
@@ -1696,6 +1715,7 @@
 				9C5890A91DFF6375001CFC34 /* TextFormatEncoder.swift in Sources */,
 				F48FDD261E4D17EF0061D5C1 /* JSONScanner.swift in Sources */,
 				9C5890AA1DFF6375001CFC34 /* TextFormatEncodingVisitor.swift in Sources */,
+				9C84E4921E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
 				9C5890AB1DFF6375001CFC34 /* TextFormatScanner.swift in Sources */,
 				9C5890AD1DFF6375001CFC34 /* TextFormatTypeAdditions.swift in Sources */,
 				ECBC5C4B1DF6ABC500F658E8 /* timestamp.pb.swift in Sources */,


### PR DESCRIPTION
This separates the error enums for each serializer (and updates the Xcode project with the new files for all targets).