### PR TITLE
Ensure generated JSON is always valid.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
@@ -91,6 +91,17 @@ fileprivate func serializeAnyJSON(for message: Message, typeURL: String) throws 
     return visitor.stringResult
 }
 
+fileprivate func serializeAnyJSON(wktValueJSON value: String, typeURL: String) throws -> String {
+    var jsonEncoder = JSONEncoder()
+    jsonEncoder.startObject()
+    jsonEncoder.startField(name: "@type")
+    jsonEncoder.putStringValue(value: typeURL)
+    jsonEncoder.startField(name: "value")
+    jsonEncoder.append(text: value)
+    jsonEncoder.endObject()
+    return jsonEncoder.stringResult
+}
+
 public extension Message {
   /// Initialize this message from the provided `google.protobuf.Any`
   /// well-known type.
@@ -550,7 +561,7 @@ public struct Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNa
             if let m = message as? _CustomJSONCodable {
                 // Serialize a Well-known type to JSON:
                 let value = try m.encodedJSONString()
-                return "{\"@type\":\"\(url)\",\"value\":\(value)}"
+                return try serializeAnyJSON(wktValueJSON: value, typeURL: url)
             } else {
                 // Serialize a regular message to JSON:
                 return try serializeAnyJSON(for: message, typeURL: url)
@@ -566,7 +577,7 @@ public struct Google_Protobuf_Any: Message, _MessageImplementationBase, _ProtoNa
                 if let messageType = Google_Protobuf_Any.wellKnownTypes[messageTypeName] {
                     let m = try messageType.init(unpackingAny: self)
                     let value = try m.jsonString()
-                    return "{\"@type\":\"\(typeURL)\",\"value\":\(value)}"
+                    return try serializeAnyJSON(wktValueJSON: value, typeURL: typeURL)
                 }
                 // Otherwise, it may be a registered type:
                 if let messageType = Google_Protobuf_Any.knownTypes[messageTypeName] {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -204,7 +204,9 @@ extension Test_Any {
             ("test_Any_Value_int_JSON_roundtrip", {try run_test(test:($0 as! Test_Any).test_Any_Value_int_JSON_roundtrip)}),
             ("test_Any_Value_int_transcode", {try run_test(test:($0 as! Test_Any).test_Any_Value_int_transcode)}),
             ("test_Any_Value_string_JSON_roundtrip", {try run_test(test:($0 as! Test_Any).test_Any_Value_string_JSON_roundtrip)}),
-            ("test_Any_Value_string_transcode", {try run_test(test:($0 as! Test_Any).test_Any_Value_string_transcode)})
+            ("test_Any_Value_string_transcode", {try run_test(test:($0 as! Test_Any).test_Any_Value_string_transcode)}),
+            ("test_Any_OddTypeURL_FromValue", {try run_test(test:($0 as! Test_Any).test_Any_OddTypeURL_FromValue)}),
+            ("test_Any_OddTypeURL_FromMessage", {try run_test(test:($0 as! Test_Any).test_Any_OddTypeURL_FromMessage)})
         ]
     }
 }

--- a/Tests/SwiftProtobufTests/Test_Any.swift
+++ b/Tests/SwiftProtobufTests/Test_Any.swift
@@ -638,4 +638,22 @@ class Test_Any: XCTestCase {
             XCTFail("Decode failed for \(start)")
         }
     }
+
+    func test_Any_OddTypeURL_FromValue() throws {
+      var msg = ProtobufTestMessages_Proto3_TestAllTypes()
+      msg.optionalAny.value = Data(bytes: [0x1a, 0x03, 0x61, 0x62, 0x63])
+      msg.optionalAny.typeURL = "Odd\nType\" prefix/google.protobuf.Value"
+      let newJSON = try msg.jsonString()
+      XCTAssertEqual(newJSON, "{\"optionalAny\":{\"@type\":\"Odd\\nType\\\" prefix/google.protobuf.Value\",\"value\":\"abc\"}}")
+    }
+
+    func test_Any_OddTypeURL_FromMessage() throws {
+      let valueMsg = Google_Protobuf_Value.with {
+        $0.stringValue = "abc"
+      }
+      var msg = ProtobufTestMessages_Proto3_TestAllTypes()
+      msg.optionalAny = Google_Protobuf_Any(message: valueMsg, typePrefix: "Odd\nPrefix\"")
+      let newJSON = try msg.jsonString()
+      XCTAssertEqual(newJSON, "{\"optionalAny\":{\"@type\":\"Odd\\nPrefix\\\"/google.protobuf.Value\",\"value\":\"abc\"}}")
+    }
 }


### PR DESCRIPTION
Since typeURL can be set by the developer, we need to ensure it
doesn't contain something that could make invalid JSON, so always
use a JSONEncoder so the string can be properly escaped.