### PR TITLE
Improve enum alias handling.

### DIFF
--- a/Protos/unittest_swift_enum.proto
+++ b/Protos/unittest_swift_enum.proto
@@ -50,3 +50,14 @@ message SwiftEnumTest {
         ENUM_TEST_RESERVED_WORD_NOT_RESERVED = 2;
     }
 }
+
+message SwiftEnumWithAliasTest {
+    enum EnumWithAlias {
+        option allow_alias = true;
+        FOO1 = 1;
+        FOO2 = 1;
+        BAR1 = 2;
+        BAR2 = 2;
+    }
+    repeated EnumWithAlias values = 1 [packed=true];
+}

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -1380,10 +1380,10 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     case UNRECOGNIZED(Int)
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       0: .same(proto: "FOO"),
       1: .same(proto: "BAR"),
       2: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -1392,20 +1392,20 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 0: self = .foo
       case 1: self = .bar
       case 2: self = .baz
-      case -1: self = .neg
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .foo: return 0
       case .bar: return 1
       case .baz: return 2
-      case .neg: return -1
       case .UNRECOGNIZED(let i): return i
       }
     }

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -100,8 +100,8 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._P
   static let bar2 = bar1
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
-    2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
+    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
     3: .same(proto: "BAZ"),
   ]
 
@@ -140,13 +140,13 @@ enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNa
   case sparseG // = 2
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -53452: .same(proto: "SPARSE_E"),
+    -15: .same(proto: "SPARSE_D"),
+    0: .same(proto: "SPARSE_F"),
+    2: .same(proto: "SPARSE_G"),
     123: .same(proto: "SPARSE_A"),
     62374: .same(proto: "SPARSE_B"),
     12589234: .same(proto: "SPARSE_C"),
-    -15: .same(proto: "SPARSE_D"),
-    -53452: .same(proto: "SPARSE_E"),
-    0: .same(proto: "SPARSE_F"),
-    2: .same(proto: "SPARSE_G"),
   ]
 
   init() {
@@ -155,26 +155,26 @@ enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNa
 
   init?(rawValue: Int) {
     switch rawValue {
+    case -53452: self = .sparseE
+    case -15: self = .sparseD
+    case 0: self = .sparseF
+    case 2: self = .sparseG
     case 123: self = .sparseA
     case 62374: self = .sparseB
     case 12589234: self = .sparseC
-    case -15: self = .sparseD
-    case -53452: self = .sparseE
-    case 0: self = .sparseF
-    case 2: self = .sparseG
     default: return nil
     }
   }
 
   var rawValue: Int {
     switch self {
+    case .sparseE: return -53452
+    case .sparseD: return -15
+    case .sparseF: return 0
+    case .sparseG: return 2
     case .sparseA: return 123
     case .sparseB: return 62374
     case .sparseC: return 12589234
-    case .sparseD: return -15
-    case .sparseE: return -53452
-    case .sparseF: return 0
-    case .sparseG: return 2
     }
   }
 
@@ -1202,10 +1202,10 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Mess
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -1214,20 +1214,20 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: return nil
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       }
     }
 

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -96,15 +96,13 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._P
   case foo1 // = 1
   case bar1 // = 2
   case baz // = 3
-  case foo2 // = 1
-  case bar2 // = 2
+  static let foo2 = foo1
+  static let bar2 = bar1
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "FOO1"),
-    2: .same(proto: "BAR1"),
+    1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
     3: .same(proto: "BAZ"),
-    1: .same(proto: "FOO2"),
-    2: .same(proto: "BAR2"),
   ]
 
   init() {
@@ -125,8 +123,6 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._P
     case .foo1: return 1
     case .bar1: return 2
     case .baz: return 3
-    case .foo2: return 1
-    case .bar2: return 2
     }
   }
 

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -381,8 +381,8 @@ struct ProtobufUnittest_DummyMessageContainingEnum: SwiftProtobuf.Message, Swift
     case testOptionEnumType2 // = -23
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      22: .same(proto: "TEST_OPTION_ENUM_TYPE1"),
       -23: .same(proto: "TEST_OPTION_ENUM_TYPE2"),
+      22: .same(proto: "TEST_OPTION_ENUM_TYPE1"),
     ]
 
     init() {
@@ -391,16 +391,16 @@ struct ProtobufUnittest_DummyMessageContainingEnum: SwiftProtobuf.Message, Swift
 
     init?(rawValue: Int) {
       switch rawValue {
-      case 22: self = .testOptionEnumType1
       case -23: self = .testOptionEnumType2
+      case 22: self = .testOptionEnumType1
       default: return nil
       }
     }
 
     var rawValue: Int {
       switch self {
-      case .testOptionEnumType1: return 22
       case .testOptionEnumType2: return -23
+      case .testOptionEnumType1: return 22
       }
     }
 

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -1140,10 +1140,10 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -1152,20 +1152,20 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: return nil
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       }
     }
 

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -109,8 +109,8 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED"),
-    1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
-    2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
+    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
     3: .same(proto: "BAZ"),
   ]
 
@@ -156,13 +156,13 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding
   case UNRECOGNIZED(Int)
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -53452: .same(proto: "SPARSE_E"),
+    -15: .same(proto: "SPARSE_D"),
     0: .same(proto: "TEST_SPARSE_ENUM_UNSPECIFIED"),
+    2: .same(proto: "SPARSE_G"),
     123: .same(proto: "SPARSE_A"),
     62374: .same(proto: "SPARSE_B"),
     12589234: .same(proto: "SPARSE_C"),
-    -15: .same(proto: "SPARSE_D"),
-    -53452: .same(proto: "SPARSE_E"),
-    2: .same(proto: "SPARSE_G"),
   ]
 
   init() {
@@ -171,26 +171,26 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding
 
   init?(rawValue: Int) {
     switch rawValue {
+    case -53452: self = .sparseE
+    case -15: self = .sparseD
     case 0: self = .testSparseEnumUnspecified
+    case 2: self = .sparseG
     case 123: self = .sparseA
     case 62374: self = .sparseB
     case 12589234: self = .sparseC
-    case -15: self = .sparseD
-    case -53452: self = .sparseE
-    case 2: self = .sparseG
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
 
   var rawValue: Int {
     switch self {
+    case .sparseE: return -53452
+    case .sparseD: return -15
     case .testSparseEnumUnspecified: return 0
+    case .sparseG: return 2
     case .sparseA: return 123
     case .sparseB: return 62374
     case .sparseC: return 12589234
-    case .sparseD: return -15
-    case .sparseE: return -53452
-    case .sparseG: return 2
     case .UNRECOGNIZED(let i): return i
     }
   }
@@ -747,11 +747,11 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
     case UNRECOGNIZED(Int)
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       0: .same(proto: "NESTED_ENUM_UNSPECIFIED"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -760,22 +760,22 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 0: self = .nestedEnumUnspecified
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .nestedEnumUnspecified: return 0
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       case .UNRECOGNIZED(let i): return i
       }
     }

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -103,17 +103,15 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
   case foo1 // = 1
   case bar1 // = 2
   case baz // = 3
-  case foo2 // = 1
-  case bar2 // = 2
+  static let foo2 = foo1
+  static let bar2 = bar1
   case UNRECOGNIZED(Int)
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED"),
-    1: .same(proto: "FOO1"),
-    2: .same(proto: "BAR1"),
+    1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
     3: .same(proto: "BAZ"),
-    1: .same(proto: "FOO2"),
-    2: .same(proto: "BAR2"),
   ]
 
   init() {
@@ -136,8 +134,6 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
     case .foo1: return 1
     case .bar1: return 2
     case .baz: return 3
-    case .foo2: return 1
-    case .bar2: return 2
     case .UNRECOGNIZED(let i): return i
     }
   }

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -689,11 +689,11 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     case UNRECOGNIZED(Int)
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       0: .same(proto: "ZERO"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -702,22 +702,22 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 0: self = .zero
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .zero: return 0
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       case .UNRECOGNIZED(let i): return i
       }
     }

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -689,11 +689,11 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     case UNRECOGNIZED(Int)
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       0: .same(proto: "ZERO"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -702,22 +702,22 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 0: self = .zero
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .zero: return 0
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       case .UNRECOGNIZED(let i): return i
       }
     }

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -689,11 +689,11 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Me
     case UNRECOGNIZED(Int)
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       0: .same(proto: "ZERO"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -702,22 +702,22 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Me
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 0: self = .zero
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .zero: return 0
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       case .UNRECOGNIZED(let i): return i
       }
     }

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -870,10 +870,10 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -882,20 +882,20 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: return nil
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       }
     }
 

--- a/Reference/unittest_swift_enum.pb.swift
+++ b/Reference/unittest_swift_enum.pb.swift
@@ -200,3 +200,76 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message, SwiftProtobuf._Mes
     return true
   }
 }
+
+struct ProtobufUnittest_SwiftEnumWithAliasTest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = "SwiftEnumWithAliasTest"
+  static let protoPackageName: String = "protobuf_unittest"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "values"),
+  ]
+
+  var values: [ProtobufUnittest_SwiftEnumWithAliasTest.EnumWithAlias] = []
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  enum EnumWithAlias: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+    typealias RawValue = Int
+    case foo1 // = 1
+    static let foo2 = foo1
+    case bar1 // = 2
+    static let bar2 = bar1
+
+    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
+      2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
+    ]
+
+    init() {
+      self = .foo1
+    }
+
+    init?(rawValue: Int) {
+      switch rawValue {
+      case 1: self = .foo1
+      case 2: self = .bar1
+      default: return nil
+      }
+    }
+
+    var rawValue: Int {
+      switch self {
+      case .foo1: return 1
+      case .bar1: return 2
+      }
+    }
+
+  }
+
+  init() {}
+
+  mutating func _protobuf_generated_decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      try decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    }
+  }
+
+  mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1: try decoder.decodeRepeatedEnumField(value: &values)
+    default: break
+    }
+  }
+
+  func _protobuf_generated_traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !values.isEmpty {
+      try visitor.visitPackedEnumField(value: values, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  func _protobuf_generated_isEqualTo(other: ProtobufUnittest_SwiftEnumWithAliasTest) -> Bool {
+    if values != other.values {return false}
+    if unknownFields != other.unknownFields {return false}
+    return true
+  }
+}

--- a/Reference/unittest_swift_enum.pb.swift
+++ b/Reference/unittest_swift_enum.pb.swift
@@ -220,8 +220,8 @@ struct ProtobufUnittest_SwiftEnumWithAliasTest: SwiftProtobuf.Message, SwiftProt
     static let bar2 = bar1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
-      2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
+      1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+      2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
     ]
 
     init() {

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -1380,10 +1380,10 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     case UNRECOGNIZED(Int)
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       0: .same(proto: "FOO"),
       1: .same(proto: "BAR"),
       2: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -1392,20 +1392,20 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 0: self = .foo
       case 1: self = .bar
       case 2: self = .baz
-      case -1: self = .neg
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .foo: return 0
       case .bar: return 1
       case .baz: return 2
-      case .neg: return -1
       case .UNRECOGNIZED(let i): return i
       }
     }

--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -66,10 +66,10 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
     /// other.
     case unique(proto: StaticString, json: StaticString)
 
-    /// Used for enum cases only to represent a value's primary name (the first
-    /// defined case) and its aliases. The JSON and text format names for enums
-    /// are always the same.
-    case aliased(primary: StaticString, aliases: [StaticString])
+    /// Used for enum cases only to represent a value's primary proto name (the
+    /// first defined case) and its aliases. The JSON and text format names for
+    /// enums are always the same.
+    case aliased(proto: StaticString, aliases: [StaticString])
 
     // TODO: Add a case for JSON names that are computable from the proto name
     // using the same algorithm implemented by protoc; for example,
@@ -81,7 +81,7 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
       switch self {
       case .same(proto: let name): return name
       case .unique(proto: let name, json: _): return name
-      case .aliased(primary: let name, aliases: _): return name
+      case .aliased(proto: let name, aliases: _): return name
       }
     }
 
@@ -90,7 +90,7 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
       switch self {
       case .same(proto: let name): return name
       case .unique(proto: _, json: let name): return name
-      case .aliased(primary: let name, aliases: _): return name
+      case .aliased(proto: let name, aliases: _): return name
       }
     }
 
@@ -100,7 +100,7 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
       switch self {
       case .same(proto: let name): return [name]
       case .unique(proto: let name, json: _): return [name]
-      case .aliased(primary: let name, aliases: let aliases):
+      case .aliased(proto: let name, aliases: let aliases):
         var names = [name]
         names.append(contentsOf: aliases)
         return names
@@ -113,7 +113,7 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
       switch self {
       case .same(proto: let name): return [name]
       case .unique(proto: _, json: let name): return [name]
-      case .aliased(primary: let name, aliases: let aliases):
+      case .aliased(proto: let name, aliases: let aliases):
         var names = [name]
         names.append(contentsOf: aliases)
         return names

--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -66,6 +66,11 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
     /// other.
     case unique(proto: StaticString, json: StaticString)
 
+    /// Used for enum cases only to represent a value's primary name (the first
+    /// defined case) and its aliases. The JSON and text format names for enums
+    /// are always the same.
+    case aliased(primary: StaticString, aliases: [StaticString])
+
     // TODO: Add a case for JSON names that are computable from the proto name
     // using the same algorithm implemented by protoc; for example,
     // "foo_bar" -> "fooBar". This allows us to only store the string pointer
@@ -76,6 +81,7 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
       switch self {
       case .same(proto: let name): return name
       case .unique(proto: let name, json: _): return name
+      case .aliased(primary: let name, aliases: _): return name
       }
     }
 
@@ -84,6 +90,33 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
       switch self {
       case .same(proto: let name): return name
       case .unique(proto: _, json: let name): return name
+      case .aliased(primary: let name, aliases: _): return name
+      }
+    }
+
+    /// Returns the array of all text format names in this bundle. Used when
+    /// building the name-to-number dictionary.
+    fileprivate var allProtoNames: [StaticString] {
+      switch self {
+      case .same(proto: let name): return [name]
+      case .unique(proto: let name, json: _): return [name]
+      case .aliased(primary: let name, aliases: let aliases):
+        var names = [name]
+        names.append(contentsOf: aliases)
+        return names
+      }
+    }
+
+    /// Returns the array of all text format names in this bundle. Used when
+    /// building the name-to-number dictionary.
+    fileprivate var allJSONNames: [StaticString] {
+      switch self {
+      case .same(proto: let name): return [name]
+      case .unique(proto: _, json: let name): return [name]
+      case .aliased(primary: let name, aliases: let aliases):
+        var names = [name]
+        names.append(contentsOf: aliases)
+        return names
       }
     }
   }
@@ -103,18 +136,20 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
   /// Creates a new bidirectional field/enum-case name/number mapping from the
   /// dictionary literal.
   public init(dictionaryLiteral elements: (Int, Names)...) {
-    for (number, name) in elements {
-      numberToNameMap[number] = name
-      let s = name.protoStaticStringName
-      let p = ASCIIName(bytes: s.utf8Start, count: s.utf8CodeUnitCount)
-      protoToNumberMap[p] = number
+    for (number, names) in elements {
+      numberToNameMap[number] = names
+      for s in names.allProtoNames {
+        let p = ASCIIName(bytes: s.utf8Start, count: s.utf8CodeUnitCount)
+        protoToNumberMap[p] = number
+      }
     }
     // JSON map includes proto names as well.
     jsonToNumberMap = protoToNumberMap
-    for (number, name) in elements {
-      let s = name.jsonStaticStringName
-      let j = ASCIIName(bytes: s.utf8Start, count: s.utf8CodeUnitCount)
-      jsonToNumberMap[j] = number
+    for (number, names) in elements {
+      for s in names.allJSONNames {
+        let j = ASCIIName(bytes: s.utf8Start, count: s.utf8CodeUnitCount)
+        jsonToNumberMap[j] = number
+      }
     }
   }
 

--- a/Sources/protoc-gen-swift/EnumCaseGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumCaseGenerator.swift
@@ -105,7 +105,7 @@ class EnumCaseGenerator {
         "\"\($0.wrapped!.protoName)\""
       }.joined(separator: ", ")
 
-      p.print("\(number): .aliased(primary: \"\(protoName)\", aliases: [\(aliasNames)]),\n")
+      p.print("\(number): .aliased(proto: \"\(protoName)\", aliases: [\(aliasNames)]),\n")
     }
   }
 }

--- a/Sources/protoc-gen-swift/EnumCaseGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumCaseGenerator.swift
@@ -23,6 +23,10 @@ class EnumCaseGenerator {
   internal let swiftName: String
   internal let path: [Int32]
   internal let comments: String
+  internal let aliasOfGenerator: EnumCaseGenerator?
+
+  private let visibility: String
+  private var aliases = [Weak<EnumCaseGenerator>]()
 
   internal var protoName: String {
     return descriptor.name
@@ -32,25 +36,76 @@ class EnumCaseGenerator {
     return Int(descriptor.number)
   }
 
+  /// True if the enum case is an alias for a case defined earlier, or false if
+  /// it is not an alias.
+  internal var isAlias: Bool {
+    return aliasOfGenerator != nil
+  }
+
   init(descriptor: Google_Protobuf_EnumValueDescriptorProto,
-       path: [Int32],
-       file: FileGenerator,
-       stripLength: Int
+    path: [Int32],
+    file: FileGenerator,
+    stripLength: Int,
+    aliasing aliasOfGenerator: EnumCaseGenerator?
   ) {
     self.descriptor = descriptor
     self.swiftName = descriptor.getSwiftName(stripLength: stripLength)
     self.path = path
     self.comments = file.commentsFor(path: path)
+    self.aliasOfGenerator = aliasOfGenerator
+
+    self.visibility = file.generatorOptions.visibilitySourceSnippet
   }
 
-  /// Generates the `case` for the enum value.
+  /// Registers the given enum case generator as an alias of the receiver.
+  ///
+  /// - Precondition: `generator.descriptor.number == self.descriptor.number`.
+  ///
+  /// - Parameter generator: The `EnumCaseGenerator` that is an alias of this
+  ///   one.
+  func registerAlias(_ generator: EnumCaseGenerator) {
+    precondition(generator.descriptor.number == descriptor.number,
+                 "Aliases must have matching numbers.")
+
+    aliases.append(Weak(generator))
+  }
+
+  /// Generates the `case` for the enum value, or a static read-only property
+  /// if it is an alias for another value.
   ///
   /// - Parameter p: The code printer.
-  func generateCase(printer p: inout CodePrinter) {
+  func generateCaseOrAlias(printer p: inout CodePrinter) {
     if !comments.isEmpty {
       p.print("\n")
       p.print(comments)
     }
-    p.print("case \(swiftName) // = \(number)\n")
+    if let aliasOf = aliasOfGenerator {
+      p.print("\(visibility)static let \(swiftName) = \(aliasOf.swiftName)\n")
+    } else {
+      p.print("case \(swiftName) // = \(number)\n")
+    }
+  }
+
+  /// Generates the `key: value` entry in the name map for the enum case and
+  /// its aliases.
+  ///
+  /// - Precondition: `self.isAlias == false`.
+  ///
+  /// - Parameter p: The code printer.
+  func generateNameMapEntry(printer p: inout CodePrinter) {
+    precondition(!isAlias, "Only supported for non-alias generators.")
+
+    if aliases.isEmpty {
+      p.print("\(number): .same(proto: \"\(protoName)\"),\n")
+    } else {
+      // The force-unwrap here on the weak wrapped reference is safe because if
+      // the generator got released, a lot of other things would have gone
+      // wrong.
+      let aliasNames = aliases.map {
+        "\"\($0.wrapped!.protoName)\""
+      }.joined(separator: ", ")
+
+      p.print("\(number): .aliased(primary: \"\(protoName)\", aliases: [\(aliasNames)]),\n")
+    }
   }
 }

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -128,7 +128,7 @@ class EnumGenerator {
     } else {
       p.print("\(visibility)static let _protobuf_nameMap: SwiftProtobuf._NameMap = [\n")
       p.indent()
-      for c in enumCases where !c.isAlias {
+      for c in enumCases.sorted(by: areCaseNumbersAscending) where !c.isAlias {
         c.generateNameMapEntry(printer: &p)
       }
       p.outdent()
@@ -143,7 +143,7 @@ class EnumGenerator {
     p.print("\(visibility)init?(rawValue: Int) {\n")
     p.indent()
     p.print("switch rawValue {\n")
-    for c in enumCases where !c.isAlias {
+    for c in enumCases.sorted(by: areCaseNumbersAscending) where !c.isAlias {
       p.print("case \(c.number): self = .\(c.swiftName)\n")
     }
     if isProto3 {
@@ -163,7 +163,7 @@ class EnumGenerator {
     p.print("\(visibility)var rawValue: Int {\n")
     p.indent()
     p.print("switch self {\n")
-    for c in enumCases where !c.isAlias {
+    for c in enumCases.sorted(by: areCaseNumbersAscending) where !c.isAlias {
       p.print("case .\(c.swiftName): return \(c.number)\n")
     }
     if isProto3 {
@@ -173,4 +173,14 @@ class EnumGenerator {
     p.outdent()
     p.print("}\n")
   }
+}
+
+/// Comparison function used to sort the enum cases based on their number.
+///
+/// - Parameter first: A case generator.
+/// - Parameter second: A case generator.
+/// - Returns: True if the cases are in ascending order based on their number.
+private func areCaseNumbersAscending(_ first: EnumCaseGenerator,
+                                     _ second: EnumCaseGenerator) -> Bool {
+  return first.number < second.number
 }

--- a/Sources/protoc-gen-swift/Weak.swift
+++ b/Sources/protoc-gen-swift/Weak.swift
@@ -1,0 +1,29 @@
+// Sources/protoc-gen-swift/Weak.swift - Weak reference helpers
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Helper types to work with weak references.
+///
+// -----------------------------------------------------------------------------
+
+/// A wrapper that holds a weak reference to an object so that it can be stored
+/// in a collection without strongly retaining the reference.
+internal struct Weak<Wrapped: AnyObject> {
+
+  /// The object that is being weakly referenced. May be nil if the object was
+  /// released after the receiver was created.
+  internal private(set) weak var wrapped: Wrapped?
+
+  /// Creates a value that weakly wraps a reference to the given object.
+  ///
+  /// - Parameter wrapped: The object to be weakly retained.
+  internal init(_ wrapped: Wrapped) {
+    self.wrapped = wrapped
+  }
+}

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -230,6 +230,9 @@
 		AAABA40C1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */; };
 		AAABA40D1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */; };
 		AAABA40E1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */; };
+		AAE0F4DF1E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE0F4DE1E6A3886005240E0 /* Test_EnumWithAliases.swift */; };
+		AAE0F4E01E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE0F4DE1E6A3886005240E0 /* Test_EnumWithAliases.swift */; };
+		AAE0F4E11E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE0F4DE1E6A3886005240E0 /* Test_EnumWithAliases.swift */; };
 		AAEA52201DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA521F1DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift */; };
 		AAEA52211DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA521F1DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift */; };
 		AAEA52721DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */; };
@@ -611,6 +614,7 @@
 		AA6CF6F01DB6D1F8007DF26B /* Test_Enum_Proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_Enum_Proto2.swift; sourceTree = "<group>"; };
 		AA86F6F91E0A0F0B006CC38A /* JSONEncodingVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONEncodingVisitor.swift; sourceTree = "<group>"; };
 		AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtobufAPIVersionCheck.swift; sourceTree = "<group>"; };
+		AAE0F4DE1E6A3886005240E0 /* Test_EnumWithAliases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_EnumWithAliases.swift; sourceTree = "<group>"; };
 		AAEA521F1DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Message+UInt8ArrayHelpers.swift"; sourceTree = "<group>"; };
 		AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Wrappers+Extensions.swift"; sourceTree = "<group>"; };
 		AAEA52731DA80DEA003F318F /* wrappers.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = wrappers.pb.swift; sourceTree = "<group>"; };
@@ -908,6 +912,7 @@
 				__PBXFileRef_Tests/ProtobufTests/Test_Empty.swift /* Test_Empty.swift */,
 				AA6CF6F01DB6D1F8007DF26B /* Test_Enum_Proto2.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Enum.swift /* Test_Enum.swift */,
+				AAE0F4DE1E6A3886005240E0 /* Test_EnumWithAliases.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_Extensions.swift /* Test_Extensions.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_ExtremeDefaultValues.swift /* Test_ExtremeDefaultValues.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_FieldMask.swift /* Test_FieldMask.swift */,
@@ -1178,6 +1183,7 @@
 				9C8CDA1F1D7A28F600E207CA /* descriptor.pb.swift in Sources */,
 				9C8CDA211D7A28F600E207CA /* map_unittest.pb.swift in Sources */,
 				AAEA52211DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift in Sources */,
+				AAE0F4E01E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */,
 				9C8CDA201D7A28F600E207CA /* TestHelpers.swift in Sources */,
 				9C8CDA231D7A28F600E207CA /* Test_AllTypes.swift in Sources */,
 				9CCD5F941E008203002D1940 /* Test_TextFormat_WKT_proto3.swift in Sources */,
@@ -1420,6 +1426,7 @@
 				9C2F237A1D77807E008524F2 /* descriptor.pb.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/map_unittest.pb.swift /* map_unittest.pb.swift in Sources */,
 				AAEA52201DA5BB81003F318F /* Message+UInt8ArrayHelpers.swift in Sources */,
+				AAE0F4DF1E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/TestHelpers.swift /* TestHelpers.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_AllTypes.swift /* Test_AllTypes.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_AllTypes_Proto3.swift /* Test_AllTypes_Proto3.swift in Sources */,
@@ -1593,6 +1600,7 @@
 				F44F93DD1DAEA8C900BC5B85 /* unittest_lite.pb.swift in Sources */,
 				F44F93B31DAEA8C900BC5B85 /* Test_Any.swift in Sources */,
 				F44F93B71DAEA8C900BC5B85 /* Test_Duration.swift in Sources */,
+				AAE0F4E11E6A3886005240E0 /* Test_EnumWithAliases.swift in Sources */,
 				F44F93DF1DAEA8C900BC5B85 /* unittest_mset.pb.swift in Sources */,
 				F44F93D51DAEA8C900BC5B85 /* unittest_empty.pb.swift in Sources */,
 				F44F93C11DAEA8C900BC5B85 /* Test_JSON.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -406,6 +406,17 @@ extension Test_Enum {
     }
 }
 
+extension Test_EnumWithAliases {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testJSONEncodeUsesOriginalNames", {try run_test(test:($0 as! Test_EnumWithAliases).testJSONEncodeUsesOriginalNames)}),
+            ("testJSONDecodeAcceptsAllNames", {try run_test(test:($0 as! Test_EnumWithAliases).testJSONDecodeAcceptsAllNames)}),
+            ("testTextFormatEncodeUsesOriginalNames", {try run_test(test:($0 as! Test_EnumWithAliases).testTextFormatEncodeUsesOriginalNames)}),
+            ("testTextFormatDecodeAcceptsAllNames", {try run_test(test:($0 as! Test_EnumWithAliases).testTextFormatDecodeAcceptsAllNames)})
+        ]
+    }
+}
+
 extension Test_Enum_Proto2 {
     static var allTests: [(String, (XCTestCase) throws -> ())] {
         return [
@@ -1080,6 +1091,7 @@ XCTMain(
         (testCaseClass: Test_Duration.self, allTests: Test_Duration.allTests),
         (testCaseClass: Test_Empty.self, allTests: Test_Empty.allTests),
         (testCaseClass: Test_Enum.self, allTests: Test_Enum.allTests),
+        (testCaseClass: Test_EnumWithAliases.self, allTests: Test_EnumWithAliases.allTests),
         (testCaseClass: Test_Enum_Proto2.self, allTests: Test_Enum_Proto2.allTests),
         (testCaseClass: Test_Extensions.self, allTests: Test_Extensions.allTests),
         (testCaseClass: Test_ExtremeDefaultValues.self, allTests: Test_ExtremeDefaultValues.allTests),

--- a/Tests/SwiftProtobufTests/Test_EnumWithAliases.swift
+++ b/Tests/SwiftProtobufTests/Test_EnumWithAliases.swift
@@ -1,6 +1,6 @@
-// Tests/SwiftProtobufTests/Test_Enum.swift - Exercise generated enums
+// Tests/SwiftProtobufTests/Test_EnumWithAliases.swift - Exercise generated enums
 //
-// Copyright (c) 2014 - 2016 Apple Inc. and the project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See LICENSE.txt for license information:

--- a/Tests/SwiftProtobufTests/Test_EnumWithAliases.swift
+++ b/Tests/SwiftProtobufTests/Test_EnumWithAliases.swift
@@ -1,0 +1,62 @@
+// Tests/SwiftProtobufTests/Test_Enum.swift - Exercise generated enums
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Check that proto enums are properly translated into Swift enums.  Among
+/// other things, enums can have duplicate tags, the names should be correctly
+/// translated into Swift lowerCamelCase conventions, etc.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+import XCTest
+
+class Test_EnumWithAliases: XCTestCase, PBTestHelpers {
+  typealias MessageTestType = ProtobufUnittest_SwiftEnumWithAliasTest
+
+  func testJSONEncodeUsesOriginalNames() {
+    assertJSONEncode("{\"values\":[\"FOO1\",\"BAR1\"]}") { (m: inout MessageTestType) in
+      m.values = [.foo1, .bar1]
+    }
+
+    assertJSONEncode("{\"values\":[\"FOO1\",\"BAR1\"]}") { (m: inout MessageTestType) in
+      m.values = [.foo2, .bar2]
+    }
+  }
+
+  func testJSONDecodeAcceptsAllNames() throws {
+    assertJSONDecodeSucceeds("{\"values\":[\"FOO1\",\"BAR1\"]}") { (m: MessageTestType) in
+      return m.values == [.foo1, .bar1]
+    }
+
+    assertJSONDecodeSucceeds("{\"values\":[\"FOO2\",\"BAR2\"]}") { (m: MessageTestType) in
+      return m.values == [.foo1, .bar1]
+    }
+  }
+
+  func testTextFormatEncodeUsesOriginalNames() {
+    assertTextFormatEncode("values: [FOO1, BAR1]\n") { (m: inout MessageTestType) in
+      m.values = [.foo1, .bar1]
+    }
+
+    assertTextFormatEncode("values: [FOO1, BAR1]\n") { (m: inout MessageTestType) in
+      m.values = [.foo2, .bar2]
+    }
+  }
+
+  func testTextFormatDecodeAcceptsAllNames() throws {
+    assertTextFormatDecodeSucceeds("values: [FOO1, BAR1]\n") { (m: MessageTestType) in
+      return m.values == [.foo1, .bar1]
+    }
+
+    assertTextFormatDecodeSucceeds("values: [FOO2, BAR2]\n") { (m: MessageTestType) in
+      return m.values == [.foo1, .bar1]
+    }
+  }
+}

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -1380,10 +1380,10 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
     case UNRECOGNIZED(Int)
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       0: .same(proto: "FOO"),
       1: .same(proto: "BAR"),
       2: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -1392,20 +1392,20 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message, SwiftPro
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 0: self = .foo
       case 1: self = .bar
       case 2: self = .baz
-      case -1: self = .neg
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .foo: return 0
       case .bar: return 1
       case .baz: return 2
-      case .neg: return -1
       case .UNRECOGNIZED(let i): return i
       }
     }

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -100,8 +100,8 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._P
   static let bar2 = bar1
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
-    2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
+    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
     3: .same(proto: "BAZ"),
   ]
 
@@ -140,13 +140,13 @@ enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNa
   case sparseG // = 2
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -53452: .same(proto: "SPARSE_E"),
+    -15: .same(proto: "SPARSE_D"),
+    0: .same(proto: "SPARSE_F"),
+    2: .same(proto: "SPARSE_G"),
     123: .same(proto: "SPARSE_A"),
     62374: .same(proto: "SPARSE_B"),
     12589234: .same(proto: "SPARSE_C"),
-    -15: .same(proto: "SPARSE_D"),
-    -53452: .same(proto: "SPARSE_E"),
-    0: .same(proto: "SPARSE_F"),
-    2: .same(proto: "SPARSE_G"),
   ]
 
   init() {
@@ -155,26 +155,26 @@ enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNa
 
   init?(rawValue: Int) {
     switch rawValue {
+    case -53452: self = .sparseE
+    case -15: self = .sparseD
+    case 0: self = .sparseF
+    case 2: self = .sparseG
     case 123: self = .sparseA
     case 62374: self = .sparseB
     case 12589234: self = .sparseC
-    case -15: self = .sparseD
-    case -53452: self = .sparseE
-    case 0: self = .sparseF
-    case 2: self = .sparseG
     default: return nil
     }
   }
 
   var rawValue: Int {
     switch self {
+    case .sparseE: return -53452
+    case .sparseD: return -15
+    case .sparseF: return 0
+    case .sparseG: return 2
     case .sparseA: return 123
     case .sparseB: return 62374
     case .sparseC: return 12589234
-    case .sparseD: return -15
-    case .sparseE: return -53452
-    case .sparseF: return 0
-    case .sparseG: return 2
     }
   }
 
@@ -1202,10 +1202,10 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Mess
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -1214,20 +1214,20 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Mess
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: return nil
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       }
     }
 

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -96,15 +96,13 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._P
   case foo1 // = 1
   case bar1 // = 2
   case baz // = 3
-  case foo2 // = 1
-  case bar2 // = 2
+  static let foo2 = foo1
+  static let bar2 = bar1
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "FOO1"),
-    2: .same(proto: "BAR1"),
+    1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
     3: .same(proto: "BAZ"),
-    1: .same(proto: "FOO2"),
-    2: .same(proto: "BAR2"),
   ]
 
   init() {
@@ -125,8 +123,6 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._P
     case .foo1: return 1
     case .bar1: return 2
     case .baz: return 3
-    case .foo2: return 1
-    case .bar2: return 2
     }
   }
 

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -381,8 +381,8 @@ struct ProtobufUnittest_DummyMessageContainingEnum: SwiftProtobuf.Message, Swift
     case testOptionEnumType2 // = -23
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      22: .same(proto: "TEST_OPTION_ENUM_TYPE1"),
       -23: .same(proto: "TEST_OPTION_ENUM_TYPE2"),
+      22: .same(proto: "TEST_OPTION_ENUM_TYPE1"),
     ]
 
     init() {
@@ -391,16 +391,16 @@ struct ProtobufUnittest_DummyMessageContainingEnum: SwiftProtobuf.Message, Swift
 
     init?(rawValue: Int) {
       switch rawValue {
-      case 22: self = .testOptionEnumType1
       case -23: self = .testOptionEnumType2
+      case 22: self = .testOptionEnumType1
       default: return nil
       }
     }
 
     var rawValue: Int {
       switch self {
-      case .testOptionEnumType1: return 22
       case .testOptionEnumType2: return -23
+      case .testOptionEnumType1: return 22
       }
     }
 

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -1140,10 +1140,10 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -1152,20 +1152,20 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: return nil
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       }
     }
 

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -109,8 +109,8 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED"),
-    1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
-    2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
+    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
     3: .same(proto: "BAZ"),
   ]
 
@@ -156,13 +156,13 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding
   case UNRECOGNIZED(Int)
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -53452: .same(proto: "SPARSE_E"),
+    -15: .same(proto: "SPARSE_D"),
     0: .same(proto: "TEST_SPARSE_ENUM_UNSPECIFIED"),
+    2: .same(proto: "SPARSE_G"),
     123: .same(proto: "SPARSE_A"),
     62374: .same(proto: "SPARSE_B"),
     12589234: .same(proto: "SPARSE_C"),
-    -15: .same(proto: "SPARSE_D"),
-    -53452: .same(proto: "SPARSE_E"),
-    2: .same(proto: "SPARSE_G"),
   ]
 
   init() {
@@ -171,26 +171,26 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding
 
   init?(rawValue: Int) {
     switch rawValue {
+    case -53452: self = .sparseE
+    case -15: self = .sparseD
     case 0: self = .testSparseEnumUnspecified
+    case 2: self = .sparseG
     case 123: self = .sparseA
     case 62374: self = .sparseB
     case 12589234: self = .sparseC
-    case -15: self = .sparseD
-    case -53452: self = .sparseE
-    case 2: self = .sparseG
     default: self = .UNRECOGNIZED(rawValue)
     }
   }
 
   var rawValue: Int {
     switch self {
+    case .sparseE: return -53452
+    case .sparseD: return -15
     case .testSparseEnumUnspecified: return 0
+    case .sparseG: return 2
     case .sparseA: return 123
     case .sparseB: return 62374
     case .sparseC: return 12589234
-    case .sparseD: return -15
-    case .sparseE: return -53452
-    case .sparseG: return 2
     case .UNRECOGNIZED(let i): return i
     }
   }
@@ -747,11 +747,11 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
     case UNRECOGNIZED(Int)
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       0: .same(proto: "NESTED_ENUM_UNSPECIFIED"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -760,22 +760,22 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplemen
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 0: self = .nestedEnumUnspecified
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .nestedEnumUnspecified: return 0
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       case .UNRECOGNIZED(let i): return i
       }
     }

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -103,17 +103,15 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
   case foo1 // = 1
   case bar1 // = 2
   case baz // = 3
-  case foo2 // = 1
-  case bar2 // = 2
+  static let foo2 = foo1
+  static let bar2 = bar1
   case UNRECOGNIZED(Int)
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED"),
-    1: .same(proto: "FOO1"),
-    2: .same(proto: "BAR1"),
+    1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
     3: .same(proto: "BAZ"),
-    1: .same(proto: "FOO2"),
-    2: .same(proto: "BAR2"),
   ]
 
   init() {
@@ -136,8 +134,6 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
     case .foo1: return 1
     case .bar1: return 2
     case .baz: return 3
-    case .foo2: return 1
-    case .bar2: return 2
     case .UNRECOGNIZED(let i): return i
     }
   }

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -689,11 +689,11 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     case UNRECOGNIZED(Int)
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       0: .same(proto: "ZERO"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -702,22 +702,22 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 0: self = .zero
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: self = .UNRECOGNIZED(rawValue)
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .zero: return 0
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       case .UNRECOGNIZED(let i): return i
       }
     }

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -870,10 +870,10 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      -1: .same(proto: "NEG"),
       1: .same(proto: "FOO"),
       2: .same(proto: "BAR"),
       3: .same(proto: "BAZ"),
-      -1: .same(proto: "NEG"),
     ]
 
     init() {
@@ -882,20 +882,20 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message, SwiftProtob
 
     init?(rawValue: Int) {
       switch rawValue {
+      case -1: self = .neg
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
-      case -1: self = .neg
       default: return nil
       }
     }
 
     var rawValue: Int {
       switch self {
+      case .neg: return -1
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
-      case .neg: return -1
       }
     }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
@@ -200,3 +200,76 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message, SwiftProtobuf._Mes
     return true
   }
 }
+
+struct ProtobufUnittest_SwiftEnumWithAliasTest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = "SwiftEnumWithAliasTest"
+  static let protoPackageName: String = "protobuf_unittest"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "values"),
+  ]
+
+  var values: [ProtobufUnittest_SwiftEnumWithAliasTest.EnumWithAlias] = []
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  enum EnumWithAlias: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+    typealias RawValue = Int
+    case foo1 // = 1
+    static let foo2 = foo1
+    case bar1 // = 2
+    static let bar2 = bar1
+
+    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+      1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
+      2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
+    ]
+
+    init() {
+      self = .foo1
+    }
+
+    init?(rawValue: Int) {
+      switch rawValue {
+      case 1: self = .foo1
+      case 2: self = .bar1
+      default: return nil
+      }
+    }
+
+    var rawValue: Int {
+      switch self {
+      case .foo1: return 1
+      case .bar1: return 2
+      }
+    }
+
+  }
+
+  init() {}
+
+  mutating func _protobuf_generated_decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      try decodeField(decoder: &decoder, fieldNumber: fieldNumber)
+    }
+  }
+
+  mutating func _protobuf_generated_decodeField<D: SwiftProtobuf.Decoder>(decoder: inout D, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1: try decoder.decodeRepeatedEnumField(value: &values)
+    default: break
+    }
+  }
+
+  func _protobuf_generated_traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !values.isEmpty {
+      try visitor.visitPackedEnumField(value: values, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  func _protobuf_generated_isEqualTo(other: ProtobufUnittest_SwiftEnumWithAliasTest) -> Bool {
+    if values != other.values {return false}
+    if unknownFields != other.unknownFields {return false}
+    return true
+  }
+}

--- a/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
@@ -220,8 +220,8 @@ struct ProtobufUnittest_SwiftEnumWithAliasTest: SwiftProtobuf.Message, SwiftProt
     static let bar2 = bar1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .aliased(primary: "FOO1", aliases: ["FOO2"]),
-      2: .aliased(primary: "BAR1", aliases: ["BAR2"]),
+      1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+      2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
     ]
 
     init() {


### PR DESCRIPTION
Generate `static let` properties for enum aliases instead of separate cases, to avoid requiring original values *and* aliases to be present in exhaustive switches.

Updated `NameMap` to support multiple names for a particular number, and added tests to verify that the primary (first encountered) name is used during encoding text format/JSON and that all names (primary and aliases) are accepted when decoding.

Fixes #354.