### PR TITLE
Make extension field names be simple String, allow generating them dynamically

### DIFF
--- a/Sources/SwiftProtobuf/MessageExtension.swift
+++ b/Sources/SwiftProtobuf/MessageExtension.swift
@@ -19,7 +19,7 @@
 /// pieces.
 public protocol MessageExtensionBase {
     var fieldNumber: Int { get }
-    var fieldName: StaticString { get }
+    var fieldName: String { get }
     var messageType: Message.Type { get }
     func _protobuf_newField() -> AnyExtensionField
 }
@@ -29,10 +29,10 @@ public protocol MessageExtensionBase {
 /// compile-time compatibility checks.
 public class MessageExtension<FieldType: ExtensionField, MessageType: Message>: MessageExtensionBase {
     public let fieldNumber: Int
-    public let fieldName: StaticString
+    public let fieldName: String
     public let messageType: Message.Type
     public let defaultValue: FieldType.ValueType
-    public init(_protobuf_fieldNumber: Int, fieldName: StaticString, defaultValue: FieldType.ValueType) {
+    public init(_protobuf_fieldNumber: Int, fieldName: String, defaultValue: FieldType.ValueType) {
         self.fieldNumber = _protobuf_fieldNumber
         self.fieldName = fieldName
         self.messageType = MessageType.self

--- a/Sources/SwiftProtobuf/TextFormatEncoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncoder.swift
@@ -59,20 +59,21 @@ internal struct TextFormatEncoder {
         data.append(contentsOf: indentString)
     }
 
-    mutating func emitFieldName(name: UnsafeBufferPointer<UInt8>, inExtension: Bool) {
+    mutating func emitFieldName(name: UnsafeBufferPointer<UInt8>) {
         indent()
-        if inExtension {
-            data.append(asciiOpenSquareBracket)
-        }
         data.append(contentsOf: name)
-        if inExtension {
-            data.append(asciiCloseSquareBracket)
-        }
     }
 
-    mutating func emitFieldName(name: StaticString, inExtension: Bool) {
+    mutating func emitFieldName(name: StaticString) {
         let buff = UnsafeBufferPointer(start: name.utf8Start, count: name.utf8CodeUnitCount)
-        emitFieldName(name: buff, inExtension: inExtension)
+        emitFieldName(name: buff)
+    }
+
+    mutating func emitExtensionFieldName(name: String) {
+        indent()
+        data.append(asciiOpenSquareBracket)
+        append(text: name)
+        data.append(asciiCloseSquareBracket)
     }
 
     mutating func emitFieldNumber(number: Int) {

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -20,7 +20,6 @@ private let mapNameResolver: [Int:StaticString] = [1: "key", 2: "value"]
 internal struct TextFormatEncodingVisitor: Visitor {
 
   private var encoder: TextFormatEncoder
-  private var inExtension = false
   private var nameMap: _NameMap?
   private var nameResolver: [Int:StaticString]
   private var extensions: ExtensionFieldValueSet?
@@ -58,11 +57,11 @@ internal struct TextFormatEncodingVisitor: Visitor {
 
   private mutating func emitFieldName(lookingUp fieldNumber: Int) {
       if let protoName = nameMap?.names(for: fieldNumber)?.proto {
-          encoder.emitFieldName(name: protoName.utf8Buffer, inExtension: inExtension)
+          encoder.emitFieldName(name: protoName.utf8Buffer)
       } else if let protoName = nameResolver[fieldNumber] {
-          encoder.emitFieldName(name: protoName, inExtension: inExtension)
+          encoder.emitFieldName(name: protoName)
       } else if let extensionName = extensions?[fieldNumber]?.protobufExtension.fieldName {
-          encoder.emitFieldName(name: extensionName, inExtension: inExtension)
+          encoder.emitExtensionFieldName(name: extensionName)
       } else {
           encoder.emitFieldNumber(number: fieldNumber)
       }
@@ -480,8 +479,6 @@ internal struct TextFormatEncodingVisitor: Visitor {
 
   /// Called for each extension range.
   mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
-    inExtension = true
     try fields.traverse(visitor: &self, start: start, end: end)
-    inExtension = false
   }
 }

--- a/Sources/protoc-gen-swift/ExtensionGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionGenerator.swift
@@ -115,10 +115,13 @@ struct ExtensionGenerator {
         let scope = swiftDeclaringMessageName == nil ? "" : "static "
         let traitsType = descriptor.getTraitsType(context: context)
 
-        var fieldNamePath = self.protoPath
-        if fieldNamePath.hasPrefix(".") {
-            fieldNamePath.remove(at: fieldNamePath.startIndex)
-            fieldNamePath = "\"\(fieldNamePath)\""
+        let fieldNamePath: String
+        if let message = swiftDeclaringMessageName {
+            fieldNamePath = "\(message).protoMessageName + \".\(fieldName)\""
+        } else if !protoPackageName.isEmpty {
+            fieldNamePath = "_protobuf_package + \".\(fieldName)\""
+        } else {
+            fieldNamePath = "\"\(fieldName)\""
         }
 
         p.print("\(scope)let \(swiftRelativeExtensionName) = SwiftProtobuf.MessageExtension<\(extensionFieldType)<\(traitsType)>, \(swiftExtendedMessageName)>(\n")


### PR DESCRIPTION
This changes the `fieldName` property on extension objects to be a simple `String` property (instead of `StaticString`).  (This was enabled by #390, which isolated the handling of extension field names.)

It then changes how extensions get generated so that the `fieldName` is computed by appending the extension field name proper to the name of the surrounding scope.  A typical extension object now looks like this:
```
 let ProtobufUnittest_Extensions_optional_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 5,
-  fieldName: "protobuf_unittest.optional_sint32_extension",
+  fieldName: _protobuf_package + ".optional_sint32_extension",
   defaultValue: 0
 )
```

This was motivated by Issue #177, which questioned whether we could eliminate the duplicated package and message names when writing extension objects.  This shows that it's possible, but it actually makes the generated/compiled Swift code slightly larger.  (`unittest.pb.swift.o` goes from 6054536 bytes unstripped to 6064584 bytes)

My inclination:  Change the `fieldName` property to `String` as a general API cleanup, but leave the generated names as constants instead of computing them (basically, keep the first commit here but drop the second one).   Thoughts?
