### PR TITLE
Allow perf harness to compare multiple revisions of SwiftProtobuf

### DIFF
--- a/Performance/css/harness-visualization.css
+++ b/Performance/css/harness-visualization.css
@@ -16,7 +16,7 @@ table.numeric td {
 
 table.numeric th {
   background-color: #eee;
-  text-align: right;
+  text-align: center;
 }
 
 table.numeric tfoot td {

--- a/Performance/generators/cpp.sh
+++ b/Performance/generators/cpp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SwiftProtobuf/Performance/perf_runner_cpp.sh - C++ test harness generator
+# SwiftProtobuf/Performance/generators/cpp.sh - C++ test harness generator
 #
 # This source file is part of the Swift.org open source project
 #
@@ -15,8 +15,6 @@
 # Functions for generating the C++ harness.
 #
 # -----------------------------------------------------------------------------
-
-set -eu
 
 function print_cpp_set_field() {
   num=$1
@@ -156,33 +154,4 @@ EOF
   cat >> "$gen_harness_path" <<EOF
 }
 EOF
-}
-
-function run_cpp_harness() {
-  harness="$1"
-
-  echo "Generating C++ harness source..."
-  gen_harness_path="$script_dir/_generated/Harness+Generated.cc"
-  generate_cpp_harness "$field_count" "$field_type"
-
-  echo "Building C++ test harness..."
-  time ( g++ --std=c++11 -O \
-      -o "$harness" \
-      -I "$script_dir" \
-      -I "$GOOGLE_PROTOBUF_CHECKOUT/src" \
-      -L "$GOOGLE_PROTOBUF_CHECKOUT/src/.libs" \
-      -lprotobuf \
-      "$gen_harness_path" \
-      "$script_dir/Harness.cc" \
-      "$script_dir/_generated/message.pb.cc" \
-      "$script_dir/main.cc" \
-  )
-  echo
-
-  # Make sure the dylib is loadable from the harness if the user hasn't
-  # actually installed them.
-  cp "$GOOGLE_PROTOBUF_CHECKOUT"/src/.libs/libprotobuf.*.dylib \
-      "$script_dir/_generated"
-
-  run_harness_and_concatenate_results "C++" "$harness" "$partial_results"
 }

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -41,22 +41,52 @@ readonly GOOGLE_PROTOBUF_CHECKOUT=${GOOGLE_PROTOBUF_CHECKOUT:-"$script_dir/../..
 
 function usage() {
   cat >&2 <<EOF
-Usage: $0 [-p <true|false>] [-s2|-s3] <field count> <field types...>
+SYNOPSIS
+    $0 [-c <rev|c++> -c <rev|c++> ...] [-p <true|false>] [-s2|-s3] <field count> <field types...>
 
-Currently supported field types:
-    int32, sint32, uint32, fixed32, sfixed32,
-    int64, sint64, uint64, fixed64, sfixed64,
-    float, double, string,
-    ...and repeated variants of the above.
+    Currently supported field types:
+        int32, sint32, uint32, fixed32, sfixed32,
+        int64, sint64, uint64, fixed64, sfixed64,
+        float, double, string,
+        ...and repeated variants of the above.
 
-    Additionally, you can specify "all" to run the harness
-    multiple times with all of the (non-repeated) field types
-    listed above.
+        Additionally, you can specify "all" to run the harness multiple
+        times with all of the (non-repeated) field types listed above.
+        ("all" is not compatible with revision comparisons.)
 
-Options:
-    -p <true|false>: Adds a packed option to each field.
-    -s[23]:          Generate proto2 or proto3 syntax. proto3 is
-                     the default.
+OPTIONS
+    -c <rev|c++> [-c <rev|c++> ...]
+        A git revision (a commit hash, branch name, or tag) or the
+        string "c++" that will be performance tested and added as a
+        series in the result plot to compare against the current
+        working tree state. Can be specified multiple times. The current
+        working tree is always tested and included as the final series.
+
+        If no "-c" options are specified, the working tree is compared
+        against the C++ implementation.
+
+    -p <true|false>
+        If true, the generator adds a packed option to each field.
+        Defaults to false.
+
+    -s2, -s3
+        Indicates whether proto2 or proto3 syntax should be generated.
+        The default is proto3.
+
+EXAMPLES
+    $0 100 fixed32
+        Runs the C++ harness and Swift harness in the current working
+        tree using a message with 100 fixed32 fields.
+
+    $0 -c string-speedup -p true 100 "repeated string"
+        Runs the Swift harness in its state at branch "string-speedup"
+        and then again in the current working tree, using a message
+        with 100 packed repeated string fields.
+
+    $0 -c 4d0b78 -c c++ -s2 100 bytes
+        Runs the Swift harness in its state at commit 4d0b78, the C++
+        harness, and then the Swift harness in the current working tree,
+        using a proto2 message with 100 bytes fields.
 EOF
   exit 1
 }
@@ -106,7 +136,9 @@ function run_harness_and_concatenate_results() {
   partial_results="$3"
 
   cat >> "$partial_results" <<EOF
-    "$language": {
+    {
+      name: "$language",
+      data: {
 EOF
 
   echo "Running $language test harness alone..."
@@ -124,21 +156,23 @@ EOF
   echo
 
   cat >> "$partial_results" <<EOF
-      harnessSize: {
-        "Unstripped": $unstripped_size,
-        "Stripped": $stripped_size,
+        harnessSize: {
+          "Unstripped": $unstripped_size,
+          "Stripped": $stripped_size,
+        },
       },
     },
 EOF
 }
 
 function profile_harness() {
-  language="$1"
+  description="$1"
   harness="$2"
+  perf_dir="$3"
 
-  echo "Running $language test harness in Instruments..."
+  echo "Running $description test harness in Instruments..."
   instruments -t "$script_dir/Protobuf" -D "$results_trace" \
-      "$harness" -e DYLD_LIBRARY_PATH "$script_dir/_generated"
+      "$harness" -e DYLD_LIBRARY_PATH "$perf_dir/_generated"
 }
 
 # Inserts the partial visualization results from all the languages tested into
@@ -156,19 +190,38 @@ function insert_visualization_results() {
   mv "${results_js}.new" "$results_js"
 }
 
-# ---------------------------------------------------------------
-# Pull in language specific helpers.
-source "$script_dir/perf_runner_cpp.sh"
-source "$script_dir/perf_runner_swift.sh"
+# build_swift_packages <workdir> <plugin_suffix>
+#
+# Builds the runtime and plug-in with Swift Package Manager, assuming the
+# package manifest and sources are in <workdir>. After being built, the
+# plug-in will be copied and renamed to "protoc-gen-swift<plugin_suffix>"
+# in the same release directory, so that it can be guaranteed unique when
+# running protoc.
+function build_swift_packages() {
+  workdir="$1"
+  plugin_suffix="$2"
+  (
+    echo "Building runtime and plug-in with Swift Package Manager..."
+
+    cd "$workdir" >/dev/null
+    swift build -c release >/dev/null
+    cp .build/release/protoc-gen-swift \
+        ".build/release/protoc-gen-swift${plugin_suffix}"
+  )
+}
 
 # ---------------------------------------------------------------
-# Script main logic.
+# Process command line options.
 
+declare -a comparisons
 packed=""
 proto_syntax="3"
 
-while getopts "p:s:" arg; do
+while getopts "c:p:s:" arg; do
   case "${arg}" in
+    c)
+      comparisons+=("$OPTARG")
+      ;;
     p)
       packed="$OPTARG"
       ;;
@@ -189,6 +242,11 @@ fi
 
 readonly field_count="$1"; shift
 if [[ "$1" == "all" ]]; then
+  # if [[ "$comparison" != "c++" ]]; then
+  #   echo "ERROR: Commit-based comparison cannot be used with 'all'."
+  #   echo
+  #   usage
+  # fi
   readonly requested_field_types=( \
     int32 sint32 uint32 fixed32 sfixed32 \
     int64 sint64 uint64 fixed64 sfixed64 \
@@ -198,13 +256,12 @@ else
   readonly requested_field_types=( "$@" )
 fi
 
-# Make sure the runtime and plug-in are up to date first.
-( cd "$script_dir/.." >/dev/null; swift build -c release )
+# ---------------------------------------------------------------
+# Pull in language-specific runners.
+source "$script_dir/runners/swift.sh"
 
-# Copy the newly built plugin with a new name so that we can ensure that we're
-# invoking the correct one when we pass it on the command line.
-cp "$script_dir/../.build/release/protoc-gen-swift" \
-    "$script_dir/../.build/release/protoc-gen-swiftForPerf"
+# ---------------------------------------------------------------
+# Script main logic.
 
 mkdir -p "$script_dir/_generated"
 mkdir -p "$script_dir/_results"
@@ -217,39 +274,95 @@ if [[ ! -f "$results_js" ]]; then
 fi
 
 # Iterate over the requested field types and run the harnesses.
+# TODO: Get rid of this multi-run; instead, just create a proto like
+# TestAllTypes that tests multiple field types in one message. This is more
+# realistic.
 for field_type in "${requested_field_types[@]}"; do
   gen_message_path="$script_dir/_generated/message.proto"
 
   echo "Generating test proto with $field_count fields of type $field_type..."
   generate_test_proto "$field_count" "$field_type"
 
-  protoc --plugin="$script_dir/../.build/release/protoc-gen-swiftForPerf" \
-      --swiftForPerf_out=FileNaming=DropPath:"$script_dir/_generated" \
-      --cpp_out="$script_dir" \
-      "$gen_message_path"
-
   # Start a session.
   partial_results="$script_dir/_results/partial.js"
+  pretty_head_rev="$(git rev-parse --abbrev-ref HEAD)"
   cat > "$partial_results" <<EOF
   {
     date: "$(date -u +"%FT%T.000Z")",
     type: "$field_count fields of type $field_type",
-    branch: "$(git rev-parse --abbrev-ref HEAD)",
+    branch: "$pretty_head_rev",
     commit: "$(git rev-parse HEAD)",
     uncommitted_changes: $([[ -z $(git status -s) ]] && echo false || echo true),
+    series: [
 EOF
 
-  harness_cpp="$script_dir/_generated/harness_cpp"
-  results_trace="$script_dir/_results/$field_count fields of $field_type (cpp)"
-  run_cpp_harness "$harness_cpp"
+  for comparison in "${comparisons[@]}"; do
+    if [[ "$comparison" == "c++" ]]; then
+      source "$script_dir/runners/cpp.sh"
+
+      echo
+      echo "==== Building/running C++ harness ===================="
+      echo
+
+      protoc --cpp_out="$script_dir" "$gen_message_path"
+
+      harness_cpp="$script_dir/_generated/harness_cpp"
+      results_trace="$script_dir/_results/$field_count fields of $field_type (cpp)"
+      run_cpp_harness "$harness_cpp"
+    else
+      commit_hash="$(git rev-parse $comparison)"
+      commit_results="$script_dir/_results/${commit_hash}_${field_type}_${field_count}.js"
+
+      # Check to see if we have past results from that commit cached. If so, we
+      # don't need to run it again.
+      if [[ ! -f "$commit_results" ]]; then
+        echo
+        echo "==== Building/running Swift harness ($comparison) ===================="
+        echo
+
+        # Check out the commit to a temporary directory and create its _generated
+        # directory. (Results will still go in the working tree.)
+        tmp_checkout="$(mktemp -d -t swiftprotoperf)"
+        git --work-tree="$tmp_checkout" checkout "$comparison" -- .
+        mkdir "$tmp_checkout/Performance/_generated"
+
+        build_swift_packages "$tmp_checkout" "ForRev"
+        protoc --plugin="$tmp_checkout/.build/release/protoc-gen-swiftForRev" \
+            --swiftForRev_out=FileNaming=DropPath:"$tmp_checkout/Performance/_generated" \
+            "$gen_message_path"
+
+        harness_swift="$tmp_checkout/Performance/_generated/harness_swift"
+        results_trace="$script_dir/_results/$field_count fields of $field_type (swift)"
+        run_swift_harness "$tmp_checkout" "$comparison" "$commit_results"
+
+        rm -r "$tmp_checkout"
+      else
+        echo
+        echo "==== Found cached results for Swift ($comparison) ===================="
+      fi
+
+      cat "$commit_results" >> "$partial_results"
+    fi
+  done
+
+  echo
+  echo "==== Building/running Swift harness (working tree) ===================="
+  echo
+
+  build_swift_packages "$script_dir/.." "ForWorkTree"
+  protoc --plugin="$script_dir/../.build/release/protoc-gen-swiftForWorkTree" \
+      --swiftForWorkTree_out=FileNaming=DropPath:"$script_dir/_generated" \
+      --cpp_out="$script_dir" \
+      "$gen_message_path"
 
   harness_swift="$script_dir/_generated/harness_swift"
   results_trace="$script_dir/_results/$field_count fields of $field_type (swift)"
   display_results_trace="$results_trace"
-  run_swift_harness "$harness_swift"
+  run_swift_harness "$script_dir/.." "working tree" "$partial_results"
 
   # Close out the session.
   cat >> "$partial_results" <<EOF
+    ],
   },
 EOF
 

--- a/Performance/runners/cpp.sh
+++ b/Performance/runners/cpp.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# SwiftProtobuf/Performance/runners/cpp.sh - C++ test harness runner
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# -----------------------------------------------------------------------------
+#
+# Functions for running the C++ harness.
+#
+# -----------------------------------------------------------------------------
+
+function run_cpp_harness() {
+  (
+    harness="$1"
+
+    source "$script_dir/generators/cpp.sh"
+
+    echo "Generating C++ harness source..."
+    gen_harness_path="$script_dir/_generated/Harness+Generated.cc"
+    generate_cpp_harness "$field_count" "$field_type"
+
+    echo "Building C++ test harness..."
+    time ( g++ --std=c++11 -O \
+        -o "$harness" \
+        -I "$script_dir" \
+        -I "$GOOGLE_PROTOBUF_CHECKOUT/src" \
+        -L "$GOOGLE_PROTOBUF_CHECKOUT/src/.libs" \
+        -lprotobuf \
+        "$gen_harness_path" \
+        "$script_dir/Harness.cc" \
+        "$script_dir/_generated/message.pb.cc" \
+        "$script_dir/main.cc" \
+    )
+    echo
+
+    # Make sure the dylib is loadable from the harness if the user hasn't
+    # actually installed them.
+    cp "$GOOGLE_PROTOBUF_CHECKOUT"/src/.libs/libprotobuf.*.dylib \
+        "$script_dir/_generated"
+
+    run_harness_and_concatenate_results "C++" "$harness" "$partial_results"
+  )
+}

--- a/Performance/runners/swift.sh
+++ b/Performance/runners/swift.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# SwiftProtobuf/Performance/runners/swift.sh - Swift test harness runner
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# -----------------------------------------------------------------------------
+#
+# Functions for generating the Swift harness.
+#
+# -----------------------------------------------------------------------------
+
+function run_swift_harness() {
+  # Wrapped in a subshell to prevent state from leaking out (important since
+  # this gets run multiple times during a comparison).
+  (
+    perf_dir="$1"
+    description="$2"
+    results_file="$3"
+
+    harness="$perf_dir/_generated/harness_swift"
+
+    # Load the generator from perf_dir so that we use the comparison revision
+    # instead of the working copy if we're running an older checkout.
+    source "$perf_dir/generators/swift.sh"
+
+    echo "Generating Swift harness source ($description)..."
+    gen_harness_path="$perf_dir/_generated/Harness+Generated.swift"
+    generate_swift_harness "$field_count" "$field_type"
+
+    # Build the dynamic library to use in the tests from the .o files that were
+    # already built for the plug-in.
+    echo "Building SwiftProtobuf dynamic library ($description)..."
+    xcrun -sdk macosx swiftc -emit-library -emit-module -O -wmo \
+        -o "$perf_dir/_generated/libSwiftProtobuf.dylib" \
+        "$perf_dir/../Sources/SwiftProtobuf/"*.swift
+
+    echo "Building Swift test harness ($description)..."
+    time ( xcrun -sdk macosx swiftc -O \
+        -o "$harness" \
+        -I "$perf_dir/_generated" \
+        -L "$perf_dir/_generated" \
+        -lSwiftProtobuf \
+        "$gen_harness_path" \
+        "$perf_dir/Harness.swift" \
+        "$perf_dir/_generated/message.pb.swift" \
+        "$perf_dir/main.swift"
+    )
+    echo
+
+    dylib="$perf_dir/_generated/libSwiftProtobuf.dylib"
+    echo "Swift ($description) dylib size before stripping: $(stat -f "%z" "$dylib") bytes"
+    cp "$dylib" "${dylib}_stripped"
+    strip -u -r "${dylib}_stripped"
+    echo "Swift ($description) dylib size after stripping:  $(stat -f "%z" "${dylib}_stripped") bytes"
+    echo
+
+    run_harness_and_concatenate_results "Swift ($description)" "$harness" "$results_file"
+    profile_harness "Swift ($description)" "$harness" "$perf_dir"
+  )
+}


### PR DESCRIPTION
Whew. I got inspired yesterday, and I should have done this a long time ago; it wasn't as bad as I thought it would be.

The harness now takes `-c` options that let you specify git revisions that should be benchmarked and compared to the current working tree. They can be specified as anything the git tools allow—I imagine branch names (probably `master`) will be most useful but you can also use commit hashes and whatnot.

`-c` also accepts the string `c++`, which means compare against C++ (the old behavior, and also what happens if you don't use any `-c` options). You can specify `-c` multiple times, each one becomes a series in the plot, and the current working tree is always last; we're not limited to two anymore (we probably won't use this very much, unless we want to compare, say, `master`, the working tree, and C++ all at once).

This works by checking out the local repo history at the given revisions into temporary locations and building the harnesses there. This means it uses the generator and the runtime at that revision—so even if you're changing generator code, you end up generating the right thing for each revision and it just works.

It should be noted that this will only work for commits *going forward from the time this is merged*; because of changes I made to the harness generating scripts to separate the generation from the running (to isolate API changes), the harness makes assumptions about the scripts that will be available in the checkout.

I tested it by adding a `usleep(1)` in the binary decoder (I can't account for the seemingly nontrivial noise elsewhere in the two branches, though):
![harness](http://i.imgur.com/SazpWhx.png)

This was generated with the command line:
```
$ Performance/perf_runner.sh -c c++ -c revision-perf -p false 100 "fixed32"
```