### PR TITLE
Add convenience init/getters for Timestamp.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
@@ -14,6 +14,7 @@
 // -----------------------------------------------------------------------------
 
 import Foundation
+
 private let minTimestampSeconds: Int64 = -62135596800  // 0001-01-01T00:00:00Z
 private let maxTimestampSeconds: Int64 = 253402300799  // 9999-12-31T23:59:59Z
 
@@ -219,6 +220,8 @@ extension Google_Protobuf_Timestamp: _CustomJSONCodable {
 }
 
 public extension Google_Protobuf_Timestamp {
+    /// Returns a `Google_Protobuf_Timestamp` initialized relative to 00:00:00
+    /// UTC on 1 January 1970 by a given number of seconds.
     public init(timeIntervalSince1970: TimeInterval) {
         let sd = floor(timeIntervalSince1970)
         let nd = round((timeIntervalSince1970 - sd) * TimeInterval(nanosPerSecond))
@@ -226,6 +229,8 @@ public extension Google_Protobuf_Timestamp {
         self.init(seconds: s, nanos: n)
     }
 
+    /// Returns a `Google_Protobuf_Timestamp` initialized relative to 00:00:00
+    /// UTC on 1 January 2001 by a given number of seconds.
     public init(timeIntervalSinceReferenceDate: TimeInterval) {
         let sd = floor(timeIntervalSinceReferenceDate)
         let nd = round((timeIntervalSinceReferenceDate - sd) * TimeInterval(nanosPerSecond))
@@ -236,6 +241,8 @@ public extension Google_Protobuf_Timestamp {
         self.init(seconds: s, nanos: n)
     }
 
+    /// Returns a `Google_Protobuf_Timestamp` initialized to the same time as
+    /// the given `Date`.
     public init(date: Date) {
         // Note: Internally, Date uses the "reference date," not the 1970 date.
         // We use it when interacting with Dates so that Date doesn't perform
@@ -243,14 +250,19 @@ public extension Google_Protobuf_Timestamp {
         self.init(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate)
     }
 
+    /// The interval between the timestamp and 00:00:00 UTC on 1 January
+    /// 1970.
     public var timeIntervalSince1970: TimeInterval {
         return TimeInterval(self.seconds) + TimeInterval(self.nanos) / TimeInterval(nanosPerSecond)
     }
 
+    /// The interval between the timestamp and 00:00:00 UTC on 1 January
+    /// 2001.
     public var timeIntervalSinceReferenceDate: TimeInterval {
         return TimeInterval(self.seconds - Int64(Date.timeIntervalBetween1970AndReferenceDate)) + TimeInterval(self.nanos) / TimeInterval(nanosPerSecond)
     }
 
+    /// A `Date` initialized to the same time as the timestamp.
     public var date: Date {
         return Date(timeIntervalSinceReferenceDate: self.timeIntervalSinceReferenceDate)
     }

--- a/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Timestamp+Extensions.swift
@@ -13,6 +13,7 @@
 ///
 // -----------------------------------------------------------------------------
 
+import Foundation
 private let minTimestampSeconds: Int64 = -62135596800  // 0001-01-01T00:00:00Z
 private let maxTimestampSeconds: Int64 = 253402300799  // 9999-12-31T23:59:59Z
 
@@ -182,7 +183,7 @@ private func formatTimestamp(seconds: Int64, nanos: Int32) -> String? {
 
     let (hh, mm, ss) = timeOfDayFromSecondsSince1970(seconds: seconds)
     let (YY, MM, DD) = gregorianDateFromSecondsSince1970(seconds: seconds)
-    
+
     if nanos == 0 {
         return String(format: "%04d-%02d-%02dT%02d:%02d:%02dZ", YY, MM, DD, hh, mm, ss)
     } else if nanos % 1000000 == 0 {
@@ -217,6 +218,44 @@ extension Google_Protobuf_Timestamp: _CustomJSONCodable {
     }
 }
 
+public extension Google_Protobuf_Timestamp {
+    public init(timeIntervalSince1970: TimeInterval) {
+        let sd = floor(timeIntervalSince1970)
+        let nd = round((timeIntervalSince1970 - sd) * TimeInterval(nanosPerSecond))
+        let (s, n) = normalizeForTimestamp(seconds: Int64(sd), nanos: Int32(nd))
+        self.init(seconds: s, nanos: n)
+    }
+
+    public init(timeIntervalSinceReferenceDate: TimeInterval) {
+        let sd = floor(timeIntervalSinceReferenceDate)
+        let nd = round((timeIntervalSinceReferenceDate - sd) * TimeInterval(nanosPerSecond))
+        // The addition of timeIntervalBetween1970And... is deliberately delayed
+        // until the input is separated into an integer part and a fraction
+        // part, so that we don't unnecessarily lose precision.
+        let (s, n) = normalizeForTimestamp(seconds: Int64(sd) + Int64(Date.timeIntervalBetween1970AndReferenceDate), nanos: Int32(nd))
+        self.init(seconds: s, nanos: n)
+    }
+
+    public init(date: Date) {
+        // Note: Internally, Date uses the "reference date," not the 1970 date.
+        // We use it when interacting with Dates so that Date doesn't perform
+        // any double arithmetic on our behalf, which might cost us precision.
+        self.init(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate)
+    }
+
+    public var timeIntervalSince1970: TimeInterval {
+        return TimeInterval(self.seconds) + TimeInterval(self.nanos) / TimeInterval(nanosPerSecond)
+    }
+
+    public var timeIntervalSinceReferenceDate: TimeInterval {
+        return TimeInterval(self.seconds - Int64(Date.timeIntervalBetween1970AndReferenceDate)) + TimeInterval(self.nanos) / TimeInterval(nanosPerSecond)
+    }
+
+    public var date: Date {
+        return Date(timeIntervalSinceReferenceDate: self.timeIntervalSinceReferenceDate)
+    }
+}
+
 private func normalizeForTimestamp(seconds: Int64, nanos: Int32) -> (seconds: Int64, nanos: Int32) {
     // The Timestamp spec says that nanos must be in the range [0, 999999999),
     // as in actual modular arithmetic.
@@ -240,4 +279,3 @@ public func -(lhs: Google_Protobuf_Timestamp, rhs: Google_Protobuf_Duration) -> 
     let (s, n) = normalizeForTimestamp(seconds: lhs.seconds - rhs.seconds, nanos: lhs.nanos - rhs.nanos)
     return Google_Protobuf_Timestamp(seconds: s, nanos: n)
 }
-

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1016,7 +1016,11 @@ extension Test_Timestamp {
             ("testJSON_conformance", {try run_test(test:($0 as! Test_Timestamp).testJSON_conformance)}),
             ("testSerializationFailure", {try run_test(test:($0 as! Test_Timestamp).testSerializationFailure)}),
             ("testBasicArithmetic", {try run_test(test:($0 as! Test_Timestamp).testBasicArithmetic)}),
-            ("testArithmeticNormalizes", {try run_test(test:($0 as! Test_Timestamp).testArithmeticNormalizes)})
+            ("testArithmeticNormalizes", {try run_test(test:($0 as! Test_Timestamp).testArithmeticNormalizes)}),
+            ("testInitializationByTimestamps", {try run_test(test:($0 as! Test_Timestamp).testInitializationByTimestamps)}),
+            ("testInitializationByReferenceTimestamp", {try run_test(test:($0 as! Test_Timestamp).testInitializationByReferenceTimestamp)}),
+            ("testInitializationByDates", {try run_test(test:($0 as! Test_Timestamp).testInitializationByDates)}),
+            ("testTimestampGetters", {try run_test(test:($0 as! Test_Timestamp).testTimestampGetters)})
         ]
     }
 }

--- a/Tests/SwiftProtobufTests/Test_Timestamp.swift
+++ b/Tests/SwiftProtobufTests/Test_Timestamp.swift
@@ -352,11 +352,76 @@ class Test_Timestamp: XCTestCase, PBTestHelpers {
         XCTAssertEqual(r7.nanos, 999999999)
     }
 
-
     // TODO: Should setter correct for out-of-range
     // nanos and other minor inconsistencies?
 
-    // TODO: Consider implementing convenience
-    // setters/getters/initializers that convert to
-    // common date/time types.
+    func testInitializationByTimestamps() throws {
+        // Negative timestamp
+        let t1 = Google_Protobuf_Timestamp(timeIntervalSince1970: -123.456)
+        XCTAssertEqual(t1.seconds, -124)
+        XCTAssertEqual(t1.nanos, 544000000)
+
+        // Full precision
+        let t2 = Google_Protobuf_Timestamp(timeIntervalSince1970: -123.999999999)
+        XCTAssertEqual(t2.seconds, -124)
+        XCTAssertEqual(t2.nanos, 1)
+
+        // Round up
+        let t3 = Google_Protobuf_Timestamp(timeIntervalSince1970: -123.9999999994)
+        XCTAssertEqual(t3.seconds, -124)
+        XCTAssertEqual(t3.nanos, 1)
+
+        // Round down
+        let t4 = Google_Protobuf_Timestamp(timeIntervalSince1970: -123.9999999996)
+        XCTAssertEqual(t4.seconds, -124)
+        XCTAssertEqual(t4.nanos, 0)
+
+        let t5 = Google_Protobuf_Timestamp(timeIntervalSince1970: 0)
+        XCTAssertEqual(t5.seconds, 0)
+        XCTAssertEqual(t5.nanos, 0)
+
+        // Positive timestamp
+        let t6 = Google_Protobuf_Timestamp(timeIntervalSince1970: 123.456)
+        XCTAssertEqual(t6.seconds, 123)
+        XCTAssertEqual(t6.nanos, 456000000)
+
+        // Full precision
+        let t7 = Google_Protobuf_Timestamp(timeIntervalSince1970: 123.999999999)
+        XCTAssertEqual(t7.seconds, 123)
+        XCTAssertEqual(t7.nanos, 999999999)
+
+        // Round down
+        let t8 = Google_Protobuf_Timestamp(timeIntervalSince1970: 123.9999999994)
+        XCTAssertEqual(t8.seconds, 123)
+        XCTAssertEqual(t8.nanos, 999999999)
+
+        // Round up
+        let t9 = Google_Protobuf_Timestamp(timeIntervalSince1970: 123.9999999996)
+        XCTAssertEqual(t9.seconds, 124)
+        XCTAssertEqual(t9.nanos, 0)
+    }
+
+    func testInitializationByReferenceTimestamp() throws {
+        let t1 = Google_Protobuf_Timestamp(timeIntervalSinceReferenceDate: 123.456)
+        XCTAssertEqual(t1.seconds, 978307323)
+        XCTAssertEqual(t1.nanos, 456000000)
+    }
+
+    func testInitializationByDates() throws {
+        let t1 = Google_Protobuf_Timestamp(date: Date(timeIntervalSinceReferenceDate: 123.456))
+        XCTAssertEqual(t1.seconds, 978307323)
+        XCTAssertEqual(t1.nanos, 456000000)
+    }
+
+    func testTimestampGetters() throws {
+        let t1 = Google_Protobuf_Timestamp(seconds: 12345678, nanos: 12345678)
+        XCTAssertEqual(t1.seconds, 12345678)
+        XCTAssertEqual(t1.nanos, 12345678)
+        // There is a lot of double arithmetic here. These values are not going
+        // to be exact, of course.
+        XCTAssertEqualWithAccuracy(t1.timeIntervalSince1970, 12345678.012345678, accuracy: 1e-30)
+        XCTAssertEqualWithAccuracy(t1.timeIntervalSinceReferenceDate, -965961521.987654322, accuracy: 1e-30)
+        let d = t1.date
+        XCTAssertEqualWithAccuracy(d.timeIntervalSinceReferenceDate, -965961521.987654322, accuracy: 1e-30)
+    }
 }


### PR DESCRIPTION
This change adds init methods to Google_Protobuf_Timestamp for
Foundation.Date, and for TimeInterval (double) values in relation to Jan
1 1970 and Jan 1 2001. Getters have also been added.

I'll look at a similar change for Google_Protobuf_Duration soon.