### PR TITLE
Performance: Text decoder infrastructure

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -62,12 +62,19 @@ public extension Google_Protobuf_Any {
   /// Decode an Any object from Protobuf Text Format.
   public init(textFormatString: String, extensions: ExtensionSet? = nil) throws {
     self.init()
-    var textDecoder = try TextFormatDecoder(messageType: Google_Protobuf_Any.self,
-                                            text: textFormatString,
-                                            extensions: extensions)
-    try decodeTextFormat(decoder: &textDecoder)
-    if !textDecoder.complete {
-      throw TextFormatDecodingError.trailingGarbage
+    if !textFormatString.isEmpty {
+      if let data = textFormatString.data(using: String.Encoding.utf8) {
+        try data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
+          var textDecoder = try TextFormatDecoder(messageType: Google_Protobuf_Any.self,
+                                                  utf8Pointer: bytes,
+                                                  count: data.count,
+                                                  extensions: extensions)
+          try decodeTextFormat(decoder: &textDecoder)
+          if !textDecoder.complete {
+            throw TextFormatDecodingError.trailingGarbage
+          }
+        }
+      }
     }
   }
 

--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -104,7 +104,7 @@ public struct _NameMap: ExpressibleByDictionaryLiteral {
         self.utf8Buffer = transientUtf8Buffer
     }
 
-    internal var utf8Buffer: UnsafeBufferPointer<UInt8>
+    private(set) var utf8Buffer: UnsafeBufferPointer<UInt8>
 
     private enum NameString {
       case string(String)

--- a/Sources/SwiftProtobuf/TextFormatDecoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatDecoder.swift
@@ -33,8 +33,8 @@ internal struct TextFormatDecoder: Decoder {
         }
     }
 
-    internal init(messageType: Message.Type, text: String, extensions: ExtensionSet?) throws {
-        scanner = TextFormatScanner(text: text, extensions: extensions)
+    internal init(messageType: Message.Type, utf8Pointer: UnsafePointer<UInt8>, count: Int, extensions: ExtensionSet?) throws {
+        scanner = TextFormatScanner(utf8Pointer: utf8Pointer, count: count, extensions: extensions)
         guard let nameProviding = (messageType as? _ProtoNameProviding.Type) else {
             throw TextFormatDecodingError.missingFieldNames
         }

--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -59,7 +59,7 @@ internal struct TextFormatEncoder {
         data.append(contentsOf: indentString)
     }
 
-    private mutating func appendFieldName(name: UnsafeBufferPointer<UInt8>, inExtension: Bool) {
+    mutating func emitFieldName(name: UnsafeBufferPointer<UInt8>, inExtension: Bool) {
         indent()
         if inExtension {
             data.append(asciiOpenSquareBracket)
@@ -70,44 +70,27 @@ internal struct TextFormatEncoder {
         }
     }
 
-    // In Text format, fields with simple types write the name with
-    // a trailing colon:
-    //    name_of_field: value
-    mutating func startField(name: UnsafeBufferPointer<UInt8>, inExtension: Bool) {
-        appendFieldName(name: name, inExtension: inExtension)
-        append(staticText: ": ")
-    }
-
-    mutating func startField(name: StaticString, inExtension: Bool) {
+    mutating func emitFieldName(name: StaticString, inExtension: Bool) {
         let buff = UnsafeBufferPointer(start: name.utf8Start, count: name.utf8CodeUnitCount)
-        appendFieldName(name: buff, inExtension: inExtension)
-        append(staticText: ": ")
+        emitFieldName(name: buff, inExtension: inExtension)
     }
 
-    mutating func startField(number: Int) {
+    mutating func emitFieldNumber(number: Int) {
         indent()
         appendUInt(value: UInt64(number))
-        append(staticText: ": ")
     }
 
-    mutating func endField() {
+    mutating func startRegularField() {
+        append(staticText: ": ")
+    }
+    mutating func endRegularField() {
         data.append(asciiNewline)
     }
 
     // In Text format, a message-valued field writes the name
     // without a trailing colon:
     //    name_of_field {key: value key2: value2}
-    mutating func startMessageField(name: UnsafeBufferPointer<UInt8>, inExtension: Bool) {
-        appendFieldName(name: name, inExtension: inExtension)
-        append(staticText: " {\n")
-        for _ in 1...tabSize {
-            indentString.append(asciiSpace)
-        }
-    }
-
-    mutating func startMessageField(number: Int) {
-        indent()
-        appendUInt(value: UInt64(number))
+    mutating func startMessageField() {
         append(staticText: " {\n")
         for _ in 1...tabSize {
             indentString.append(asciiSpace)

--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -78,6 +78,12 @@ internal struct TextFormatEncoder {
         append(staticText: ": ")
     }
 
+    mutating func startField(name: StaticString, inExtension: Bool) {
+        let buff = UnsafeBufferPointer(start: name.utf8Start, count: name.utf8CodeUnitCount)
+        appendFieldName(name: buff, inExtension: inExtension)
+        append(staticText: ": ")
+    }
+
     mutating func startField(number: Int) {
         indent()
         appendUInt(value: UInt64(number))

--- a/Sources/SwiftProtobuf/TextFormatEncodingError.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingError.swift
@@ -13,6 +13,4 @@
 // -----------------------------------------------------------------------------
 
 public enum TextFormatEncodingError: Error {
-    /// Field names were not compiled into the binary
-    case missingFieldNames
 }

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -57,12 +57,6 @@ internal struct TextFormatEncodingVisitor: Visitor {
   }
 
   private mutating func emitFieldName(lookingUp fieldNumber: Int) {
-      // This compact form of startField(lookingUp:) slows the entire
-      // TextFormat encoding process by over 2x.
-      //let buff = try protoFieldName(for: fieldNumber)
-      //startField(name: buff)
-
-      // This manually unrolled version is *much* faster.
       if let protoName = nameMap?.names(for: fieldNumber)?.proto {
           encoder.emitFieldName(name: protoName.utf8Buffer, inExtension: inExtension)
       } else if let protoName = nameResolver[fieldNumber] {

--- a/Sources/SwiftProtobuf/TextFormatTypeAdditions.swift
+++ b/Sources/SwiftProtobuf/TextFormatTypeAdditions.swift
@@ -38,12 +38,19 @@ public extension Message {
     /// - Throws: an instance of `TextFormatDecodingError` on failure.
     public init(textFormatString: String, extensions: ExtensionSet? = nil) throws {
         self.init()
-        var textDecoder = try TextFormatDecoder(messageType: Self.self,
-                                                text: textFormatString,
-                                                extensions: extensions)
-        try decodeMessage(decoder: &textDecoder)
-        if !textDecoder.complete {
-            throw TextFormatDecodingError.trailingGarbage
+        if !textFormatString.isEmpty {
+            if let data = textFormatString.data(using: String.Encoding.utf8) {
+                try data.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
+                    var decoder = try TextFormatDecoder(messageType: Self.self,
+                                                    utf8Pointer: bytes,
+                                                    count: data.count,
+                                                    extensions: extensions)
+                    try decodeMessage(decoder: &decoder)
+                    if !decoder.complete {
+                        throw TextFormatDecodingError.trailingGarbage
+                    }
+                }
+            }
         }
     }
 }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -728,7 +728,7 @@ class MessageGenerator {
     alsoCapturing capturedVariable: String? = nil,
     body: (inout CodePrinter) -> Void
   ) {
-    if let storage = storage {
+    if storage != nil {
       let prefixKeywords = "\(returns ? "return " : "")" +
         "\(canThrow ? "try " : "")"
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -206,7 +206,8 @@ extension Test_Any {
             ("test_Any_Value_string_JSON_roundtrip", {try run_test(test:($0 as! Test_Any).test_Any_Value_string_JSON_roundtrip)}),
             ("test_Any_Value_string_transcode", {try run_test(test:($0 as! Test_Any).test_Any_Value_string_transcode)}),
             ("test_Any_OddTypeURL_FromValue", {try run_test(test:($0 as! Test_Any).test_Any_OddTypeURL_FromValue)}),
-            ("test_Any_OddTypeURL_FromMessage", {try run_test(test:($0 as! Test_Any).test_Any_OddTypeURL_FromMessage)})
+            ("test_Any_OddTypeURL_FromMessage", {try run_test(test:($0 as! Test_Any).test_Any_OddTypeURL_FromMessage)}),
+            ("test_Any_Registery", {try run_test(test:($0 as! Test_Any).test_Any_Registery)})
         ]
     }
 }

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -149,7 +149,7 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
                 let decoded = try MessageTestType(textFormatString: encoded, extensions: extensions)
                 XCTAssert(decoded == configured, "Encode/decode cycle should generate equal object: \(decoded) != \(configured)", file: file, line: line)
             } catch {
-                XCTFail("Encode/decode cycle should not throw error, decoding: \(error)", file: file, line: line)
+                XCTFail("Encode/decode cycle should not throw error but got \(error) while decoding \(encoded)", file: file, line: line)
             }
         } catch let e {
             XCTFail("Failed to serialize Text: \(e)\n    \(configured)", file: file, line: line)
@@ -205,8 +205,8 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
             } catch let e {
                 XCTFail("Swift should have recoded without error but got \(e)\n    \(decoded)", file: file, line: line)
             }
-        } catch {
-            XCTFail("Swift should have decoded without error: \(text)", file: file, line: line)
+        } catch let e {
+            XCTFail("Swift should have decoded without error but got \(e) decoding: \(text)", file: file, line: line)
             return
         }
     }


### PR DESCRIPTION
This switches the Text decoder over to use the same overall design as the JSON decoder, for a significant boost in performance.

For `int64` fields, this now runs as much as 2x faster than Google's C++ implementation.  There are still specific performance issues with particular field types, but I think this shows that the core decoder design -- including the field name lookup and schema-driven decoding -- is fast enough.
