### PR TITLE
Clean up Any support of required fields.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -51,7 +51,19 @@ public extension Google_Protobuf_Any {
   /// needs to be serialized.  This design avoids unnecessary
   /// decoding/recoding when writing JSON format.
   ///
-  public init(message: Message, typePrefix: String = defaultTypePrefix) {
+  /// - Parameters:
+  ///   - partial: The binary serialization format requires all `required` fields
+  ///     be present; when `partial` is `false`, `BinaryEncodingError.missingRequiredFields`
+  ///     is thrown if any were missing. When `partial` is `true`, then partial
+  ///     messages are allowed, and `Message.isRequired` is not checked.
+  ///   - typePrefix: The prefix to be used when building the `type_url`.  Defaults to
+  ///     "type.googleapis.com".
+  /// - Throws: `BinaryEncodingError.missingRequiredFields` if `partial` is false and
+  ///     `message` wasn't fully initialized.
+  public init(message: Message, partial: Bool = false, typePrefix: String = defaultTypePrefix) throws {
+    if !partial && !message.isInitialized {
+      throw BinaryEncodingError.missingRequiredFields
+    }
     self.init()
     typeURL = buildTypeURL(forMessage:message, typePrefix: typePrefix)
     _storage.state = .message(message)

--- a/Tests/SwiftProtobufTests/Test_Any.swift
+++ b/Tests/SwiftProtobufTests/Test_Any.swift
@@ -27,7 +27,7 @@ class Test_Any: XCTestCase {
 
         var m = ProtobufUnittest_TestAny()
         m.int32Value = 12
-        m.anyValue = Google_Protobuf_Any(message: content)
+        m.anyValue = try Google_Protobuf_Any(message: content)
 
         // The Any holding an object can be JSON serialized
         XCTAssertNotNil(try m.jsonString())
@@ -149,7 +149,7 @@ class Test_Any: XCTestCase {
 
         var m = ProtobufUnittest_TestAny()
         m.int32Value = 12
-        m.anyValue = Google_Protobuf_Any(message: content)
+        m.anyValue = try Google_Protobuf_Any(message: content)
 
         let encoded = try m.jsonString()
         XCTAssertEqual(encoded, "{\"int32Value\":12,\"anyValue\":{\"@type\":\"type.googleapis.com/protobuf_unittest.TestAllTypes\",\"optionalInt32\":7}}")
@@ -640,7 +640,7 @@ class Test_Any: XCTestCase {
         $0.stringValue = "abc"
       }
       var msg = ProtobufTestMessages_Proto3_TestAllTypes()
-      msg.optionalAny = Google_Protobuf_Any(message: valueMsg, typePrefix: "Odd\nPrefix\"")
+      msg.optionalAny = try Google_Protobuf_Any(message: valueMsg, typePrefix: "Odd\nPrefix\"")
       let newJSON = try msg.jsonString()
       XCTAssertEqual(newJSON, "{\"optionalAny\":{\"@type\":\"Odd\\nPrefix\\\"/google.protobuf.Value\",\"value\":\"abc\"}}")
     }

--- a/Tests/SwiftProtobufTests/Test_Api.swift
+++ b/Tests/SwiftProtobufTests/Test_Api.swift
@@ -28,7 +28,7 @@ class Test_Api: XCTestCase, PBTestHelpers {
         }
     }
 
-    func testInitializer() {
+    func testInitializer() throws {
         var m = MessageTestType()
         m.name = "apiName"
         var method = Google_Protobuf_Method()
@@ -36,7 +36,7 @@ class Test_Api: XCTestCase, PBTestHelpers {
         m.methods = [method]
         var option = Google_Protobuf_Option()
         option.name = "option1"
-        option.value = Google_Protobuf_Any(message: Google_Protobuf_StringValue("value1"))
+        option.value = try Google_Protobuf_Any(message: Google_Protobuf_StringValue("value1"))
         m.options = [option]
         m.version = "1.0.0"
         m.syntax = .proto3

--- a/Tests/SwiftProtobufTests/Test_TextFormat_WKT_proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_WKT_proto3.swift
@@ -22,7 +22,11 @@ class Test_TextFormat_WKT_proto3: XCTestCase, PBTestHelpers {
     func assertAnyTest<M: Message & Equatable>(_ message: M, expected: String, file: XCTestFileArgType = #file, line: UInt = #line) {
         let empty = MessageTestType()
         var configured = empty
-        configured.anyField = Google_Protobuf_Any(message: message)
+        do {
+            configured.anyField = try Google_Protobuf_Any(message: message)
+        } catch {
+            XCTFail("Assigning to any field failed: \(error)", file: file, line: line)
+        }
         XCTAssert(configured != empty, "Object should not be equal to empty object", file: file, line: line)
         let encoded = configured.textFormatString()
         XCTAssert(expected == encoded, "Did not encode correctly: got \(encoded)", file: file, line: line)
@@ -45,8 +49,8 @@ class Test_TextFormat_WKT_proto3: XCTestCase, PBTestHelpers {
                       expected: "any_field {\n  [type.googleapis.com/google.protobuf.Empty] {\n  }\n}\n")
 
         // Nested any
-        let a = ProtobufUnittest_TestWellKnownTypes.with {
-            $0.anyField = Google_Protobuf_Any(message: Google_Protobuf_Any(message: Google_Protobuf_Duration(seconds: 123, nanos: 234567890)))
+        let a = try ProtobufUnittest_TestWellKnownTypes.with {
+            $0.anyField = try Google_Protobuf_Any(message: Google_Protobuf_Any(message: Google_Protobuf_Duration(seconds: 123, nanos: 234567890)))
         }
         let a_encoded = a.textFormatString()
         XCTAssertEqual(a_encoded, "any_field {\n  [type.googleapis.com/google.protobuf.Any] {\n    [type.googleapis.com/google.protobuf.Duration] {\n      seconds: 123\n      nanos: 234567890\n    }\n  }\n}\n")


### PR DESCRIPTION
- Expose `partial` on the helper to create a Google_Protobuf_Any from a Message,
  and do the validation there.
- With AnyMessageStorage always use partial support since validation was done
  up front or should have been done by whoever sent us the payload. In almost
  all of these cases, there's no good way to deal missing required fields any
  way, so just let things slide.
- Remove the isInitialized check in preTraverse. This was wrong in that it was
  causing required fields to get checked for TextFormat and JSON encoding.