### PR TITLE
Add an isA() to Google_Protobuf_Any.

### DIFF
--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -93,16 +93,16 @@ internal class AnyMessageStorage {
     return clone
   }
 
-  func unpackTo<M: Message>(target: inout M) throws {
+  func isA<M: Message>(_ type: M.Type) -> Bool {
     if _typeURL.isEmpty {
-      throw AnyUnpackError.emptyAnyField
+      return false
     }
     let encodedType = typeName(fromURL: _typeURL)
-    if encodedType.isEmpty {
-      throw AnyUnpackError.malformedTypeURL
-    }
-    let messageType = typeName(fromMessage: target)
-    if encodedType != messageType {
+    return encodedType == M.protoMessageName
+  }
+
+  func unpackTo<M: Message>(target: inout M) throws {
+    guard isA(M.self) else {
       throw AnyUnpackError.typeMismatch
     }
     var protobuf: Data?

--- a/Sources/SwiftProtobuf/AnyUnpackError.swift
+++ b/Sources/SwiftProtobuf/AnyUnpackError.swift
@@ -28,14 +28,8 @@ public enum AnyUnpackError: Error {
   /// fields:  the `@type` field and a `value` field containing
   /// the specialized JSON coding of the well-known type.
   case malformedWellKnownTypeJSON
-  /// The `typeURL` field could not be parsed.
-  case malformedTypeURL
   /// There was something else wrong...
   case malformedAnyField
-  /// The Any field is empty.  You can only `unpack()` an Any
-  /// field if it contains an object (either from an initializer
-  /// or from having been decoded).
-  case emptyAnyField
   /// Decoding JSON or Text format requires the message type
   /// to have been compiled with textual field names.
   case missingFieldNames

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -78,6 +78,13 @@ public extension Google_Protobuf_Any {
     }
   }
 
+  /// Check if this Any message contains the given type. The check is
+  /// done by looking at the passed `Message.Type` and the `typeURL`
+  /// of this message.
+  public func isA<M: Message>(_ type: M.Type) -> Bool {
+    return _storage.isA(type)
+  }
+
   ///
   /// Update the provided object from the data in the Any container.
   /// This is essentially just a deferred deserialization; the Any

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -207,6 +207,7 @@ extension Test_Any {
             ("test_Any_Value_string_transcode", {try run_test(test:($0 as! Test_Any).test_Any_Value_string_transcode)}),
             ("test_Any_OddTypeURL_FromValue", {try run_test(test:($0 as! Test_Any).test_Any_OddTypeURL_FromValue)}),
             ("test_Any_OddTypeURL_FromMessage", {try run_test(test:($0 as! Test_Any).test_Any_OddTypeURL_FromMessage)}),
+            ("test_IsA", {try run_test(test:($0 as! Test_Any).test_IsA)}),
             ("test_Any_Registery", {try run_test(test:($0 as! Test_Any).test_Any_Registery)})
         ]
     }

--- a/Tests/SwiftProtobufTests/Test_Any.swift
+++ b/Tests/SwiftProtobufTests/Test_Any.swift
@@ -641,6 +641,27 @@ class Test_Any: XCTestCase {
       XCTAssertEqual(newJSON, "{\"optionalAny\":{\"@type\":\"Odd\\nPrefix\\\"/google.protobuf.Value\",\"value\":\"abc\"}}")
     }
 
+    func test_IsA() {
+      var msg = Google_Protobuf_Any()
+
+      msg.typeURL = "type.googleapis.com/protobuf_unittest.TestAllTypes"
+      XCTAssertTrue(msg.isA(ProtobufUnittest_TestAllTypes.self))
+      XCTAssertFalse(msg.isA(Google_Protobuf_Empty.self))
+      msg.typeURL = "random.site.org/protobuf_unittest.TestAllTypes"
+      XCTAssertTrue(msg.isA(ProtobufUnittest_TestAllTypes.self))
+      XCTAssertFalse(msg.isA(Google_Protobuf_Empty.self))
+      msg.typeURL = "/protobuf_unittest.TestAllTypes"
+      XCTAssertTrue(msg.isA(ProtobufUnittest_TestAllTypes.self))
+      XCTAssertFalse(msg.isA(Google_Protobuf_Empty.self))
+      msg.typeURL = "protobuf_unittest.TestAllTypes"
+      XCTAssertTrue(msg.isA(ProtobufUnittest_TestAllTypes.self))
+      XCTAssertFalse(msg.isA(Google_Protobuf_Empty.self))
+
+      msg.typeURL = ""
+      XCTAssertFalse(msg.isA(ProtobufUnittest_TestAllTypes.self))
+      XCTAssertFalse(msg.isA(Google_Protobuf_Empty.self))
+    }
+
     func test_Any_Registery() {
       // Registering the same type multiple times is ok.
       XCTAssertTrue(Google_Protobuf_Any.register(messageType: ProtobufUnittest_TestAllTypes.self))


### PR DESCRIPTION
Allows developers to quickly check the type of an Any, so they can
see if it something they actually want to unpack and inspect.