### PR TITLE
Fold contiguous oneof field number sequences into a range.

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -428,7 +428,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Proto3Message, SwiftProtob
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 6, 2, 3, 4, 5:
+    case 1...6:
       if result != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -357,7 +357,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Proto3Message, SwiftProtobuf._Messag
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2, 3, 4, 5, 6:
+    case 1...6:
       if _storage._kind != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -1573,7 +1573,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Proto3Message, Sw
     case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignMessage>.self, value: &_storage._mapStringForeignMessage)
     case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum>.self, value: &_storage._mapStringNestedEnum)
     case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: &_storage._mapStringForeignEnum)
-    case 111, 112, 113, 114, 115, 116, 117, 118, 119:
+    case 111...119:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -1474,7 +1474,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Proto2Message, SwiftProtobuf
     case 83: try decoder.decodeSingularEnumField(value: &_storage._defaultImportEnum)
     case 84: try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece)
     case 85: try decoder.decodeSingularStringField(value: &_storage._defaultCord)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -5994,7 +5994,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Proto2Message, SwiftProtobuf._M
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2, 3, 4:
+    case 1...4:
       if _storage._foo != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -6911,7 +6911,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Proto2Message, SwiftProtobuf._
         try decoder.handleConflictingOneOf()
       }
       _storage._foo = try ProtobufUnittest_TestOneof2.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
-    case 12, 13, 14, 15, 16, 17:
+    case 12...17:
       if _storage._bar != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -7166,7 +7166,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Proto2Message, SwiftPro
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2, 3:
+    case 1...3:
       if _storage._foo != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -9293,7 +9293,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Proto2Message, Swift
     case 536870007: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
     case 536870008: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
     case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._stringStringMap)
-    case 536870011, 536870012, 536870013, 536870014:
+    case 536870011...536870014:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -1485,7 +1485,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Proto2Message, SwiftProt
     case 83: try decoder.decodeSingularEnumField(value: &_storage._defaultImportEnum)
     case 84: try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece)
     case 85: try decoder.decodeSingularStringField(value: &_storage._defaultCord)
-    case 111, 112, 113, 114, 115:
+    case 111...115:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -3510,7 +3510,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Proto2Message, S
     case 536870007: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
     case 536870008: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
     case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._stringStringMap)
-    case 536870011, 536870012, 536870013, 536870014:
+    case 536870011...536870014:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -1408,7 +1408,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Proto2Message, SwiftP
     case 83: try decoder.decodeSingularEnumField(value: &_storage._defaultImportEnum)
     case 84: try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece)
     case 85: try decoder.decodeSingularStringField(value: &_storage._defaultCord)
-    case 111, 112, 113, 114, 115:
+    case 111...115:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -775,7 +775,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, 
     case 54: try decoder.decodeRepeatedStringField(value: &_storage._repeatedStringPiece)
     case 55: try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord)
     case 57: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -880,7 +880,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageIm
     case 52: try decoder.decodeRepeatedEnumField(value: &_storage._repeatedForeignEnum)
     case 53: try decoder.decodeRepeatedEnumField(value: &_storage._repeatedImportEnum)
     case 54: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedPublicImportMessage)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -2499,7 +2499,7 @@ struct Proto3TestOneof: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageImple
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2, 3:
+    case 1...3:
       if _storage._foo != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -821,7 +821,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProto
     case 54: try decoder.decodeRepeatedStringField(value: &_storage._repeatedStringPiece)
     case 55: try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord)
     case 57: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -821,7 +821,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, SwiftP
     case 54: try decoder.decodeRepeatedStringField(value: &_storage._repeatedStringPiece)
     case 55: try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord)
     case 57: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -821,7 +821,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProtob
     case 54: try decoder.decodeRepeatedStringField(value: &_storage._repeatedStringPiece)
     case 55: try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord)
     case 57: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -1269,7 +1269,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Proto3Message, SwiftP
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18:
+    case 1...18:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -1134,7 +1134,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Proto2Message, Swift
     case 83: try decoder.decodeSingularEnumField(value: &_storage._defaultImportEnum)
     case 84: try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece)
     case 85: try decoder.decodeSingularStringField(value: &_storage._defaultCord)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -344,7 +344,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Proto2Message, SwiftProt
     case 11: try decoder.decodeSingularStringField(value: &_storage._myString)
     case 1: try decoder.decodeSingularInt64Field(value: &_storage._myInt)
     case 101: try decoder.decodeSingularFloatField(value: &_storage._myFloat)
-    case 60, 9, 150, 10:
+    case 9, 10, 60, 150:
       if _storage._options != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -428,7 +428,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Proto3Message, SwiftProtob
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 6, 2, 3, 4, 5:
+    case 1...6:
       if result != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -1573,7 +1573,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Proto3Message, Sw
     case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignMessage>.self, value: &_storage._mapStringForeignMessage)
     case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum>.self, value: &_storage._mapStringNestedEnum)
     case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: &_storage._mapStringForeignEnum)
-    case 111, 112, 113, 114, 115, 116, 117, 118, 119:
+    case 111...119:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -365,14 +365,8 @@ class MessageGenerator {
         if f.descriptor.hasOneofIndex {
           let oneofIndex = f.descriptor.oneofIndex
           if !oneofHandled.contains(oneofIndex) {
-            p.print("case \(f.number)")
-            for other in fields {
-              if other.descriptor.hasOneofIndex && other.descriptor.oneofIndex == oneofIndex && other.number != f.number {
-                p.print(", \(other.number)")
-              }
-            }
+            p.print("case \(oneofFieldNumbersPattern(index: oneofIndex)):\n")
             let oneof = f.oneof!
-            p.print(":\n")
             p.indent()
             p.print("if \(storedProperty(forOneof: oneof)) != nil {\n")
             p.print("  try decoder.handleConflictingOneOf()\n")
@@ -407,6 +401,48 @@ class MessageGenerator {
 
     p.outdent()
     p.print("}\n")
+  }
+
+  /// Returns a Swift pattern (or list of patterns) suitable for a `case`
+  /// statement that matches any of the field numbers corresponding to the
+  /// `oneof` with the given index.
+  ///
+  /// This function collapses large contiguous field number sequences into
+  /// into range patterns instead of listing all of the fields explicitly.
+  ///
+  /// - Parameter index: The index of the `oneof`.
+  /// - Returns: The Swift pattern(s) that match the `oneof`'s field numbers.
+  private func oneofFieldNumbersPattern(index: Int32) -> String {
+    let oneofFields = fields.lazy.filter {
+      $0.descriptor.hasOneofIndex && $0.descriptor.oneofIndex == index
+    }.map { $0.number }.sorted()
+
+    assert(oneofFields.count > 0)
+
+    if oneofFields.count <= 2 {
+      // For one or two fields, just return "n" or "n, m". ("n...m" would
+      // also be valid, but this is one character shorter.)
+      return oneofFields.lazy.map { String($0) }.joined(separator: ", ")
+    }
+
+    var it = oneofFields.makeIterator()
+
+    // Safe force-unwraps from here on down: We know there's at least one.
+    let first = it.next()!
+    var previous = first
+    while let current = it.next() {
+      if current - previous > 1 {
+        // Not a contiguous range, so just print the comma-delimited list of
+        // field numbers. (We could consider optimizing this to print ranges
+        // for contiguous subsequences later, as well.)
+        return oneofFields.lazy.map { String($0) }.joined(separator: ", ")
+      }
+      previous = current
+    }
+
+    // The field numbers were contiguous, so return a range instead.
+    let last = oneofFields.last!
+    return "\(first)...\(last)"
   }
 
   /// Generates the `_protobuf_generated_traverse` method for the message.

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -428,7 +428,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Proto3Message, SwiftProtob
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 6, 2, 3, 4, 5:
+    case 1...6:
       if result != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -1573,7 +1573,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Proto3Message, Sw
     case 72: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMessageMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignMessage>.self, value: &_storage._mapStringForeignMessage)
     case 73: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum>.self, value: &_storage._mapStringNestedEnum)
     case 74: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: &_storage._mapStringForeignEnum)
-    case 111, 112, 113, 114, 115, 116, 117, 118, 119:
+    case 111...119:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -1474,7 +1474,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Proto2Message, SwiftProtobuf
     case 83: try decoder.decodeSingularEnumField(value: &_storage._defaultImportEnum)
     case 84: try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece)
     case 85: try decoder.decodeSingularStringField(value: &_storage._defaultCord)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -5994,7 +5994,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Proto2Message, SwiftProtobuf._M
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2, 3, 4:
+    case 1...4:
       if _storage._foo != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -6911,7 +6911,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Proto2Message, SwiftProtobuf._
         try decoder.handleConflictingOneOf()
       }
       _storage._foo = try ProtobufUnittest_TestOneof2.OneOf_Foo(byDecodingFrom: &decoder, fieldNumber: fieldNumber)
-    case 12, 13, 14, 15, 16, 17:
+    case 12...17:
       if _storage._bar != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -7166,7 +7166,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Proto2Message, SwiftPro
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2, 3:
+    case 1...3:
       if _storage._foo != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -9293,7 +9293,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Proto2Message, Swift
     case 536870007: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
     case 536870008: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
     case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._stringStringMap)
-    case 536870011, 536870012, 536870013, 536870014:
+    case 536870011...536870014:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -1485,7 +1485,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Proto2Message, SwiftProt
     case 83: try decoder.decodeSingularEnumField(value: &_storage._defaultImportEnum)
     case 84: try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece)
     case 85: try decoder.decodeSingularStringField(value: &_storage._defaultCord)
-    case 111, 112, 113, 114, 115:
+    case 111...115:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -3510,7 +3510,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Proto2Message, S
     case 536870007: try decoder.decodeSingularMessageField(value: &_storage._optionalMessage)
     case 536870008: try decoder.decodeSingularGroupField(value: &_storage._optionalGroup)
     case 536870010: try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &_storage._stringStringMap)
-    case 536870011, 536870012, 536870013, 536870014:
+    case 536870011...536870014:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -1408,7 +1408,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Proto2Message, SwiftP
     case 83: try decoder.decodeSingularEnumField(value: &_storage._defaultImportEnum)
     case 84: try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece)
     case 85: try decoder.decodeSingularStringField(value: &_storage._defaultCord)
-    case 111, 112, 113, 114, 115:
+    case 111...115:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -775,7 +775,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, 
     case 54: try decoder.decodeRepeatedStringField(value: &_storage._repeatedStringPiece)
     case 55: try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord)
     case 57: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -880,7 +880,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageIm
     case 52: try decoder.decodeRepeatedEnumField(value: &_storage._repeatedForeignEnum)
     case 53: try decoder.decodeRepeatedEnumField(value: &_storage._repeatedImportEnum)
     case 54: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedPublicImportMessage)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }
@@ -2499,7 +2499,7 @@ struct Proto3TestOneof: SwiftProtobuf.Proto3Message, SwiftProtobuf._MessageImple
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2, 3:
+    case 1...3:
       if _storage._foo != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -821,7 +821,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Proto3Message, SwiftProto
     case 54: try decoder.decodeRepeatedStringField(value: &_storage._repeatedStringPiece)
     case 55: try decoder.decodeRepeatedStringField(value: &_storage._repeatedCord)
     case 57: try decoder.decodeRepeatedMessageField(value: &_storage._repeatedLazyMessage)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -1134,7 +1134,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Proto2Message, Swift
     case 83: try decoder.decodeSingularEnumField(value: &_storage._defaultImportEnum)
     case 84: try decoder.decodeSingularStringField(value: &_storage._defaultStringPiece)
     case 85: try decoder.decodeSingularStringField(value: &_storage._defaultCord)
-    case 111, 112, 113, 114:
+    case 111...114:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -344,7 +344,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Proto2Message, SwiftProt
     case 11: try decoder.decodeSingularStringField(value: &_storage._myString)
     case 1: try decoder.decodeSingularInt64Field(value: &_storage._myInt)
     case 101: try decoder.decodeSingularFloatField(value: &_storage._myFloat)
-    case 60, 9, 150, 10:
+    case 9, 10, 60, 150:
       if _storage._options != nil {
         try decoder.handleConflictingOneOf()
       }

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -1269,7 +1269,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Proto3Message, SwiftP
 
   mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
     switch fieldNumber {
-    case 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18:
+    case 1...18:
       if _storage._oneofField != nil {
         try decoder.handleConflictingOneOf()
       }


### PR DESCRIPTION
When decoding, we now fold oneofs with more than two field numbers into ranges: e.g., `case 1, 6, 2, 3, 4, 5` into `case 1...6` (note that out-of-order fields in the original .proto are handled correctly).

Two fields are still written as `case 1, 2`, for no reason other than it saves a character compared to `case 1...2`. The number of comparisons would be the same anyway.