### PR TITLE
Ensure internal state gets reset.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
@@ -417,10 +417,14 @@ public struct Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNa
     // message type available), so the deferred logic here is still needed.
     mutating func decodeJSON(from decoder: inout JSONDecoder) throws {
         try decoder.scanner.skipRequiredObjectStart()
+        // Reset state
+        typeURL = nil
+        _jsonFields = nil
+        _message = nil
+        _value = nil
         if decoder.scanner.skipOptionalObjectEnd() {
             return
         }
-        _jsonFields = nil
         var jsonFields = [String:String]()
         while true {
             let key = try decoder.scanner.nextQuotedString()


### PR DESCRIPTION
During json decode, once the object is started, ensure the internal state is
completely reset even if the decode doesn't complete.