### PR TITLE
Drop leading_detached_comments except where trying to get copyright.

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -51,25 +51,6 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "conformance"
 
-//  This defines the conformance testing protocol.  This protocol exists between
-//  the conformance test suite itself and the code being tested.  For each test,
-//  the suite will send a ConformanceRequest message and expect a
-//  ConformanceResponse message.
-// 
-//  You can either run the tests in two different ways:
-// 
-//    1. in-process (using the interface in conformance_test.h).
-// 
-//    2. as a sub-process communicating over a pipe.  Information about how to
-//       do this is in conformance_test_runner.cc.
-// 
-//  Pros/cons of the two approaches:
-// 
-//    - running as a sub-process is much simpler for languages other than C/C++.
-// 
-//    - running as a sub-process may be more tricky in unusual environments like
-//      iOS apps, where fork/stdin/stdout are not available.
-
 enum Conformance_WireFormat: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case unspecified // = 0

--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -1785,38 +1785,6 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-//  ===================================================================
-//  Options
-
-//  Each of the definitions above may have "options" attached.  These are
-//  just annotations which may cause code to be generated slightly differently
-//  or may contain hints for code that manipulates protocol messages.
-// 
-//  Clients may define custom options as extensions of the *Options messages.
-//  These extensions may not yet be known at parsing time, so the parser cannot
-//  store the values in them.  Instead it stores them in a field in the *Options
-//  message called uninterpreted_option. This field must have the same name
-//  across all *Options messages. We then use this field to populate the
-//  extensions when we build a descriptor, at which point all protos have been
-//  parsed and so all extensions are known.
-// 
-//  Extension numbers for custom options may be chosen as follows:
-//  * For options which will only be used within a single application or
-//    organization, or for experimental options, use field numbers 50000
-//    through 99999.  It is up to you to ensure that you do not use the
-//    same number for multiple options.
-//  * For options which will be published and used publicly by multiple
-//    independent entities, e-mail protobuf-global-extension-registry@google.com
-//    to reserve extension numbers. Simply provide your project name (e.g.
-//    Objective-C plugin) and your project website (if available) -- there's no
-//    need to explain how you intend to use them. Usually you only need one
-//    extension number. You can declare multiple options with only one extension
-//    number by putting them in a sub-message. See the Custom Options section of
-//    the docs for examples:
-//    https://developers.google.com/protocol-buffers/docs/proto#options
-//    If this turns out to be popular, a web service will be set up
-//    to automatically assign option numbers.
-
 struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FileOptions"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -2893,11 +2861,6 @@ struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     999: .standard(proto: "uninterpreted_option"),
   ]
 
-  //  Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
-  //    framework.  We apologize for hoarding these numbers to ourselves, but
-  //    we were already using them long before we decided to release Protocol
-  //    Buffers.
-
   ///   Is this service deprecated?
   ///   Depending on the target platform, this can emit Deprecated annotations
   ///   for the service, or it will be completely ignored; in the very least,
@@ -2968,11 +2931,6 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.Exten
     34: .standard(proto: "idempotency_level"),
     999: .standard(proto: "uninterpreted_option"),
   ]
-
-  //  Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
-  //    framework.  We apologize for hoarding these numbers to ourselves, but
-  //    we were already using them long before we decided to release Protocol
-  //    Buffers.
 
   ///   Is this method deprecated?
   ///   Depending on the target platform, this can emit Deprecated annotations
@@ -3325,9 +3283,6 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message, SwiftProtobuf
     return true
   }
 }
-
-//  ===================================================================
-//  Optional source code info
 
 ///   Encapsulates information about the original source file from which a
 ///   FileDescriptorProto was generated.

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -6879,8 +6879,6 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-//  Test messages for packed fields
-
 struct ProtobufUnittest_TestPackedTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestPackedTypes"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -343,8 +343,6 @@ struct ProtobufUnittest_CustomOptionFooServerMessage: SwiftProtobuf.Message, Swi
   }
 }
 
-//  Options of every possible field type, so we can test them all exhaustively.
-
 struct ProtobufUnittest_DummyMessageContainingEnum: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DummyMessageContainingEnum"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
@@ -536,9 +534,6 @@ struct ProtobufUnittest_SettingRealsFromNegativeInts: SwiftProtobuf.Message, Swi
     return true
   }
 }
-
-//  Options of complex message types, themselves combined and extended in
-//  various ways.
 
 struct ProtobufUnittest_ComplexOptionType1: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ComplexOptionType1"
@@ -1043,10 +1038,6 @@ struct ProtobufUnittest_VariousComplexOptions: SwiftProtobuf.Message, SwiftProto
     return true
   }
 }
-
-//  ------------------------------------------------------
-//  Definitions for testing aggregate option parsing.
-//  See descriptor_unittest.cc.
 
 struct ProtobufUnittest_AggregateMessageSet: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".AggregateMessageSet"

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -249,17 +249,6 @@ struct ProtobufUnittest_TestMessageSetExtension2: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-//  This message was used to generate
-//  //net/proto2/python/internal/testdata/message_set_message, but is commented
-//  out since it must not actually exist in code, to simulate an "unknown"
-//  extension.
-//  message TestMessageSetUnknownExtension {
-//    extend TestMessageSet {
-//      optional TestMessageSetUnknownExtension message_set_extension = 56141421;
-//    }
-//    optional int64 a = 1;
-//  }
-
 ///   MessageSet wire format is equivalent to this.
 struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RawMessageSet"

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -80,8 +80,6 @@ enum Google_Protobuf_NoGenericServicesTest_TestEnum: SwiftProtobuf.Enum, SwiftPr
 
 }
 
-//  *_generic_services are false by default.
-
 struct Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestMessage"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -2515,8 +2515,6 @@ struct Proto3TestOneof: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
   }
 }
 
-//  Test messages for packed fields
-
 struct Proto3TestPackedTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestPackedTypes"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -341,11 +341,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  //  Groups are not allowed in proto3.
-  //  optional group OptionalGroup = 16 {
-  //    optional int32 a = 17;
-  //  }
-
   var optionalNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Proto3ArenaUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
@@ -388,11 +383,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
-
-  //  Omitted (compared to unittest.proto) because proto2 enums are not allowed
-  //  inside proto2 messages.
-  // 
-  //  optional protobuf_unittest_import.ImportEnum    optional_import_enum  = 23;
 
   var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
@@ -503,11 +493,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  //  Groups are not allowed in proto3.
-  //  repeated group RepeatedGroup = 46 {
-  //    optional int32 a = 47;
-  //  }
-
   var repeatedNestedMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
@@ -532,11 +517,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
-
-  //  Omitted (compared to unittest.proto) because proto2 enums are not allowed
-  //  inside proto2 messages.
-  // 
-  //  repeated protobuf_unittest_import.ImportEnum    repeated_import_enum  = 53;
 
   var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
@@ -1035,8 +1015,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     return true
   }
 }
-
-//  Test messages for packed fields
 
 struct Proto3ArenaUnittest_TestPackedTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestPackedTypes"

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -341,11 +341,6 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  //  Groups are not allowed in proto3.
-  //  optional group OptionalGroup = 16 {
-  //    optional int32 a = 17;
-  //  }
-
   var optionalNestedMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
@@ -388,11 +383,6 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
-
-  //  Omitted (compared to unittest.proto) because proto2 enums are not allowed
-  //  inside proto2 messages.
-  // 
-  //  optional protobuf_unittest_import.ImportEnum    optional_import_enum  = 23;
 
   var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
@@ -503,11 +493,6 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  //  Groups are not allowed in proto3.
-  //  repeated group RepeatedGroup = 46 {
-  //    optional int32 a = 47;
-  //  }
-
   var repeatedNestedMessage: [Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
@@ -532,11 +517,6 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
-
-  //  Omitted (compared to unittest.proto) because proto2 enums are not allowed
-  //  inside proto2 messages.
-  // 
-  //  repeated protobuf_unittest_import.ImportEnum    repeated_import_enum  = 53;
 
   var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
@@ -1035,8 +1015,6 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobu
     return true
   }
 }
-
-//  Test messages for packed fields
 
 struct Proto3ArenaLiteUnittest_TestPackedTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestPackedTypes"

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -341,11 +341,6 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Me
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  //  Groups are not allowed in proto3.
-  //  optional group OptionalGroup = 16 {
-  //    optional int32 a = 17;
-  //  }
-
   var optionalNestedMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Proto3LiteUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
@@ -388,11 +383,6 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Me
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
-
-  //  Omitted (compared to unittest.proto) because proto2 enums are not allowed
-  //  inside proto2 messages.
-  // 
-  //  optional protobuf_unittest_import.ImportEnum    optional_import_enum  = 23;
 
   var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
@@ -503,11 +493,6 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Me
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  //  Groups are not allowed in proto3.
-  //  repeated group RepeatedGroup = 46 {
-  //    optional int32 a = 47;
-  //  }
-
   var repeatedNestedMessage: [Proto3LiteUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
@@ -532,11 +517,6 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Me
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
-
-  //  Omitted (compared to unittest.proto) because proto2 enums are not allowed
-  //  inside proto2 messages.
-  // 
-  //  repeated protobuf_unittest_import.ImportEnum    repeated_import_enum  = 53;
 
   var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
@@ -1035,8 +1015,6 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._Me
     return true
   }
 }
-
-//  Test messages for packed fields
 
 struct Proto3LiteUnittest_TestPackedTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestPackedTypes"

--- a/Reference/unittest_swift_cycle.pb.swift
+++ b/Reference/unittest_swift_cycle.pb.swift
@@ -50,14 +50,6 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-//  Cycles in the Message graph can cause problems for the mutable classes
-//  since the properties on the mutable class change types. This file just
-//  needs to generate source, and that source must compile, to ensure the
-//  generated source works for this sort of case.
-
-//  You can't make a object graph that spans files, so this can only be done
-//  within a single proto file.
-
 struct ProtobufUnittest_CycleFoo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CycleFoo"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -185,14 +185,6 @@ struct ProtobufUnittest_Extend_C: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-// 
-// extend Foo.Bar.Baz.C {
-// optional bool d = 12;
-// }
-
-//  If this compiles then it means we deal with unique proto names that
-//  could end up with naming collisions when remapped to Swifty names.
-
 struct ProtobufUnittest_Extend_Msg1: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Msg1"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
@@ -262,8 +254,6 @@ struct ProtobufUnittest_Extend_Msg2: SwiftProtobuf.Message, SwiftProtobuf.Extens
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
-
-//  These allow testing where a StorageClass is and isn't used.
 
 struct ProtobufUnittest_Extend_MsgNoStorage: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MsgNoStorage"

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -933,9 +933,6 @@ enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum, SwiftProtobuf._Pro
 
 }
 
-//  TODO: Build a MessageNames message with a submessage of every name below
-//  TODO: Create tests that access every field, enum, message to verify the name is generated correctly
-
 struct SwiftUnittest_Names_FieldNames: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FieldNames"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -20809,8 +20806,6 @@ struct SwiftUnittest_Names_FieldNamingInitials: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-//  For message scoped extensions.
-
 struct SwiftUnittest_Names_ExtensionNamingInitials: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExtensionNamingInitials"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
@@ -21145,8 +21140,6 @@ struct SwiftUnittest_Names_WordCase: SwiftProtobuf.Message, SwiftProtobuf._Messa
     return true
   }
 }
-
-//  For global scoped extensions.
 
 struct SwiftUnittest_Names_ExtensionNamingInitialsLowers: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExtensionNamingInitialsLowers"

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -1629,8 +1629,6 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-//  These allow testing where a StorageClass is and isn't used.
-
 struct ProtobufUnittest_Msg2NoStorage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Msg2NoStorage"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -1295,8 +1295,6 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-//  These allow testing where a StorageClass is and isn't used.
-
 struct ProtobufUnittest_Msg3NoStorage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Msg3NoStorage"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -51,25 +51,6 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "conformance"
 
-//  This defines the conformance testing protocol.  This protocol exists between
-//  the conformance test suite itself and the code being tested.  For each test,
-//  the suite will send a ConformanceRequest message and expect a
-//  ConformanceResponse message.
-// 
-//  You can either run the tests in two different ways:
-// 
-//    1. in-process (using the interface in conformance_test.h).
-// 
-//    2. as a sub-process communicating over a pipe.  Information about how to
-//       do this is in conformance_test_runner.cc.
-// 
-//  Pros/cons of the two approaches:
-// 
-//    - running as a sub-process is much simpler for languages other than C/C++.
-// 
-//    - running as a sub-process may be more tricky in unusual environments like
-//      iOS apps, where fork/stdin/stdout are not available.
-
 enum Conformance_WireFormat: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case unspecified // = 0

--- a/Sources/PluginLibrary/descriptor.pb.swift
+++ b/Sources/PluginLibrary/descriptor.pb.swift
@@ -1785,38 +1785,6 @@ public struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message, Swif
   }
 }
 
-//  ===================================================================
-//  Options
-
-//  Each of the definitions above may have "options" attached.  These are
-//  just annotations which may cause code to be generated slightly differently
-//  or may contain hints for code that manipulates protocol messages.
-// 
-//  Clients may define custom options as extensions of the *Options messages.
-//  These extensions may not yet be known at parsing time, so the parser cannot
-//  store the values in them.  Instead it stores them in a field in the *Options
-//  message called uninterpreted_option. This field must have the same name
-//  across all *Options messages. We then use this field to populate the
-//  extensions when we build a descriptor, at which point all protos have been
-//  parsed and so all extensions are known.
-// 
-//  Extension numbers for custom options may be chosen as follows:
-//  * For options which will only be used within a single application or
-//    organization, or for experimental options, use field numbers 50000
-//    through 99999.  It is up to you to ensure that you do not use the
-//    same number for multiple options.
-//  * For options which will be published and used publicly by multiple
-//    independent entities, e-mail protobuf-global-extension-registry@google.com
-//    to reserve extension numbers. Simply provide your project name (e.g.
-//    Objective-C plugin) and your project website (if available) -- there's no
-//    need to explain how you intend to use them. Usually you only need one
-//    extension number. You can declare multiple options with only one extension
-//    number by putting them in a sub-message. See the Custom Options section of
-//    the docs for examples:
-//    https://developers.google.com/protocol-buffers/docs/proto#options
-//    If this turns out to be popular, a web service will be set up
-//    to automatically assign option numbers.
-
 public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".FileOptions"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -2893,11 +2861,6 @@ public struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtob
     999: .standard(proto: "uninterpreted_option"),
   ]
 
-  //  Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
-  //    framework.  We apologize for hoarding these numbers to ourselves, but
-  //    we were already using them long before we decided to release Protocol
-  //    Buffers.
-
   ///   Is this service deprecated?
   ///   Depending on the target platform, this can emit Deprecated annotations
   ///   for the service, or it will be completely ignored; in the very least,
@@ -2968,11 +2931,6 @@ public struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobu
     34: .standard(proto: "idempotency_level"),
     999: .standard(proto: "uninterpreted_option"),
   ]
-
-  //  Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
-  //    framework.  We apologize for hoarding these numbers to ourselves, but
-  //    we were already using them long before we decided to release Protocol
-  //    Buffers.
 
   ///   Is this method deprecated?
   ///   Depending on the target platform, this can emit Deprecated annotations
@@ -3325,9 +3283,6 @@ public struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message, SwiftP
     return true
   }
 }
-
-//  ===================================================================
-//  Optional source code info
 
 ///   Encapsulates information about the original source file from which a
 ///   FileDescriptorProto was generated.

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -218,7 +218,7 @@ class FileGenerator {
         }
     }
 
-    func commentsFor(path: [Int32]) -> String {
+    func commentsFor(path: [Int32], includeLeadingDetached: Bool = false) -> String {
         func escapeMarkup(_ text: String) -> String {
             // Proto file comments don't really have any markup associated with
             // them.  Swift uses something like MarkDown:
@@ -248,17 +248,15 @@ class FileGenerator {
         if let location = descriptor.locationFor(path: path) {
             var result = ""
 
-            // https://github.com/apple/swift-protobuf/issues/108 is opened to
-            // confirm that we really want the detached comments. Since file
-            // structure is lost, they might not make sense where we pull them
-            // over.
-            for detached in location.leadingDetachedComments {
-                let comment = prefixLines(text: detached, prefix: "// ")
-                if !comment.isEmpty {
-                    result += comment
-                    // Detached comments have blank lines between then (and
-                    // anything that follows them).
-                    result += "\n"
+            if includeLeadingDetached {
+                for detached in location.leadingDetachedComments {
+                    let comment = prefixLines(text: detached, prefix: "// ")
+                    if !comment.isEmpty {
+                        result += comment
+                        // Detached comments have blank lines between then (and
+                        // anything that follows them).
+                        result += "\n"
+                    }
                 }
             }
 
@@ -281,11 +279,15 @@ class FileGenerator {
             " */\n",
             "\n")
 
+        // Attempt to bring over the comments at the top of the .proto file as
+        // they likely contain copyrights/preamble/etc.
+        //
         // The C++ FileDescriptor::GetSourceLocation(), says the location for
         // the file is an empty path. That never seems to have comments on it.
         // https://github.com/google/protobuf/issues/2249 opened to figure out
         // the right way to do this since the syntax entry is optional.
-        let comments = commentsFor(path: [Google_Protobuf_FileDescriptorProto.FieldNumbers.syntax])
+        let comments = commentsFor(path: [Google_Protobuf_FileDescriptorProto.FieldNumbers.syntax],
+                                   includeLeadingDetached: true)
         if !comments.isEmpty {
             p.print(comments)
             // If the was a leading or tailing comment it won't have a blank

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -51,25 +51,6 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "conformance"
 
-//  This defines the conformance testing protocol.  This protocol exists between
-//  the conformance test suite itself and the code being tested.  For each test,
-//  the suite will send a ConformanceRequest message and expect a
-//  ConformanceResponse message.
-// 
-//  You can either run the tests in two different ways:
-// 
-//    1. in-process (using the interface in conformance_test.h).
-// 
-//    2. as a sub-process communicating over a pipe.  Information about how to
-//       do this is in conformance_test_runner.cc.
-// 
-//  Pros/cons of the two approaches:
-// 
-//    - running as a sub-process is much simpler for languages other than C/C++.
-// 
-//    - running as a sub-process may be more tricky in unusual environments like
-//      iOS apps, where fork/stdin/stdout are not available.
-
 enum Conformance_WireFormat: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case unspecified // = 0

--- a/Tests/SwiftProtobufTests/descriptor.pb.swift
+++ b/Tests/SwiftProtobufTests/descriptor.pb.swift
@@ -1785,38 +1785,6 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message, SwiftProtob
   }
 }
 
-//  ===================================================================
-//  Options
-
-//  Each of the definitions above may have "options" attached.  These are
-//  just annotations which may cause code to be generated slightly differently
-//  or may contain hints for code that manipulates protocol messages.
-// 
-//  Clients may define custom options as extensions of the *Options messages.
-//  These extensions may not yet be known at parsing time, so the parser cannot
-//  store the values in them.  Instead it stores them in a field in the *Options
-//  message called uninterpreted_option. This field must have the same name
-//  across all *Options messages. We then use this field to populate the
-//  extensions when we build a descriptor, at which point all protos have been
-//  parsed and so all extensions are known.
-// 
-//  Extension numbers for custom options may be chosen as follows:
-//  * For options which will only be used within a single application or
-//    organization, or for experimental options, use field numbers 50000
-//    through 99999.  It is up to you to ensure that you do not use the
-//    same number for multiple options.
-//  * For options which will be published and used publicly by multiple
-//    independent entities, e-mail protobuf-global-extension-registry@google.com
-//    to reserve extension numbers. Simply provide your project name (e.g.
-//    Objective-C plugin) and your project website (if available) -- there's no
-//    need to explain how you intend to use them. Usually you only need one
-//    extension number. You can declare multiple options with only one extension
-//    number by putting them in a sub-message. See the Custom Options section of
-//    the docs for examples:
-//    https://developers.google.com/protocol-buffers/docs/proto#options
-//    If this turns out to be popular, a web service will be set up
-//    to automatically assign option numbers.
-
 struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FileOptions"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -2893,11 +2861,6 @@ struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     999: .standard(proto: "uninterpreted_option"),
   ]
 
-  //  Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
-  //    framework.  We apologize for hoarding these numbers to ourselves, but
-  //    we were already using them long before we decided to release Protocol
-  //    Buffers.
-
   ///   Is this service deprecated?
   ///   Depending on the target platform, this can emit Deprecated annotations
   ///   for the service, or it will be completely ignored; in the very least,
@@ -2968,11 +2931,6 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.Exten
     34: .standard(proto: "idempotency_level"),
     999: .standard(proto: "uninterpreted_option"),
   ]
-
-  //  Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
-  //    framework.  We apologize for hoarding these numbers to ourselves, but
-  //    we were already using them long before we decided to release Protocol
-  //    Buffers.
 
   ///   Is this method deprecated?
   ///   Depending on the target platform, this can emit Deprecated annotations
@@ -3325,9 +3283,6 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message, SwiftProtobuf
     return true
   }
 }
-
-//  ===================================================================
-//  Optional source code info
 
 ///   Encapsulates information about the original source file from which a
 ///   FileDescriptorProto was generated.

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -6879,8 +6879,6 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message, SwiftProtobuf.
   }
 }
 
-//  Test messages for packed fields
-
 struct ProtobufUnittest_TestPackedTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestPackedTypes"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -343,8 +343,6 @@ struct ProtobufUnittest_CustomOptionFooServerMessage: SwiftProtobuf.Message, Swi
   }
 }
 
-//  Options of every possible field type, so we can test them all exhaustively.
-
 struct ProtobufUnittest_DummyMessageContainingEnum: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".DummyMessageContainingEnum"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
@@ -536,9 +534,6 @@ struct ProtobufUnittest_SettingRealsFromNegativeInts: SwiftProtobuf.Message, Swi
     return true
   }
 }
-
-//  Options of complex message types, themselves combined and extended in
-//  various ways.
 
 struct ProtobufUnittest_ComplexOptionType1: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ComplexOptionType1"
@@ -1043,10 +1038,6 @@ struct ProtobufUnittest_VariousComplexOptions: SwiftProtobuf.Message, SwiftProto
     return true
   }
 }
-
-//  ------------------------------------------------------
-//  Definitions for testing aggregate option parsing.
-//  See descriptor_unittest.cc.
 
 struct ProtobufUnittest_AggregateMessageSet: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".AggregateMessageSet"

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -249,17 +249,6 @@ struct ProtobufUnittest_TestMessageSetExtension2: SwiftProtobuf.Message, SwiftPr
   }
 }
 
-//  This message was used to generate
-//  //net/proto2/python/internal/testdata/message_set_message, but is commented
-//  out since it must not actually exist in code, to simulate an "unknown"
-//  extension.
-//  message TestMessageSetUnknownExtension {
-//    extend TestMessageSet {
-//      optional TestMessageSetUnknownExtension message_set_extension = 56141421;
-//    }
-//    optional int64 a = 1;
-//  }
-
 ///   MessageSet wire format is equivalent to this.
 struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".RawMessageSet"

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -80,8 +80,6 @@ enum Google_Protobuf_NoGenericServicesTest_TestEnum: SwiftProtobuf.Enum, SwiftPr
 
 }
 
-//  *_generic_services are false by default.
-
 struct Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestMessage"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -2515,8 +2515,6 @@ struct Proto3TestOneof: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
   }
 }
 
-//  Test messages for packed fields
-
 struct Proto3TestPackedTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestPackedTypes"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -341,11 +341,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  //  Groups are not allowed in proto3.
-  //  optional group OptionalGroup = 16 {
-  //    optional int32 a = 17;
-  //  }
-
   var optionalNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {return _storage._optionalNestedMessage ?? Proto3ArenaUnittest_TestAllTypes.NestedMessage()}
     set {_uniqueStorage()._optionalNestedMessage = newValue}
@@ -388,11 +383,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
   }
-
-  //  Omitted (compared to unittest.proto) because proto2 enums are not allowed
-  //  inside proto2 messages.
-  // 
-  //  optional protobuf_unittest_import.ImportEnum    optional_import_enum  = 23;
 
   var optionalStringPiece: String {
     get {return _storage._optionalStringPiece}
@@ -503,11 +493,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  //  Groups are not allowed in proto3.
-  //  repeated group RepeatedGroup = 46 {
-  //    optional int32 a = 47;
-  //  }
-
   var repeatedNestedMessage: [Proto3ArenaUnittest_TestAllTypes.NestedMessage] {
     get {return _storage._repeatedNestedMessage}
     set {_uniqueStorage()._repeatedNestedMessage = newValue}
@@ -532,11 +517,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     get {return _storage._repeatedForeignEnum}
     set {_uniqueStorage()._repeatedForeignEnum = newValue}
   }
-
-  //  Omitted (compared to unittest.proto) because proto2 enums are not allowed
-  //  inside proto2 messages.
-  // 
-  //  repeated protobuf_unittest_import.ImportEnum    repeated_import_enum  = 53;
 
   var repeatedStringPiece: [String] {
     get {return _storage._repeatedStringPiece}
@@ -1035,8 +1015,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message, SwiftProtobuf._M
     return true
   }
 }
-
-//  Test messages for packed fields
 
 struct Proto3ArenaUnittest_TestPackedTypes: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".TestPackedTypes"

--- a/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
@@ -50,14 +50,6 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-//  Cycles in the Message graph can cause problems for the mutable classes
-//  since the properties on the mutable class change types. This file just
-//  needs to generate source, and that source must compile, to ensure the
-//  generated source works for this sort of case.
-
-//  You can't make a object graph that spans files, so this can only be done
-//  within a single proto file.
-
 struct ProtobufUnittest_CycleFoo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".CycleFoo"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -185,14 +185,6 @@ struct ProtobufUnittest_Extend_C: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-// 
-// extend Foo.Bar.Baz.C {
-// optional bool d = 12;
-// }
-
-//  If this compiles then it means we deal with unique proto names that
-//  could end up with naming collisions when remapped to Swifty names.
-
 struct ProtobufUnittest_Extend_Msg1: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Msg1"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
@@ -262,8 +254,6 @@ struct ProtobufUnittest_Extend_Msg2: SwiftProtobuf.Message, SwiftProtobuf.Extens
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
-
-//  These allow testing where a StorageClass is and isn't used.
 
 struct ProtobufUnittest_Extend_MsgNoStorage: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".MsgNoStorage"

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -933,9 +933,6 @@ enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum, SwiftProtobuf._Pro
 
 }
 
-//  TODO: Build a MessageNames message with a submessage of every name below
-//  TODO: Create tests that access every field, enum, message to verify the name is generated correctly
-
 struct SwiftUnittest_Names_FieldNames: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".FieldNames"
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -20809,8 +20806,6 @@ struct SwiftUnittest_Names_FieldNamingInitials: SwiftProtobuf.Message, SwiftProt
   }
 }
 
-//  For message scoped extensions.
-
 struct SwiftUnittest_Names_ExtensionNamingInitials: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExtensionNamingInitials"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()
@@ -21145,8 +21140,6 @@ struct SwiftUnittest_Names_WordCase: SwiftProtobuf.Message, SwiftProtobuf._Messa
     return true
   }
 }
-
-//  For global scoped extensions.
 
 struct SwiftUnittest_Names_ExtensionNamingInitialsLowers: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ExtensionNamingInitialsLowers"

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -1629,8 +1629,6 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-//  These allow testing where a StorageClass is and isn't used.
-
 struct ProtobufUnittest_Msg2NoStorage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Msg2NoStorage"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -1295,8 +1295,6 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 }
 
-//  These allow testing where a StorageClass is and isn't used.
-
 struct ProtobufUnittest_Msg3NoStorage: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".Msg3NoStorage"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap()


### PR DESCRIPTION
The other generators that pull over comments don't seem to bring over leading detached
comments, so follow in their lead.

Fixes https://github.com/apple/swift-protobuf/issues/108