### PR TITLE
Use our init(safely:) for float/double -> Int64 conversions.

### DIFF
--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -130,7 +130,7 @@ public struct JSONEncoder {
         } else {
             // TODO: Be smarter here about choosing significant digits
             // See: protoc source has C++ code for this with interesting ideas
-            if let v = Int64(exactly: value) {
+            if let v = Int64(safely: value) {
                 appendInt(value: v)
             } else {
                 let s = String(value)

--- a/Sources/SwiftProtobuf/JSONIntegerConverting.swift
+++ b/Sources/SwiftProtobuf/JSONIntegerConverting.swift
@@ -46,20 +46,6 @@ internal protocol JSONIntegerConverting {
 }
 
 
-extension Int32: JSONIntegerConverting {
-
-  init?(safely value: Double) {
-    let upper = Double(sign: .plus, exponent: 31, significand: 1)
-    let lower = -upper - 1
-    guard lower < value && value < upper &&
-      value == value.rounded(.towardZero) else {
-      return nil
-    }
-    self.init(value)
-  }
-}
-
-
 extension Int64: JSONIntegerConverting {
 
   init?(safely value: Double) {
@@ -72,19 +58,6 @@ extension Int64: JSONIntegerConverting {
     let ulp = Double(1 << 11)
     let lower = -upper - ulp
     guard lower < value && value < upper &&
-      value == value.rounded(.towardZero) else {
-      return nil
-    }
-    self.init(value)
-  }
-}
-
-
-extension UInt32: JSONIntegerConverting {
-
-  init?(safely value: Double) {
-    let upper = Double(sign: .plus, exponent: 32, significand: 1)
-    guard -1 < value && value < upper &&
       value == value.rounded(.towardZero) else {
       return nil
     }

--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -137,7 +137,7 @@ internal struct TextFormatEncoder {
         } else {
             // TODO: Be smarter here about choosing significant digits
             // See: protoc source has C++ code for this with interesting ideas
-            if let v = Int64(exactly: value) {
+            if let v = Int64(safely: value) {
                 appendInt(value: v)
             } else {
                 let s = String(value)


### PR DESCRIPTION
init(exactly:) for double is only in Swift 3.1, so use our helper
so we support building in the current GM Swift.