### PR TITLE
Keep the lists sorted and unsorted.

### DIFF
--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -28,6 +28,7 @@ class EnumGenerator {
   private let swiftRelativeName: String
   private let swiftFullName: String
   private let enumCases: [EnumCaseGenerator]
+  private let enumCasesSortedByNumber: [EnumCaseGenerator]
   private let defaultCase: EnumCaseGenerator
   private let path: [Int32]
   private let comments: String
@@ -76,6 +77,7 @@ class EnumGenerator {
       }
     }
     self.enumCases = enumCases
+    enumCasesSortedByNumber = enumCases.sorted {$0.number < $1.number}
     self.defaultCase = self.enumCases[0]
     self.path = path
     self.comments = file.commentsFor(path: path)
@@ -128,7 +130,7 @@ class EnumGenerator {
     } else {
       p.print("\(visibility)static let _protobuf_nameMap: SwiftProtobuf._NameMap = [\n")
       p.indent()
-      for c in enumCases.sorted(by: areCaseNumbersAscending) where !c.isAlias {
+      for c in enumCasesSortedByNumber where !c.isAlias {
         c.generateNameMapEntry(printer: &p)
       }
       p.outdent()
@@ -143,7 +145,7 @@ class EnumGenerator {
     p.print("\(visibility)init?(rawValue: Int) {\n")
     p.indent()
     p.print("switch rawValue {\n")
-    for c in enumCases.sorted(by: areCaseNumbersAscending) where !c.isAlias {
+    for c in enumCasesSortedByNumber where !c.isAlias {
       p.print("case \(c.number): self = .\(c.swiftName)\n")
     }
     if isProto3 {
@@ -163,7 +165,7 @@ class EnumGenerator {
     p.print("\(visibility)var rawValue: Int {\n")
     p.indent()
     p.print("switch self {\n")
-    for c in enumCases.sorted(by: areCaseNumbersAscending) where !c.isAlias {
+    for c in enumCasesSortedByNumber where !c.isAlias {
       p.print("case .\(c.swiftName): return \(c.number)\n")
     }
     if isProto3 {
@@ -173,14 +175,4 @@ class EnumGenerator {
     p.outdent()
     p.print("}\n")
   }
-}
-
-/// Comparison function used to sort the enum cases based on their number.
-///
-/// - Parameter first: A case generator.
-/// - Parameter second: A case generator.
-/// - Returns: True if the cases are in ascending order based on their number.
-private func areCaseNumbersAscending(_ first: EnumCaseGenerator,
-                                     _ second: EnumCaseGenerator) -> Bool {
-  return first.number < second.number
 }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -30,6 +30,7 @@ class MessageGenerator {
   private let protoMessageName: String
   private let protoPackageName: String
   private let fields: [MessageFieldGenerator]
+  private let fieldsSortedByNumber: [MessageFieldGenerator]
   private let oneofs: [OneofGenerator]
   private let extensions: [ExtensionGenerator]
   private let storage: MessageStorageClassGenerator?
@@ -91,6 +92,7 @@ class MessageGenerator {
       fields.append(MessageFieldGenerator(descriptor: f, path: fieldPath, messageDescriptor: descriptor, file: file, context: context))
     }
     self.fields = fields
+    fieldsSortedByNumber = fields.sorted {$0.number < $1.number}
 
     i = 0
     var extensions = [ExtensionGenerator]()
@@ -434,7 +436,7 @@ class MessageGenerator {
       var currentOneof: Google_Protobuf_OneofDescriptorProto?
       var oneofStart = 0
       var oneofEnd = 0
-      for f in (fields.sorted {$0.number < $1.number}) {
+      for f in fieldsSortedByNumber {
         while nextRange != nil && Int(nextRange!.start) < f.number {
           p.print("try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: \(nextRange!.start), end: \(nextRange!.end))\n")
           nextRange = ranges.next()

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -32,6 +32,7 @@ class OneofGenerator {
     let descriptor: Google_Protobuf_OneofDescriptorProto
     let generatorOptions: GeneratorOptions
     let fields: [MessageFieldGenerator]
+    let fieldsSortedByNumber: [MessageFieldGenerator]
     let swiftRelativeName: String
     let swiftFullName: String
     let isProto3: Bool
@@ -40,6 +41,7 @@ class OneofGenerator {
         self.descriptor = descriptor
         self.generatorOptions = generatorOptions
         self.fields = fields
+        self.fieldsSortedByNumber = fields.sorted {$0.number < $1.number}
         self.isProto3 = isProto3
         self.swiftRelativeName = sanitizeOneofTypeName(descriptor.swiftRelativeType)
         self.swiftFullName = swiftMessageFullName + "." + swiftRelativeName
@@ -81,7 +83,7 @@ class OneofGenerator {
         p.print("fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {\n")
         p.indent()
         p.print("switch fieldNumber {\n")
-        for f in fields.sorted(by: {$0.number < $1.number}) {
+        for f in fieldsSortedByNumber {
             let modifier = "Singular"
             let special = f.isGroup ? "Group"
                         : f.isMessage ? "Message"
@@ -121,7 +123,7 @@ class OneofGenerator {
         p.print("fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {\n")
         p.indent()
         p.print("switch self {\n")
-        for f in fields.sorted(by: {$0.number < $1.number}) {
+        for f in fieldsSortedByNumber {
             p.print("case .\(f.swiftName)(let v):\n")
             p.indent()
             p.print("if start <= \(f.number) && \(f.number) < end {\n")


### PR DESCRIPTION
Instead of sorting on demand, keep both orders around so the sorting doesn't
have to be repeated multiple times during generation.