### PR TITLE
Change how Any caches when created from JSON.

### DIFF
--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -88,6 +88,11 @@ internal struct JSONEncoder {
         data.append(contentsOf: text.utf8)
     }
 
+    /// Append a raw utf8 in a `Data` to the JSON text.
+    internal mutating func append(utf8Data: Data) {
+        data.append(contentsOf: utf8Data)
+    }
+
     /// Begin a new field whose name is given as a `StaticString`.
     internal mutating func startField(name: StaticString) {
         if let s = separator {


### PR DESCRIPTION
- Store all the content JSON in a Data so it is more compact compared to
  a [String:String].
- When decoding use JSONDecoder.decodeFullObject(), this sends things
  through the plumbing to ensure the Message has uniqueStorage, otherwise
  unpackTo could have been used into something using shared storage.