### PR TITLE
Group and Unknown fixups.

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -61,6 +61,7 @@ internal struct BinaryDecoder: Decoder {
         // the varint parser.
         if fieldNumber > 0 {
             if let override = unknownOverride {
+                assert(fieldWireFormat != .startGroup && fieldWireFormat != .endGroup)
                 if unknownData == nil {
                     unknownData = override
                 } else {
@@ -1022,10 +1023,8 @@ internal struct BinaryDecoder: Decoder {
         case .startGroup:
             while true {
                 if let innerTag = try getTagWithoutUpdatingFieldStart() {
-                    if innerTag.fieldNumber == tag.fieldNumber {
-                        if innerTag.wireFormat == .endGroup {
-                            break
-                        }
+                    if innerTag.fieldNumber == tag.fieldNumber && innerTag.wireFormat == .endGroup {
+                        break
                     } else {
                         try skipOver(tag: innerTag)
                     }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -107,7 +107,9 @@ extension Test_AllTypes {
             ("testDebugDescription3", {try run_test(test:($0 as! Test_AllTypes).testDebugDescription3)}),
             ("testDebugDescription4", {try run_test(test:($0 as! Test_AllTypes).testDebugDescription4)}),
             ("testWithFactoryHelper", {try run_test(test:($0 as! Test_AllTypes).testWithFactoryHelper)}),
-            ("testWithFactoryHelperRethrows", {try run_test(test:($0 as! Test_AllTypes).testWithFactoryHelperRethrows)})
+            ("testWithFactoryHelperRethrows", {try run_test(test:($0 as! Test_AllTypes).testWithFactoryHelperRethrows)}),
+            ("testUnknownFields_Success", {try run_test(test:($0 as! Test_AllTypes).testUnknownFields_Success)}),
+            ("testUnknownFields_Failures", {try run_test(test:($0 as! Test_AllTypes).testUnknownFields_Failures)})
         ]
     }
 }
@@ -584,7 +586,9 @@ extension Test_Map {
             ("test_mapInt32Bytes", {try run_test(test:($0 as! Test_Map).test_mapInt32Bytes)}),
             ("test_mapInt32Enum", {try run_test(test:($0 as! Test_Map).test_mapInt32Enum)}),
             ("test_mapInt32ForeignMessage", {try run_test(test:($0 as! Test_Map).test_mapInt32ForeignMessage)}),
-            ("test_mapStringForeignMessage", {try run_test(test:($0 as! Test_Map).test_mapStringForeignMessage)})
+            ("test_mapStringForeignMessage", {try run_test(test:($0 as! Test_Map).test_mapStringForeignMessage)}),
+            ("test_mapEnumUnknowns_Proto2", {try run_test(test:($0 as! Test_Map).test_mapEnumUnknowns_Proto2)}),
+            ("test_mapEnumUnknowns_Proto3", {try run_test(test:($0 as! Test_Map).test_mapEnumUnknowns_Proto3)})
         ]
     }
 }

--- a/Tests/SwiftProtobufTests/Test_Map.swift
+++ b/Tests/SwiftProtobufTests/Test_Map.swift
@@ -84,14 +84,6 @@ class Test_Map: XCTestCase, PBTestHelpers {
         assertDecodeSucceeds(inputBytes: [10, 6, 8, 1, 24, 3, 16, 2], recodedBytes: [10, 4, 8, 1, 16, 2]) {
             $0.mapInt32Int32 == [1: 2]
         }
-
-        // TODO: This current doens't fail -
-        // 1. The comment imples it should be a bad wire type, but that doesn't
-        //    appear to be true, it is a field 1 startGroup.
-        // 2. The current known field support seems not to handle startGroups
-        //    correctly in that they don't seem to push everything in until the
-        //    endGroup.
-//        assertDecodeFails([11, 4, 8, 1, 16, 2]) // Bad wire type
     }
 
     func test_mapInt64Int64() {


### PR DESCRIPTION
- Fix issues parsing a group within a group when the outer group was unknown.
- Add some more unknown parsing tests (success and failure).
- Add some more group parsing tests (missing & wrong endGroup).