### PR TITLE
Simplify generated extension range checks.

### DIFF
--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -2185,9 +2185,9 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Proto2Message, SwiftProtobuf.E
     case 37: try decoder.decodeSingularStringField(value: &_csharpNamespace)
     case 39: try decoder.decodeSingularStringField(value: &_swiftPrefix)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FileOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FileOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2422,9 +2422,9 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Proto2Message, SwiftProtobu
     case 3: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 7: try decoder.decodeSingularBoolField(value: &_mapEntry)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MessageOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MessageOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2726,9 +2726,9 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Proto2Message, SwiftProtobuf.
     case 3: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 10: try decoder.decodeSingularBoolField(value: &_weak)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FieldOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FieldOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2825,9 +2825,9 @@ struct Google_Protobuf_OneofOptions: SwiftProtobuf.Proto2Message, SwiftProtobuf.
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_OneofOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_OneofOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2934,9 +2934,9 @@ struct Google_Protobuf_EnumOptions: SwiftProtobuf.Proto2Message, SwiftProtobuf.E
     case 2: try decoder.decodeSingularBoolField(value: &_allowAlias)
     case 3: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3035,9 +3035,9 @@ struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Proto2Message, SwiftProto
     switch fieldNumber {
     case 1: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumValueOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumValueOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3137,9 +3137,9 @@ struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Proto2Message, SwiftProtobu
     switch fieldNumber {
     case 33: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_ServiceOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_ServiceOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3295,9 +3295,9 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Proto2Message, SwiftProtobuf
     case 33: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 34: try decoder.decodeSingularEnumField(value: &_idempotencyLevel)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MethodOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MethodOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -4618,9 +4618,9 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Proto2Message, SwiftPr
     case 1: try decoder.decodeSingularInt64Field(value: &_storage._myInt)
     case 101: try decoder.decodeSingularFloatField(value: &_storage._myFloat)
     case 200: try decoder.decodeSingularMessageField(value: &_storage._optionalNestedMessage)
-    default: if (2 <= fieldNumber && fieldNumber < 11) || (12 <= fieldNumber && fieldNumber < 101) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestFieldOrderings.self, fieldNumber: fieldNumber)
-      }
+    case 2..<11, 12..<101:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestFieldOrderings.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -8501,9 +8501,9 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Proto2Message, SwiftProt
     case 3: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedAllTypes)
     case 10: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
     case 20: try decoder.decodeRepeatedGroupField(value: &_storage._repeatedGroup)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMerge.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMerge.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -9298,9 +9298,9 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Proto2Message, Swift
         try decoder.handleConflictingOneOf()
       }
       _storage._oneofField = try ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
-    default: if (536860000 <= fieldNumber && fieldNumber < 536870000) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber)
-      }
+    case 536860000..<536870000:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -667,9 +667,9 @@ struct ProtobufUnittest_ComplexOptionType1: SwiftProtobuf.Proto2Message, SwiftPr
     case 2: try decoder.decodeSingularInt32Field(value: &_foo2)
     case 3: try decoder.decodeSingularInt32Field(value: &_foo3)
     case 4: try decoder.decodeRepeatedInt32Field(value: &foo4)
-    default: if (100 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType1.self, fieldNumber: fieldNumber)
-      }
+    case 100..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType1.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -886,9 +886,9 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.Proto2Message, SwiftPr
     case 2: try decoder.decodeSingularInt32Field(value: &_storage._baz)
     case 3: try decoder.decodeSingularMessageField(value: &_storage._fred)
     case 4: try decoder.decodeRepeatedMessageField(value: &_storage._barney)
-    default: if (100 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType2.self, fieldNumber: fieldNumber)
-      }
+    case 100..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType2.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -2839,9 +2839,9 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Proto2Message, Swift
     case 3: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedAllTypes)
     case 10: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
     case 20: try decoder.decodeRepeatedGroupField(value: &_storage._repeatedGroup)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMergeLite.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMergeLite.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3515,9 +3515,9 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Proto2Message, S
         try decoder.handleConflictingOneOf()
       }
       _storage._oneofField = try ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
-    default: if (536860000 <= fieldNumber && fieldNumber < 536870000) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber)
-      }
+    case 536860000..<536870000:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -117,9 +117,9 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf.Proto2Me
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1: try decoder.decodeSingularInt32Field(value: &_a)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_NoGenericServicesTest_TestMessage.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_NoGenericServicesTest_TestMessage.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -235,9 +235,9 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Proto2Message, Swift
         try decoder.handleConflictingOneOf()
       }
       _storage._foo = try ProtobufUnittest_TestOptimizedForSize.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestOptimizedForSize.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestOptimizedForSize.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -86,9 +86,9 @@ struct ProtobufUnittest_Extend_Foo: SwiftProtobuf.Proto2Message, SwiftProtobuf._
       mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
         switch fieldNumber {
         case 1: try decoder.decodeSingularInt32Field(value: &_a)
-        default: if (100 <= fieldNumber && fieldNumber < 1001) {
-            try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Baz.self, fieldNumber: fieldNumber)
-          }
+        case 100..<1001:
+          try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Baz.self, fieldNumber: fieldNumber)
+        default: break
         }
       }
 
@@ -396,9 +396,9 @@ struct ProtobufUnittest_Extend_MsgNoStorage: SwiftProtobuf.Proto2Message, SwiftP
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1: try decoder.decodeSingularInt32Field(value: &_x)
-    default: if (100 <= fieldNumber && fieldNumber < 201) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_MsgNoStorage.self, fieldNumber: fieldNumber)
-      }
+    case 100..<201:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_MsgNoStorage.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -521,9 +521,9 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Proto2Message, Swif
     switch fieldNumber {
     case 1: try decoder.decodeSingularInt32Field(value: &_storage._x)
     case 2: try decoder.decodeSingularMessageField(value: &_storage._y)
-    default: if (100 <= fieldNumber && fieldNumber < 201) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_MsgUsesStorage.self, fieldNumber: fieldNumber)
-      }
+    case 100..<201:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_MsgUsesStorage.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -350,9 +350,9 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Proto2Message, SwiftProt
       }
       _storage._options = try Swift_Protobuf_TestFieldOrderings.OneOf_Options(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     case 200: try decoder.decodeSingularMessageField(value: &_storage._optionalNestedMessage)
-    default: if (2 <= fieldNumber && fieldNumber < 9) || (12 <= fieldNumber && fieldNumber < 56) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Swift_Protobuf_TestFieldOrderings.self, fieldNumber: fieldNumber)
-      }
+    case 2..<9, 12..<56:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Swift_Protobuf_TestFieldOrderings.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -87,9 +87,9 @@ struct SwiftTestGroupExtensions: SwiftProtobuf.Proto2Message, SwiftProtobuf.Exte
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1: try decoder.decodeSingularInt32Field(value: &_a)
-    default: if (2 <= fieldNumber && fieldNumber < 11) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: SwiftTestGroupExtensions.self, fieldNumber: fieldNumber)
-      }
+    case 2..<11:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: SwiftTestGroupExtensions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Sources/PluginLibrary/descriptor.pb.swift
+++ b/Sources/PluginLibrary/descriptor.pb.swift
@@ -2185,9 +2185,9 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Proto2Message, SwiftPro
     case 37: try decoder.decodeSingularStringField(value: &_csharpNamespace)
     case 39: try decoder.decodeSingularStringField(value: &_swiftPrefix)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FileOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FileOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2422,9 +2422,9 @@ public struct Google_Protobuf_MessageOptions: SwiftProtobuf.Proto2Message, Swift
     case 3: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 7: try decoder.decodeSingularBoolField(value: &_mapEntry)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MessageOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MessageOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2726,9 +2726,9 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Proto2Message, SwiftPr
     case 3: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 10: try decoder.decodeSingularBoolField(value: &_weak)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FieldOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FieldOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2825,9 +2825,9 @@ public struct Google_Protobuf_OneofOptions: SwiftProtobuf.Proto2Message, SwiftPr
   public mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_OneofOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_OneofOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2934,9 +2934,9 @@ public struct Google_Protobuf_EnumOptions: SwiftProtobuf.Proto2Message, SwiftPro
     case 2: try decoder.decodeSingularBoolField(value: &_allowAlias)
     case 3: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3035,9 +3035,9 @@ public struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Proto2Message, Swi
     switch fieldNumber {
     case 1: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumValueOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumValueOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3137,9 +3137,9 @@ public struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Proto2Message, Swift
     switch fieldNumber {
     case 33: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_ServiceOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_ServiceOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3295,9 +3295,9 @@ public struct Google_Protobuf_MethodOptions: SwiftProtobuf.Proto2Message, SwiftP
     case 33: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 34: try decoder.decodeSingularEnumField(value: &_idempotencyLevel)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MethodOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MethodOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Sources/protoc-gen-swift/Google_Protobuf_DescriptorProto+Extensions.swift
+++ b/Sources/protoc-gen-swift/Google_Protobuf_DescriptorProto+Extensions.swift
@@ -18,67 +18,108 @@ import PluginLibrary
 import SwiftProtobuf
 
 extension Google_Protobuf_DescriptorProto {
-    func getMessageForPath(path: String, parentPath: String) -> Google_Protobuf_DescriptorProto? {
-        for m in nestedType {
-            let messagePath = parentPath + "." + m.name
-            if messagePath == path {
-                return m
-            }
-            if let n = m.getMessageForPath(path: path, parentPath: messagePath) {
-                return n
-            }
-        }
-        return nil
+
+  /// A `String` containing a comma-delimited list of Swift range expressions
+  /// covering the extension ranges for this message.
+  ///
+  /// This expression list is suitable as a pattern match in a `case`
+  /// statement. For example, `"case 5..<10, 20..<30:"`.
+  var swiftExtensionRangeExpressions: String {
+    return extensionRange.lazy.map {
+      $0.swiftRangeExpression
+    }.joined(separator: ", ")
+  }
+
+  /// A `String` containing a Swift Boolean expression that tests if the given
+  /// variable is in any of the extension ranges for this message.
+  ///
+  /// - Parameter variable: The name of the variable to test in the expression.
+  /// - Returns: A `String` containing the Boolean expression.
+  func swiftExtensionRangeBooleanExpression(variable: String) -> String {
+    return extensionRange.lazy.map {
+      "(\($0.swiftBooleanExpression(variable: variable)))"
+    }.joined(separator: " || ")
+  }
+
+  func getMessageForPath(path: String, parentPath: String) -> Google_Protobuf_DescriptorProto? {
+    for m in nestedType {
+      let messagePath = parentPath + "." + m.name
+      if messagePath == path {
+        return m
+      }
+      if let n = m.getMessageForPath(path: path, parentPath: messagePath) {
+        return n
+      }
+    }
+    return nil
+  }
+
+  func getMessageNameForPath(path: String, parentPath: String, swiftPrefix: String) -> String? {
+    for m in nestedType {
+      let messagePath = parentPath + "." + m.name
+      let messageSwiftPath = swiftPrefix + "." + sanitizeMessageTypeName(m.name)
+      if messagePath == path {
+        return messageSwiftPath
+      }
+      if let n = m.getMessageNameForPath(path: path, parentPath: messagePath, swiftPrefix: messageSwiftPath) {
+        return n
+      }
+    }
+    return nil
+  }
+
+  func getEnumNameForPath(path: String, parentPath: String, swiftPrefix: String) -> String? {
+    for e in enumType {
+      let enumPath = parentPath + "." + e.name
+      if enumPath == path {
+        return swiftPrefix + "." + sanitizeEnumTypeName(e.name)
+      }
     }
 
-    func getMessageNameForPath(path: String, parentPath: String, swiftPrefix: String) -> String? {
-        for m in nestedType {
-            let messagePath = parentPath + "." + m.name
-            let messageSwiftPath = swiftPrefix + "." + sanitizeMessageTypeName(m.name)
-            if messagePath == path {
-                return messageSwiftPath
-            }
-            if let n = m.getMessageNameForPath(path: path, parentPath: messagePath, swiftPrefix: messageSwiftPath) {
-                return n
-            }
-        }
-        return nil
+    for m in nestedType {
+      let messagePath = parentPath + "." + m.name
+      let messageSwiftPath = swiftPrefix + "." + sanitizeMessageTypeName(m.name)
+      if let n = m.getEnumNameForPath(path: path, parentPath: messagePath, swiftPrefix: messageSwiftPath) {
+        return n
+      }
+    }
+    return nil
+  }
+
+  func getSwiftNameForEnumCase(path: String, caseName: String, parentPath: String, swiftPrefix: String) -> String? {
+    for e in enumType {
+      let enumPath = parentPath + "." + e.name
+      if enumPath == path {
+        let enumSwiftName = swiftPrefix + "." + sanitizeEnumTypeName(e.name)
+        return enumSwiftName + "." + e.getSwiftNameForEnumCase(caseName: caseName)
+      }
     }
 
-    func getEnumNameForPath(path: String, parentPath: String, swiftPrefix: String) -> String? {
-        for e in enumType {
-            let enumPath = parentPath + "." + e.name
-            if enumPath == path {
-                return swiftPrefix + "." + sanitizeEnumTypeName(e.name)
-            }
-        }
-
-        for m in nestedType {
-            let messagePath = parentPath + "." + m.name
-            let messageSwiftPath = swiftPrefix + "." + sanitizeMessageTypeName(m.name)
-            if let n = m.getEnumNameForPath(path: path, parentPath: messagePath, swiftPrefix: messageSwiftPath) {
-                return n
-            }
-        }
-        return nil
+    for m in nestedType {
+      let messagePath = parentPath + "." + m.name
+      let messageSwiftPath = swiftPrefix + "." + sanitizeMessageTypeName(m.name)
+      if let n = m.getSwiftNameForEnumCase(path: path, caseName: caseName, parentPath: messagePath, swiftPrefix: messageSwiftPath) {
+        return n
+      }
     }
+    return nil
+  }
+}
 
-    func getSwiftNameForEnumCase(path: String, caseName: String, parentPath: String, swiftPrefix: String) -> String? {
-        for e in enumType {
-            let enumPath = parentPath + "." + e.name
-            if enumPath == path {
-                let enumSwiftName = swiftPrefix + "." + sanitizeEnumTypeName(e.name)
-                return enumSwiftName + "." + e.getSwiftNameForEnumCase(caseName: caseName)
-            }
-        }
+extension Google_Protobuf_DescriptorProto.ExtensionRange {
 
-        for m in nestedType {
-            let messagePath = parentPath + "." + m.name
-            let messageSwiftPath = swiftPrefix + "." + sanitizeMessageTypeName(m.name)
-            if let n = m.getSwiftNameForEnumCase(path: path, caseName: caseName, parentPath: messagePath, swiftPrefix: messageSwiftPath) {
-                return n
-            }
-        }
-        return nil
-    }
+  /// A `String` containing the Swift range expression that represents this
+  /// extension range.
+  var swiftRangeExpression: String {
+    return "\(start)..<\(end)"
+  }
+
+  /// A `String` containing the Swift Boolean expression that tests the given
+  /// variable for containment within this extension range.
+  ///
+  /// - Parameter variable: The name of the variable to test in the expression.
+  /// - Returns: A `String` containing the Boolean expression.
+  func swiftBooleanExpression(variable: String) -> String {
+    return "\(start) <= \(variable) && \(variable) < \(end)"
+  }
 }

--- a/Tests/SwiftProtobufTests/descriptor.pb.swift
+++ b/Tests/SwiftProtobufTests/descriptor.pb.swift
@@ -2185,9 +2185,9 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Proto2Message, SwiftProtobuf.E
     case 37: try decoder.decodeSingularStringField(value: &_csharpNamespace)
     case 39: try decoder.decodeSingularStringField(value: &_swiftPrefix)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FileOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FileOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2422,9 +2422,9 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Proto2Message, SwiftProtobu
     case 3: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 7: try decoder.decodeSingularBoolField(value: &_mapEntry)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MessageOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MessageOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2726,9 +2726,9 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Proto2Message, SwiftProtobuf.
     case 3: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 10: try decoder.decodeSingularBoolField(value: &_weak)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FieldOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_FieldOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2825,9 +2825,9 @@ struct Google_Protobuf_OneofOptions: SwiftProtobuf.Proto2Message, SwiftProtobuf.
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_OneofOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_OneofOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -2934,9 +2934,9 @@ struct Google_Protobuf_EnumOptions: SwiftProtobuf.Proto2Message, SwiftProtobuf.E
     case 2: try decoder.decodeSingularBoolField(value: &_allowAlias)
     case 3: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3035,9 +3035,9 @@ struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Proto2Message, SwiftProto
     switch fieldNumber {
     case 1: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumValueOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_EnumValueOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3137,9 +3137,9 @@ struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Proto2Message, SwiftProtobu
     switch fieldNumber {
     case 33: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_ServiceOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_ServiceOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3295,9 +3295,9 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Proto2Message, SwiftProtobuf
     case 33: try decoder.decodeSingularBoolField(value: &_deprecated)
     case 34: try decoder.decodeSingularEnumField(value: &_idempotencyLevel)
     case 999: try decoder.decodeRepeatedMessageField(value: &uninterpretedOption)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MethodOptions.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_MethodOptions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -4618,9 +4618,9 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Proto2Message, SwiftPr
     case 1: try decoder.decodeSingularInt64Field(value: &_storage._myInt)
     case 101: try decoder.decodeSingularFloatField(value: &_storage._myFloat)
     case 200: try decoder.decodeSingularMessageField(value: &_storage._optionalNestedMessage)
-    default: if (2 <= fieldNumber && fieldNumber < 11) || (12 <= fieldNumber && fieldNumber < 101) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestFieldOrderings.self, fieldNumber: fieldNumber)
-      }
+    case 2..<11, 12..<101:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestFieldOrderings.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -8501,9 +8501,9 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Proto2Message, SwiftProt
     case 3: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedAllTypes)
     case 10: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
     case 20: try decoder.decodeRepeatedGroupField(value: &_storage._repeatedGroup)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMerge.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMerge.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -9298,9 +9298,9 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Proto2Message, Swift
         try decoder.handleConflictingOneOf()
       }
       _storage._oneofField = try ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
-    default: if (536860000 <= fieldNumber && fieldNumber < 536870000) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber)
-      }
+    case 536860000..<536870000:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbers.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -667,9 +667,9 @@ struct ProtobufUnittest_ComplexOptionType1: SwiftProtobuf.Proto2Message, SwiftPr
     case 2: try decoder.decodeSingularInt32Field(value: &_foo2)
     case 3: try decoder.decodeSingularInt32Field(value: &_foo3)
     case 4: try decoder.decodeRepeatedInt32Field(value: &foo4)
-    default: if (100 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType1.self, fieldNumber: fieldNumber)
-      }
+    case 100..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType1.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -886,9 +886,9 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.Proto2Message, SwiftPr
     case 2: try decoder.decodeSingularInt32Field(value: &_storage._baz)
     case 3: try decoder.decodeSingularMessageField(value: &_storage._fred)
     case 4: try decoder.decodeRepeatedMessageField(value: &_storage._barney)
-    default: if (100 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType2.self, fieldNumber: fieldNumber)
-      }
+    case 100..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_ComplexOptionType2.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -2839,9 +2839,9 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Proto2Message, Swift
     case 3: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedAllTypes)
     case 10: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
     case 20: try decoder.decodeRepeatedGroupField(value: &_storage._repeatedGroup)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMergeLite.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestParsingMergeLite.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -3515,9 +3515,9 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Proto2Message, S
         try decoder.handleConflictingOneOf()
       }
       _storage._oneofField = try ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
-    default: if (536860000 <= fieldNumber && fieldNumber < 536870000) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber)
-      }
+    case 536860000..<536870000:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestHugeFieldNumbersLite.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -117,9 +117,9 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf.Proto2Me
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1: try decoder.decodeSingularInt32Field(value: &_a)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_NoGenericServicesTest_TestMessage.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Google_Protobuf_NoGenericServicesTest_TestMessage.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -235,9 +235,9 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Proto2Message, Swift
         try decoder.handleConflictingOneOf()
       }
       _storage._foo = try ProtobufUnittest_TestOptimizedForSize.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
-    default: if (1000 <= fieldNumber && fieldNumber < 536870912) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestOptimizedForSize.self, fieldNumber: fieldNumber)
-      }
+    case 1000..<536870912:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_TestOptimizedForSize.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -86,9 +86,9 @@ struct ProtobufUnittest_Extend_Foo: SwiftProtobuf.Proto2Message, SwiftProtobuf._
       mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
         switch fieldNumber {
         case 1: try decoder.decodeSingularInt32Field(value: &_a)
-        default: if (100 <= fieldNumber && fieldNumber < 1001) {
-            try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Baz.self, fieldNumber: fieldNumber)
-          }
+        case 100..<1001:
+          try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Baz.self, fieldNumber: fieldNumber)
+        default: break
         }
       }
 
@@ -396,9 +396,9 @@ struct ProtobufUnittest_Extend_MsgNoStorage: SwiftProtobuf.Proto2Message, SwiftP
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1: try decoder.decodeSingularInt32Field(value: &_x)
-    default: if (100 <= fieldNumber && fieldNumber < 201) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_MsgNoStorage.self, fieldNumber: fieldNumber)
-      }
+    case 100..<201:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_MsgNoStorage.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 
@@ -521,9 +521,9 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Proto2Message, Swif
     switch fieldNumber {
     case 1: try decoder.decodeSingularInt32Field(value: &_storage._x)
     case 2: try decoder.decodeSingularMessageField(value: &_storage._y)
-    default: if (100 <= fieldNumber && fieldNumber < 201) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_MsgUsesStorage.self, fieldNumber: fieldNumber)
-      }
+    case 100..<201:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: ProtobufUnittest_Extend_MsgUsesStorage.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -350,9 +350,9 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Proto2Message, SwiftProt
       }
       _storage._options = try Swift_Protobuf_TestFieldOrderings.OneOf_Options(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
     case 200: try decoder.decodeSingularMessageField(value: &_storage._optionalNestedMessage)
-    default: if (2 <= fieldNumber && fieldNumber < 9) || (12 <= fieldNumber && fieldNumber < 56) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Swift_Protobuf_TestFieldOrderings.self, fieldNumber: fieldNumber)
-      }
+    case 2..<9, 12..<56:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: Swift_Protobuf_TestFieldOrderings.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -87,9 +87,9 @@ struct SwiftTestGroupExtensions: SwiftProtobuf.Proto2Message, SwiftProtobuf.Exte
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1: try decoder.decodeSingularInt32Field(value: &_a)
-    default: if (2 <= fieldNumber && fieldNumber < 11) {
-        try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: SwiftTestGroupExtensions.self, fieldNumber: fieldNumber)
-      }
+    case 2..<11:
+      try decoder.decodeExtensionField(values: &_extensionFieldValues, messageType: SwiftTestGroupExtensions.self, fieldNumber: fieldNumber)
+    default: break
     }
   }
 


### PR DESCRIPTION
When decoding, instead of a `default` clause with Boolean expressions to check if a field number is in an extension range, now we generate a list of range patterns for a case; e.g.,

    case 5..<10, 15..<30:
      try decoder.decodeExtensionField....

The exception is if the message is empty with *only* extensions; then we just generate the `if` statement as before.