### PR TITLE
Add init/getter to Duration for TimeInterval

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -134,6 +134,10 @@ extension Google_Protobuf_Duration: _CustomJSONCodable {
 extension Google_Protobuf_Duration: ExpressibleByFloatLiteral {
     public typealias FloatLiteralType = Double
 
+    /// Returns a `Google_Protobuf_Duration` initialized to have the same
+    /// meaning as the given literal, when interpreted as a duration in seconds.
+    /// The result will be rounded to the nearest nano if the input has
+    /// precision beyond 1e-9.
     public init(floatLiteral value: Double) {
         let sd = trunc(value)
         let nd = round((value - sd) * TimeInterval(nanosPerSecond))
@@ -145,7 +149,8 @@ extension Google_Protobuf_Duration: ExpressibleByFloatLiteral {
 extension Google_Protobuf_Duration {
     /// Returns a `Google_Protobuf_Duration` initialized to have the same
     /// meaning as the given `TimeInterval`, when interpreted as a duration in
-    /// seconds.
+    /// seconds. The result will be rounded to the nearest nano if the input
+    /// has precision beyond 1e-9.
     public init(timeInterval: TimeInterval) {
         let sd = trunc(timeInterval)
         let nd = round((timeInterval - sd) * TimeInterval(nanosPerSecond))

--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -14,6 +14,8 @@
 ///
 // -----------------------------------------------------------------------------
 
+import Foundation
+
 private let minDurationSeconds: Int64 = -maxDurationSeconds
 private let maxDurationSeconds: Int64 = 315576000000
 
@@ -129,15 +131,38 @@ extension Google_Protobuf_Duration: _CustomJSONCodable {
     }
 }
 
-
 extension Google_Protobuf_Duration: ExpressibleByFloatLiteral {
     public typealias FloatLiteralType = Double
 
     public init(floatLiteral value: Double) {
+        // TODO: this rounds the nanos part towards zero, not to the nearest
+        // integer. So, 1.9999999999999... will get (1, 999999999), not 2. I
+        // believe this is OK in this case because the inputs are literals, so
+        // the programmer needed to actually type a lot of nines to get here,
+        // but it's a little weird that this is different than the conversion
+        // that happens for TimeInterval.
         let seconds = Int64(value)  // rounded towards zero
         let fractionalSeconds = value - Double(seconds)
         let nanos = Int32(fractionalSeconds * Double(nanosPerSecond))
         self.init(seconds: seconds, nanos: nanos)
+    }
+}
+
+extension Google_Protobuf_Duration {
+    /// Returns a `Google_Protobuf_Duration` initialized to have the same
+    /// meaning as the given `TimeInterval`, when interpreted as a duration in
+    /// seconds.
+    public init(timeInterval: TimeInterval) {
+        let sd = trunc(timeInterval)
+        let nd = round((timeInterval - sd) * TimeInterval(nanosPerSecond))
+        let (s, n) = normalizeForDuration(seconds: Int64(sd), nanos: Int32(nd))
+        self.init(seconds: s, nanos: n)
+    }
+
+    /// The `TimeInterval`, as a duration in seconds, with the same meaning as
+    /// this duration.
+    public var timeInterval: TimeInterval {
+        return TimeInterval(self.seconds) + TimeInterval(self.nanos) / TimeInterval(nanosPerSecond)
     }
 }
 

--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -135,16 +135,10 @@ extension Google_Protobuf_Duration: ExpressibleByFloatLiteral {
     public typealias FloatLiteralType = Double
 
     public init(floatLiteral value: Double) {
-        // TODO: this rounds the nanos part towards zero, not to the nearest
-        // integer. So, 1.9999999999999... will get (1, 999999999), not 2. I
-        // believe this is OK in this case because the inputs are literals, so
-        // the programmer needed to actually type a lot of nines to get here,
-        // but it's a little weird that this is different than the conversion
-        // that happens for TimeInterval.
-        let seconds = Int64(value)  // rounded towards zero
-        let fractionalSeconds = value - Double(seconds)
-        let nanos = Int32(fractionalSeconds * Double(nanosPerSecond))
-        self.init(seconds: seconds, nanos: nanos)
+        let sd = trunc(value)
+        let nd = round((value - sd) * TimeInterval(nanosPerSecond))
+        let (s, n) = normalizeForDuration(seconds: Int64(sd), nanos: Int32(nd))
+        self.init(seconds: s, nanos: n)
     }
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -381,7 +381,9 @@ extension Test_Duration {
             ("testConformance", {try run_test(test:($0 as! Test_Duration).testConformance)}),
             ("testBasicArithmetic", {try run_test(test:($0 as! Test_Duration).testBasicArithmetic)}),
             ("testArithmeticNormalizes", {try run_test(test:($0 as! Test_Duration).testArithmeticNormalizes)}),
-            ("testFloatLiteralConvertible", {try run_test(test:($0 as! Test_Duration).testFloatLiteralConvertible)})
+            ("testFloatLiteralConvertible", {try run_test(test:($0 as! Test_Duration).testFloatLiteralConvertible)}),
+            ("testInitializationByTimeIntervals", {try run_test(test:($0 as! Test_Duration).testInitializationByTimeIntervals)}),
+            ("testGetters", {try run_test(test:($0 as! Test_Duration).testGetters)})
         ]
     }
 }

--- a/Tests/SwiftProtobufTests/Test_Duration.swift
+++ b/Tests/SwiftProtobufTests/Test_Duration.swift
@@ -193,9 +193,8 @@ class Test_Duration: XCTestCase, PBTestHelpers {
         XCTAssertEqual(a, Google_Protobuf_Duration(seconds: 100, nanos: 1))
         a = 1.9999999991
         XCTAssertEqual(a, Google_Protobuf_Duration(seconds: 1, nanos: 999999999))
-        // See TODO in code--should this be rounded to nearest instead?
         a = 1.9999999999
-        XCTAssertEqual(a, Google_Protobuf_Duration(seconds: 1, nanos: 999999999))
+        XCTAssertEqual(a, Google_Protobuf_Duration(seconds: 2, nanos: 0))
 
         var c = ProtobufTestMessages_Proto3_TestAllTypes()
         c.optionalDuration = 100.000000001

--- a/Tests/SwiftProtobufTests/Test_Duration.swift
+++ b/Tests/SwiftProtobufTests/Test_Duration.swift
@@ -191,6 +191,11 @@ class Test_Duration: XCTestCase, PBTestHelpers {
         XCTAssertEqual(a, Google_Protobuf_Duration(seconds: 1, nanos: 500000000))
         a = 100.000000001
         XCTAssertEqual(a, Google_Protobuf_Duration(seconds: 100, nanos: 1))
+        a = 1.9999999991
+        XCTAssertEqual(a, Google_Protobuf_Duration(seconds: 1, nanos: 999999999))
+        // See TODO in code--should this be rounded to nearest instead?
+        a = 1.9999999999
+        XCTAssertEqual(a, Google_Protobuf_Duration(seconds: 1, nanos: 999999999))
 
         var c = ProtobufTestMessages_Proto3_TestAllTypes()
         c.optionalDuration = 100.000000001
@@ -198,5 +203,57 @@ class Test_Duration: XCTestCase, PBTestHelpers {
         XCTAssertEqual("{\"optionalDuration\":\"100.000000001s\"}", try c.jsonString())
     }
 
-    // TODO: Exercise convenience methods that interoperate with Foundation time types.
+    func testInitializationByTimeIntervals() throws {
+        // Negative interval
+        let t1 = Google_Protobuf_Duration(timeInterval: -123.456)
+        XCTAssertEqual(t1.seconds, -123)
+        XCTAssertEqual(t1.nanos, -456000000)
+
+        // Full precision
+        let t2 = Google_Protobuf_Duration(timeInterval: -123.999999999)
+        XCTAssertEqual(t2.seconds, -123)
+        XCTAssertEqual(t2.nanos, -999999999)
+
+        // Round up
+        let t3 = Google_Protobuf_Duration(timeInterval: -123.9999999994)
+        XCTAssertEqual(t3.seconds, -123)
+        XCTAssertEqual(t3.nanos, -999999999)
+
+        // Round down
+        let t4 = Google_Protobuf_Duration(timeInterval: -123.9999999996)
+        XCTAssertEqual(t4.seconds, -124)
+        XCTAssertEqual(t4.nanos, 0)
+
+        let t5 = Google_Protobuf_Duration(timeInterval: 0)
+        XCTAssertEqual(t5.seconds, 0)
+        XCTAssertEqual(t5.nanos, 0)
+
+        // Positive interval
+        let t6 = Google_Protobuf_Duration(timeInterval: 123.456)
+        XCTAssertEqual(t6.seconds, 123)
+        XCTAssertEqual(t6.nanos, 456000000)
+
+        // Full precision
+        let t7 = Google_Protobuf_Duration(timeInterval: 123.999999999)
+        XCTAssertEqual(t7.seconds, 123)
+        XCTAssertEqual(t7.nanos, 999999999)
+
+        // Round down
+        let t8 = Google_Protobuf_Duration(timeInterval: 123.9999999994)
+        XCTAssertEqual(t8.seconds, 123)
+        XCTAssertEqual(t8.nanos, 999999999)
+
+        // Round up
+        let t9 = Google_Protobuf_Duration(timeInterval: 123.9999999996)
+        XCTAssertEqual(t9.seconds, 124)
+        XCTAssertEqual(t9.nanos, 0)
+    }
+
+    func testGetters() throws {
+        let t1 = Google_Protobuf_Duration(seconds: -123, nanos: -123456789)
+        XCTAssertEqualWithAccuracy(t1.timeInterval, -123.123456789, accuracy: 1e-30)
+
+        let t2 = Google_Protobuf_Duration(seconds: 123, nanos: 123456789)
+        XCTAssertEqualWithAccuracy(t2.timeInterval, 123.123456789, accuracy: 1e-30)
+    }
 }


### PR DESCRIPTION
In Swift, TimeIntervals are durations in seconds, and this adds some
code and tests to work with them from Google_Protobuf_Duration.