### PR TITLE
Inline and refactor the only use of jsonFieldNameResolver

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any.swift
@@ -77,7 +77,7 @@ fileprivate func typeName(fromMessage message: Message) -> String {
 /// This mimics the standard JSON message encoding logic, but adds
 /// the additional `@type` field.
 fileprivate func serializeAnyJSON(for message: Message, typeURL: String) throws -> String {
-    var visitor = JSONEncodingVisitor(message: message)
+    var visitor = try JSONEncodingVisitor(message: message)
     visitor.encoder.startObject()
     visitor.encoder.startField(name: "@type")
     visitor.encoder.putStringValue(value: typeURL)

--- a/Sources/SwiftProtobuf/JSONTypeAdditions.swift
+++ b/Sources/SwiftProtobuf/JSONTypeAdditions.swift
@@ -23,7 +23,7 @@ public extension Message {
         if let m = self as? _CustomJSONCodable {
             return try m.encodedJSONString()
         }
-        var visitor = JSONEncodingVisitor(message: self)
+        var visitor = try JSONEncodingVisitor(message: self)
         visitor.encoder.startObject()
         try traverse(visitor: &visitor)
         visitor.encoder.endObject()

--- a/Sources/SwiftProtobuf/ProtoNameResolvers.swift
+++ b/Sources/SwiftProtobuf/ProtoNameResolvers.swift
@@ -30,22 +30,4 @@ internal enum ProtoNameResolvers {
       return { _ in nil }
     }
   }
-
-  /// Returns a function that resolves the JSON name for fields defined on the
-  /// given message or in any set extensions.
-  ///
-  /// If the name cannot be resolved (because the field number is not defined
-  /// on the message or any of its extensions, or names were not compiled into
-  /// the binary), then the resolver returns nil.
-  static func jsonFieldNameResolver(
-    for message: Message
-  ) -> (Int) -> StaticString? {
-    if let nameProviding = message as? _ProtoNameProviding {
-      return { number in
-        nameProviding._protobuf_names(for: number)?.jsonStaticStringName
-      }
-    } else {
-      return { _ in nil }
-    }
-  }
 }


### PR DESCRIPTION
The JSON encoder now uses the NameMap directly, instead of going
through `_protobuf_fieldname()`.  This untangles the JSON encoder from
the complexities of extension field name handling (which is the key
point of `_protobuf_fieldname()`).

It also allows JSON encoding to detect missing field name support
earlier -- when the `JSONEncodingVisitor` is initialized -- rather than
waiting until the first field name is looked up.

The real goal of this change: The TextFormat encoder is now the only
client of `_protobuf_fieldname()`.  This might allow us to simplify
field name handling for extensions by reworking
`_protobuf_fieldname()` to only support `.proto` field names.  I'm
still exploring to see where that leads.