### PR TITLE
Tweak/Document Any's hashValue and equality support.

### DIFF
--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -331,6 +331,16 @@ extension AnyMessageStorage {
       return true
     }
 
+    // If both have contentJSON, and they exactly match; the messages are equal.
+    // Because there could be map in the message (or the JSON could just be in a different
+    // order), the fact that the JSON isn't the same doesn't always mean the messages
+    // aren't equal.
+    if let myJSON = _contentJSON, let otherJSON = other._contentJSON, myJSON == otherJSON {
+      return true
+    }
+
+    // Out of options; to do more compares, the states conversions would have to be
+    // done to do comparisions.  Give up and say they aren't equal.
     return false
   }
 }

--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -284,6 +284,18 @@ extension AnyMessageStorage {
   }
 }
 
+/// The obvious goal for Hashable/Equatable conformance would be for
+/// hash and equality to behave as if we always decoded the inner
+/// object and hashed or compared that.  Unfortunately, Any typically
+/// stores serialized contents and we don't always have the ability to
+/// deserialize it.  Since none of our supported serializations are
+/// fully deterministic, we can't even ensure that equality will
+/// behave this way when the Any contents are in the same
+/// serialization.
+///
+/// As a result, we can only really perform a "best effort" equality
+/// test.  Of course, regardless of the above, we must guarantee that
+/// hashValue is compatible with equality.
 extension AnyMessageStorage {
   var hashValue: Int {
     var hash: Int = i_2166136261
@@ -326,7 +338,9 @@ extension AnyMessageStorage {
 
     // If both have serialized data, and they exactly match; the messages are equal.
     // Because there could be map in the message, the fact that the data isn't the
-    // same doesn't always mean the messages aren't equal.
+    // same doesn't always mean the messages aren't equal. Likewise, the binary could
+    // have been created by a library that doesn't order the fields, or the binary was
+    // created using the appending ability in of the binary format.
     if let myValue = _valueData, let otherValue = other._valueData, myValue == otherValue {
       return true
     }

--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -315,22 +315,14 @@ extension AnyMessageStorage {
     // implementation details/bugs around serialized form order, etc.; but that
     // would also greatly slow down equality tests.
     //
-    // Despite the problems with binary serialization, that may be the best bet
-    // as looking at most other language implementations around Any they don't
-    // do lazy decode and instead keep all the `value` fields in binary form and
-    // end up just comparing those binary fields when comparing Anys.
+    // Do our best to compare what is present have...
 
     // If both have messages, check if they are the same.
-//    if let myMsg = _message, let otherMsg = other._message, type(of: myMsg) == type(of: otherMsg) {
-//      // There doesn't seem to be a way to use `==` or `_protobuf_generated_isEqualTo`
-//      // since _MessageImplementationBase has a constraint one can't do
-//      // `as? _MessageImplementationBase`.
-//      if let myMsg = myMsg as? _MessageImplementationBase, let otherMsg = otherMsg as? _MessageImplementationBase {
-//        if (myMsg._protobuf_generated_isEqualTo(other: otherMsg)) {
-//          return true
-//        }
-//      }
-//    }
+    if let myMsg = _message, let otherMsg = other._message, type(of: myMsg) == type(of: otherMsg) {
+      // Since the messages are known to be same type, we can claim both equal and
+      // not equal based on the equality comparison.
+      return myMsg.isEqualTo(message: otherMsg)
+    }
 
     // If both have serialized data, and they exactly match; the messages are equal.
     // Because there could be map in the message, the fact that the data isn't the

--- a/Sources/SwiftProtobuf/Message.swift
+++ b/Sources/SwiftProtobuf/Message.swift
@@ -112,6 +112,11 @@ public protocol Message: CustomDebugStringConvertible {
   /// debugging, for conformance with the `CustomDebugStringConvertible`
   /// protocol.
   var debugDescription: String { get }
+
+  /// Helper to compare `Message`s when not having a specific type to use
+  /// normal `Equatable`. `Equatable` is provided with specific generated
+  /// types.
+  func isEqualTo(message: Message) -> Bool
 }
 
 public extension Message {
@@ -191,6 +196,13 @@ public protocol _MessageImplementationBase: Message, Hashable {
 }
 
 public extension _MessageImplementationBase {
+  public func isEqualTo(message: Message) -> Bool {
+    guard let other = message as? Self else {
+      return false
+    }
+    return self == other
+  }
+
   public static func ==(lhs: Self, rhs: Self) -> Bool {
     return lhs._protobuf_generated_isEqualTo(other: rhs)
   }


### PR DESCRIPTION
- typeURL seems to be the only safe thing to use in hashValue.
- Update docs for equality support, but it sorta seems like with current
  types we might not be able to do it unless we go down the binary path
  only.