### PR TITLE
Rename _mergeSerializedBytes -> _protobuf_mergeSerializedBytes.

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -822,7 +822,7 @@ internal struct BinaryDecoder: Decoder {
         if value == nil {
             value = M()
         }
-        try value!._mergeSerializedBytes(from: p, count: count, extensions: extensions)
+        try value!._protobuf_mergeSerializedBytes(from: p, count: count, extensions: extensions)
         consumed = true
     }
 
@@ -833,7 +833,7 @@ internal struct BinaryDecoder: Decoder {
         var count: Int = 0
         let p = try getFieldBodyBytes(count: &count)
         var newValue = M()
-        try newValue._mergeSerializedBytes(from: p, count: count, extensions: extensions)
+        try newValue._protobuf_mergeSerializedBytes(from: p, count: count, extensions: extensions)
         value.append(newValue)
         consumed = true
     }

--- a/Sources/SwiftProtobuf/BinaryTypeAdditions.swift
+++ b/Sources/SwiftProtobuf/BinaryTypeAdditions.swift
@@ -90,9 +90,9 @@ public extension Message {
     mutating func merge(serializedData data: Data, extensions: ExtensionSet? = nil, partial: Bool = false) throws {
         if !data.isEmpty {
             try data.withUnsafeBytes { (pointer: UnsafePointer<UInt8>) in
-                try _mergeSerializedBytes(from: pointer,
-                                          count: data.count,
-                                          extensions: extensions)
+                try _protobuf_mergeSerializedBytes(from: pointer,
+                                                   count: data.count,
+                                                   extensions: extensions)
             }
         }
         if !partial && !isInitialized {
@@ -103,7 +103,7 @@ public extension Message {
 
 /// Proto2 messages preserve unknown fields
 public extension Proto2Message {
-    public mutating func _mergeSerializedBytes(from bytes: UnsafePointer<UInt8>, count: Int, extensions: ExtensionSet?) throws {
+    public mutating func _protobuf_mergeSerializedBytes(from bytes: UnsafePointer<UInt8>, count: Int, extensions: ExtensionSet?) throws {
         var decoder = BinaryDecoder(forReadingFrom: bytes, count: count, extensions: extensions)
         try decodeMessage(decoder: &decoder)
         guard decoder.complete else {
@@ -117,7 +117,7 @@ public extension Proto2Message {
 
 // Proto3 messages ignore unknown fields
 public extension Proto3Message {
-    public mutating func _mergeSerializedBytes(from bytes: UnsafePointer<UInt8>, count: Int, extensions: ExtensionSet?) throws {
+    public mutating func _protobuf_mergeSerializedBytes(from bytes: UnsafePointer<UInt8>, count: Int, extensions: ExtensionSet?) throws {
         var decoder = BinaryDecoder(forReadingFrom: bytes, count: count, extensions: extensions)
         try decodeMessage(decoder: &decoder)
         guard decoder.complete else {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
@@ -367,7 +367,7 @@ public struct Google_Protobuf_Any: Message, Proto3Message, _MessageImplementatio
             // Decode protobuf from the stored bytes
             if protobuf.count > 0 {
                 try protobuf.withUnsafeBytes { (p: UnsafePointer<UInt8>) in
-                    try target._mergeSerializedBytes(from: p, count: protobuf.count, extensions: nil)
+                    try target._protobuf_mergeSerializedBytes(from: p, count: protobuf.count, extensions: nil)
                 }
             }
             return

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -80,9 +80,9 @@ public protocol Message: CustomDebugStringConvertible {
   func traverse<V: Visitor>(visitor: inout V) throws
 
   /// SwiftProtobuf Internal: Common support for decoding.
-  mutating func _mergeSerializedBytes(from: UnsafePointer<UInt8>,
-                                      count: Int,
-                                      extensions: ExtensionSet?) throws
+  mutating func _protobuf_mergeSerializedBytes(from: UnsafePointer<UInt8>,
+                                               count: Int,
+                                               extensions: ExtensionSet?) throws
 
   //
   // Protobuf Text decoding


### PR DESCRIPTION
Working on prefixing all internal functions with _protobuf to get them out of
the message/enum namespaces and mark them as not really for use by developers.