### PR TITLE
Linux fixes

### DIFF
--- a/Sources/SwiftProtobuf/JSONTypeAdditions.swift
+++ b/Sources/SwiftProtobuf/JSONTypeAdditions.swift
@@ -28,8 +28,11 @@ public extension Message {
     }
 
     public init(jsonString: String) throws {
-        let data = jsonString.data(using: String.Encoding.utf8)!
-        try self.init(jsonUTF8Data: data)
+        if let data = jsonString.data(using: String.Encoding.utf8) {
+            try self.init(jsonUTF8Data: data)
+        } else {
+            throw JSONDecodingError.truncated
+        }
     }
 
     public init(jsonUTF8Data: Data) throws {

--- a/Sources/SwiftProtobuf/MathUtils.swift
+++ b/Sources/SwiftProtobuf/MathUtils.swift
@@ -12,6 +12,12 @@
 ///
 // -----------------------------------------------------------------------------
 
+#if os(Linux)
+// Linux doesn't seem to define these by default.
+internal let FLT_DIG=6
+internal let DBL_DIG=15
+#endif
+
 /// Remainder in standard modular arithmetic (modulo). This coincides with (%)
 /// when a > 0.
 ///

--- a/Sources/SwiftProtobuf/MathUtils.swift
+++ b/Sources/SwiftProtobuf/MathUtils.swift
@@ -14,6 +14,7 @@
 
 #if os(Linux)
 // Linux doesn't seem to define these by default.
+// https://bugs.swift.org/browse/SR-4198
 internal let FLT_DIG=6
 internal let DBL_DIG=15
 #endif


### PR DESCRIPTION
This fixes two failures seen with Swift 3.0.2 Release on Ubuntu 16.04.

One appears to be a Swift bug:  attempting to convert an empty string to UTF8 consistently fails with some versions of Swift.

The other provides basic definitions of two C library constants that we use when converting floats and doubles to strings.