### PR TITLE
Map entry decoding uses the default values if key/value are missing.

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -892,13 +892,13 @@ internal struct BinaryDecoder: Decoder {
         if !subdecoder.complete {
             throw BinaryDecodingError.trailingGarbage
         }
-
-        if let k = k, let v = v {
-            value[k] = v
-            consumed = true
-        } else {
-            throw BinaryDecodingError.malformedProtobuf
-        }
+        // A map<> definition can't provide a default value for the keys/values,
+        // so it is safe to use the proto3 default to get the right
+        // integer/string/bytes. The one catch is a proto2 enum (which can be the
+        // value) can have a non zero value, but that case is the next
+        // custom decodeMapField<>() method and handles it.
+        value[k ?? KeyType.proto3DefaultValue] = v ?? ValueType.proto3DefaultValue
+        consumed = true
     }
 
     internal mutating func decodeMapField<KeyType: MapKeyType, ValueType: Enum>(fieldType: _ProtobufEnumMap<KeyType, ValueType>.Type, value: inout _ProtobufEnumMap<KeyType, ValueType>.BaseType) throws where ValueType.RawValue == Int {
@@ -924,13 +924,10 @@ internal struct BinaryDecoder: Decoder {
         if !subdecoder.complete {
             throw BinaryDecodingError.trailingGarbage
         }
-
-        if let k = k, let v = v {
-            value[k] = v
-            consumed = true
-        } else {
-            throw BinaryDecodingError.malformedProtobuf
-        }
+        // A map<> definition can't provide a default value for the keys, so it
+        // is safe to use the proto3 default to get the right integer/string/bytes.
+        value[k ?? KeyType.proto3DefaultValue] = v ?? ValueType()
+        consumed = true
     }
 
     internal mutating func decodeMapField<KeyType: MapKeyType, ValueType: Message & Hashable>(fieldType: _ProtobufMessageMap<KeyType, ValueType>.Type, value: inout _ProtobufMessageMap<KeyType, ValueType>.BaseType) throws {
@@ -956,13 +953,10 @@ internal struct BinaryDecoder: Decoder {
         if !subdecoder.complete {
             throw BinaryDecodingError.trailingGarbage
         }
-
-        if let k = k, let v = v {
-            value[k] = v
-            consumed = true
-        } else {
-            throw BinaryDecodingError.malformedProtobuf
-        }
+        // A map<> definition can't provide a default value for the keys, so it
+        // is safe to use the proto3 default to get the right integer/string/bytes.
+        value[k ?? KeyType.proto3DefaultValue] = v ?? ValueType()
+        consumed = true
     }
 
     internal mutating func decodeExtensionField(values: inout ExtensionFieldValueSet, messageType: Message.Type, fieldNumber: Int) throws {

--- a/Tests/SwiftProtobufTests/Test_Map.swift
+++ b/Tests/SwiftProtobufTests/Test_Map.swift
@@ -68,6 +68,18 @@ class Test_Map: XCTestCase, PBTestHelpers {
         assertDecodeSucceeds([10, 4, 8, 1, 16, 2]) {
             $0.mapInt32Int32 == [1: 2]
         }
+        // Missing map value on the wire.
+        assertDecodeSucceeds(inputBytes: [10, 2, 8, 1], recodedBytes: [10, 4, 8, 1, 16, 0]) {
+            $0.mapInt32Int32 == [1: 0]
+        }
+        // Missing map key on the wire.
+        assertDecodeSucceeds(inputBytes: [10, 2, 16, 2], recodedBytes: [10, 4, 8, 0, 16, 2]) {
+            $0.mapInt32Int32 == [0: 2]
+        }
+        // Missing map key and value on the wire.
+        assertDecodeSucceeds(inputBytes: [10, 0], recodedBytes: [10, 4, 8, 0, 16, 0]) {
+            $0.mapInt32Int32 == [0: 0]
+        }
         // TODO: This current doens't fail -
         // 1. The comment imples it should be a bad wire type, but that doesn't
         //    appear to be true, it is a field 1 startGroup.
@@ -81,12 +93,35 @@ class Test_Map: XCTestCase, PBTestHelpers {
         assertMapEncode([[18, 4, 8, 0, 16, 0], [18, 21, 8, 255,255,255,255,255,255,255,255,127, 16, 128,128,128,128,128,128,128,128,128,1]]) {(o: inout MessageTestType) in
             o.mapInt64Int64 = [Int64.max: Int64.min, 0: 0]
         }
+        // Missing map value on the wire.
+        assertDecodeSucceeds(inputBytes: [18, 2, 8, 1], recodedBytes: [18, 4, 8, 1, 16, 0]) {
+            $0.mapInt64Int64 == [1: 0]
+        }
+        // Missing map key on the wire.
+        assertDecodeSucceeds(inputBytes: [18, 2, 16, 2], recodedBytes: [18, 4, 8, 0, 16, 2]) {
+            $0.mapInt64Int64 == [0: 2]
+        }
+        // Missing map key and value on the wire.
+        assertDecodeSucceeds(inputBytes: [18, 0], recodedBytes: [18, 4, 8, 0, 16, 0]) {
+            $0.mapInt64Int64 == [0: 0]
+        }
     }
 
-    // TODO: Figure out why Swift crashes on this test
-    func XXXtest_mapUint32Uint32() {
+    func test_mapUint32Uint32() {
         assertMapEncode([[26, 4, 8, 1, 16, 2], [26, 8, 8, 255,255,255,255,15, 16, 0]]) {(o: inout MessageTestType) in
             o.mapUint32Uint32 = [UInt32.max: UInt32.min, 1: 2]
+        }
+        // Missing map value on the wire.
+        assertDecodeSucceeds(inputBytes: [26, 2, 8, 1], recodedBytes: [26, 4, 8, 1, 16, 0]) {
+            $0.mapUint32Uint32 == [1: 0]
+        }
+        // Missing map key on the wire.
+        assertDecodeSucceeds(inputBytes: [26, 2, 16, 2], recodedBytes: [26, 4, 8, 0, 16, 2]) {
+            $0.mapUint32Uint32 == [0: 2]
+        }
+        // Missing map key and value on the wire.
+        assertDecodeSucceeds(inputBytes: [26, 0], recodedBytes: [26, 4, 8, 0, 16, 0]) {
+            $0.mapUint32Uint32 == [0: 0]
         }
     }
 
@@ -118,7 +153,19 @@ class Test_Map: XCTestCase, PBTestHelpers {
     }
 
     func test_mapBoolBool() {
-        assertDecodeSucceeds([106, 4, 8, 0, 16, 0]) {
+        assertDecodeSucceeds([106, 4, 8, 1, 16, 1]) {
+            $0.mapBoolBool == [true: true]
+        }
+        // Missing map value on the wire.
+        assertDecodeSucceeds(inputBytes: [106, 2, 8, 1], recodedBytes: [106, 4, 8, 1, 16, 0]) {
+            $0.mapBoolBool == [true: false]
+        }
+        // Missing map key on the wire.
+        assertDecodeSucceeds(inputBytes: [106, 2, 16, 1], recodedBytes: [106, 4, 8, 0, 16, 1]) {
+            $0.mapBoolBool == [false: true]
+        }
+        // Missing map key and value on the wire.
+        assertDecodeSucceeds(inputBytes: [106, 0], recodedBytes: [106, 4, 8, 0, 16, 0]) {
             $0.mapBoolBool == [false: false]
         }
     }
@@ -126,6 +173,18 @@ class Test_Map: XCTestCase, PBTestHelpers {
     func test_mapStringString() {
         assertDecodeSucceeds([114, 8, 10, 2, 65, 66, 18, 2, 97, 98]) {
             $0.mapStringString == ["AB": "ab"]
+        }
+        // Missing map value on the wire.
+        assertDecodeSucceeds(inputBytes: [114, 4, 10, 2, 65, 66], recodedBytes: [114, 6, 10, 2, 65, 66, 18, 0]) {
+            $0.mapStringString == ["AB": ""]
+        }
+        // Missing map key on the wire.
+        assertDecodeSucceeds(inputBytes: [114, 4, 18, 2, 97, 98], recodedBytes: [114, 6, 10, 0, 18, 2, 97, 98]) {
+            $0.mapStringString == ["": "ab"]
+        }
+        // Missing map key and value on the wire.
+        assertDecodeSucceeds(inputBytes: [114, 0], recodedBytes: [114, 4, 10, 0, 18, 0]) {
+            $0.mapStringString == ["": ""]
         }
     }
 
@@ -139,11 +198,35 @@ class Test_Map: XCTestCase, PBTestHelpers {
         assertDecodeSucceeds([]) {
             $0.mapInt32Bytes == [:]
         }
+        // Missing map value on the wire.
+        assertDecodeSucceeds(inputBytes: [122, 2, 8, 1], recodedBytes: [122, 4, 8, 1, 18, 0]) {
+            $0.mapInt32Bytes == [1: Data()]
+        }
+        // Missing map key on the wire.
+        assertDecodeSucceeds(inputBytes: [122, 3, 18, 1, 1], recodedBytes: [122, 5, 8, 0, 18, 1, 1]) {
+            $0.mapInt32Bytes == [0: Data(bytes: [1])]
+        }
+        // Missing map key and value on the wire.
+        assertDecodeSucceeds(inputBytes: [122, 0], recodedBytes: [122, 4, 8, 0, 18, 0]) {
+            $0.mapInt32Bytes == [0: Data()]
+        }
     }
 
     func test_mapInt32Enum() {
         assertMapEncode([[130, 1, 4, 8, 1, 16, 2]]) {(o: inout MessageTestType) in
             o.mapInt32Enum = [1: ProtobufUnittest_MapEnum.baz]
+        }
+        // Missing map value on the wire.
+        assertDecodeSucceeds(inputBytes: [130, 1, 2, 8, 1], recodedBytes: [130, 1, 4, 8, 1, 16, 0]) {
+            $0.mapInt32Enum == [1: ProtobufUnittest_MapEnum.foo]
+        }
+        // Missing map key on the wire.
+        assertDecodeSucceeds(inputBytes: [130, 1, 2, 16, 2], recodedBytes: [130, 1, 4, 8, 0, 16, 2]) {
+            $0.mapInt32Enum == [0: ProtobufUnittest_MapEnum.baz]
+        }
+        // Missing map key and value on the wire.
+        assertDecodeSucceeds(inputBytes: [130, 1, 0], recodedBytes: [130, 1, 4, 8, 0, 16, 0]) {
+            $0.mapInt32Enum == [0: ProtobufUnittest_MapEnum.foo]
         }
     }
 
@@ -153,6 +236,20 @@ class Test_Map: XCTestCase, PBTestHelpers {
             m1.c = 7
             o.mapInt32ForeignMessage = [1: m1]
         }
+        // Missing map value on the wire.
+        assertDecodeSucceeds(inputBytes: [138, 1, 2, 8, 1], recodedBytes: [138, 1, 4, 8, 1, 18, 0]) {
+            $0.mapInt32ForeignMessage == [1: ProtobufUnittest_ForeignMessage()]
+        }
+        // Missing map key on the wire.
+        assertDecodeSucceeds(inputBytes: [138, 1, 4, 18, 2, 8, 7], recodedBytes: [138, 1, 6, 8, 0, 18, 2, 8, 7]) {
+            var m1 = ProtobufUnittest_ForeignMessage()
+            m1.c = 7
+            return $0.mapInt32ForeignMessage == [0: m1]
+        }
+        // Missing map key and value on the wire.
+        assertDecodeSucceeds(inputBytes: [138, 1, 0], recodedBytes: [138, 1, 4, 8, 0, 18, 0]) {
+            $0.mapInt32ForeignMessage == [0: ProtobufUnittest_ForeignMessage()]
+        }
     }
 
     func test_mapStringForeignMessage() {
@@ -160,6 +257,20 @@ class Test_Map: XCTestCase, PBTestHelpers {
             var m1 = ProtobufUnittest_ForeignMessage()
             m1.c = 7
             o.mapStringForeignMessage = ["a": m1]
+        }
+        // Missing map value on the wire.
+        assertDecodeSucceeds(inputBytes: [146, 1, 3, 10, 1, 97], recodedBytes: [146, 1, 5, 10, 1, 97, 18, 0]) {
+            $0.mapStringForeignMessage == ["a": ProtobufUnittest_ForeignMessage()]
+        }
+        // Missing map key on the wire.
+        assertDecodeSucceeds(inputBytes: [146, 1, 4, 18, 2, 8, 7], recodedBytes: [146, 1, 6, 10, 0, 18, 2, 8, 7]) {
+            var m1 = ProtobufUnittest_ForeignMessage()
+            m1.c = 7
+            return $0.mapStringForeignMessage == ["": m1]
+        }
+        // Missing map key and value on the wire.
+        assertDecodeSucceeds(inputBytes: [146, 1, 0], recodedBytes: [146, 1, 4, 10, 0, 18, 0]) {
+            $0.mapStringForeignMessage == ["": ProtobufUnittest_ForeignMessage()]
         }
     }
 }


### PR DESCRIPTION
- Add tests to cover missing key/value.

Fixes https://github.com/apple/swift-protobuf/issues/335