### PR TITLE
Bump run_count to 1000, add autoreleasepool, support `bool` fields

### DIFF
--- a/Performance/Harness.cc
+++ b/Performance/Harness.cc
@@ -35,7 +35,7 @@ using std::vector;
 Harness::Harness(std::ostream* results_stream) :
     results_stream(results_stream),
     measurement_count(10),
-    run_count(100),
+    run_count(1000),
     repeated_count(10) {}
 
 void Harness::write_to_log(const string& name,

--- a/Performance/Harness.swift
+++ b/Performance/Harness.swift
@@ -29,7 +29,7 @@ class Harness {
 
   /// The number of times to loop the body of the run() method.
   /// Increase this to get better precision...
-  var runCount = 100
+  var runCount = 1000
 
   /// The number of times to call append() for repeated fields.
   let repeatedCount: Int32 = 10
@@ -125,13 +125,15 @@ class Harness {
     _ name: String,
     block: () throws -> Result
   ) rethrows -> Result {
-    taskNames.append(name)
-    let start = Date()
-    let result = try block()
-    let end = Date()
-    let diff = end.timeIntervalSince(start) / Double(runCount) * 1000000.0
-    currentSubtasks[name] = (currentSubtasks[name] ?? 0) + diff
-    return result
+      return try autoreleasepool { () -> Result in
+          taskNames.append(name)
+          let start = Date()
+          let result = try block()
+          let end = Date()
+          let diff = end.timeIntervalSince(start) / Double(runCount) * 1000000.0
+          currentSubtasks[name] = (currentSubtasks[name] ?? 0) + diff
+          return result
+      }
   }
 
   /// Compute the mean and standard deviation of the given time intervals.

--- a/Performance/perf_runner_swift.sh
+++ b/Performance/perf_runner_swift.sh
@@ -28,6 +28,9 @@ function print_swift_set_field() {
       echo "          message.field$num.append(Data(repeating:$((num)), count: 20))"
       echo "        }"
       ;;
+    repeated\ bool)
+      echo "        message.field$num = [true, false, true, false, true, false, true, false]"
+      ;;
     repeated\ string)
       echo "        for _ in 0..<repeatedCount {"
       echo "          message.field$num.append(\"$((200+num))\")"
@@ -40,6 +43,9 @@ function print_swift_set_field() {
       ;;
     bytes)
       echo "        message.field$num = Data(repeating:$((num)), count: 20)"
+      ;;
+    bool)
+      echo "        message.field$num = true"
       ;;
     string)
       echo "        message.field$num = \"$((200+num))\""


### PR DESCRIPTION
Three minor improvements that I've been using in my local branch:

* Bump the run_count from 100 to 1000.  SwiftProtobuf is faster now,
  so we need more runs to get useful detail from Instruments.  ;-)
  The higher run_count also brings down the relative stddev, which
  makes it easier to see differences of 10%-20% (with run_count 100,
  you can easily see differences of 2x, but not much less).

* Add an autoreleasepool around the big loop for the Swift version.
  In particular, Data tends to leak autoreleased objects.

* Add support for `bool` fields.  Swift `bool` cannot be initialized
  with a number, so we need a special case to initialize them.