### PR TITLE
Unknown enum handling.

### DIFF
--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -67,6 +67,7 @@ internal struct BinaryDecoder: Decoder {
                 } else {
                     unknownData!.append(override)
                 }
+                unknownOverride = nil
             } else if !consumed {
                 let u = try getRawField()
                 if unknownData == nil {
@@ -788,9 +789,7 @@ internal struct BinaryDecoder: Decoder {
                     extras.append(i32)
                 }
             }
-            if extras.isEmpty {
-                unknownOverride = nil
-            } else {
+            if !extras.isEmpty {
                 let fieldTag = FieldTag(fieldNumber: fieldNumber, wireFormat: .lengthDelimited)
                 var bodySize = 0
                 for v in extras {

--- a/Tests/SwiftProtobufTests/Test_Enum.swift
+++ b/Tests/SwiftProtobufTests/Test_Enum.swift
@@ -47,4 +47,26 @@ class Test_Enum: XCTestCase, PBTestHelpers {
         XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest2.enumTest2FirstValue.rawValue, 1)
         XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest2.secondValue.rawValue, 2)
     }
+
+    func testUnknownValues() throws {
+        let orig = Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.with {
+            $0.e = .eExtra
+            $0.repeatedE.append(.eExtra)
+            $0.repeatedPackedE.append(.eExtra)
+            $0.oneofE1 = .eExtra
+        }
+
+        let origSerialized = try orig.serializedData()
+        let msg = try Proto3PreserveUnknownEnumUnittest_MyMessage(serializedData: origSerialized)
+
+        // Nothing in unknowns, they should just be unrecognized.
+        XCTAssertEqual(msg.e, .UNRECOGNIZED(3))
+        XCTAssertEqual(msg.repeatedE, [.UNRECOGNIZED(3)])
+        XCTAssertEqual(msg.repeatedPackedE, [.UNRECOGNIZED(3)])
+        XCTAssertEqual(msg.o, .oneofE1(.UNRECOGNIZED(3)))
+        XCTAssertTrue(msg.unknownFields.data.isEmpty)
+
+        let msgSerialized = try msg.serializedData()
+        XCTAssertEqual(origSerialized, msgSerialized)
+    }
 }

--- a/Tests/SwiftProtobufTests/Test_Enum_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_Enum_Proto2.swift
@@ -59,4 +59,33 @@ class Test_Enum_Proto2: XCTestCase, PBTestHelpers {
         XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest2.enumTest2FirstValue.rawValue, 1)
         XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest2.secondValue.rawValue, 2)
     }
+
+    func testUnknownValues() throws {
+        let orig = Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.with {
+            $0.e = .eExtra
+            $0.repeatedE.append(.eExtra)
+            $0.repeatedPackedE.append(.eExtra)
+            $0.oneofE1 = .eExtra
+        }
+
+        let origSerialized = try orig.serializedData()
+        let msg = try Proto2PreserveUnknownEnumUnittest_MyMessage(serializedData: origSerialized)
+
+        // Nothing should be set, should all be in unknowns.
+        XCTAssertFalse(msg.hasE)
+        XCTAssertEqual(msg.repeatedE.count, 0)
+        XCTAssertEqual(msg.repeatedPackedE.count, 0)
+        XCTAssertNil(msg.o)
+        XCTAssertFalse(msg.unknownFields.data.isEmpty)
+
+        let msgSerialized = try msg.serializedData()
+        let msgPrime = try Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra(serializedData: msgSerialized)
+
+        // They should be back in the right fields.
+        XCTAssertEqual(msgPrime.e, .eExtra)
+        XCTAssertEqual(msgPrime.repeatedE, [.eExtra])
+        XCTAssertEqual(msgPrime.repeatedPackedE, [.eExtra])
+        XCTAssertEqual(msgPrime.o, .oneofE1(.eExtra))
+        XCTAssertTrue(msgPrime.unknownFields.data.isEmpty)
+    }
 }


### PR DESCRIPTION
- Tests for all field types.
- Fix issue where the BinaryDecoders unknown overrides would stick
  and be captured as an unknown after every field.