### PR TITLE
Use more-accurate JSON float and double output when appropriate.

### DIFF
--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -135,6 +135,33 @@ internal struct TextFormatEncoder {
         }
     }
 
+    mutating func putFloatValue(value: Float) {
+        if value.isNaN {
+            append(staticText: "nan")
+        } else if !value.isFinite {
+            if value < 0 {
+                append(staticText: "-inf")
+            } else {
+                append(staticText: "inf")
+            }
+        } else {
+            if let v = Int64(safely: Double(value)) {
+                appendInt(value: v)
+            } else {
+                let s = String(value)
+                let reparsed = Float(s)
+                // If exact match, then default precision is sufficient:
+                if value == reparsed {
+                    append(text: s)
+                } else {
+                    let precision = FLT_DIG + 2
+                    let s = String(format: "%.*g", precision, Double(value))
+                    append(text: s)
+                }
+            }
+        }
+    }
+
     mutating func putDoubleValue(value: Double) {
         if value.isNaN {
             append(staticText: "nan")
@@ -145,13 +172,19 @@ internal struct TextFormatEncoder {
                 append(staticText: "inf")
             }
         } else {
-            // TODO: Be smarter here about choosing significant digits
-            // See: protoc source has C++ code for this with interesting ideas
             if let v = Int64(safely: value) {
                 appendInt(value: v)
             } else {
                 let s = String(value)
-                append(text: s)
+                let reparsed = Double(s)
+                // If exact match, then default precision is sufficient:
+                if value == reparsed {
+                    append(text: s)
+                } else {
+                    let precision = DBL_DIG + 2
+                    let s = String(format: "%.*g", precision, value)
+                    append(text: s)
+                }
             }
         }
     }

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -193,7 +193,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
     let protoFieldName = try self.protoFieldName(for: fieldNumber)
     for v in value {
       startField(name: protoFieldName)
-      encoder.putDoubleValue(value: Double(v))
+      encoder.putFloatValue(value: v)
       encoder.endField()
     }
   }
@@ -341,7 +341,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
 
   mutating func visitPackedFloatField(value: [Float], fieldNumber: Int) throws {
     try _visitPacked(value: value, fieldNumber: fieldNumber) { (v: Float) in
-      encoder.putDoubleValue(value: Double(v))
+      encoder.putFloatValue(value: v)
     }
   }
 

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -301,7 +301,23 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         assertJSONDecodeSucceeds("{\"singleInt64\":2147483648}") {$0.singleInt64 == 2147483648}
     }
 
-    func testSingleDouble() {
+    private func assertRoundTripJSON(file: XCTestFileArgType = #file, line: UInt = #line, configure: (inout MessageTestType) -> Void) {
+        var original = MessageTestType()
+        configure(&original)
+        do {
+            let json = try original.jsonString()
+            do {
+                let decoded = try MessageTestType(jsonString: json)
+                XCTAssertEqual(original, decoded)
+            } catch let e {
+                XCTFail("Failed to decode \(e): \(json)", file: file, line: line)
+            }
+        } catch let e {
+            XCTFail("Failed to encode \(e)", file: file, line: line)
+        }
+    }
+
+    func testSingleDouble() throws {
         assertJSONEncode("{\"singleDouble\":1}") {(o: inout MessageTestType) in
             o.singleDouble = 1.0
         }
@@ -346,6 +362,26 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("{\"singleDouble\":1e3.2}")
         assertJSONDecodeFails("{\"singleDouble\":\"1e3.2\"}")
         assertJSONDecodeFails("{\"singleDouble\":1.0.0}")
+
+        // A wide range of numbers should exactly round-trip
+        assertRoundTripJSON {$0.singleDouble = 0.1}
+        assertRoundTripJSON {$0.singleDouble = 0.01}
+        assertRoundTripJSON {$0.singleDouble = 0.001}
+        assertRoundTripJSON {$0.singleDouble = 0.0001}
+        assertRoundTripJSON {$0.singleDouble = 0.00001}
+        assertRoundTripJSON {$0.singleDouble = 0.000001}
+        assertRoundTripJSON {$0.singleDouble = 1e-10}
+        assertRoundTripJSON {$0.singleDouble = 1e-20}
+        assertRoundTripJSON {$0.singleDouble = 1e-30}
+        assertRoundTripJSON {$0.singleDouble = 1e-40}
+        assertRoundTripJSON {$0.singleDouble = 1e-50}
+        assertRoundTripJSON {$0.singleDouble = 1e-60}
+        assertRoundTripJSON {$0.singleDouble = 1e-100}
+        assertRoundTripJSON {$0.singleDouble = 1e-200}
+        assertRoundTripJSON {$0.singleDouble = Double.pi}
+        assertRoundTripJSON {$0.singleDouble = 123456.789123456789123}
+        assertRoundTripJSON {$0.singleDouble = 1.7976931348623157e+308}
+        assertRoundTripJSON {$0.singleDouble = 2.22507385850720138309e-308}
     }
 
     func testSingleFloat() {
@@ -394,6 +430,30 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         assertJSONDecodeFails("{\"singleFloat\":\"1e3.2\"}")
         // Out-of-range numbers should fail
         assertJSONDecodeFails("{\"singleFloat\":1e39}")
+
+        // A wide range of numbers should exactly round-trip
+        assertRoundTripJSON {$0.singleFloat = 0.1}
+        assertRoundTripJSON {$0.singleFloat = 0.01}
+        assertRoundTripJSON {$0.singleFloat = 0.001}
+        assertRoundTripJSON {$0.singleFloat = 0.0001}
+        assertRoundTripJSON {$0.singleFloat = 0.00001}
+        assertRoundTripJSON {$0.singleFloat = 0.000001}
+        assertRoundTripJSON {$0.singleFloat = 1e-10}
+        assertRoundTripJSON {$0.singleFloat = 1e-20}
+        assertRoundTripJSON {$0.singleFloat = 1e-30}
+        assertRoundTripJSON {$0.singleFloat = 1e-40}
+        assertRoundTripJSON {$0.singleFloat = 1e-50}
+        assertRoundTripJSON {$0.singleFloat = 1e-60}
+        assertRoundTripJSON {$0.singleFloat = 1e-100}
+        assertRoundTripJSON {$0.singleFloat = 1e-200}
+        assertRoundTripJSON {$0.singleFloat = Float.pi}
+        assertRoundTripJSON {$0.singleFloat = 123456.789123456789123}
+        assertRoundTripJSON {$0.singleFloat = 1999.9999999999}
+        assertRoundTripJSON {$0.singleFloat = 1999.9}
+        assertRoundTripJSON {$0.singleFloat = 1999.99}
+        assertRoundTripJSON {$0.singleFloat = 1999.99}
+        assertRoundTripJSON {$0.singleFloat = 3.402823567e+38}
+        assertRoundTripJSON {$0.singleFloat = 1.1754944e-38}
     }
 
     func testSingleDouble_NaN() throws {

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto3.swift
@@ -219,6 +219,22 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         assertTextFormatDecodeFails("single_sfixed64: a\n")
     }
 
+    private func assertRoundTripText(file: XCTestFileArgType = #file, line: UInt = #line, configure: (inout MessageTestType) -> Void) {
+        var original = MessageTestType()
+        configure(&original)
+        do {
+            let json = try original.textFormatString()
+            do {
+                let decoded = try MessageTestType(textFormatString: json)
+                XCTAssertEqual(original, decoded)
+            } catch let e {
+                XCTFail("Failed to decode \(e): \(json)", file: file, line: line)
+            }
+        } catch let e {
+            XCTFail("Failed to encode \(e)", file: file, line: line)
+        }
+    }
+
     func testEncoding_singleFloat() {
         var a = MessageTestType()
         a.singleFloat = 11
@@ -293,6 +309,30 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         assertTextFormatDecodeFails("single_float: 1,2\n")
         assertTextFormatDecodeFails("single_float: 0xf\n")
         assertTextFormatDecodeFails("single_float: 012\n")
+
+        // A wide range of numbers should exactly round-trip
+        assertRoundTripText {$0.singleFloat = 0.1}
+        assertRoundTripText {$0.singleFloat = 0.01}
+        assertRoundTripText {$0.singleFloat = 0.001}
+        assertRoundTripText {$0.singleFloat = 0.0001}
+        assertRoundTripText {$0.singleFloat = 0.00001}
+        assertRoundTripText {$0.singleFloat = 0.000001}
+        assertRoundTripText {$0.singleFloat = 1e-10}
+        assertRoundTripText {$0.singleFloat = 1e-20}
+        assertRoundTripText {$0.singleFloat = 1e-30}
+        assertRoundTripText {$0.singleFloat = 1e-40}
+        assertRoundTripText {$0.singleFloat = 1e-50}
+        assertRoundTripText {$0.singleFloat = 1e-60}
+        assertRoundTripText {$0.singleFloat = 1e-100}
+        assertRoundTripText {$0.singleFloat = 1e-200}
+        assertRoundTripText {$0.singleFloat = Float.pi}
+        assertRoundTripText {$0.singleFloat = 123456.789123456789123}
+        assertRoundTripText {$0.singleFloat = 1999.9999999999}
+        assertRoundTripText {$0.singleFloat = 1999.9}
+        assertRoundTripText {$0.singleFloat = 1999.99}
+        assertRoundTripText {$0.singleFloat = 1999.99}
+        assertRoundTripText {$0.singleFloat = 3.402823567e+38}
+        assertRoundTripText {$0.singleFloat = 1.1754944e-38}
     }
 
     func testEncoding_singleDouble() {
@@ -325,6 +365,26 @@ class Test_TextFormat_proto3: XCTestCase, PBTestHelpers {
         assertTextFormatDecodeFails("single_double: 1.2.3\n")
         assertTextFormatDecodeFails("single_double: 0xf\n")
         assertTextFormatDecodeFails("single_double: 0123\n")
+
+        // A wide range of numbers should exactly round-trip
+        assertRoundTripText {$0.singleDouble = 0.1}
+        assertRoundTripText {$0.singleDouble = 0.01}
+        assertRoundTripText {$0.singleDouble = 0.001}
+        assertRoundTripText {$0.singleDouble = 0.0001}
+        assertRoundTripText {$0.singleDouble = 0.00001}
+        assertRoundTripText {$0.singleDouble = 0.000001}
+        assertRoundTripText {$0.singleDouble = 1e-10}
+        assertRoundTripText {$0.singleDouble = 1e-20}
+        assertRoundTripText {$0.singleDouble = 1e-30}
+        assertRoundTripText {$0.singleDouble = 1e-40}
+        assertRoundTripText {$0.singleDouble = 1e-50}
+        assertRoundTripText {$0.singleDouble = 1e-60}
+        assertRoundTripText {$0.singleDouble = 1e-100}
+        assertRoundTripText {$0.singleDouble = 1e-200}
+        assertRoundTripText {$0.singleDouble = Double.pi}
+        assertRoundTripText {$0.singleDouble = 123456.789123456789123}
+        assertRoundTripText {$0.singleDouble = 1.7976931348623157e+308}
+        assertRoundTripText {$0.singleDouble = 2.22507385850720138309e-308}
     }
 
     func testEncoding_singleBool() {

--- a/failure_list_swift.txt
+++ b/failure_list_swift.txt
@@ -1,2 +1,0 @@
-Required.ProtobufInput.RepeatedScalarSelectsLast.DOUBLE.JsonOutput
-Required.ProtobufInput.ValidDataRepeated.DOUBLE.JsonOutput


### PR DESCRIPTION
This addresses Issue #222 by fixing the last failing conformance test.

The full logic used for writing a float or double to JSON is now:

* If the number is nan or infinite, write the appropriate string
* If the number is an exact integer, write as an integer (for performance)
* Try using the default string conversion
* Reparse the result just above:
   * If the reparsed result is exactly the same, use it as-is
   * If not, reformat with `DBL_DIG + 2` digits (or `FLT_DIG + 2` for floats)

This is slightly different than the logic used by the C++ implementation:  we short-circuit the integer format for performance reasons, and in our floating-point trial conversion, we just use the default conversion instead of explicitly specifying `DBL_DIG` or `FLT_DIG`.