### PR TITLE
Text encoder now writes out binary unknown fields

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -32,7 +32,7 @@ struct BinaryDecoder: Decoder {
     // Whether or not the field value  has actually been parsed
     private var consumed = true
     // Wire format for last-examined field
-    private var fieldWireFormat = WireFormat.varint
+    internal var fieldWireFormat = WireFormat.varint
     // Field number for last-parsed field tag
     private var fieldNumber: Int = 0
     // Collection of extension fields for this decode
@@ -1099,7 +1099,7 @@ struct BinaryDecoder: Decoder {
 
     /// Private: Get the tag that starts a new field.
     /// This also bookmarks the start of field for a possible skip().
-    private mutating func getTag() throws -> FieldTag? {
+    internal mutating func getTag() throws -> FieldTag? {
         fieldStartP = p
         fieldEndP = nil
         return try getTagWithoutUpdatingFieldStart()

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -69,6 +69,9 @@
 		9C667A9A1E4C203D008B974F /* TextFormatDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */; };
 		9C667A9B1E4C203D008B974F /* TextFormatDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */; };
 		9C667A9C1E4C203D008B974F /* TextFormatDecodingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */; };
+		9C7254661E5F9B1600486C98 /* Test_Text_Unknown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7254651E5F9B1600486C98 /* Test_Text_Unknown.swift */; };
+		9C7254671E5F9B1600486C98 /* Test_Text_Unknown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7254651E5F9B1600486C98 /* Test_Text_Unknown.swift */; };
+		9C7254681E5F9B1600486C98 /* Test_Text_Unknown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7254651E5F9B1600486C98 /* Test_Text_Unknown.swift */; };
 		9C75F8801DDBE0DE005CCFF2 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */; };
 		9C75F8811DDBE0FC005CCFF2 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */; };
 		9C75F8821DDBE10D005CCFF2 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */; };
@@ -572,6 +575,7 @@
 		9C667A8E1E4C203D008B974F /* JSONDecodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONDecodingError.swift; sourceTree = "<group>"; };
 		9C667A8F1E4C203D008B974F /* BinaryDecodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryDecodingError.swift; sourceTree = "<group>"; };
 		9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormatDecodingError.swift; sourceTree = "<group>"; };
+		9C7254651E5F9B1600486C98 /* Test_Text_Unknown.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_Text_Unknown.swift; sourceTree = "<group>"; };
 		9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Visitor.swift; sourceTree = "<group>"; };
 		9C75F8841DDD3045005CCFF2 /* ExtensionSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionSet.swift; sourceTree = "<group>"; };
 		9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionFieldValueSet.swift; sourceTree = "<group>"; };
@@ -916,6 +920,7 @@
 				9C5890A51DFF5EC8001CFC34 /* Test_Text_proto2_extensions.swift */,
 				9C60CBEB1DF9DEEA00F7B14E /* Test_Text_proto2.swift */,
 				BCCA0E751DB123F800957D74 /* Test_Text_proto3.swift */,
+				9C7254651E5F9B1600486C98 /* Test_Text_Unknown.swift */,
 				9CCD5F921E008203002D1940 /* Test_Text_WKT_proto3.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Timestamp.swift /* Test_Timestamp.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Type.swift /* Test_Type.swift */,
@@ -1233,6 +1238,7 @@
 				9C8CDA5B1D7A28F600E207CA /* unittest_proto3.pb.swift in Sources */,
 				9C8CDA5D1D7A28F600E207CA /* unittest_swift_all_required_types.pb.swift in Sources */,
 				9C8CDA5E1D7A28F600E207CA /* unittest_swift_cycle.pb.swift in Sources */,
+				9C7254671E5F9B1600486C98 /* Test_Text_Unknown.swift in Sources */,
 				9C8CDA611D7A28F600E207CA /* unittest_swift_extension.pb.swift in Sources */,
 				F4D315491DEC811B005D4A80 /* unittest_swift_extension2.pb.swift in Sources */,
 				F4D315551DECA0EA005D4A80 /* unittest_swift_extension4.pb.swift in Sources */,
@@ -1470,6 +1476,7 @@
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_cycle.pb.swift /* unittest_swift_cycle.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_enum.pb.swift /* unittest_swift_enum.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_enum_optional_default.pb.swift /* unittest_swift_enum_optional_default.pb.swift in Sources */,
+				9C7254661E5F9B1600486C98 /* Test_Text_Unknown.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/unittest_swift_extension.pb.swift /* unittest_swift_extension.pb.swift in Sources */,
 				F4D315471DEC8117005D4A80 /* unittest_swift_extension2.pb.swift in Sources */,
 				F4D315481DEC8117005D4A80 /* unittest_swift_extension3.pb.swift in Sources */,
@@ -1639,6 +1646,7 @@
 				F44F93AD1DAEA8C900BC5B85 /* TestHelpers.swift in Sources */,
 				F44F93F61DAEA8C900BC5B85 /* unittest_swift_startup.pb.swift in Sources */,
 				F44F93C51DAEA8C900BC5B85 /* Test_ParsingMerge.swift in Sources */,
+				9C7254681E5F9B1600486C98 /* Test_Text_Unknown.swift in Sources */,
 				F44F93E91DAEA8C900BC5B85 /* unittest_proto3.pb.swift in Sources */,
 				F44F93D21DAEA8C900BC5B85 /* unittest_custom_options.pb.swift in Sources */,
 				F44F93B91DAEA8C900BC5B85 /* Test_Enum.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -859,6 +859,22 @@ extension Test_Text_Map_proto3 {
     }
 }
 
+extension Test_Text_Unknown {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("test_unknown_varint", {try run_test(test:($0 as! Test_Text_Unknown).test_unknown_varint)}),
+            ("test_unknown_fixed64", {try run_test(test:($0 as! Test_Text_Unknown).test_unknown_fixed64)}),
+            ("test_unknown_lengthDelimited_string", {try run_test(test:($0 as! Test_Text_Unknown).test_unknown_lengthDelimited_string)}),
+            ("test_unknown_lengthDelimited_message", {try run_test(test:($0 as! Test_Text_Unknown).test_unknown_lengthDelimited_message)}),
+            ("test_unknown_lengthDelimited_notmessage", {try run_test(test:($0 as! Test_Text_Unknown).test_unknown_lengthDelimited_notmessage)}),
+            ("test_unknown_lengthDelimited_nested_message", {try run_test(test:($0 as! Test_Text_Unknown).test_unknown_lengthDelimited_nested_message)}),
+            ("test_unknown_group", {try run_test(test:($0 as! Test_Text_Unknown).test_unknown_group)}),
+            ("test_unknown_nested_group", {try run_test(test:($0 as! Test_Text_Unknown).test_unknown_nested_group)}),
+            ("test_unknown_fixed32", {try run_test(test:($0 as! Test_Text_Unknown).test_unknown_fixed32)})
+        ]
+    }
+}
+
 extension Test_Text_WKT_proto3 {
     static var allTests: [(String, (XCTestCase) throws -> ())] {
         return [
@@ -1064,6 +1080,7 @@ XCTMain(
         (testCaseClass: Test_JSON_ListValue.self, allTests: Test_JSON_ListValue.allTests),
         (testCaseClass: Test_JSON_Value.self, allTests: Test_JSON_Value.allTests),
         (testCaseClass: Test_Text_Map_proto3.self, allTests: Test_Text_Map_proto3.allTests),
+        (testCaseClass: Test_Text_Unknown.self, allTests: Test_Text_Unknown.allTests),
         (testCaseClass: Test_Text_WKT_proto3.self, allTests: Test_Text_WKT_proto3.allTests),
         (testCaseClass: Test_Text_proto2.self, allTests: Test_Text_proto2.allTests),
         (testCaseClass: Test_Text_proto2_extensions.self, allTests: Test_Text_proto2_extensions.allTests),

--- a/Tests/SwiftProtobufTests/Test_Text_Unknown.swift
+++ b/Tests/SwiftProtobufTests/Test_Text_Unknown.swift
@@ -1,0 +1,87 @@
+// Tests/SwiftProtobufTests/Test_Text_Unknown.swift - Exercise unknown field text format coding
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// This is a set of tests for text format protobuf files.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+import XCTest
+import SwiftProtobuf
+
+class Test_Text_Unknown: XCTestCase, PBTestHelpers {
+    typealias MessageTestType = ProtobufUnittest_TestEmptyMessage
+
+    func test_unknown_varint() throws {
+        let bytes = Data(bytes: [8, 0])
+        let msg = try MessageTestType(serializedData: bytes)
+        let text = try msg.textFormatString()
+        XCTAssertEqual(text, "1: 0\n")
+    }
+
+    func test_unknown_fixed64() throws {
+        let bytes = Data(bytes: [9, 0, 1, 2, 3, 4, 5, 6, 7])
+        let msg = try MessageTestType(serializedData: bytes)
+        let text = try msg.textFormatString()
+        XCTAssertEqual(text, "1: 0x0706050403020100\n")
+    }
+
+    func test_unknown_lengthDelimited_string() throws {
+        let bytes = Data(bytes: [10, 3, 97, 98, 99])
+        let msg = try MessageTestType(serializedData: bytes)
+        let text = try msg.textFormatString()
+        XCTAssertEqual(text, "1: \"abc\"\n")
+    }
+
+    func test_unknown_lengthDelimited_message() throws {
+        // If inner data looks like a message, display it as such:
+        let bytes = Data(bytes: [10, 6, 8, 1, 18, 2, 97, 98])
+        let msg = try MessageTestType(serializedData: bytes)
+        let text = try msg.textFormatString()
+        XCTAssertEqual(text, "1 {\n  1: 1\n  2: \"ab\"\n}\n")
+    }
+
+    func test_unknown_lengthDelimited_notmessage() throws {
+        // Inner data is almost a message, but has an error at the end...
+        // This should cause it to be displayed as a string.
+        let bytes = Data(bytes: [10, 6, 8, 1, 18, 3, 97, 98])
+        let msg = try MessageTestType(serializedData: bytes)
+        let text = try msg.textFormatString()
+        XCTAssertEqual(text, "1: \"\\b\\001\\022\\003ab\"\n")
+    }
+
+    func test_unknown_lengthDelimited_nested_message() throws {
+        let bytes = Data(bytes: [8, 1, 18, 6, 8, 2, 18, 2, 8, 3])
+        let msg = try MessageTestType(serializedData: bytes)
+        let text = try msg.textFormatString()
+        XCTAssertEqual(text, "1: 1\n2 {\n  1: 2\n  2 {\n    1: 3\n  }\n}\n")
+    }
+
+    func test_unknown_group() throws {
+        let bytes = Data(bytes: [8, 1, 19, 26, 2, 8, 1, 20])
+        let msg = try MessageTestType(serializedData: bytes)
+        let text = try msg.textFormatString()
+        XCTAssertEqual(text, "1: 1\n2 {\n  3 {\n    1: 1\n  }\n}\n")
+    }
+
+    func test_unknown_nested_group() throws {
+        let bytes = Data(bytes: [8, 1, 19, 26, 2, 8, 1, 35, 40, 7, 36, 20])
+        let msg = try MessageTestType(serializedData: bytes)
+        let text = try msg.textFormatString()
+        XCTAssertEqual(text, "1: 1\n2 {\n  3 {\n    1: 1\n  }\n  4 {\n    5: 7\n  }\n}\n")
+    }
+
+    func test_unknown_fixed32() throws {
+        let bytes = Data(bytes: [13, 0, 1, 2, 3])
+        let msg = try MessageTestType(serializedData: bytes)
+        let text = try msg.textFormatString()
+        XCTAssertEqual(text, "1: 0x03020100\n")
+    }
+}


### PR DESCRIPTION
I believe this matches the output of the C++ text formatter.

The text encoder now uses the binary decoder to parse out the unknown data and prints the results.

I ended up refactoring the Text encoder to simplify things a bit.  For example, writing a message field now just brackets the contents with `startMessageField`/`endMessageField` and no longer needs to `startObject`/`endObject` to adjust the indentation.