### PR TITLE
Fix format string for Int64.

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Duration+Extensions.swift
@@ -101,13 +101,13 @@ private func formatDuration(seconds: Int64, nanos: Int32) -> String? {
   }
 
   if nanos == 0 {
-    return String(format: "%lds", seconds)
+    return String(format: "%llds", seconds)
   } else if nanos % 1000000 == 0 {
-    return String(format: "%ld.%03ds", seconds, abs(nanos) / 1000000)
+    return String(format: "%lld.%03ds", seconds, abs(nanos) / 1000000)
   } else if nanos % 1000 == 0 {
-    return String(format: "%ld.%06ds", seconds, abs(nanos) / 1000)
+    return String(format: "%lld.%06ds", seconds, abs(nanos) / 1000)
   } else {
-    return String(format: "%ld.%09ds", seconds, abs(nanos))
+    return String(format: "%lld.%09ds", seconds, abs(nanos))
   }
 }
 


### PR DESCRIPTION
On 64bit, ld is fine, but it really is an lld, and this was choking 32bit.

Fixes https://github.com/apple/swift-protobuf/issues/430