### PR TITLE
Move anyTypePrefix and anyTypeURL off message.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
@@ -535,15 +535,18 @@ public struct Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNa
     // into an object, then reserializing back to JSON.
     internal func encodedJSONString() throws -> String {
         if let message = _message {
-            // We were initialized from a message object, means typeURL
-            // also was initialized.
+            // We were initialized from a message object.
+
+            // We should have been initialized with a typeURL, but
+            // ensure it wasn't cleared.
+            let url = typeURL ?? buildTypeURL(forMessage: message, typePrefix: defaultTypePrefix)
             if let m = message as? _CustomJSONCodable {
                 // Serialize a Well-known type to JSON:
                 let value = try m.encodedJSONString()
-                return "{\"@type\":\"\(typeURL!)\",\"value\":\(value)}"
+                return "{\"@type\":\"\(url)\",\"value\":\(value)}"
             } else {
                 // Serialize a regular message to JSON:
-                return try _serializeAnyJSON(for: message, typeURL: typeURL!)
+                return try _serializeAnyJSON(for: message, typeURL: url)
             }
         } else if let typeURL = typeURL {
             if _value != nil {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
@@ -44,6 +44,16 @@ public enum AnyUnpackError: Error {
     case missingFieldNames
 }
 
+fileprivate let defaultTypePrefix: String = "type.googleapis.com"
+
+fileprivate func buildTypeURL(forMessage message: Message, typePrefix: String) -> String {
+  var url = typePrefix
+  if typePrefix.isEmpty || typePrefix.characters.last != "/" {
+    url += "/"
+  }
+  return url + typeName(fromMessage: message)
+}
+
 fileprivate func typeName(fromURL s: String) -> String {
     var typeStart = s.startIndex
     var i = typeStart
@@ -61,7 +71,7 @@ fileprivate func typeName(fromURL s: String) -> String {
 fileprivate func typeName(fromMessage message: Message) -> String {
     let msgType = type(of: message)
     let protoPackageName = msgType.protoPackageName
-    if protoPackageName == "" {
+    if protoPackageName.isEmpty {
         return msgType.protoMessageName
     } else {
         return "\(protoPackageName).\(msgType.protoMessageName)"
@@ -305,9 +315,9 @@ public struct Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNa
     /// needs to be serialized.  This design avoids unnecessary
     /// decoding/recoding when writing JSON format.
     ///
-    public init(message: Message) {
+    public init(message: Message, typePrefix: String = defaultTypePrefix) {
         _message = message
-        typeURL = type(of: message).anyTypeURL
+        typeURL = buildTypeURL(forMessage:message, typePrefix: typePrefix)
     }
 
     /// Decode an Any object from Protobuf Text Format.
@@ -424,7 +434,7 @@ public struct Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNa
             throw AnyUnpackError.emptyAnyField
         }
         let encodedType = typeName(fromURL: typeURL!)
-        if encodedType == "" {
+        if encodedType.isEmpty {
             throw AnyUnpackError.malformedTypeURL
         }
         let messageType = typeName(fromMessage: target)
@@ -506,11 +516,11 @@ public struct Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNa
     /// Traversal-based JSON encoding of a standard message type
     /// This mimics the standard JSON message encoding logic, but adds
     /// the additional `@type` field.
-    private func _serializeAnyJSON(for message: Message) throws -> String {
+    private func _serializeAnyJSON(for message: Message, typeURL: String) throws -> String {
         var visitor = JSONEncodingVisitor(message: message)
         visitor.encoder.startObject()
         visitor.encoder.startField(name: "@type")
-        visitor.encoder.putStringValue(value: type(of: message).anyTypeURL)
+        visitor.encoder.putStringValue(value: typeURL)
         try message.traverse(visitor: &visitor)
         visitor.encoder.endObject()
         return visitor.stringResult
@@ -525,14 +535,15 @@ public struct Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNa
     // into an object, then reserializing back to JSON.
     internal func encodedJSONString() throws -> String {
         if let message = _message {
-            // We were initialized from a message object
+            // We were initialized from a message object, means typeURL
+            // also was initialized.
             if let m = message as? _CustomJSONCodable {
                 // Serialize a Well-known type to JSON:
                 let value = try m.encodedJSONString()
-                return "{\"@type\":\"\(type(of: message).anyTypeURL)\",\"value\":\(value)}"
+                return "{\"@type\":\"\(typeURL!)\",\"value\":\(value)}"
             } else {
                 // Serialize a regular message to JSON:
-                return try _serializeAnyJSON(for: message)
+                return try _serializeAnyJSON(for: message, typeURL: typeURL!)
             }
         } else if let typeURL = typeURL {
             if _value != nil {
@@ -545,12 +556,12 @@ public struct Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNa
                 if let messageType = Google_Protobuf_Any.wellKnownTypes[messageTypeName] {
                     let m = try messageType.init(unpackingAny: self)
                     let value = try m.jsonString()
-                    return "{\"@type\":\"\(type(of: m).anyTypeURL)\",\"value\":\(value)}"
+                    return "{\"@type\":\"\(typeURL)\",\"value\":\(value)}"
                 }
                 // Otherwise, it may be a registered type:
                 if let messageType = Google_Protobuf_Any.knownTypes[messageTypeName] {
                     let m = try messageType.init(unpackingAny: self)
-                    return try _serializeAnyJSON(for: m)
+                    return try _serializeAnyJSON(for: m, typeURL: typeURL)
                 }
 
                 // If we don't have the type available, we can't decode the
@@ -595,7 +606,7 @@ public struct Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNa
     // Caveat:  This can be very expensive.  We should consider organizing
     // the code generation so that generated equality tests check Any fields last.
     public func _protobuf_generated_isEqualTo(other: Google_Protobuf_Any) -> Bool {
-        if ((typeURL != nil && typeURL != "") || (other.typeURL != nil && other.typeURL != "")) && (typeURL == nil || other.typeURL == nil || typeURL! != other.typeURL!) {
+        if ((typeURL != nil && !typeURL!.isEmpty) || (other.typeURL != nil && !other.typeURL!.isEmpty)) && (typeURL == nil || other.typeURL == nil || typeURL! != other.typeURL!) {
             return false
         }
 

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -38,8 +38,6 @@ public protocol Message: CustomDebugStringConvertible {
   // Used by various encoders and decoders
   static var protoMessageName: String { get }
   static var protoPackageName: String { get }
-  static var anyTypePrefix: String { get }
-  static var anyTypeURL: String { get }
 
   /// Check if all required fields (if any) have values set on this message
   /// on any messages withing this message.
@@ -128,20 +126,6 @@ public extension Message {
       result += "<internal error>"
     }
     return result
-  }
-
-  static var anyTypePrefix: String { return "type.googleapis.com" }
-  static var anyTypeURL: String {
-    var url = anyTypePrefix
-    if anyTypePrefix == "" || anyTypePrefix.characters.last! != "/" {
-      url += "/"
-    }
-    if protoPackageName != "" {
-      url += protoPackageName
-      url += "."
-    }
-    url += protoMessageName
-    return url
   }
 
   /// Creates an instance of the message type on which this method is called,

--- a/Tests/SwiftProtobufTests/Test_Any.swift
+++ b/Tests/SwiftProtobufTests/Test_Any.swift
@@ -24,7 +24,6 @@ class Test_Any: XCTestCase {
     func test_Any() throws {
         var content = ProtobufUnittest_TestAllTypes()
         content.optionalInt32 = 7
-        XCTAssertEqual(type(of: content).anyTypeURL, "type.googleapis.com/protobuf_unittest.TestAllTypes")
 
         var m = ProtobufUnittest_TestAny()
         m.int32Value = 12


### PR DESCRIPTION
- Remove the static properties from Message.
- Take a typePrefix to the Any initializer that defaults.
- If a typeURL came into an Any, honor it in all the transforms instead
  of potentially overriding it with values from the Message type.