### PR TITLE
Fix performance of bytes encoding

### DIFF
--- a/Reference/google/protobuf/any.pb.swift
+++ b/Reference/google/protobuf/any.pb.swift
@@ -171,7 +171,7 @@ struct Google_Protobuf_Any: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageI
     if !typeURL.isEmpty {
       try visitor.visitSingularStringField(value: typeURL, fieldNumber: 1)
     }
-    if value != Data() {
+    if !value.isEmpty {
       try visitor.visitSingularBytesField(value: value, fieldNumber: 2)
     }
   }

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -1674,7 +1674,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Proto3Message, Sw
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalNestedMessage {

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -828,7 +828,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, 
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalNestedMessage {

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -933,7 +933,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageIm
       if !_storage._singleString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._singleString, fieldNumber: 14)
       }
-      if _storage._singleBytes != Data() {
+      if !_storage._singleBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._singleBytes, fieldNumber: 15)
       }
       if let v = _storage._singleNestedMessage {
@@ -2127,7 +2127,7 @@ struct Proto3OneBytes: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageImplem
   }
 
   func _protobuf_generated_traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if data != Data() {
+    if !data.isEmpty {
       try visitor.visitSingularBytesField(value: data, fieldNumber: 1)
     }
   }
@@ -2163,7 +2163,7 @@ struct Proto3MoreBytes: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageImple
   }
 
   func _protobuf_generated_traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if data != Data() {
+    if !data.isEmpty {
       try visitor.visitSingularBytesField(value: data, fieldNumber: 1)
     }
   }

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -874,7 +874,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProto
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalNestedMessage {

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -874,7 +874,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, SwiftP
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalNestedMessage {

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -874,7 +874,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProtob
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalNestedMessage {

--- a/Reference/google/protobuf/wrappers.pb.swift
+++ b/Reference/google/protobuf/wrappers.pb.swift
@@ -402,7 +402,7 @@ struct Google_Protobuf_BytesValue: SwiftProtobuf.Proto3Message, SwiftProtobuf._M
   }
 
   func _protobuf_generated_traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if value != Data() {
+    if !value.isEmpty {
       try visitor.visitSingularBytesField(value: value, fieldNumber: 1)
     }
   }

--- a/Reference/unittest_swift_performance.pb.swift
+++ b/Reference/unittest_swift_performance.pb.swift
@@ -426,7 +426,7 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProtobu
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if !_storage._repeatedRecursiveMessage.isEmpty {

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -1108,7 +1108,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Proto3Message, SwiftProtobuf._Me
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalMessage {

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -1674,7 +1674,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Proto3Message, Sw
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalNestedMessage {

--- a/Sources/SwiftProtobuf/wrappers.pb.swift
+++ b/Sources/SwiftProtobuf/wrappers.pb.swift
@@ -402,7 +402,7 @@ public struct Google_Protobuf_BytesValue: SwiftProtobuf.Proto3Message, SwiftProt
   }
 
   public func _protobuf_generated_traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if value != Data() {
+    if !value.isEmpty {
       try visitor.visitSingularBytesField(value: value, fieldNumber: 1)
     }
   }

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -320,6 +320,7 @@ struct MessageFieldGenerator {
     var isMessage: Bool {return descriptor.isMessage}
     var isEnum: Bool {return descriptor.type == .enum}
     var isString: Bool {return descriptor.type == .string}
+    var isBytes: Bool {return descriptor.type == .bytes}
     var isPacked: Bool {return descriptor.isPackable &&
         (descriptor.options.hasPacked ? descriptor.options.packed : isProto3)}
     var isRepeated: Bool {return descriptor.isRepeated}
@@ -563,7 +564,7 @@ struct MessageFieldGenerator {
         } else {
             assert(isProto3)
             varName = prefix + swiftName
-            if isString {
+            if isString || isBytes {
                 conditional = ("!\(varName).isEmpty")
             } else {
                 conditional = ("\(varName) != \(swiftDefaultValue)")

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -1674,7 +1674,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Proto3Message, Sw
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalNestedMessage {

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -828,7 +828,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, 
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalNestedMessage {

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -933,7 +933,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageIm
       if !_storage._singleString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._singleString, fieldNumber: 14)
       }
-      if _storage._singleBytes != Data() {
+      if !_storage._singleBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._singleBytes, fieldNumber: 15)
       }
       if let v = _storage._singleNestedMessage {
@@ -2127,7 +2127,7 @@ struct Proto3OneBytes: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageImplem
   }
 
   func _protobuf_generated_traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if data != Data() {
+    if !data.isEmpty {
       try visitor.visitSingularBytesField(value: data, fieldNumber: 1)
     }
   }
@@ -2163,7 +2163,7 @@ struct Proto3MoreBytes: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageImple
   }
 
   func _protobuf_generated_traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if data != Data() {
+    if !data.isEmpty {
       try visitor.visitSingularBytesField(value: data, fieldNumber: 1)
     }
   }

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -874,7 +874,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProto
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalNestedMessage {

--- a/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
@@ -426,7 +426,7 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProtobu
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if !_storage._repeatedRecursiveMessage.isEmpty {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -1108,7 +1108,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Proto3Message, SwiftProtobuf._Me
       if !_storage._optionalString.isEmpty {
         try visitor.visitSingularStringField(value: _storage._optionalString, fieldNumber: 14)
       }
-      if _storage._optionalBytes != Data() {
+      if !_storage._optionalBytes.isEmpty {
         try visitor.visitSingularBytesField(value: _storage._optionalBytes, fieldNumber: 15)
       }
       if let v = _storage._optionalMessage {


### PR DESCRIPTION
The traversal method was using the following idiom to testing whether a `bytes` field was empty:
```
    if field != Data() { ... }
```
Obviously, constructing a `Data()` object for every such comparison is quite expensive.  Changing it to
```
   if !field.isEmpty { ... }
```
provides a dramatic speedup.
