### PR TITLE
Make extension lookup go through a protocol

### DIFF
--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -10987,7 +10987,7 @@ extension ProtobufUnittest_TestHugeFieldNumbers {
   }
 }
 
-let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_optional_int32_extension,
   ProtobufUnittest_Extensions_optional_int64_extension,
   ProtobufUnittest_Extensions_optional_uint32_extension,

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -2500,7 +2500,7 @@ extension Google_Protobuf_MessageOptions {
   }
 }
 
-let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_file_opt1,
   ProtobufUnittest_Extensions_message_opt1,
   ProtobufUnittest_Extensions_field_opt1,

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -5146,7 +5146,7 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite {
   }
 }
 
-let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_optional_int32_extension_lite,
   ProtobufUnittest_Extensions_optional_int64_extension_lite,
   ProtobufUnittest_Extensions_optional_uint32_extension_lite,

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -396,7 +396,7 @@ extension Proto2WireformatUnittest_TestMessageSet {
   }
 }
 
-let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension,
   ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension
 ]

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -157,6 +157,6 @@ extension Google_Protobuf_NoGenericServicesTest_TestMessage {
   }
 }
 
-let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.ExtensionSet = [
+let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Google_Protobuf_NoGenericServicesTest_Extensions_test_extension
 ]

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -427,7 +427,7 @@ extension ProtobufUnittest_TestOptimizedForSize {
   }
 }
 
-let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension,
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2
 ]

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -583,7 +583,7 @@ extension ProtobufUnittest_Extend_MsgUsesStorage {
   }
 }
 
-let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend_Extensions_b,
   ProtobufUnittest_Extend_Extensions_C,
   ProtobufUnittest_Extend_Extensions_a_b,

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -231,7 +231,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
-let ProtobufUnittest_Extend2_UnittestSwiftExtension2_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_Extend2_UnittestSwiftExtension2_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend2_Extensions_b,
   ProtobufUnittest_Extend2_Extensions_C,
   ProtobufUnittest_Extend2_MyMessage.Extensions.b,

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -231,7 +231,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
-let ProtobufUnittest_Extend3_UnittestSwiftExtension3_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_Extend3_UnittestSwiftExtension3_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend3_Extensions_b,
   ProtobufUnittest_Extend3_Extensions_C,
   ProtobufUnittest_Extend3_MyMessage.Extensions.b,

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -231,7 +231,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
-let Ext4UnittestSwiftExtension4_Extensions: SwiftProtobuf.ExtensionSet = [
+let Ext4UnittestSwiftExtension4_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Ext4Extensions_b,
   Ext4Extensions_C,
   Ext4MyMessage.Extensions.b,

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -427,7 +427,7 @@ extension Swift_Protobuf_TestFieldOrderings {
   }
 }
 
-let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: SwiftProtobuf.ExtensionSet = [
+let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Swift_Protobuf_Extensions_my_extension_string,
   Swift_Protobuf_Extensions_my_extension_int
 ]

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -625,7 +625,7 @@ extension SwiftTestGroupExtensions {
   }
 }
 
-let UnittestSwiftGroups_Extensions: SwiftProtobuf.ExtensionSet = [
+let UnittestSwiftGroups_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_ExtensionGroup,
   Extensions_RepeatedExtensionGroup
 ]

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -22437,7 +22437,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   }
 }
 
-let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.ExtensionSet = [
+let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   SwiftUnittest_Names_Extensions_http,
   SwiftUnittest_Names_Extensions_http_request,
   SwiftUnittest_Names_Extensions_the_http_request,

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -419,7 +419,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   }
 }
 
-let ProtobufUnittest_UnittestSwiftReserved_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_UnittestSwiftReserved_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_debug_description,
   ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value
 ]

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -171,7 +171,7 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   }
 }
 
-let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufObjcUnittest_Extensions_optional_int32_extension,
   ProtobufObjcUnittest_Extensions_repeated_int32_extension,
   ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension

--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -103,7 +103,7 @@ internal class AnyMessageStorage {
 
   // This is only ever called with the expactation that target will be fully
   // replaced during the unpacking and never as a merge.
-  func unpackTo<M: Message>(target: inout M, extensions: ExtensionSet?) throws {
+  func unpackTo<M: Message>(target: inout M, extensions: ExtensionMap?) throws {
     guard isA(M.self) else {
       throw AnyUnpackError.typeMismatch
     }

--- a/Sources/SwiftProtobuf/BinaryDecoder.swift
+++ b/Sources/SwiftProtobuf/BinaryDecoder.swift
@@ -36,7 +36,7 @@ internal struct BinaryDecoder: Decoder {
     // Field number for last-parsed field tag
     private var fieldNumber: Int = 0
     // Collection of extension fields for this decode
-    private var extensions: ExtensionSet?
+    private var extensions: ExtensionMap?
     // The current group number. See decodeFullGroup(group:fieldNumber:) for how
     // this is used.
     private var groupFieldNumber: Int?
@@ -45,7 +45,7 @@ internal struct BinaryDecoder: Decoder {
 
     internal var complete: Bool {return available == 0}
 
-    internal init(forReadingFrom pointer: UnsafePointer<UInt8>, count: Int, extensions: ExtensionSet? = nil) {
+    internal init(forReadingFrom pointer: UnsafePointer<UInt8>, count: Int, extensions: ExtensionMap? = nil) {
         // Assuming baseAddress is not nil.
         p = pointer
         available = count

--- a/Sources/SwiftProtobuf/BinaryTypeAdditions.swift
+++ b/Sources/SwiftProtobuf/BinaryTypeAdditions.swift
@@ -58,7 +58,7 @@ public extension Message {
     ///
     /// - Parameters:
     ///   - serializedData: The binary serialization data to decode.
-    ///   - extensions: An `ExtensionSet` to look up and decode any extensions in this
+    ///   - extensions: An `ExtensionMap` to look up and decode any extensions in this
     ///     message or messages nested within this message's fields.
     ///   - partial: By default, the binary serialization format requires all `required`
     ///     fields be present; when `partial` is `false`,
@@ -66,7 +66,7 @@ public extension Message {
     ///     When `partial` is `true`, then partial messages are allowed, and
     ///     `Message.isInitialized` is not checked.
     /// - Throws: An instance of `BinaryDecodingError` on failure.
-    init(serializedData data: Data, extensions: ExtensionSet? = nil, partial: Bool = false) throws {
+    init(serializedData data: Data, extensions: ExtensionMap? = nil, partial: Bool = false) throws {
         self.init()
         try merge(serializedData: data, extensions: extensions, partial: partial)
     }
@@ -79,7 +79,7 @@ public extension Message {
     ///
     /// - Parameters:
     ///   - serializedData: The binary serialization data to decode.
-    ///   - extensions: An `ExtensionSet` to look up and decode any extensions in this
+    ///   - extensions: An `ExtensionMap` to look up and decode any extensions in this
     ///     message or messages nested within this message's fields.
     ///   - partial: By default, the binary serialization format requires all `required`
     ///     fields be present; when `partial` is `false`,
@@ -87,7 +87,7 @@ public extension Message {
     ///     When `partial` is `true`, then partial messages are allowed, and
     ///     `Message.isInitialized` is not checked.
     /// - Throws: An instance of `BinaryDecodingError` on failure.
-    mutating func merge(serializedData data: Data, extensions: ExtensionSet? = nil, partial: Bool = false) throws {
+    mutating func merge(serializedData data: Data, extensions: ExtensionMap? = nil, partial: Bool = false) throws {
         if !data.isEmpty {
             try data.withUnsafeBytes { (pointer: UnsafePointer<UInt8>) in
                 try _protobuf_mergeSerializedBytes(from: pointer,
@@ -101,7 +101,7 @@ public extension Message {
     }
 
     /// SwiftProtobuf Internal: Common support for decoding.
-    internal mutating func _protobuf_mergeSerializedBytes(from bytes: UnsafePointer<UInt8>, count: Int, extensions: ExtensionSet?) throws {
+    internal mutating func _protobuf_mergeSerializedBytes(from bytes: UnsafePointer<UInt8>, count: Int, extensions: ExtensionMap?) throws {
         var decoder = BinaryDecoder(forReadingFrom: bytes, count: count, extensions: extensions)
         try decodeMessage(decoder: &decoder)
         guard decoder.complete else {

--- a/Sources/SwiftProtobuf/ExtensionMap.swift
+++ b/Sources/SwiftProtobuf/ExtensionMap.swift
@@ -1,0 +1,38 @@
+// Sources/SwiftProtobuf/ExtensionMap.swift - Extension support
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// A set of extensions that can be passed into deserializers
+/// to provide details of the particular extensions that should
+/// be recognized.
+///
+// -----------------------------------------------------------------------------
+
+/// A collection of extension objects.
+///
+/// An `ExtensionMap` is used during decoding to look up
+/// extension objects corresponding to the serialized data.
+///
+/// This is a protocol so that developers can build their own
+/// extension handling if they need something more complex than the
+/// standard `ExtensionSet` implementation.
+public protocol ExtensionMap {
+    /// Returns the extension object describing an extension or nil
+    subscript(messageType: Message.Type, fieldNumber: Int) -> MessageExtensionBase? { get }
+
+    /// Returns the field number for a message with a specific field name
+    ///
+    /// The field name here matches the format used by the protobuf
+    /// Text serialization: it typically looks like
+    /// `package.message.field_name`, where `package` is the package
+    /// for the proto file and `message` is the name of the message in
+    /// which the extension was defined. (This is different from the
+    /// message that is being extended!)
+    func fieldNumberForProto(messageType: Message.Type, protoFieldName: String) -> Int?
+}

--- a/Sources/SwiftProtobuf/ExtensionMap.swift
+++ b/Sources/SwiftProtobuf/ExtensionMap.swift
@@ -21,7 +21,7 @@
 ///
 /// This is a protocol so that developers can build their own
 /// extension handling if they need something more complex than the
-/// standard `ExtensionSet` implementation.
+/// standard `SimpleExtensionMap` implementation.
 public protocol ExtensionMap {
     /// Returns the extension object describing an extension or nil
     subscript(messageType: Message.Type, fieldNumber: Int) -> MessageExtensionBase? { get }

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -33,7 +33,7 @@ public extension Message {
   /// - Parameter unpackingAny: the message to decode.
   /// - Throws: an instance of `AnyUnpackError`, `JSONDecodingError`, or
   ///   `BinaryDecodingError` on failure.
-  public init(unpackingAny: Google_Protobuf_Any, extensions: ExtensionSet? = nil) throws {
+  public init(unpackingAny: Google_Protobuf_Any, extensions: ExtensionMap? = nil) throws {
     self.init()
     try unpackingAny._storage.unpackTo(target: &self, extensions: extensions)
   }
@@ -60,7 +60,7 @@ public extension Google_Protobuf_Any {
 
 
   /// Decode an Any object from Protobuf Text Format.
-  public init(textFormatString: String, extensions: ExtensionSet? = nil) throws {
+  public init(textFormatString: String, extensions: ExtensionMap? = nil) throws {
     self.init()
     if !textFormatString.isEmpty {
       if let data = textFormatString.data(using: String.Encoding.utf8) {

--- a/Sources/SwiftProtobuf/SimpleExtensionMap.swift
+++ b/Sources/SwiftProtobuf/SimpleExtensionMap.swift
@@ -1,4 +1,4 @@
-// Sources/SwiftProtobuf/ExtensionSet.swift - Extension support
+// Sources/SwiftProtobuf/SimpleExtensionMap.swift - Extension support
 //
 // Copyright (c) 2014 - 2016 Apple Inc. and the project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
@@ -14,7 +14,7 @@
 
 
 // Note: The generated code only relies on ExpressibleByArrayLiteral
-public struct ExtensionSet: ExtensionMap, ExpressibleByArrayLiteral, CustomDebugStringConvertible {
+public struct SimpleExtensionMap: ExtensionMap, ExpressibleByArrayLiteral, CustomDebugStringConvertible {
     public typealias Element = MessageExtensionBase
 
     // Since type objects aren't Hashable, we can't do much better than this...
@@ -74,7 +74,7 @@ public struct ExtensionSet: ExtensionMap, ExpressibleByArrayLiteral, CustomDebug
         }
     }
 
-    public mutating func union(_ other: ExtensionSet) -> ExtensionSet {
+    public mutating func union(_ other: SimpleExtensionMap) -> SimpleExtensionMap {
         var out = self
         for (_, list) in other.fields {
             for (_, e) in list {
@@ -93,7 +93,7 @@ public struct ExtensionSet: ExtensionMap, ExpressibleByArrayLiteral, CustomDebug
             }
         }
         let d = names.joined(separator: ",")
-        return "ExtensionSet(\(d))"
+        return "SimpleExtensionMap(\(d))"
     }
 
 }

--- a/Sources/SwiftProtobuf/TextFormatDecoder.swift
+++ b/Sources/SwiftProtobuf/TextFormatDecoder.swift
@@ -33,7 +33,7 @@ internal struct TextFormatDecoder: Decoder {
         }
     }
 
-    internal init(messageType: Message.Type, utf8Pointer: UnsafePointer<UInt8>, count: Int, extensions: ExtensionSet?) throws {
+    internal init(messageType: Message.Type, utf8Pointer: UnsafePointer<UInt8>, count: Int, extensions: ExtensionMap?) throws {
         scanner = TextFormatScanner(utf8Pointer: utf8Pointer, count: count, extensions: extensions)
         guard let nameProviding = (messageType as? _ProtoNameProviding.Type) else {
             throw TextFormatDecodingError.missingFieldNames

--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -260,7 +260,7 @@ private func decodeString(_ s: String) -> String? {
 /// TextFormatScanner has no public members.
 ///
 internal struct TextFormatScanner {
-    internal var extensions: ExtensionSet?
+    internal var extensions: ExtensionMap?
     private var p: UnsafePointer<UInt8>
     private var end: UnsafePointer<UInt8>
 
@@ -270,7 +270,7 @@ internal struct TextFormatScanner {
         }
     }
 
-    internal init(utf8Pointer: UnsafePointer<UInt8>, count: Int, extensions: ExtensionSet? = nil) {
+    internal init(utf8Pointer: UnsafePointer<UInt8>, count: Int, extensions: ExtensionMap? = nil) {
         p = utf8Pointer
         end = p + count
         self.extensions = extensions

--- a/Sources/SwiftProtobuf/TextFormatTypeAdditions.swift
+++ b/Sources/SwiftProtobuf/TextFormatTypeAdditions.swift
@@ -33,10 +33,10 @@ public extension Message {
     ///
     /// - Parameters:
     ///   - textFormatString: the text serialization string to decode.
-    ///   - extensions: an `ExtensionSet` to look up and decode any extensions
+    ///   - extensions: an `ExtensionMap` to look up and decode any extensions
     ///     in this message or messages nested within this message's fields.
     /// - Throws: an instance of `TextFormatDecodingError` on failure.
-    public init(textFormatString: String, extensions: ExtensionSet? = nil) throws {
+    public init(textFormatString: String, extensions: ExtensionMap? = nil) throws {
         self.init()
         if !textFormatString.isEmpty {
             if let data = textFormatString.data(using: String.Encoding.utf8) {

--- a/Sources/SwiftProtobuf/any.pb.swift
+++ b/Sources/SwiftProtobuf/any.pb.swift
@@ -122,7 +122,7 @@ fileprivate let _protobuf_package = "google.protobuf"
 public struct Google_Protobuf_Any: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Any"
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .unique(proto: "type_url", json: "typeUrl"),
+    1: .standard(proto: "type_url"),
     2: .same(proto: "value"),
   ]
 

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -365,7 +365,7 @@ class FileGenerator {
         if !registry.isEmpty {
             let filename = toUpperCamelCase(baseFilename)
             p.print("\n")
-            p.print("\(generatorOptions.visibilitySourceSnippet)let \(descriptor.swiftPrefix)\(filename)_Extensions: SwiftProtobuf.ExtensionSet = [\n")
+            p.print("\(generatorOptions.visibilitySourceSnippet)let \(descriptor.swiftPrefix)\(filename)_Extensions: SwiftProtobuf.SimpleExtensionMap = [\n")
             p.indent()
             var separator = ""
             for e in registry {

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -38,6 +38,10 @@
 		9C2F239B1D7780D1008524F2 /* source_context.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */; };
 		9C2F239C1D7780D1008524F2 /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */; };
 		9C2F239D1D7780D1008524F2 /* type.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/type.pb.swift /* type.pb.swift */; };
+		9C4178611E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
+		9C4178621E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
+		9C4178631E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
+		9C4178641E809DA2007830C3 /* ExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C4178601E809DA2007830C3 /* ExtensionMap.swift */; };
 		9C5890A71DFF5FFC001CFC34 /* Test_TextFormat_proto2_extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5890A51DFF5EC8001CFC34 /* Test_TextFormat_proto2_extensions.swift */; };
 		9C5890A81DFF6375001CFC34 /* TextFormatDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E661DB1210E00957D74 /* TextFormatDecoder.swift */; };
 		9C5890A91DFF6375001CFC34 /* TextFormatEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */; };
@@ -608,6 +612,7 @@
 		8DC1CA0E1E54B81400CA8A26 /* TimeUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUtils.swift; sourceTree = "<group>"; };
 		9C0B366A1E5FAB910094E128 /* JSONMapEncodingVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONMapEncodingVisitor.swift; sourceTree = "<group>"; };
 		9C2F23781D778003008524F2 /* descriptor.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = descriptor.pb.swift; sourceTree = "<group>"; };
+		9C4178601E809DA2007830C3 /* ExtensionMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionMap.swift; sourceTree = "<group>"; };
 		9C5890A51DFF5EC8001CFC34 /* Test_TextFormat_proto2_extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_proto2_extensions.swift; sourceTree = "<group>"; };
 		9C60CBE71DF8AC3F00F7B14E /* Test_TextFormat_Map_proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_Map_proto3.swift; sourceTree = "<group>"; };
 		9C60CBEB1DF9DEEA00F7B14E /* Test_TextFormat_proto2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_proto2.swift; sourceTree = "<group>"; };
@@ -875,6 +880,7 @@
 				9C75F88E1DDD3108005CCFF2 /* ExtensibleMessage.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */,
 				9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */,
+				9C4178601E809DA2007830C3 /* ExtensionMap.swift */,
 				9C75F8841DDD3045005CCFF2 /* ExtensionSet.swift */,
 				__PBXFileRef_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift */,
 				AA05BF4E1DAEB7E800619042 /* FieldTag.swift */,
@@ -1374,6 +1380,7 @@
 				9C5890B61DFF6389001CFC34 /* TextFormatEncodingVisitor.swift in Sources */,
 				9C5890B71DFF6389001CFC34 /* TextFormatScanner.swift in Sources */,
 				9C5890B91DFF6389001CFC34 /* TextFormatTypeAdditions.swift in Sources */,
+				9C4178621E809DA2007830C3 /* ExtensionMap.swift in Sources */,
 				F48FDD241E4D17ED0061D5C1 /* JSONScanner.swift in Sources */,
 				9C75F8861DDD3045005CCFF2 /* ExtensionSet.swift in Sources */,
 				9C84E4901E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
@@ -1406,6 +1413,7 @@
 				AAE0F4E31E6F5CB9005240E0 /* Google_Protobuf_Value+Extensions.swift in Sources */,
 				8DC1CA0F1E54B81400CA8A26 /* TimeUtils.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift in Sources */,
+				9C4178611E809DA2007830C3 /* ExtensionMap.swift in Sources */,
 				9C75F88A1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */,
 				F47138961E4E56AC00C8492C /* Internal.swift in Sources */,
 				9C75F8851DDD3045005CCFF2 /* ExtensionSet.swift in Sources */,
@@ -1630,6 +1638,7 @@
 				9C5890B01DFF6384001CFC34 /* TextFormatEncodingVisitor.swift in Sources */,
 				9C5890B11DFF6384001CFC34 /* TextFormatScanner.swift in Sources */,
 				9C5890B31DFF6384001CFC34 /* TextFormatTypeAdditions.swift in Sources */,
+				9C4178631E809DA2007830C3 /* ExtensionMap.swift in Sources */,
 				F48FDD251E4D17EE0061D5C1 /* JSONScanner.swift in Sources */,
 				9C84E4911E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
 				F44F93931DAEA76700BC5B85 /* FieldTypes.swift in Sources */,
@@ -1810,6 +1819,7 @@
 				9C5890A81DFF6375001CFC34 /* TextFormatDecoder.swift in Sources */,
 				9C5890A91DFF6375001CFC34 /* TextFormatEncoder.swift in Sources */,
 				F48FDD261E4D17EF0061D5C1 /* JSONScanner.swift in Sources */,
+				9C4178641E809DA2007830C3 /* ExtensionMap.swift in Sources */,
 				9C5890AA1DFF6375001CFC34 /* TextFormatEncodingVisitor.swift in Sources */,
 				9C84E4921E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
 				9C5890AB1DFF6375001CFC34 /* TextFormatScanner.swift in Sources */,

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -83,10 +83,10 @@
 		9C75F8811DDBE0FC005CCFF2 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */; };
 		9C75F8821DDBE10D005CCFF2 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */; };
 		9C75F8831DDBE118005CCFF2 /* Visitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */; };
-		9C75F8851DDD3045005CCFF2 /* ExtensionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* ExtensionSet.swift */; };
-		9C75F8861DDD3045005CCFF2 /* ExtensionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* ExtensionSet.swift */; };
-		9C75F8871DDD3045005CCFF2 /* ExtensionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* ExtensionSet.swift */; };
-		9C75F8881DDD3045005CCFF2 /* ExtensionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* ExtensionSet.swift */; };
+		9C75F8851DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */; };
+		9C75F8861DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */; };
+		9C75F8871DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */; };
+		9C75F8881DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */; };
 		9C75F88A1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */; };
 		9C75F88B1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */; };
 		9C75F88C1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */; };
@@ -621,7 +621,7 @@
 		9C667A901E4C203D008B974F /* TextFormatDecodingError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormatDecodingError.swift; sourceTree = "<group>"; };
 		9C7254651E5F9B1600486C98 /* Test_TextFormat_Unknown.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_Unknown.swift; sourceTree = "<group>"; };
 		9C75F87F1DDBE0DE005CCFF2 /* Visitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Visitor.swift; sourceTree = "<group>"; };
-		9C75F8841DDD3045005CCFF2 /* ExtensionSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionSet.swift; sourceTree = "<group>"; };
+		9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleExtensionMap.swift; sourceTree = "<group>"; };
 		9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionFieldValueSet.swift; sourceTree = "<group>"; };
 		9C75F88E1DDD3108005CCFF2 /* ExtensibleMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensibleMessage.swift; sourceTree = "<group>"; };
 		9C75F8931DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryEncodingVisitor.swift; sourceTree = "<group>"; };
@@ -881,7 +881,6 @@
 				__PBXFileRef_Sources/Protobuf/ProtobufExtensionFields.swift /* ExtensionFields.swift */,
 				9C75F8891DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift */,
 				9C4178601E809DA2007830C3 /* ExtensionMap.swift */,
-				9C75F8841DDD3045005CCFF2 /* ExtensionSet.swift */,
 				__PBXFileRef_Sources/Protobuf/field_mask.pb.swift /* field_mask.pb.swift */,
 				AA05BF4E1DAEB7E800619042 /* FieldTag.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufTypes.swift /* FieldTypes.swift */,
@@ -912,6 +911,7 @@
 				AAABA40A1E4A42CD00365CDF /* ProtobufAPIVersionCheck.swift */,
 				9C75F8A21DDD44A1005CCFF2 /* ProtobufMap.swift */,
 				AAF2ED3E1DEF4D94007B510F /* ProtoNameProviding.swift */,
+				9C75F8841DDD3045005CCFF2 /* SimpleExtensionMap.swift */,
 				__PBXFileRef_Sources/Protobuf/source_context.pb.swift /* source_context.pb.swift */,
 				9CA424411E286D4E00C0E5B4 /* StringUtils.swift */,
 				AA3640901E60D043000C3CF4 /* struct.pb.swift */,
@@ -1382,7 +1382,7 @@
 				9C5890B91DFF6389001CFC34 /* TextFormatTypeAdditions.swift in Sources */,
 				9C4178621E809DA2007830C3 /* ExtensionMap.swift in Sources */,
 				F48FDD241E4D17ED0061D5C1 /* JSONScanner.swift in Sources */,
-				9C75F8861DDD3045005CCFF2 /* ExtensionSet.swift in Sources */,
+				9C75F8861DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */,
 				9C84E4901E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
 				9C75F8811DDBE0FC005CCFF2 /* Visitor.swift in Sources */,
 				9C0B366C1E5FAB910094E128 /* JSONMapEncodingVisitor.swift in Sources */,
@@ -1416,7 +1416,7 @@
 				9C4178611E809DA2007830C3 /* ExtensionMap.swift in Sources */,
 				9C75F88A1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */,
 				F47138961E4E56AC00C8492C /* Internal.swift in Sources */,
-				9C75F8851DDD3045005CCFF2 /* ExtensionSet.swift in Sources */,
+				9C75F8851DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift in Sources */,
 				AAF2ED3A1DEF3FBC007B510F /* NameMap.swift in Sources */,
 				9CA424421E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
@@ -1643,7 +1643,7 @@
 				9C84E4911E5E3ABD00513BE0 /* BinaryEncodingError.swift in Sources */,
 				F44F93931DAEA76700BC5B85 /* FieldTypes.swift in Sources */,
 				9C0B366D1E5FAB910094E128 /* JSONMapEncodingVisitor.swift in Sources */,
-				9C75F8871DDD3045005CCFF2 /* ExtensionSet.swift in Sources */,
+				9C75F8871DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */,
 				F44F937D1DAEA76700BC5B85 /* Google_Protobuf_FieldMask+Extensions.swift in Sources */,
 				F44F93771DAEA76700BC5B85 /* api.pb.swift in Sources */,
 				F44F93791DAEA76700BC5B85 /* empty.pb.swift in Sources */,
@@ -1776,7 +1776,7 @@
 				F44F94171DAEB23500BC5B85 /* ExtensionFields.swift in Sources */,
 				9C75F88D1DDD30A5005CCFF2 /* ExtensionFieldValueSet.swift in Sources */,
 				F47138991E4E56AC00C8492C /* Internal.swift in Sources */,
-				9C75F8881DDD3045005CCFF2 /* ExtensionSet.swift in Sources */,
+				9C75F8881DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */,
 				F44F94191DAEB23500BC5B85 /* Decoder.swift in Sources */,
 				AAF2ED3D1DEF3FBC007B510F /* NameMap.swift in Sources */,
 				9CA424451E286D4E00C0E5B4 /* StringUtils.swift in Sources */,

--- a/Tests/SwiftProtobufTests/Message+UInt8ArrayHelpers.swift
+++ b/Tests/SwiftProtobufTests/Message+UInt8ArrayHelpers.swift
@@ -18,7 +18,7 @@ import Foundation
 import SwiftProtobuf
 
 extension SwiftProtobuf.Message {
-    init(serializedBytes: [UInt8], extensions: SwiftProtobuf.ExtensionSet? = nil) throws {
+    init(serializedBytes: [UInt8], extensions: SwiftProtobuf.SimpleExtensionMap? = nil) throws {
         try self.init(serializedData: Data(serializedBytes), extensions: extensions)
     }
 

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -136,7 +136,7 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
     /// This uses the provided block to initialize the object, then:
     /// * Encodes the object and checks that the result is the expected result
     /// * Decodes it again and verifies that the round-trip gives an equal object
-    func assertTextFormatEncode(_ expected: String, extensions: ExtensionSet? = nil, file: XCTestFileArgType = #file, line: UInt = #line, configure: (inout MessageTestType) -> Void) {
+    func assertTextFormatEncode(_ expected: String, extensions: SimpleExtensionMap? = nil, file: XCTestFileArgType = #file, line: UInt = #line, configure: (inout MessageTestType) -> Void) {
         let empty = MessageTestType()
         var configured = empty
         configure(&configured)

--- a/Tests/SwiftProtobufTests/Test_Extensions.swift
+++ b/Tests/SwiftProtobufTests/Test_Extensions.swift
@@ -20,7 +20,7 @@ import SwiftProtobuf
 
 class Test_Extensions: XCTestCase, PBTestHelpers {
     typealias MessageTestType = ProtobufUnittest_TestAllExtensions
-    var extensions = SwiftProtobuf.ExtensionSet()
+    var extensions = SwiftProtobuf.SimpleExtensionMap()
 
     func assertEncode(_ expected: [UInt8], file: XCTestFileArgType = #file, line: UInt = #line, configure: (inout MessageTestType) -> Void) {
         let empty = MessageTestType()
@@ -122,7 +122,7 @@ class Test_Extensions: XCTestCase, PBTestHelpers {
     func test_extensionMessageSpecificity() throws {
         // An extension set with two extensions for field #5, but for
         // different messages and with different types
-        var extensions = ExtensionSet()
+        var extensions = SimpleExtensionMap()
         extensions.insert(ProtobufUnittest_Extensions_optional_sint32_extension)
         extensions.insert(ProtobufUnittest_Extensions_my_extension_int)
 

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -10987,7 +10987,7 @@ extension ProtobufUnittest_TestHugeFieldNumbers {
   }
 }
 
-let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_optional_int32_extension,
   ProtobufUnittest_Extensions_optional_int64_extension,
   ProtobufUnittest_Extensions_optional_uint32_extension,

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -2500,7 +2500,7 @@ extension Google_Protobuf_MessageOptions {
   }
 }
 
-let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_file_opt1,
   ProtobufUnittest_Extensions_message_opt1,
   ProtobufUnittest_Extensions_field_opt1,

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -5146,7 +5146,7 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite {
   }
 }
 
-let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_optional_int32_extension_lite,
   ProtobufUnittest_Extensions_optional_int64_extension_lite,
   ProtobufUnittest_Extensions_optional_uint32_extension_lite,

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -396,7 +396,7 @@ extension Proto2WireformatUnittest_TestMessageSet {
   }
 }
 
-let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension,
   ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension
 ]

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -157,6 +157,6 @@ extension Google_Protobuf_NoGenericServicesTest_TestMessage {
   }
 }
 
-let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.ExtensionSet = [
+let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Google_Protobuf_NoGenericServicesTest_Extensions_test_extension
 ]

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -427,7 +427,7 @@ extension ProtobufUnittest_TestOptimizedForSize {
   }
 }
 
-let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension,
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -583,7 +583,7 @@ extension ProtobufUnittest_Extend_MsgUsesStorage {
   }
 }
 
-let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend_Extensions_b,
   ProtobufUnittest_Extend_Extensions_C,
   ProtobufUnittest_Extend_Extensions_a_b,

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -231,7 +231,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
-let ProtobufUnittest_Extend2_UnittestSwiftExtension2_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_Extend2_UnittestSwiftExtension2_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend2_Extensions_b,
   ProtobufUnittest_Extend2_Extensions_C,
   ProtobufUnittest_Extend2_MyMessage.Extensions.b,

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -231,7 +231,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
-let ProtobufUnittest_Extend3_UnittestSwiftExtension3_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_Extend3_UnittestSwiftExtension3_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend3_Extensions_b,
   ProtobufUnittest_Extend3_Extensions_C,
   ProtobufUnittest_Extend3_MyMessage.Extensions.b,

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -231,7 +231,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
-let Ext4UnittestSwiftExtension4_Extensions: SwiftProtobuf.ExtensionSet = [
+let Ext4UnittestSwiftExtension4_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Ext4Extensions_b,
   Ext4Extensions_C,
   Ext4MyMessage.Extensions.b,

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -427,7 +427,7 @@ extension Swift_Protobuf_TestFieldOrderings {
   }
 }
 
-let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: SwiftProtobuf.ExtensionSet = [
+let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Swift_Protobuf_Extensions_my_extension_string,
   Swift_Protobuf_Extensions_my_extension_int
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -625,7 +625,7 @@ extension SwiftTestGroupExtensions {
   }
 }
 
-let UnittestSwiftGroups_Extensions: SwiftProtobuf.ExtensionSet = [
+let UnittestSwiftGroups_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_ExtensionGroup,
   Extensions_RepeatedExtensionGroup
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -22437,7 +22437,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   }
 }
 
-let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.ExtensionSet = [
+let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   SwiftUnittest_Names_Extensions_http,
   SwiftUnittest_Names_Extensions_http_request,
   SwiftUnittest_Names_Extensions_the_http_request,

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -419,7 +419,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   }
 }
 
-let ProtobufUnittest_UnittestSwiftReserved_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufUnittest_UnittestSwiftReserved_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_debug_description,
   ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value
 ]

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -171,7 +171,7 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   }
 }
 
-let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: SwiftProtobuf.ExtensionSet = [
+let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufObjcUnittest_Extensions_optional_int32_extension,
   ProtobufObjcUnittest_Extensions_repeated_int32_extension,
   ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension


### PR DESCRIPTION
This implements #293.

It introduces a new `ExtensionMap` protocol that has two methods for looking up information about extensions:
* A method that looks up the extension number given the message being extended and the name
* A method that returns the extension object given the message being extended and the number

The old `ExtensionSet` struct has been renamed `SimpleExtensionSet`.  It provides a basic implementation of this protocol and is used by the code generator.

This will allow developers to optimize extension lookup by providing tailored implementations of the protocol (for example, that used switch statements for faster lookup).  We could even have our code generator build such tailored implementations if we wanted.