### PR TITLE
Expose the library version.

### DIFF
--- a/Sources/SwiftProtobuf/Version.swift
+++ b/Sources/SwiftProtobuf/Version.swift
@@ -1,0 +1,28 @@
+// Sources/SwiftProtobuf/Version.swift - Runtime Version info
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// A interface for exposing the version of the runtime.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+
+// Expose version information about the library.
+public struct Version {
+  /// Major version.
+  static public let major = 0
+  /// Minor version.
+  static public let minor = 9
+  /// Revision number.
+  static public let revision = 29
+
+  /// String form of the version number.
+  static public let versionString = "\(major).\(minor).\(revision)"
+}

--- a/Sources/protoc-gen-swift/Version.swift
+++ b/Sources/protoc-gen-swift/Version.swift
@@ -12,12 +12,9 @@
 ///
 // ----------------------------------------------------------------------------
 
-struct Version {
-    static let major = 0
-    static let minor = 9
-    static let revision = 29
-    static let versionString = "\(major).\(minor).\(revision)"
+import SwiftProtobuf
 
+struct Version {
     // The "compatibility version" of the runtime library, which must be
     // incremented every time a breaking change (either behavioral or
     // API-changing) is introduced.
@@ -31,7 +28,7 @@ struct Version {
     static let compatibilityVersion = 1
 
     static let name = "protoc-gen-swift"
-    static let versionedName = "protoc-gen-swift \(versionString)"
+    static let versionedName = "protoc-gen-swift \(SwiftProtobuf.Version.versionString)"
     static let copyright = "Copyright (C) 2014-2017 Apple Inc. and the project authors"
     static let summary = "Convert parsed proto definitions into Swift"
     static let help = (
@@ -45,7 +42,7 @@ struct Version {
                + "In particular, if you have renamed this program, you will need to\n"
                + "adjust the protoc command-line option accordingly.\n"
                + "\n"
-               + "The generated Swift output requires the SwiftProtobuf \(versionString)\n"
+               + "The generated Swift output requires the SwiftProtobuf \(SwiftProtobuf.Version.versionString)\n"
                + "library be included in your project.\n"
                + "\n"
                + "If you use `swift build` to compile your project, add this to\n"
@@ -53,7 +50,7 @@ struct Version {
                + "\n"
                + "   dependencies: [\n"
                + "     .Package(url: \"https://github.com/apple/swift-protobuf-runtime.git\",\n"
-               + "              Version(\(major),\(minor),\(revision))\n"
+               + "              Version(\(SwiftProtobuf.Version.versionString))\n"
                + "   ]\n"
                + "\n"
                + "\n"

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -460,6 +460,10 @@
 		F482B6931E857BC100A25EF8 /* unittest_swift_naming_no_prefix.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6911E857BBC00A25EF8 /* unittest_swift_naming_no_prefix.pb.swift */; };
 		F482B6941E857BC100A25EF8 /* unittest_swift_naming_no_prefix.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6911E857BBC00A25EF8 /* unittest_swift_naming_no_prefix.pb.swift */; };
 		F482B6951E857BC200A25EF8 /* unittest_swift_naming_no_prefix.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6911E857BBC00A25EF8 /* unittest_swift_naming_no_prefix.pb.swift */; };
+		F482B6B31E89940E00A25EF8 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6B21E89940E00A25EF8 /* Version.swift */; };
+		F482B6B61E89941500A25EF8 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6B21E89940E00A25EF8 /* Version.swift */; };
+		F482B6B71E89941600A25EF8 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6B21E89940E00A25EF8 /* Version.swift */; };
+		F482B6B81E89941600A25EF8 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482B6B21E89940E00A25EF8 /* Version.swift */; };
 		F48FDD241E4D17ED0061D5C1 /* JSONScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */; };
 		F48FDD251E4D17EE0061D5C1 /* JSONScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */; };
 		F48FDD261E4D17EF0061D5C1 /* JSONScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE9CF361E32C9F8004FBED6 /* JSONScanner.swift */; };
@@ -686,6 +690,7 @@
 		F47138951E4E56AC00C8492C /* Internal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Internal.swift; sourceTree = "<group>"; };
 		F482B6771E856D1700A25EF8 /* unittest_swift_reserved_ext.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_reserved_ext.pb.swift; sourceTree = "<group>"; };
 		F482B6911E857BBC00A25EF8 /* unittest_swift_naming_no_prefix.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_naming_no_prefix.pb.swift; sourceTree = "<group>"; };
+		F482B6B21E89940E00A25EF8 /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		F4A07B2A1E4A3E500035678A /* test_messages_proto3.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = test_messages_proto3.pb.swift; sourceTree = "<group>"; };
 		F4A1A8AB1E65E2EA0022E078 /* map_proto2_unittest.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = map_proto2_unittest.pb.swift; sourceTree = "<group>"; };
 		F4D315431DEC8110005D4A80 /* unittest_swift_extension2.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = unittest_swift_extension2.pb.swift; sourceTree = "<group>"; };
@@ -872,6 +877,7 @@
 		"_______Group_Protobuf" /* SwiftProtobuf */ = {
 			isa = PBXGroup;
 			children = (
+				F482B6B21E89940E00A25EF8 /* Version.swift */,
 				F41BA43F1E7AE4AC004F6E95 /* any.pb.swift */,
 				F41BA4411E7AE53C004F6E95 /* AnyMessageStorage.swift */,
 				F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */,
@@ -1389,6 +1395,7 @@
 				AAEA52771DA832A8003F318F /* wrappers.pb.swift in Sources */,
 				9C2F23931D7780D1008524F2 /* Message.swift in Sources */,
 				F4F4F11B1E5C7556006C6CAD /* TimeUtils.swift in Sources */,
+				F482B6B61E89941500A25EF8 /* Version.swift in Sources */,
 				9C2F23981D7780D1008524F2 /* FieldTypes.swift in Sources */,
 				9C2F23991D7780D1008524F2 /* UnknownStorage.swift in Sources */,
 				9C5890B41DFF6389001CFC34 /* TextFormatDecoder.swift in Sources */,
@@ -1466,6 +1473,7 @@
 				__src_cc_ref_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift in Sources */,
 				AA28A4AC1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift in Sources */,
+				F482B6B31E89940E00A25EF8 /* Version.swift in Sources */,
 				F41BA4401E7AE4AC004F6E95 /* any.pb.swift in Sources */,
 				9C75F8941DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufBinaryTypes.swift /* Message+BinaryAdditions.swift in Sources */,
@@ -1650,6 +1658,7 @@
 				F44F93991DAEA76700BC5B85 /* wrappers.pb.swift in Sources */,
 				F44F93811DAEA76700BC5B85 /* BinaryDecoder.swift in Sources */,
 				F4F4F11C1E5C7556006C6CAD /* TimeUtils.swift in Sources */,
+				F482B6B71E89941600A25EF8 /* Version.swift in Sources */,
 				F44F93981DAEA76700BC5B85 /* Varint.swift in Sources */,
 				F44F937C1DAEA76700BC5B85 /* Google_Protobuf_Duration+Extensions.swift in Sources */,
 				9C5890AE1DFF6384001CFC34 /* TextFormatDecoder.swift in Sources */,
@@ -1834,6 +1843,7 @@
 				F44F94111DAEB23500BC5B85 /* BinaryEncoder.swift in Sources */,
 				F44F94121DAEB23500BC5B85 /* BinaryEncodingSizeVisitor.swift in Sources */,
 				F4F4F11D1E5C7557006C6CAD /* TimeUtils.swift in Sources */,
+				F482B6B81E89941600A25EF8 /* Version.swift in Sources */,
 				9C75F8971DDD3D20005CCFF2 /* BinaryEncodingVisitor.swift in Sources */,
 				F44F94131DAEB23500BC5B85 /* Message+BinaryAdditions.swift in Sources */,
 				AAF2ED421DEF4D94007B510F /* ProtoNameProviding.swift in Sources */,


### PR DESCRIPTION
Just like we ended up checking the protoc version in the generator, there
might be cases where a developer wants to report the library version
being used (metrics for bug tracking, etc.), so expose the basic version
from within the library.