### PR TITLE
Linux string correctness

### DIFF
--- a/Sources/SwiftProtobuf/JSONTypeAdditions.swift
+++ b/Sources/SwiftProtobuf/JSONTypeAdditions.swift
@@ -36,6 +36,9 @@ public extension Message {
     /// - Throws: an instance of `JSONDecodingError` if the JSON cannot be
     ///   decoded.
     public init(jsonString: String) throws {
+        if jsonString.isEmpty {
+            throw JSONDecodingError.truncated
+        }
         if let data = jsonString.data(using: String.Encoding.utf8) {
             try self.init(jsonUTF8Data: data)
         } else {

--- a/Sources/SwiftProtobuf/StringUtils.swift
+++ b/Sources/SwiftProtobuf/StringUtils.swift
@@ -17,7 +17,40 @@ import Foundation
 // Convert a pointer/count that refers to a block of UTF8 bytes
 // in memory into a String.
 // Returns nil if UTF8 is invalid.
+
+// This is painfully slow but seems to work correctly on every platform.
+#if os(Linux)
+fileprivate func slowUtf8ToString(bytes: UnsafePointer<UInt8>, count: Int) -> String? {
+    var s = ""
+    let buffer = UnsafeBufferPointer<UInt8>(start: bytes, count: count)
+    var bytes = buffer.makeIterator()
+    var utf8Decoder = UTF8()
+    while true {
+        switch utf8Decoder.decode(&bytes) {
+        case .scalarValue(let scalar): s.append(String(scalar))
+        case .emptyInput: return s
+        case .error: return nil
+        }
+    }
+}
+#endif
+
 internal func utf8ToString(bytes: UnsafePointer<UInt8>, count: Int) -> String? {
+    if count == 0 {
+        return ""
+    }
+#if os(Linux)
+    // As of March, 2017, the NSString(bytes:length:encoding:)
+    // initializer incorrectly stops at the first zero character for
+    // Linux versions of Swift.  So test for the presence of a zero byte
+    // and fall back to a slow-but-correct conversion in that case:
+    if count > Int(Int32.max) {
+        return nil
+    }
+    if let zeroLocation = memchr(bytes, Int32(truncatingBitPattern: count), 0) {
+        return slowUtf8ToString(bytes: bytes, count: count)
+    }
+#endif
     let s = NSString(bytes: bytes, length: count, encoding: String.Encoding.utf8.rawValue)
     if let s = s {
         return String._unconditionallyBridgeFromObjectiveC(s)

--- a/Sources/SwiftProtobuf/StringUtils.swift
+++ b/Sources/SwiftProtobuf/StringUtils.swift
@@ -44,10 +44,7 @@ internal func utf8ToString(bytes: UnsafePointer<UInt8>, count: Int) -> String? {
     // initializer incorrectly stops at the first zero character for
     // Linux versions of Swift.  So test for the presence of a zero byte
     // and fall back to a slow-but-correct conversion in that case:
-    if count > Int(Int32.max) {
-        return nil
-    }
-    if let zeroLocation = memchr(bytes, Int32(truncatingBitPattern: count), 0) {
+    if memchr(bytes, 0, count) != nil {
         return slowUtf8ToString(bytes: bytes, count: count)
     }
 #endif

--- a/Sources/SwiftProtobuf/StringUtils.swift
+++ b/Sources/SwiftProtobuf/StringUtils.swift
@@ -18,8 +18,9 @@ import Foundation
 // in memory into a String.
 // Returns nil if UTF8 is invalid.
 
-// This is painfully slow but seems to work correctly on every platform.
 #if os(Linux)
+// This is painfully slow but seems to work correctly on every platform.
+// We currently only use it on Linux.  See below.
 fileprivate func slowUtf8ToString(bytes: UnsafePointer<UInt8>, count: Int) -> String? {
     var s = ""
     let buffer = UnsafeBufferPointer<UInt8>(start: bytes, count: count)
@@ -42,8 +43,11 @@ internal func utf8ToString(bytes: UnsafePointer<UInt8>, count: Int) -> String? {
 #if os(Linux)
     // As of March, 2017, the NSString(bytes:length:encoding:)
     // initializer incorrectly stops at the first zero character for
-    // Linux versions of Swift.  So test for the presence of a zero byte
-    // and fall back to a slow-but-correct conversion in that case:
+    // Linux versions of Swift:
+    //     https://bugs.swift.org/browse/SR-4216
+    //
+    // On Linux, test for the presence of a zero byte
+    // and fall back to a much slower conversion in that case:
     if memchr(bytes, 0, count) != nil {
         return slowUtf8ToString(bytes: bytes, count: count)
     }


### PR DESCRIPTION
This works around a couple of bugs in the String type on Linux:
* `String.data()` crashes for empty strings -- workaround is to test for an empty string first
* `NSString(bytes:length:encoding:)` stops at zero bytes on Linux -- workaround is to explicitly look for a zero byte and use a much slower method when we see one.  (Note that even with the additional check for a zero byte, it's still much faster to use `NSString(bytes:length:encoding:)` when it does work.)

The first bug above seems to be fixed in newer snapshots, but I believe it still appears in the most recent official release build.

The second bug has been reported: https://bugs.swift.org/browse/SR-4216