### PR TITLE
Update JSON decoding to use UnsafeBufferPointer.

### DIFF
--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -59,8 +59,8 @@ fileprivate func unpack(contentJSON: Data, as messageType: Message.Type) throws 
 
   var value = String()
   try contentJSON.withUnsafeBytes { (bytes:UnsafePointer<UInt8>) in
-    var scanner = JSONScanner(utf8Pointer: bytes,
-                              count: contentJSON.count)
+    let buffer = UnsafeBufferPointer(start: bytes, count: contentJSON.count)
+    var scanner = JSONScanner(source: buffer)
     let key = try scanner.nextQuotedString()
     if key != "value" {
       // The only thing within a WKT should be "value".

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -24,8 +24,8 @@ internal struct JSONDecoder: Decoder {
     throw JSONDecodingError.conflictingOneOf
   }
 
-  internal init(utf8Pointer: UnsafePointer<UInt8>, count: Int) {
-    self.scanner = JSONScanner(utf8Pointer: utf8Pointer, count: count)
+  internal init(source: UnsafeBufferPointer<UInt8>) {
+    self.scanner = JSONScanner(source: source)
   }
 
   private init(scanner: JSONScanner) {

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -15,702 +15,725 @@
 import Foundation
 
 internal struct JSONDecoder: Decoder {
-    internal var scanner: JSONScanner
-    private var fieldCount = 0
-    private var isMapKey = false
-    private var fieldNameMap: _NameMap?
+  internal var scanner: JSONScanner
+  private var fieldCount = 0
+  private var isMapKey = false
+  private var fieldNameMap: _NameMap?
 
-    mutating func handleConflictingOneOf() throws {
-        throw JSONDecodingError.conflictingOneOf
+  mutating func handleConflictingOneOf() throws {
+    throw JSONDecodingError.conflictingOneOf
+  }
+
+  internal init(utf8Pointer: UnsafePointer<UInt8>, count: Int) {
+    self.scanner = JSONScanner(utf8Pointer: utf8Pointer, count: count)
+  }
+
+  private init(scanner: JSONScanner) {
+    self.scanner = scanner
+  }
+
+  mutating func nextFieldNumber() throws -> Int? {
+    if scanner.skipOptionalObjectEnd() {
+      return nil
     }
-
-    internal init(utf8Pointer: UnsafePointer<UInt8>, count: Int) {
-        self.scanner = JSONScanner(utf8Pointer: utf8Pointer, count: count)
+    if fieldCount > 0 {
+      try scanner.skipRequiredComma()
     }
-
-    private init(scanner: JSONScanner) {
-        self.scanner = scanner
+    if let fieldNumber = try scanner.nextFieldNumber(names: fieldNameMap!) {
+      fieldCount += 1
+      return fieldNumber
     }
+    return nil
+  }
 
-    mutating func nextFieldNumber() throws -> Int? {
-        if scanner.skipOptionalObjectEnd() {
-            return nil
-        }
-        if fieldCount > 0 {
-            try scanner.skipRequiredComma()
-        }
-        if let fieldNumber = try scanner.nextFieldNumber(names: fieldNameMap!) {
-            fieldCount += 1
-            return fieldNumber
-        }
-        return nil
+  mutating func decodeSingularFloatField(value: inout Float) throws {
+    if scanner.skipOptionalNull() {
+      value = 0
+      return
     }
+    value = try scanner.nextFloat()
+  }
 
-    mutating func decodeSingularFloatField(value: inout Float) throws {
-        if scanner.skipOptionalNull() {
-            value = 0
-            return
-        }
-        value = try scanner.nextFloat()
+  mutating func decodeSingularFloatField(value: inout Float?) throws {
+    if scanner.skipOptionalNull() {
+      value = nil
+      return
     }
+    value = try scanner.nextFloat()
+  }
 
-    mutating func decodeSingularFloatField(value: inout Float?) throws {
-        if scanner.skipOptionalNull() {
-            value = nil
-            return
-        }
-        value = try scanner.nextFloat()
+  mutating func decodeRepeatedFloatField(value: inout [Float]) throws {
+    if scanner.skipOptionalNull() {
+      return
     }
-
-    mutating func decodeRepeatedFloatField(value: inout [Float]) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            let n = try scanner.nextFloat()
-            value.append(n)
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
     }
-
-    mutating func decodeSingularDoubleField(value: inout Double) throws {
-        if scanner.skipOptionalNull() {
-            value = 0
-            return
-        }
-        value = try scanner.nextDouble()
+    while true {
+      let n = try scanner.nextFloat()
+      value.append(n)
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
     }
+  }
 
-    mutating func decodeSingularDoubleField(value: inout Double?) throws {
-        if scanner.skipOptionalNull() {
-            value = nil
-            return
-        }
-        value = try scanner.nextDouble()
+  mutating func decodeSingularDoubleField(value: inout Double) throws {
+    if scanner.skipOptionalNull() {
+      value = 0
+      return
     }
+    value = try scanner.nextDouble()
+  }
 
-    mutating func decodeRepeatedDoubleField(value: inout [Double]) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            let n = try scanner.nextDouble()
-            value.append(n)
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
+  mutating func decodeSingularDoubleField(value: inout Double?) throws {
+    if scanner.skipOptionalNull() {
+      value = nil
+      return
     }
+    value = try scanner.nextDouble()
+  }
 
-    mutating func decodeSingularInt32Field(value: inout Int32) throws {
-        if scanner.skipOptionalNull() {
-            value = 0
-            return
+  mutating func decodeRepeatedDoubleField(value: inout [Double]) throws {
+    if scanner.skipOptionalNull() {
+      return
+    }
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
+    }
+    while true {
+      let n = try scanner.nextDouble()
+      value.append(n)
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
+
+  mutating func decodeSingularInt32Field(value: inout Int32) throws {
+    if scanner.skipOptionalNull() {
+      value = 0
+      return
+    }
+    let n = try scanner.nextSInt()
+    if n > Int64(Int32.max) || n < Int64(Int32.min) {
+      throw JSONDecodingError.numberRange
+    }
+    value = Int32(truncatingBitPattern: n)
+  }
+
+  mutating func decodeSingularInt32Field(value: inout Int32?) throws {
+    if scanner.skipOptionalNull() {
+      value = nil
+      return
+    }
+    let n = try scanner.nextSInt()
+    if n > Int64(Int32.max) || n < Int64(Int32.min) {
+      throw JSONDecodingError.numberRange
+    }
+    value = Int32(truncatingBitPattern: n)
+  }
+
+  mutating func decodeRepeatedInt32Field(value: inout [Int32]) throws {
+    if scanner.skipOptionalNull() {
+      return
+    }
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
+    }
+    while true {
+      let n = try scanner.nextSInt()
+      if n > Int64(Int32.max) || n < Int64(Int32.min) {
+        throw JSONDecodingError.numberRange
+      }
+      value.append(Int32(truncatingBitPattern: n))
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
+
+  mutating func decodeSingularInt64Field(value: inout Int64) throws {
+    if scanner.skipOptionalNull() {
+      value = 0
+      return
+    }
+    value = try scanner.nextSInt()
+  }
+
+  mutating func decodeSingularInt64Field(value: inout Int64?) throws {
+    if scanner.skipOptionalNull() {
+      value = nil
+      return
+    }
+    value = try scanner.nextSInt()
+  }
+
+  mutating func decodeRepeatedInt64Field(value: inout [Int64]) throws {
+    if scanner.skipOptionalNull() {
+      return
+    }
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
+    }
+    while true {
+      let n = try scanner.nextSInt()
+      value.append(n)
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
+
+  mutating func decodeSingularUInt32Field(value: inout UInt32) throws {
+    if scanner.skipOptionalNull() {
+      value = 0
+      return
+    }
+    let n = try scanner.nextUInt()
+    if n > UInt64(UInt32.max) {
+      throw JSONDecodingError.numberRange
+    }
+    value = UInt32(truncatingBitPattern: n)
+  }
+
+  mutating func decodeSingularUInt32Field(value: inout UInt32?) throws {
+    if scanner.skipOptionalNull() {
+      value = nil
+      return
+    }
+    let n = try scanner.nextUInt()
+    if n > UInt64(UInt32.max) {
+      throw JSONDecodingError.numberRange
+    }
+    value = UInt32(truncatingBitPattern: n)
+  }
+
+  mutating func decodeRepeatedUInt32Field(value: inout [UInt32]) throws {
+    if scanner.skipOptionalNull() {
+      return
+    }
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
+    }
+    while true {
+      let n = try scanner.nextUInt()
+      if n > UInt64(UInt32.max) {
+        throw JSONDecodingError.numberRange
+      }
+      value.append(UInt32(truncatingBitPattern: n))
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
+
+  mutating func decodeSingularUInt64Field(value: inout UInt64) throws {
+    if scanner.skipOptionalNull() {
+      value = 0
+      return
+    }
+    value = try scanner.nextUInt()
+  }
+
+  mutating func decodeSingularUInt64Field(value: inout UInt64?) throws {
+    if scanner.skipOptionalNull() {
+      value = nil
+      return
+    }
+    value = try scanner.nextUInt()
+  }
+
+  mutating func decodeRepeatedUInt64Field(value: inout [UInt64]) throws {
+    if scanner.skipOptionalNull() {
+      return
+    }
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
+    }
+    while true {
+      let n = try scanner.nextUInt()
+      value.append(n)
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
+
+  mutating func decodeSingularSInt32Field(value: inout Int32) throws {
+    try decodeSingularInt32Field(value: &value)
+  }
+
+  mutating func decodeSingularSInt32Field(value: inout Int32?) throws {
+    try decodeSingularInt32Field(value: &value)
+  }
+
+  mutating func decodeRepeatedSInt32Field(value: inout [Int32]) throws {
+    try decodeRepeatedInt32Field(value: &value)
+  }
+
+  mutating func decodeSingularSInt64Field(value: inout Int64) throws {
+    try decodeSingularInt64Field(value: &value)
+  }
+
+  mutating func decodeSingularSInt64Field(value: inout Int64?) throws {
+    try decodeSingularInt64Field(value: &value)
+  }
+
+  mutating func decodeRepeatedSInt64Field(value: inout [Int64]) throws {
+    try decodeRepeatedInt64Field(value: &value)
+  }
+
+  mutating func decodeSingularFixed32Field(value: inout UInt32) throws {
+    try decodeSingularUInt32Field(value: &value)
+  }
+
+  mutating func decodeSingularFixed32Field(value: inout UInt32?) throws {
+    try decodeSingularUInt32Field(value: &value)
+  }
+
+  mutating func decodeRepeatedFixed32Field(value: inout [UInt32]) throws {
+    try decodeRepeatedUInt32Field(value: &value)
+  }
+
+  mutating func decodeSingularFixed64Field(value: inout UInt64) throws {
+    try decodeSingularUInt64Field(value: &value)
+  }
+
+  mutating func decodeSingularFixed64Field(value: inout UInt64?) throws {
+    try decodeSingularUInt64Field(value: &value)
+  }
+
+  mutating func decodeRepeatedFixed64Field(value: inout [UInt64]) throws {
+    try decodeRepeatedUInt64Field(value: &value)
+  }
+
+  mutating func decodeSingularSFixed32Field(value: inout Int32) throws {
+    try decodeSingularInt32Field(value: &value)
+  }
+
+  mutating func decodeSingularSFixed32Field(value: inout Int32?) throws {
+    try decodeSingularInt32Field(value: &value)
+  }
+
+  mutating func decodeRepeatedSFixed32Field(value: inout [Int32]) throws {
+    try decodeRepeatedInt32Field(value: &value)
+  }
+
+  mutating func decodeSingularSFixed64Field(value: inout Int64) throws {
+    try decodeSingularInt64Field(value: &value)
+  }
+
+  mutating func decodeSingularSFixed64Field(value: inout Int64?) throws {
+    try decodeSingularInt64Field(value: &value)
+  }
+
+  mutating func decodeRepeatedSFixed64Field(value: inout [Int64]) throws {
+    try decodeRepeatedInt64Field(value: &value)
+  }
+
+  mutating func decodeSingularBoolField(value: inout Bool) throws {
+    if scanner.skipOptionalNull() {
+      value = false
+      return
+    }
+    if isMapKey {
+      value = try scanner.nextQuotedBool()
+    } else {
+      value = try scanner.nextBool()
+    }
+  }
+
+  mutating func decodeSingularBoolField(value: inout Bool?) throws {
+    if scanner.skipOptionalNull() {
+      value = nil
+      return
+    }
+    if isMapKey {
+      value = try scanner.nextQuotedBool()
+    } else {
+      value = try scanner.nextBool()
+    }
+  }
+
+  mutating func decodeRepeatedBoolField(value: inout [Bool]) throws {
+    if scanner.skipOptionalNull() {
+      return
+    }
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
+    }
+    while true {
+      let n = try scanner.nextBool()
+      value.append(n)
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
+
+  mutating func decodeSingularStringField(value: inout String) throws {
+    if scanner.skipOptionalNull() {
+      value = ""
+      return
+    }
+    value = try scanner.nextQuotedString()
+  }
+
+  mutating func decodeSingularStringField(value: inout String?) throws {
+    if scanner.skipOptionalNull() {
+      value = nil
+      return
+    }
+    value = try scanner.nextQuotedString()
+  }
+
+  mutating func decodeRepeatedStringField(value: inout [String]) throws {
+    if scanner.skipOptionalNull() {
+      return
+    }
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
+    }
+    while true {
+      let n = try scanner.nextQuotedString()
+      value.append(n)
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
+
+  mutating func decodeSingularBytesField(value: inout Data) throws {
+    if scanner.skipOptionalNull() {
+      value = Data()
+      return
+    }
+    value = try scanner.nextBytesValue()
+  }
+
+  mutating func decodeSingularBytesField(value: inout Data?) throws {
+    if scanner.skipOptionalNull() {
+      value = nil
+      return
+    }
+    value = try scanner.nextBytesValue()
+  }
+
+  mutating func decodeRepeatedBytesField(value: inout [Data]) throws {
+    if scanner.skipOptionalNull() {
+      return
+    }
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
+    }
+    while true {
+      let n = try scanner.nextBytesValue()
+      value.append(n)
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
+
+
+  mutating func decodeSingularEnumField<E: Enum>(value: inout E?) throws
+  where E.RawValue == Int {
+    if scanner.skipOptionalNull() {
+      value = nil
+      return
+    } else if let name = try scanner.nextOptionalQuotedString() {
+      if let v = E(name: name) {
+        value = v
+        return
+      }
+    } else {
+      let n = try scanner.nextSInt()
+      if let i = Int(exactly: n) {
+        value = E(rawValue: i)
+        return
+      }
+    }
+    throw JSONDecodingError.unrecognizedEnumValue
+  }
+
+  mutating func decodeSingularEnumField<E: Enum>(value: inout E) throws
+  where E.RawValue == Int {
+    if scanner.skipOptionalNull() {
+      value = E()
+      return
+    } else if let name = try scanner.nextOptionalQuotedString() {
+      if let v = E(name: name) {
+        value = v
+        return
+      }
+    } else {
+      let n = try scanner.nextSInt()
+      if let i = Int(exactly: n) {
+        if let v = E(rawValue: i) {
+          value = v
+          return
         }
+      }
+    }
+    throw JSONDecodingError.unrecognizedEnumValue
+  }
+
+  mutating func decodeRepeatedEnumField<E: Enum>(value: inout [E]) throws
+  where E.RawValue == Int {
+    if scanner.skipOptionalNull() {
+      return
+    }
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
+    }
+    while true {
+      if let name = try scanner.nextOptionalQuotedString() {
+        if let v = E(name: name) {
+          value.append(v)
+        } else {
+          throw JSONDecodingError.unrecognizedEnumValue
+        }
+      } else {
         let n = try scanner.nextSInt()
-        if n > Int64(Int32.max) || n < Int64(Int32.min) {
-            throw JSONDecodingError.numberRange
-        }
-        value = Int32(truncatingBitPattern: n)
-    }
-
-    mutating func decodeSingularInt32Field(value: inout Int32?) throws {
-        if scanner.skipOptionalNull() {
-            value = nil
-            return
-        }
-        let n = try scanner.nextSInt()
-        if n > Int64(Int32.max) || n < Int64(Int32.min) {
-            throw JSONDecodingError.numberRange
-        }
-        value = Int32(truncatingBitPattern: n)
-    }
-
-    mutating func decodeRepeatedInt32Field(value: inout [Int32]) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            let n = try scanner.nextSInt()
-            if n > Int64(Int32.max) || n < Int64(Int32.min) {
-                throw JSONDecodingError.numberRange
-            }
-            value.append(Int32(truncatingBitPattern: n))
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
-    }
-
-    mutating func decodeSingularInt64Field(value: inout Int64) throws {
-        if scanner.skipOptionalNull() {
-            value = 0
-            return
-        }
-        value = try scanner.nextSInt()
-    }
-
-    mutating func decodeSingularInt64Field(value: inout Int64?) throws {
-        if scanner.skipOptionalNull() {
-            value = nil
-            return
-        }
-        value = try scanner.nextSInt()
-    }
-
-    mutating func decodeRepeatedInt64Field(value: inout [Int64]) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            let n = try scanner.nextSInt()
-            value.append(n)
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
-    }
-
-    mutating func decodeSingularUInt32Field(value: inout UInt32) throws {
-        if scanner.skipOptionalNull() {
-            value = 0
-            return
-        }
-        let n = try scanner.nextUInt()
-        if n > UInt64(UInt32.max) {
-            throw JSONDecodingError.numberRange
-        }
-        value = UInt32(truncatingBitPattern: n)
-    }
-
-    mutating func decodeSingularUInt32Field(value: inout UInt32?) throws {
-        if scanner.skipOptionalNull() {
-            value = nil
-            return
-        }
-        let n = try scanner.nextUInt()
-        if n > UInt64(UInt32.max) {
-            throw JSONDecodingError.numberRange
-        }
-        value = UInt32(truncatingBitPattern: n)
-    }
-
-    mutating func decodeRepeatedUInt32Field(value: inout [UInt32]) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            let n = try scanner.nextUInt()
-            if n > UInt64(UInt32.max) {
-                throw JSONDecodingError.numberRange
-            }
-            value.append(UInt32(truncatingBitPattern: n))
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
-    }
-
-    mutating func decodeSingularUInt64Field(value: inout UInt64) throws {
-        if scanner.skipOptionalNull() {
-            value = 0
-            return
-        }
-        value = try scanner.nextUInt()
-    }
-
-    mutating func decodeSingularUInt64Field(value: inout UInt64?) throws {
-        if scanner.skipOptionalNull() {
-            value = nil
-            return
-        }
-        value = try scanner.nextUInt()
-    }
-
-    mutating func decodeRepeatedUInt64Field(value: inout [UInt64]) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            let n = try scanner.nextUInt()
-            value.append(n)
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
-    }
-
-    mutating func decodeSingularSInt32Field(value: inout Int32) throws {
-        try decodeSingularInt32Field(value: &value)
-    }
-
-    mutating func decodeSingularSInt32Field(value: inout Int32?) throws {
-        try decodeSingularInt32Field(value: &value)
-    }
-
-    mutating func decodeRepeatedSInt32Field(value: inout [Int32]) throws {
-        try decodeRepeatedInt32Field(value: &value)
-    }
-
-    mutating func decodeSingularSInt64Field(value: inout Int64) throws {
-        try decodeSingularInt64Field(value: &value)
-    }
-
-    mutating func decodeSingularSInt64Field(value: inout Int64?) throws {
-        try decodeSingularInt64Field(value: &value)
-    }
-
-    mutating func decodeRepeatedSInt64Field(value: inout [Int64]) throws {
-        try decodeRepeatedInt64Field(value: &value)
-    }
-
-    mutating func decodeSingularFixed32Field(value: inout UInt32) throws {
-        try decodeSingularUInt32Field(value: &value)
-    }
-
-    mutating func decodeSingularFixed32Field(value: inout UInt32?) throws {
-        try decodeSingularUInt32Field(value: &value)
-    }
-
-    mutating func decodeRepeatedFixed32Field(value: inout [UInt32]) throws {
-        try decodeRepeatedUInt32Field(value: &value)
-    }
-
-    mutating func decodeSingularFixed64Field(value: inout UInt64) throws {
-        try decodeSingularUInt64Field(value: &value)
-    }
-
-    mutating func decodeSingularFixed64Field(value: inout UInt64?) throws {
-        try decodeSingularUInt64Field(value: &value)
-    }
-
-    mutating func decodeRepeatedFixed64Field(value: inout [UInt64]) throws {
-        try decodeRepeatedUInt64Field(value: &value)
-    }
-
-    mutating func decodeSingularSFixed32Field(value: inout Int32) throws {
-        try decodeSingularInt32Field(value: &value)
-    }
-
-    mutating func decodeSingularSFixed32Field(value: inout Int32?) throws {
-        try decodeSingularInt32Field(value: &value)
-    }
-
-    mutating func decodeRepeatedSFixed32Field(value: inout [Int32]) throws {
-        try decodeRepeatedInt32Field(value: &value)
-    }
-
-    mutating func decodeSingularSFixed64Field(value: inout Int64) throws {
-        try decodeSingularInt64Field(value: &value)
-    }
-
-    mutating func decodeSingularSFixed64Field(value: inout Int64?) throws {
-        try decodeSingularInt64Field(value: &value)
-    }
-
-    mutating func decodeRepeatedSFixed64Field(value: inout [Int64]) throws {
-        try decodeRepeatedInt64Field(value: &value)
-    }
-
-    mutating func decodeSingularBoolField(value: inout Bool) throws {
-        if scanner.skipOptionalNull() {
-            value = false
-            return
-        }
-        if isMapKey {
-            value = try scanner.nextQuotedBool()
+        if let i = Int(exactly: n) {
+          if let v = E(rawValue: i) {
+            value.append(v)
+          } else {
+            throw JSONDecodingError.unrecognizedEnumValue
+          }
         } else {
-            value = try scanner.nextBool()
+          throw JSONDecodingError.numberRange
         }
+      }
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
     }
+  }
 
-    mutating func decodeSingularBoolField(value: inout Bool?) throws {
-        if scanner.skipOptionalNull() {
-            value = nil
-            return
-        }
-        if isMapKey {
-            value = try scanner.nextQuotedBool()
-        } else {
-            value = try scanner.nextBool()
-        }
+  internal mutating func decodeFullObject<M: Message>(message: inout M) throws {
+    guard let nameProviding = (M.self as? _ProtoNameProviding.Type) else {
+      throw JSONDecodingError.missingFieldNames
     }
-
-    mutating func decodeRepeatedBoolField(value: inout [Bool]) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            let n = try scanner.nextBool()
-            value.append(n)
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
+    fieldNameMap = nameProviding._protobuf_nameMap
+    if let m = message as? _CustomJSONCodable {
+      var customCodable = m
+      try customCodable.decodeJSON(from: &self)
+      message = customCodable as! M
+    } else {
+      try scanner.skipRequiredObjectStart()
+      if scanner.skipOptionalObjectEnd() {
+        return
+      }
+      try message.decodeMessage(decoder: &self)
     }
+  }
 
-    mutating func decodeSingularStringField(value: inout String) throws {
-        if scanner.skipOptionalNull() {
-            value = ""
-            return
-        }
-        value = try scanner.nextQuotedString()
+  mutating func decodeSingularMessageField<M: Message>(value: inout M?) throws {
+    if scanner.skipOptionalNull() {
+      if M.self is _CustomJSONCodable.Type {
+        value =
+          try (M.self as! _CustomJSONCodable.Type).decodedFromJSONNull() as? M
+        return
+      }
+      // All other message field types treat 'null' as an unset
+      value = nil
+      return
     }
-
-    mutating func decodeSingularStringField(value: inout String?) throws {
-        if scanner.skipOptionalNull() {
-            value = nil
-            return
-        }
-        value = try scanner.nextQuotedString()
+    if value == nil {
+      value = M()
     }
+    var subDecoder = JSONDecoder(scanner: scanner)
+    try subDecoder.decodeFullObject(message: &value!)
+    scanner = subDecoder.scanner
+  }
 
-    mutating func decodeRepeatedStringField(value: inout [String]) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            let n = try scanner.nextQuotedString()
-            value.append(n)
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
+  mutating func decodeRepeatedMessageField<M: Message>(
+    value: inout [M]
+  ) throws {
+    if scanner.skipOptionalNull() {
+      return
     }
-
-    mutating func decodeSingularBytesField(value: inout Data) throws {
-        if scanner.skipOptionalNull() {
-            value = Data()
-            return
-        }
-        value = try scanner.nextBytesValue()
+    try scanner.skipRequiredArrayStart()
+    if scanner.skipOptionalArrayEnd() {
+      return
     }
-
-    mutating func decodeSingularBytesField(value: inout Data?) throws {
-        if scanner.skipOptionalNull() {
-            value = nil
-            return
+    while true {
+      if scanner.skipOptionalNull() {
+        var appended = false
+        if M.self is _CustomJSONCodable.Type {
+          if let message = try (M.self as! _CustomJSONCodable.Type)
+            .decodedFromJSONNull() as? M {
+            value.append(message)
+            appended = true
+          }
         }
-        value = try scanner.nextBytesValue()
-    }
-
-    mutating func decodeRepeatedBytesField(value: inout [Data]) throws {
-        if scanner.skipOptionalNull() {
-            return
+        if !appended {
+          throw JSONDecodingError.illegalNull
         }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            let n = try scanner.nextBytesValue()
-            value.append(n)
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
-    }
-
-
-    mutating func decodeSingularEnumField<E: Enum>(value: inout E?) throws where E.RawValue == Int {
-        if scanner.skipOptionalNull() {
-            value = nil
-            return
-        } else if let name = try scanner.nextOptionalQuotedString() {
-            if let v = E(name: name) {
-                value = v
-                return
-            }
-        } else {
-            let n = try scanner.nextSInt()
-            if let i = Int(exactly: n) {
-                value = E(rawValue: i)
-                return
-            }
-        }
-        throw JSONDecodingError.unrecognizedEnumValue
-    }
-
-    mutating func decodeSingularEnumField<E: Enum>(value: inout E) throws where E.RawValue == Int {
-        if scanner.skipOptionalNull() {
-            value = E()
-            return
-        } else if let name = try scanner.nextOptionalQuotedString() {
-            if let v = E(name: name) {
-                value = v
-                return
-            }
-        } else {
-            let n = try scanner.nextSInt()
-            if let i = Int(exactly: n) {
-                if let v = E(rawValue: i) {
-                    value = v
-                    return
-                }
-            }
-        }
-        throw JSONDecodingError.unrecognizedEnumValue
-    }
-
-    mutating func decodeRepeatedEnumField<E: Enum>(value: inout [E]) throws where E.RawValue == Int {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            if let name = try scanner.nextOptionalQuotedString() {
-                if let v = E(name: name) {
-                    value.append(v)
-                } else {
-                    throw JSONDecodingError.unrecognizedEnumValue
-                }
-            } else {
-                let n = try scanner.nextSInt()
-                if let i = Int(exactly: n) {
-                    if let v = E(rawValue: i) {
-                        value.append(v)
-                    } else {
-                        throw JSONDecodingError.unrecognizedEnumValue
-                    }
-                } else {
-                    throw JSONDecodingError.numberRange
-                }
-            }
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
-    }
-
-    internal mutating func decodeFullObject<M: Message>(message: inout M) throws {
-        guard let nameProviding = (M.self as? _ProtoNameProviding.Type) else {
-            throw JSONDecodingError.missingFieldNames
-        }
-        fieldNameMap = nameProviding._protobuf_nameMap
-        if let m = message as? _CustomJSONCodable {
-            var customCodable = m
-            try customCodable.decodeJSON(from: &self)
-            message = customCodable as! M
-        } else {
-            try scanner.skipRequiredObjectStart()
-            if scanner.skipOptionalObjectEnd() {
-                return
-            }
-            try message.decodeMessage(decoder: &self)
-        }
-    }
-
-    mutating func decodeSingularMessageField<M: Message>(value: inout M?) throws {
-        if scanner.skipOptionalNull() {
-            if M.self is _CustomJSONCodable.Type {
-                value = try (M.self as! _CustomJSONCodable.Type).decodedFromJSONNull() as? M
-                return
-            }
-            // All other message field types treat 'null' as an unset 
-            value = nil
-            return
-        }
-        if value == nil {
-            value = M()
-        }
+      } else {
+        var message = M()
         var subDecoder = JSONDecoder(scanner: scanner)
-        try subDecoder.decodeFullObject(message: &value!)
+        try subDecoder.decodeFullObject(message: &message)
         scanner = subDecoder.scanner
+        value.append(message)
+        scanner = subDecoder.scanner
+      }
+      if scanner.skipOptionalArrayEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
     }
+  }
 
-    mutating func decodeRepeatedMessageField<M: Message>(value: inout [M]) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredArrayStart()
-        if scanner.skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            if scanner.skipOptionalNull() {
-                var appended = false
-                if M.self is _CustomJSONCodable.Type {
-                    if let message = try (M.self as! _CustomJSONCodable.Type).decodedFromJSONNull() as? M {
-                        value.append(message)
-                        appended = true
-                    }
-                }
-                if !appended {
-                    throw JSONDecodingError.illegalNull
-                }
-            } else {
-                var message = M()
-                var subDecoder = JSONDecoder(scanner: scanner)
-                try subDecoder.decodeFullObject(message: &message)
-                scanner = subDecoder.scanner
-                value.append(message)
-                scanner = subDecoder.scanner
-            }
-            if scanner.skipOptionalArrayEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
-    }
+  mutating func decodeSingularGroupField<G: Message>(value: inout G?) throws {
+    throw JSONDecodingError.schemaMismatch
+  }
 
-    mutating func decodeSingularGroupField<G: Message>(value: inout G?) throws {
-        throw JSONDecodingError.schemaMismatch
-    }
+  mutating func decodeRepeatedGroupField<G: Message>(value: inout [G]) throws {
+    throw JSONDecodingError.schemaMismatch
+  }
 
-    mutating func decodeRepeatedGroupField<G: Message>(value: inout [G]) throws {
-        throw JSONDecodingError.schemaMismatch
+  mutating func decodeMapField<KeyType: MapKeyType, ValueType: MapValueType>(
+    fieldType: _ProtobufMap<KeyType, ValueType>.Type,
+    value: inout _ProtobufMap<KeyType, ValueType>.BaseType
+  ) throws {
+    if scanner.skipOptionalNull() {
+      return
     }
+    try scanner.skipRequiredObjectStart()
+    if scanner.skipOptionalObjectEnd() {
+      return
+    }
+    while true {
+      // Next character must be double quote, because
+      // map keys must always be quoted strings.
+      let c = try scanner.peekOneCharacter()
+      if c != "\"" {
+        throw JSONDecodingError.unquotedMapKey
+      }
+      isMapKey = true
+      var keyField: KeyType.BaseType?
+      try KeyType.decodeSingular(value: &keyField, from: &self)
+      isMapKey = false
+      try scanner.skipRequiredColon()
+      var valueField: ValueType.BaseType?
+      try ValueType.decodeSingular(value: &valueField, from: &self)
+      if let keyField = keyField, let valueField = valueField {
+        value[keyField] = valueField
+      } else {
+        throw JSONDecodingError.malformedMap
+      }
+      if scanner.skipOptionalObjectEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
 
-    mutating func decodeMapField<KeyType: MapKeyType, ValueType: MapValueType>(fieldType: _ProtobufMap<KeyType, ValueType>.Type, value: inout _ProtobufMap<KeyType, ValueType>.BaseType) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredObjectStart()
-        if scanner.skipOptionalObjectEnd() {
-            return
-        }
-        while true {
-            // Next character must be double quote, because
-            // map keys must always be quoted strings.
-            let c = try scanner.peekOneCharacter()
-            if c != "\"" {
-                throw JSONDecodingError.unquotedMapKey
-            }
-            isMapKey = true
-            var keyField: KeyType.BaseType?
-            try KeyType.decodeSingular(value: &keyField, from: &self)
-            isMapKey = false
-            try scanner.skipRequiredColon()
-            var valueField: ValueType.BaseType?
-            try ValueType.decodeSingular(value: &valueField, from: &self)
-            if let keyField = keyField, let valueField = valueField {
-                value[keyField] = valueField
-            } else {
-                throw JSONDecodingError.malformedMap
-            }
-            if scanner.skipOptionalObjectEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
+  mutating func decodeMapField<KeyType: MapKeyType, ValueType: Enum>(
+    fieldType: _ProtobufEnumMap<KeyType, ValueType>.Type,
+    value: inout _ProtobufEnumMap<KeyType, ValueType>.BaseType
+  ) throws where ValueType.RawValue == Int {
+    if scanner.skipOptionalNull() {
+      return
     }
+    try scanner.skipRequiredObjectStart()
+    if scanner.skipOptionalObjectEnd() {
+      return
+    }
+    while true {
+      // Next character must be double quote, because
+      // map keys must always be quoted strings.
+      let c = try scanner.peekOneCharacter()
+      if c != "\"" {
+        throw JSONDecodingError.unquotedMapKey
+      }
+      isMapKey = true
+      var keyField: KeyType.BaseType?
+      try KeyType.decodeSingular(value: &keyField, from: &self)
+      isMapKey = false
+      try scanner.skipRequiredColon()
+      var valueField: ValueType?
+      try decodeSingularEnumField(value: &valueField)
+      if let keyField = keyField, let valueField = valueField {
+        value[keyField] = valueField
+      } else {
+        throw JSONDecodingError.malformedMap
+      }
+      if scanner.skipOptionalObjectEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
 
-    mutating func decodeMapField<KeyType: MapKeyType, ValueType: Enum>(fieldType: _ProtobufEnumMap<KeyType, ValueType>.Type, value: inout _ProtobufEnumMap<KeyType, ValueType>.BaseType) throws where ValueType.RawValue == Int {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredObjectStart()
-        if scanner.skipOptionalObjectEnd() {
-            return
-        }
-        while true {
-            // Next character must be double quote, because
-            // map keys must always be quoted strings.
-            let c = try scanner.peekOneCharacter()
-            if c != "\"" {
-                throw JSONDecodingError.unquotedMapKey
-            }
-            isMapKey = true
-            var keyField: KeyType.BaseType?
-            try KeyType.decodeSingular(value: &keyField, from: &self)
-            isMapKey = false
-            try scanner.skipRequiredColon()
-            var valueField: ValueType?
-            try decodeSingularEnumField(value: &valueField)
-            if let keyField = keyField, let valueField = valueField {
-                value[keyField] = valueField
-            } else {
-                throw JSONDecodingError.malformedMap
-            }
-            if scanner.skipOptionalObjectEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
+  mutating func decodeMapField<
+    KeyType: MapKeyType,
+    ValueType: Message & Hashable
+  >(
+    fieldType: _ProtobufMessageMap<KeyType, ValueType>.Type,
+    value: inout _ProtobufMessageMap<KeyType, ValueType>.BaseType
+  ) throws {
+    if scanner.skipOptionalNull() {
+      return
     }
+    try scanner.skipRequiredObjectStart()
+    if scanner.skipOptionalObjectEnd() {
+      return
+    }
+    while true {
+      // Next character must be double quote, because
+      // map keys must always be quoted strings.
+      let c = try scanner.peekOneCharacter()
+      if c != "\"" {
+        throw JSONDecodingError.unquotedMapKey
+      }
+      isMapKey = true
+      var keyField: KeyType.BaseType?
+      try KeyType.decodeSingular(value: &keyField, from: &self)
+      isMapKey = false
+      try scanner.skipRequiredColon()
+      var valueField: ValueType?
+      try decodeSingularMessageField(value: &valueField)
+      if let keyField = keyField, let valueField = valueField {
+        value[keyField] = valueField
+      } else {
+        throw JSONDecodingError.malformedMap
+      }
+      if scanner.skipOptionalObjectEnd() {
+        return
+      }
+      try scanner.skipRequiredComma()
+    }
+  }
 
-    mutating func decodeMapField<KeyType: MapKeyType, ValueType: Message & Hashable>(fieldType: _ProtobufMessageMap<KeyType, ValueType>.Type, value: inout _ProtobufMessageMap<KeyType, ValueType>.BaseType) throws {
-        if scanner.skipOptionalNull() {
-            return
-        }
-        try scanner.skipRequiredObjectStart()
-        if scanner.skipOptionalObjectEnd() {
-            return
-        }
-        while true {
-            // Next character must be double quote, because
-            // map keys must always be quoted strings.
-            let c = try scanner.peekOneCharacter()
-            if c != "\"" {
-                throw JSONDecodingError.unquotedMapKey
-            }
-            isMapKey = true
-            var keyField: KeyType.BaseType?
-            try KeyType.decodeSingular(value: &keyField, from: &self)
-            isMapKey = false
-            try scanner.skipRequiredColon()
-            var valueField: ValueType?
-            try decodeSingularMessageField(value: &valueField)
-            if let keyField = keyField, let valueField = valueField {
-                value[keyField] = valueField
-            } else {
-                throw JSONDecodingError.malformedMap
-            }
-            if scanner.skipOptionalObjectEnd() {
-                return
-            }
-            try scanner.skipRequiredComma()
-        }
-    }
-
-    mutating func decodeExtensionField(values: inout ExtensionFieldValueSet, messageType: Message.Type, fieldNumber: Int) throws {
-        throw JSONDecodingError.schemaMismatch
-    }
+  mutating func decodeExtensionField(
+    values: inout ExtensionFieldValueSet,
+    messageType: Message.Type,
+    fieldNumber: Int
+  ) throws {
+    throw JSONDecodingError.schemaMismatch
+  }
 }

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -90,7 +90,8 @@ private func decodeBytes(base64String s: String) -> Data? {
     n <<= 6
     switch digit {
     case asciiUpperA...asciiUpperZ: n |= Int(digit - asciiUpperA); bits += 6
-    case asciiLowerA...asciiLowerZ: n |= Int(digit - asciiLowerA + 26); bits += 6
+    case asciiLowerA...asciiLowerZ:
+      n |= Int(digit - asciiLowerA + 26); bits += 6
     case asciiZero...asciiNine: n |= Int(digit - asciiZero + 52); bits += 6
     case 43: n |= 62; bits += 6
     case 47: n |= 63; bits += 6
@@ -118,92 +119,394 @@ private func decodeBytes(base64String s: String) -> Data? {
 // JSON encoding allows a variety of \-escapes, including
 // escaping UTF-16 code points (which may be surrogate pairs).
 private func decodeString(_ s: String) -> String? {
-    var out = String.UnicodeScalarView()
-    var chars = s.unicodeScalars.makeIterator()
-    while let c = chars.next() {
-        switch c.value {
-        case UInt32(asciiBackslash): // backslash
-            if let escaped = chars.next() {
-                switch escaped.value {
-                case UInt32(asciiLowerU): // "\u"
-                    // Exactly 4 hex digits:
-                    if let digit1 = chars.next(),
-                       let d1 = fromHexDigit(digit1),
-                       let digit2 = chars.next(),
-                       let d2 = fromHexDigit(digit2),
-                       let digit3 = chars.next(),
-                       let d3 = fromHexDigit(digit3),
-                       let digit4 = chars.next(),
-                       let d4 = fromHexDigit(digit4) {
-                        let codePoint = ((d1 * 16 + d2) * 16 + d3) * 16 + d4
-                        if let scalar = UnicodeScalar(codePoint) {
-                            out.append(scalar)
-                        } else if codePoint < 0xD800 || codePoint >= 0xE000 {
-                            // Not a valid Unicode scalar.
-                            return nil
-                        } else if codePoint >= 0xDC00 {
-                            // Low surrogate without a preceding high surrogate.
-                            return nil
-                        } else {
-                            // We have a high surrogate (in the range 0xD800..<0xDC00), so verify that
-                            // it is followed by a low surrogate.
-                            guard chars.next() == "\\", chars.next() == "u" else {
-                                // High surrogate was not followed by a Unicode escape sequence.
-                                return nil
-                            }
-                            if let digit1 = chars.next(),
-                               let d1 = fromHexDigit(digit1),
-                               let digit2 = chars.next(),
-                               let d2 = fromHexDigit(digit2),
-                               let digit3 = chars.next(),
-                               let d3 = fromHexDigit(digit3),
-                               let digit4 = chars.next(),
-                               let d4 = fromHexDigit(digit4) {
-                                let follower = ((d1 * 16 + d2) * 16 + d3) * 16 + d4
-                                guard 0xDC00 <= follower && follower < 0xE000 else {
-                                    // High surrogate was not followed by a low surrogate.
-                                    return nil
-                                }
-                                let high = codePoint - 0xD800
-                                let low = follower - 0xDC00
-                                let composed = 0x10000 | high << 10 | low
-                                guard let composedScalar = UnicodeScalar(composed) else {
-                                    // Composed value is not a valid Unicode scalar.
-                                    return nil
-                                }
-                                out.append(composedScalar)
-                            } else {
-                                // Malformed \u escape for low surrogate
-                                return nil
-                            }
-                        }
-                    } else {
-                        // Malformed \u escape
-                        return nil
-                    }
-                case UInt32(asciiLowerB): // \b
-                    out.append("\u{08}")
-                case UInt32(asciiLowerF): // \f
-                    out.append("\u{0c}")
-                case UInt32(asciiLowerN): // \n
-                    out.append("\u{0a}")
-                case UInt32(asciiLowerR): // \r
-                    out.append("\u{0d}")
-                case UInt32(asciiLowerT): // \t
-                    out.append("\u{09}")
-                case UInt32(asciiDoubleQuote), UInt32(asciiBackslash), UInt32(asciiForwardSlash): // " \ /
-                    out.append(escaped)
-                default:
-                    return nil // Unrecognized escape
-                }
+  var out = String.UnicodeScalarView()
+  var chars = s.unicodeScalars.makeIterator()
+  while let c = chars.next() {
+    switch c.value {
+    case UInt32(asciiBackslash): // backslash
+      if let escaped = chars.next() {
+        switch escaped.value {
+        case UInt32(asciiLowerU): // "\u"
+          // Exactly 4 hex digits:
+          if let digit1 = chars.next(),
+            let d1 = fromHexDigit(digit1),
+            let digit2 = chars.next(),
+            let d2 = fromHexDigit(digit2),
+            let digit3 = chars.next(),
+            let d3 = fromHexDigit(digit3),
+            let digit4 = chars.next(),
+            let d4 = fromHexDigit(digit4) {
+            let codePoint = ((d1 * 16 + d2) * 16 + d3) * 16 + d4
+            if let scalar = UnicodeScalar(codePoint) {
+              out.append(scalar)
+            } else if codePoint < 0xD800 || codePoint >= 0xE000 {
+              // Not a valid Unicode scalar.
+              return nil
+            } else if codePoint >= 0xDC00 {
+              // Low surrogate without a preceding high surrogate.
+              return nil
             } else {
-                return nil // Input ends with backslash
+              // We have a high surrogate (in the range 0xD800..<0xDC00), so
+              // verify that it is followed by a low surrogate.
+              guard chars.next() == "\\", chars.next() == "u" else {
+                // High surrogate was not followed by a Unicode escape sequence.
+                return nil
+              }
+              if let digit1 = chars.next(),
+                let d1 = fromHexDigit(digit1),
+                let digit2 = chars.next(),
+                let d2 = fromHexDigit(digit2),
+                let digit3 = chars.next(),
+                let d3 = fromHexDigit(digit3),
+                let digit4 = chars.next(),
+                let d4 = fromHexDigit(digit4) {
+                let follower = ((d1 * 16 + d2) * 16 + d3) * 16 + d4
+                guard 0xDC00 <= follower && follower < 0xE000 else {
+                  // High surrogate was not followed by a low surrogate.
+                  return nil
+                }
+                let high = codePoint - 0xD800
+                let low = follower - 0xDC00
+                let composed = 0x10000 | high << 10 | low
+                guard let composedScalar = UnicodeScalar(composed) else {
+                  // Composed value is not a valid Unicode scalar.
+                  return nil
+                }
+                out.append(composedScalar)
+              } else {
+                // Malformed \u escape for low surrogate
+                return nil
+              }
             }
+          } else {
+            // Malformed \u escape
+            return nil
+          }
+        case UInt32(asciiLowerB): // \b
+          out.append("\u{08}")
+        case UInt32(asciiLowerF): // \f
+          out.append("\u{0c}")
+        case UInt32(asciiLowerN): // \n
+          out.append("\u{0a}")
+        case UInt32(asciiLowerR): // \r
+          out.append("\u{0d}")
+        case UInt32(asciiLowerT): // \t
+          out.append("\u{09}")
+        case UInt32(asciiDoubleQuote), UInt32(asciiBackslash),
+             UInt32(asciiForwardSlash): // " \ /
+          out.append(escaped)
         default:
-            out.append(c)
+          return nil // Unrecognized escape
         }
+      } else {
+        return nil // Input ends with backslash
+      }
+    default:
+      out.append(c)
     }
-    return String(out)
+  }
+  return String(out)
+}
+
+// Parse the leading UInt64 from the provided utf8 bytes.
+//
+// This usually does a direct conversion of utf8 to UInt64.  It is
+// called for both unquoted numbers and for numbers stored in quoted
+// strings.  In the latter case, the caller is responsible for
+// consuming the leading quote and verifying the trailing quote.
+//
+// If the number is in floating-point format, this uses a slower
+// and less accurate approach: it identifies a substring comprising
+// a float, and then uses Double() and UInt64() to convert that
+// string to an unsigned intger.
+//
+// If it encounters a "\" backslash character, it returns a nil.  This
+// is used by callers that are parsing quoted numbers.  See nextSInt()
+// and nextUInt() below.
+private func parseBareUInt(
+  p: inout UnsafePointer<UInt8>,
+  end: UnsafePointer<UInt8>
+) throws -> UInt64? {
+  let start = p
+  let c = p[0]
+  p = p + 1
+  switch c {
+  case asciiZero: // 0
+    if p != end {
+      let after = p[0]
+      switch after {
+      case asciiZero...asciiNine: // 0...9
+        // leading '0' forbidden unless it is the only digit
+        throw JSONDecodingError.leadingZero
+      case asciiPeriod, asciiLowerE, asciiUpperE: // . e
+        // Slow path: JSON numbers can be written in floating-point notation
+        p = start
+        if let s = try parseBareFloatString(p: &p, end: end) {
+          if let d = Double(s) {
+            if let u = UInt64(exactly: d) {
+              return u
+            }
+          }
+        }
+        throw JSONDecodingError.malformedNumber
+      case asciiBackslash:
+        return nil
+      default:
+        return 0
+      }
+    }
+    return 0
+  case asciiOne...asciiNine: // 1...9
+    var n = UInt64(c - 48)
+    while p != end {
+      let digit = p[0]
+      switch digit {
+      case asciiZero...asciiNine: // 0...9
+        let val = UInt64(digit - asciiZero)
+        if n >= UInt64.max / 10 {
+          if n > UInt64.max / 10 || val > UInt64.max % 10 {
+            throw JSONDecodingError.numberRange
+          }
+        }
+        p = p + 1
+        n = n * 10 + val
+      case asciiPeriod, asciiLowerE, asciiUpperE: // . e
+        // Slow path: JSON allows floating-point notation for integers
+        p = start
+        if let s = try parseBareFloatString(p: &p, end: end) {
+          if let d = Double(s) {
+            if let u = UInt64(exactly: d) {
+              return u
+            }
+          }
+        }
+        throw JSONDecodingError.malformedNumber
+      case asciiBackslash:
+        return nil
+      default:
+        return n
+      }
+    }
+    return n
+  case asciiBackslash:
+    return nil
+  default:
+    throw JSONDecodingError.malformedNumber
+  }
+}
+
+// Parse the leading Int64 from the provided utf8.
+//
+// This uses parseBareUInt() to do the heavy lifting;
+// we just check for a leading minus and negate the result
+// as necessary.
+//
+// As with parseBareUInt(), if it encounters a "\" backslash
+// character, it returns a nil.  This is used by callers that are
+// parsing quoted numbers.  See nextSInt() and nextUInt() below.
+
+private func parseBareSInt(
+  p: inout UnsafePointer<UInt8>,
+  end: UnsafePointer<UInt8>
+) throws -> Int64? {
+  if p == end {
+    throw JSONDecodingError.truncated
+  }
+  let c = p[0]
+  if c == asciiMinus { // -
+    p = p + 1
+    // character after '-' must be digit
+    let digit = p[0]
+    if digit < asciiZero || digit > asciiNine {
+      throw JSONDecodingError.malformedNumber
+    }
+    if let n = try parseBareUInt(p: &p, end: end) {
+      if n >= 0x8000000000000000 { // -Int64.min
+        if n > 0x8000000000000000 {
+          // Too large negative number
+          throw JSONDecodingError.numberRange
+        } else {
+          return Int64.min // Special case for Int64.min
+        }
+      }
+      return -Int64(bitPattern: n)
+    } else {
+      return nil
+    }
+  } else if let n = try parseBareUInt(p: &p, end: end) {
+    if n > UInt64(bitPattern: Int64.max) {
+      throw JSONDecodingError.numberRange
+    }
+    return Int64(bitPattern: n)
+  } else {
+    return nil
+  }
+}
+
+// Identify a floating-point token in the upcoming UTF8 bytes.
+//
+// This implements the full grammar defined by the JSON RFC 7159.
+// Note that Swift's string-to-number conversions are much more
+// lenient, so this is necessary if we want to accurately reject
+// malformed JSON numbers.
+//
+// This is used by nextDouble() and nextFloat() to parse double and
+// floating-point values, including values that happen to be in quotes.
+// It's also used by the slow path in parseBareSInt() and parseBareUInt()
+// above to handle integer values that are written in float-point notation.
+private func parseBareFloatString(
+  p: inout UnsafePointer<UInt8>,
+  end: UnsafePointer<UInt8>
+) throws -> String? {
+  // RFC 7159 defines the grammar for JSON numbers as:
+  // number = [ minus ] int [ frac ] [ exp ]
+  let start = p
+  var c = p[0]
+  if c == asciiBackslash {
+    return nil
+  }
+
+  // Optional leading minus sign
+  if c == asciiMinus { // -
+    p += 1
+    if p == end {
+      p = start
+      throw JSONDecodingError.truncated
+    }
+    c = p[0]
+    if c == asciiBackslash {
+      return nil
+    }
+  } else if c == asciiUpperN { // Maybe NaN?
+    // Return nil, let the caller deal with it.
+    return nil
+  }
+
+  if c == asciiUpperI { // Maybe Infinity, Inf, -Infinity, or -Inf ?
+    // Return nil, let the caller deal with it.
+    return nil
+  }
+
+  // Integer part can be zero or a series of digits not starting with zero
+  // int = zero / (digit1-9 *DIGIT)
+  switch c {
+  case asciiZero:
+    // First digit can be zero only if not followed by a digit
+    p += 1
+    if p == end {
+      if let s = utf8ToString(bytes: start, count: p - start) {
+        return s
+      } else {
+        throw JSONDecodingError.invalidUTF8
+      }
+    }
+    c = p[0]
+    if c == asciiBackslash {
+      return nil
+    }
+    if c >= asciiZero && c <= asciiNine {
+      throw JSONDecodingError.leadingZero
+    }
+  case asciiOne...asciiNine:
+    while c >= asciiZero && c <= asciiNine {
+      p = p + 1
+      if p == end {
+        if let s = utf8ToString(bytes: start, count: p - start) {
+          return s
+        } else {
+          throw JSONDecodingError.invalidUTF8
+        }
+      }
+      c = p[0]
+      if c == asciiBackslash {
+        return nil
+      }
+    }
+  default:
+    // Integer part cannot be empty
+    throw JSONDecodingError.malformedNumber
+  }
+
+  // frac = decimal-point 1*DIGIT
+  if c == asciiPeriod {
+    p = p + 1
+    if p == end {
+      // decimal point must have a following digit
+      throw JSONDecodingError.truncated
+    }
+    c = p[0]
+    switch c {
+    case asciiZero...asciiNine: // 0...9
+      while c >= asciiZero && c <= asciiNine {
+        p = p + 1
+        if p == end {
+          if let s = utf8ToString(bytes: start, count: p - start) {
+            return s
+          } else {
+            throw JSONDecodingError.invalidUTF8
+          }
+        }
+        c = p[0]
+        if c == asciiBackslash {
+          return nil
+        }
+      }
+    case asciiBackslash:
+      return nil
+    default:
+      // decimal point must be followed by at least one digit
+      throw JSONDecodingError.malformedNumber
+    }
+  }
+
+  // exp = e [ minus / plus ] 1*DIGIT
+  if c == asciiLowerE || c == asciiUpperE {
+    p = p + 1
+    if p == end {
+      // "e" must be followed by +,-, or digit
+      throw JSONDecodingError.truncated
+    }
+    c = p[0]
+    if c == asciiBackslash {
+      return nil
+    }
+    if c == asciiPlus || c == asciiMinus { // + -
+      p = p + 1
+      if p == end {
+        // must be at least one digit in exponent
+        throw JSONDecodingError.truncated
+      }
+      c = p[0]
+      if c == asciiBackslash {
+        return nil
+      }
+    }
+    switch c {
+    case asciiZero...asciiNine:
+      while c >= asciiZero && c <= asciiNine {
+        p = p + 1
+        if p == end {
+          if let s = utf8ToString(bytes: start, count: p - start) {
+            return s
+          } else {
+            throw JSONDecodingError.invalidUTF8
+          }
+        }
+        c = p[0]
+        if c == asciiBackslash {
+          return nil
+        }
+      }
+    default:
+      // must be at least one digit in exponent
+      throw JSONDecodingError.malformedNumber
+    }
+  }
+  if let s = utf8ToString(bytes: start, count: p - start) {
+    return s
+  } else {
+    throw JSONDecodingError.invalidUTF8
+  }
 }
 
 ///
@@ -212,954 +515,685 @@ private func decodeString(_ s: String) -> String? {
 /// For performance, it works directly against UTF-8 bytes in memory.
 ///
 internal struct JSONScanner {
-    private var p: UnsafePointer<UInt8>
-    private var end: UnsafePointer<UInt8>
-    private var doubleFormatter = DoubleFormatter()
+  private var p: UnsafePointer<UInt8>
+  private var end: UnsafePointer<UInt8>
 
-    internal var complete: Bool {
-        mutating get {
-            skipWhitespace()
-            return p == end
-        }
+  internal var complete: Bool {
+    mutating get {
+      skipWhitespace()
+      return p == end
     }
+  }
 
-    internal init(utf8Pointer: UnsafePointer<UInt8>, count: Int) {
-        p = utf8Pointer
-        end = p + count
+  internal init(utf8Pointer: UnsafePointer<UInt8>, count: Int) {
+    p = utf8Pointer
+    end = p + count
+  }
+
+  /// Skip whitespace
+  private mutating func skipWhitespace() {
+    while p != end {
+      let u = p[0]
+      switch u {
+      case asciiSpace, asciiTab, asciiNewLine, asciiCarriageReturn:
+        p += 1
+      default:
+        return
+      }
     }
+  }
 
-    // Parse the leading UInt64 from the provided utf8 bytes.
-    //
-    // This usually does a direct conversion of utf8 to UInt64.  It is
-    // called for both unquoted numbers and for numbers stored in quoted
-    // strings.  In the latter case, the caller is responsible for
-    // consuming the leading quote and verifying the trailing quote.
-    //
-    // If the number is in floating-point format, this uses a slower
-    // and less accurate approach: it identifies a substring comprising
-    // a float, and then uses Double() and UInt64() to convert that
-    // string to an unsigned intger.
-    //
-    // If it encounters a "\" backslash character, it returns a nil.  This
-    // is used by callers that are parsing quoted numbers.  See nextSInt()
-    // and nextUInt() below.
-    private func parseBareUInt(p: inout UnsafePointer<UInt8>, end: UnsafePointer<UInt8>) throws -> UInt64? {
-        let start = p
-        let c = p[0]
+  /// Returns (but does not consume) the next non-whitespace
+  /// character.  This is used by google.protobuf.Value, for
+  /// example, for custom JSON parsing.
+  internal mutating func peekOneCharacter() throws -> Character {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
+    }
+    return Character(UnicodeScalar(UInt32(p[0]))!)
+  }
+
+  /// Returns a fully-parsed string with all backslash escapes
+  /// correctly processed, or nil if next token is not a string.
+  ///
+  /// Assumes the leading quote has been verified (but not consumed)
+  private mutating func parseOptionalQuotedString() -> String? {
+    // Caller has already asserted that p[0] == quote here
+    var sawBackslash = false
+    p = p + 1
+    let start = p
+    while p != end {
+      switch p[0] {
+      case asciiDoubleQuote: // "
+        let s = utf8ToString(bytes: start, count: p - start)
         p = p + 1
-        switch c {
-        case asciiZero: // 0
-            if p != end {
-                let after = p[0]
-                switch after {
-                case asciiZero...asciiNine: // 0...9
-                    // leading '0' forbidden unless it is the only digit
-                    throw JSONDecodingError.leadingZero
-                case asciiPeriod, asciiLowerE, asciiUpperE: // . e E
-                    // Slow path: JSON numbers can be written in floating-point notation
-                    p = start
-                    if let d = try parseBareDouble(p: &p, end: end) {
-                        if let u = UInt64(exactly: d) {
-                            return u
-                        }
-                    }
-                    throw JSONDecodingError.malformedNumber
-                case asciiBackslash:
-                    return nil
-                default:
-                    return 0
-                }
+        if let t = s {
+          if sawBackslash {
+            return decodeString(t)
+          } else {
+            return t
+          }
+        } else {
+          return nil // Invalid UTF8
+        }
+      case asciiBackslash: //  \
+        p = p + 1
+        if p == end {
+          return nil // Unterminated escape
+        }
+        sawBackslash = true
+      default:
+        break
+      }
+      p = p + 1
+    }
+    return nil // Unterminated quoted string
+  }
+
+  /// Parse an unsigned integer, whether or not its quoted.
+  /// This also handles cases such as quoted numbers that have
+  /// backslash escapes in them.
+  ///
+  /// This supports the full range of UInt64 (whether quoted or not)
+  /// unless the number is written in floating-point format.  In that
+  /// case, we decode it with only Double precision.
+  internal mutating func nextUInt() throws -> UInt64 {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
+    }
+    let c = p[0]
+    if c == asciiDoubleQuote {
+      let start = p
+      p = p + 1
+      if let u = try parseBareUInt(p: &p, end: end) {
+        if p == end {
+          throw JSONDecodingError.truncated
+        }
+        if p[0] != asciiDoubleQuote {
+          throw JSONDecodingError.malformedNumber
+        }
+        p = p + 1
+        return u
+      } else {
+        // Couldn't parse because it had a "\" in the string,
+        // so parse out the quoted string and then reparse
+        // the result to get a UInt
+        p = start
+        let s = try nextQuotedString()
+        let raw = s.data(using: String.Encoding.utf8)!
+        let n = try raw.withUnsafeBytes {
+          (bytes: UnsafePointer<UInt8>) -> UInt64? in
+          var p = bytes
+          let end = p + raw.count
+          if let u = try parseBareUInt(p: &p, end: end) {
+            if p == end {
+              return u
             }
-            return 0
-        case asciiOne...asciiNine: // 1...9
-            var n = UInt64(c - 48)
-            while p != end {
-                let digit = p[0]
-                switch digit {
-                case asciiZero...asciiNine: // 0...9
-                    let val = UInt64(digit - asciiZero)
-                    if n >= UInt64.max / 10 {
-                        if n > UInt64.max / 10 || val > UInt64.max % 10 {
-                            throw JSONDecodingError.numberRange
-                        }
-                    }
-                    p = p + 1
-                    n = n * 10 + val
-                case asciiPeriod, asciiLowerE, asciiUpperE: // . e E
-                    // Slow path: JSON allows floating-point notation for integers
-                    p = start
-                    if let d = try parseBareDouble(p: &p, end: end) {
-                        if let u = UInt64(exactly: d) {
-                            return u
-                        }
-                    }
-                    throw JSONDecodingError.malformedNumber
-                case asciiBackslash:
-                    return nil
-                default:
-                    return n
-                }
+          }
+          return nil
+        }
+        if let n = n {
+          return n
+        }
+      }
+    } else if let u = try parseBareUInt(p: &p, end: end) {
+      return u
+    }
+    throw JSONDecodingError.malformedNumber
+  }
+
+
+  /// Parse a signed integer, quoted or not, including handling
+  /// backslash escapes for quoted values.
+  ///
+  /// This supports the full range of Int64 (whether quoted or not)
+  /// unless the number is written in floating-point format.  In that
+  /// case, we decode it with only Double precision.
+  internal mutating func nextSInt() throws -> Int64 {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
+    }
+    let c = p[0]
+    if c == asciiDoubleQuote {
+      let start = p
+      p = p + 1
+      if let s = try parseBareSInt(p: &p, end: end) {
+        if p == end {
+          throw JSONDecodingError.truncated
+        }
+        if p[0] != asciiDoubleQuote {
+          throw JSONDecodingError.malformedNumber
+        }
+        p = p + 1
+        return s
+      } else {
+        // Couldn't parse because it had a "\" in the string,
+        // so parse out the quoted string and then reparse
+        // the result as an SInt
+        p = start
+        let s = try nextQuotedString()
+        let raw = s.data(using: String.Encoding.utf8)!
+        let n = try raw.withUnsafeBytes {
+          (bytes: UnsafePointer<UInt8>) -> Int64? in
+          var p = bytes
+          let end = p + raw.count
+          if let s = try parseBareSInt(p: &p, end: end) {
+            if p == end {
+              return s
             }
+          }
+          return nil
+        }
+        if let n = n {
+          return n
+        }
+      }
+    } else if let s = try parseBareSInt(p: &p, end: end) {
+      return s
+    }
+    throw JSONDecodingError.malformedNumber
+  }
+
+  /// Parse the next Float value, regardless of whether it
+  /// is quoted, including handling backslash escapes for
+  /// quoted strings.
+  internal mutating func nextFloat() throws -> Float {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
+    }
+    let c = p[0]
+    if c == asciiDoubleQuote { // "
+      let start = p
+      p = p + 1
+      if let s = try parseBareFloatString(p: &p, end: end) {
+        if p == end {
+          throw JSONDecodingError.truncated
+        }
+        if p[0] != asciiDoubleQuote {
+          throw JSONDecodingError.malformedNumber
+        }
+        p = p + 1
+        if let f = Float(s) {
+          return f
+        }
+      } else {
+        // Slow Path: parseBareFloatString returned nil: It might be
+        // a valid float, but had something that
+        // parseBareFloatString cannot directly handle.  So we reset,
+        // try a full string parse, then examine the result:
+        p = start
+        let s = try nextQuotedString()
+        switch s {
+        case "NaN": return Float.nan
+        case "Inf": return Float.infinity
+        case "-Inf": return -Float.infinity
+        case "Infinity": return Float.infinity
+        case "-Infinity": return -Float.infinity
+        default:
+          let raw = s.data(using: String.Encoding.utf8)!
+          let n = try raw.withUnsafeBytes {
+            (bytes: UnsafePointer<UInt8>) -> Float? in
+            var p = bytes
+            let end = p + raw.count
+            if let s = try parseBareFloatString(p: &p, end: end) {
+              if p == end {
+                return Float(s)
+              }
+            }
+            return nil
+          }
+          if let n = n {
             return n
-        case asciiBackslash:
-            return nil
-        default:
-            throw JSONDecodingError.malformedNumber
+          }
         }
+      }
+    } else {
+      if let s = try parseBareFloatString(p: &p, end: end), let n = Float(s) {
+        return n
+      }
     }
+    throw JSONDecodingError.malformedNumber
+  }
 
-    // Parse the leading Int64 from the provided utf8.
-    //
-    // This uses parseBareUInt() to do the heavy lifting;
-    // we just check for a leading minus and negate the result
-    // as necessary.
-    //
-    // As with parseBareUInt(), if it encounters a "\" backslash
-    // character, it returns a nil.  This is used by callers that are
-    // parsing quoted numbers.  See nextSInt() and nextUInt() below.
-    private func parseBareSInt(p: inout UnsafePointer<UInt8>, end: UnsafePointer<UInt8>) throws -> Int64? {
+  /// Parse the next Double value, regardless of whether it
+  /// is quoted, including handling backslash escapes for
+  /// quoted strings.
+  internal mutating func nextDouble() throws -> Double {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
+    }
+    let c = p[0]
+    if c == asciiDoubleQuote { // "
+      let start = p
+      p = p + 1
+      if let s = try parseBareFloatString(p: &p, end: end) {
         if p == end {
-            throw JSONDecodingError.truncated
+          throw JSONDecodingError.truncated
         }
-        let c = p[0]
-        if c == asciiMinus { // -
-            p = p + 1
-            // character after '-' must be digit
-            let digit = p[0]
-            if digit < asciiZero || digit > asciiNine {
-                throw JSONDecodingError.malformedNumber
-            }
-            if let n = try parseBareUInt(p: &p, end: end) {
-                if n >= 0x8000000000000000 { // -Int64.min
-                    if n > 0x8000000000000000 {
-                        // Too large negative number
-                        throw JSONDecodingError.numberRange
-                    } else {
-                        return Int64.min // Special case for Int64.min
-                    }
-                }
-                return -Int64(bitPattern: n)
-            } else {
-                return nil
-            }
-        } else if let n = try parseBareUInt(p: &p, end: end) {
-            if n > UInt64(bitPattern: Int64.max) {
-                throw JSONDecodingError.numberRange
-            }
-            return Int64(bitPattern: n)
-        } else {
-            return nil
+        if p[0] != asciiDoubleQuote {
+          throw JSONDecodingError.malformedNumber
         }
-    }
-
-    // Identify a floating-point token in the upcoming UTF8 bytes.
-    //
-    // This implements the full grammar defined by the JSON RFC 7159.
-    // Note that Swift's string-to-number conversions are much more
-    // lenient, so this is necessary if we want to accurately reject
-    // malformed JSON numbers.
-    //
-    // This is used by nextDouble() and nextFloat() to parse double and
-    // floating-point values, including values that happen to be in quotes.
-    // It's also used by the slow path in parseBareSInt() and parseBareUInt()
-    // above to handle integer values that are written in float-point notation.
-    private func parseBareDouble(p: inout UnsafePointer<UInt8>, end: UnsafePointer<UInt8>) throws -> Double? {
-        // RFC 7159 defines the grammar for JSON numbers as:
-        // number = [ minus ] int [ frac ] [ exp ]
-        let start = p
-        var c = p[0]
-        if c == asciiBackslash {
-            return nil
-        }
-
-        // Optional leading minus sign
-        if c == asciiMinus { // -
-            p += 1
-            if p == end {
-                p = start
-                throw JSONDecodingError.truncated
-            }
-            c = p[0]
-            if c == asciiBackslash {
-                return nil
-            }
-        } else if c == asciiUpperN { // Maybe NaN?
-            // Return nil, let the caller deal with it.
-            return nil
-        }
-
-        if c == asciiUpperI { // Maybe Infinity, Inf, -Infinity, or -Inf ?
-            // Return nil, let the caller deal with it.
-            return nil
-        }
-
-        // Integer part can be zero or a series of digits not starting with zero
-        // int = zero / (digit1-9 *DIGIT)
-        switch c {
-        case asciiZero:
-            // First digit can be zero only if not followed by a digit
-            p += 1
-            if p == end {
-                if let d = doubleFormatter.utf8ToDouble(bytes: start, count: p - start) {
-                    return d
-                } else {
-                    throw JSONDecodingError.malformedNumber
-                }
-            }
-            c = p[0]
-            if c == asciiBackslash {
-                return nil
-            }
-            if c >= asciiZero && c <= asciiNine {
-                throw JSONDecodingError.leadingZero
-            }
-        case asciiOne...asciiNine:
-            while c >= asciiZero && c <= asciiNine {
-                p = p + 1
-                if p == end {
-                    if let d = doubleFormatter.utf8ToDouble(bytes: start, count: p - start) {
-                        return d
-                    } else {
-                        throw JSONDecodingError.invalidUTF8
-                    }
-                }
-                c = p[0]
-                if c == asciiBackslash {
-                    return nil
-                }
-            }
-        default:
-            // Integer part cannot be empty
-            throw JSONDecodingError.malformedNumber
-        }
-
-        // frac = decimal-point 1*DIGIT
-        if c == asciiPeriod {
-            p = p + 1
-            if p == end {
-                // decimal point must have a following digit
-                throw JSONDecodingError.truncated
-            }
-            c = p[0]
-            switch c {
-            case asciiZero...asciiNine: // 0...9
-                while c >= asciiZero && c <= asciiNine {
-                    p = p + 1
-                    if p == end {
-                        if let d = doubleFormatter.utf8ToDouble(bytes: start, count: p - start) {
-                            return d
-                        } else {
-                            throw JSONDecodingError.malformedNumber
-                        }
-                    }
-                    c = p[0]
-                    if c == asciiBackslash {
-                        return nil
-                    }
-                }
-            case asciiBackslash:
-                return nil
-            default:
-                throw JSONDecodingError.malformedNumber // decimal point must be followed by at least one digit
-            }
-        }
-
-        // exp = e [ minus / plus ] 1*DIGIT
-        if c == asciiLowerE || c == asciiUpperE {
-            p = p + 1
-            if p == end {
-                // "e" must be followed by +,-, or digit
-                throw JSONDecodingError.truncated
-            }
-            c = p[0]
-            if c == asciiBackslash {
-                return nil
-            }
-            if c == asciiPlus || c == asciiMinus { // + -
-                p = p + 1
-                if p == end {
-                    // must be at least one digit in exponent
-                    throw JSONDecodingError.truncated
-                }
-                c = p[0]
-                if c == asciiBackslash {
-                    return nil
-                }
-            }
-            switch c {
-            case asciiZero...asciiNine:
-                while c >= asciiZero && c <= asciiNine {
-                    p = p + 1
-                    if p == end {
-                        if let d = doubleFormatter.utf8ToDouble(bytes: start, count: p - start) {
-                            return d
-                        } else {
-                            throw JSONDecodingError.malformedNumber
-                        }
-                    }
-                    c = p[0]
-                    if c == asciiBackslash {
-                        return nil
-                    }
-                }
-            default:
-                // must be at least one digit in exponent
-                throw JSONDecodingError.malformedNumber
-            }
-        }
-        if let d = doubleFormatter.utf8ToDouble(bytes: start, count: p - start) {
-            return d
-        } else {
-            throw JSONDecodingError.malformedNumber
-        }
-    }
-
-    /// Skip whitespace
-    private mutating func skipWhitespace() {
-        while p != end {
-            let u = p[0]
-            switch u {
-            case asciiSpace, asciiTab, asciiNewLine, asciiCarriageReturn: // space, tab, NL, CR
-                p += 1
-            default:
-                return
-            }
-        }
-    }
-
-    /// Returns (but does not consume) the next non-whitespace
-    /// character.  This is used by google.protobuf.Value, for
-    /// example, for custom JSON parsing.
-    internal mutating func peekOneCharacter() throws -> Character {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        return Character(UnicodeScalar(UInt32(p[0]))!)
-    }
-
-    /// Returns a fully-parsed string with all backslash escapes
-    /// correctly processed, or nil if next token is not a string.
-    ///
-    /// Assumes the leading quote has been verified (but not consumed)
-    private mutating func parseOptionalQuotedString() -> String? {
-        // Caller has already asserted that p[0] == quote here
-        var sawBackslash = false
         p = p + 1
-        let start = p
-        while p != end {
-            switch p[0] {
-            case asciiDoubleQuote: // "
-                let s = utf8ToString(bytes: start, count: p - start)
-                p = p + 1
-                if let t = s {
-                    if sawBackslash {
-                        return decodeString(t)
-                    } else {
-                        return t
-                    }
-                } else {
-                    return nil // Invalid UTF8
-                }
-            case asciiBackslash: //  \
-                p = p + 1
-                if p == end {
-                    return nil // Unterminated escape
-                }
-                sawBackslash = true
-            default:
-                break
+        if let f = Double(s) {
+          return f
+        }
+      } else {
+        // Slow Path: parseBareFloatString returned nil: It might be
+        // a valid float, but had something that
+        // parseBareFloatString cannot directly handle.  So we reset,
+        // try a full string parse, then examine the result:
+        p = start
+        let s = try nextQuotedString()
+        switch s {
+        case "NaN": return Double.nan
+        case "Inf": return Double.infinity
+        case "-Inf": return -Double.infinity
+        case "Infinity": return Double.infinity
+        case "-Infinity": return -Double.infinity
+        default:
+          let raw = s.data(using: String.Encoding.utf8)!
+          let n = try raw.withUnsafeBytes {
+            (bytes: UnsafePointer<UInt8>) -> Double? in
+            var p = bytes
+            let end = p + raw.count
+            if let s = try parseBareFloatString(p: &p, end: end) {
+              if p == end {
+                return Double(s)
+              }
             }
-            p = p + 1
-        }
-        return nil // Unterminated quoted string
-    }
-
-    /// Parse an unsigned integer, whether or not its quoted.
-    /// This also handles cases such as quoted numbers that have
-    /// backslash escapes in them.
-    ///
-    /// This supports the full range of UInt64 (whether quoted or not)
-    /// unless the number is written in floating-point format.  In that
-    /// case, we decode it with only Double precision.
-    internal mutating func nextUInt() throws -> UInt64 {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        let c = p[0]
-        if c == asciiDoubleQuote {
-            let start = p
-            p = p + 1
-            if let u = try parseBareUInt(p: &p, end: end) {
-               if p == end {
-                   throw JSONDecodingError.truncated
-               }
-               if p[0] != asciiDoubleQuote {
-                   throw JSONDecodingError.malformedNumber
-               }
-               p = p + 1
-               return u
-            } else {
-                // Couldn't parse because it had a "\" in the string,
-                // so parse out the quoted string and then reparse
-                // the result to get a UInt
-                p = start
-                let s = try nextQuotedString()
-                let raw = s.data(using: String.Encoding.utf8)!
-                let n = try raw.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> UInt64? in
-                    var p = bytes
-                    let end = p + raw.count
-                    if let u = try parseBareUInt(p: &p, end: end) {
-                        if p == end {
-                            return u
-                        }
-                    }
-                    return nil
-                }
-                if let n = n {
-                    return n
-                }
-            }
-        } else if let u = try parseBareUInt(p: &p, end: end) {
-            return u
-        }
-        throw JSONDecodingError.malformedNumber
-    }
-
-
-    /// Parse a signed integer, quoted or not, including handling
-    /// backslash escapes for quoted values.
-    ///
-    /// This supports the full range of Int64 (whether quoted or not)
-    /// unless the number is written in floating-point format.  In that
-    /// case, we decode it with only Double precision.
-    internal mutating func nextSInt() throws -> Int64 {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        let c = p[0]
-        if c == asciiDoubleQuote {
-            let start = p
-            p = p + 1
-            if let s = try parseBareSInt(p: &p, end: end) {
-                if p == end {
-                    throw JSONDecodingError.truncated
-                }
-                if p[0] != asciiDoubleQuote {
-                    throw JSONDecodingError.malformedNumber
-                }
-                p = p + 1
-                return s
-            } else {
-                // Couldn't parse because it had a "\" in the string,
-                // so parse out the quoted string and then reparse
-                // the result as an SInt
-                p = start
-                let s = try nextQuotedString()
-                let raw = s.data(using: String.Encoding.utf8)!
-                let n = try raw.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Int64? in
-                    var p = bytes
-                    let end = p + raw.count
-                    if let s = try parseBareSInt(p: &p, end: end) {
-                        if p == end {
-                            return s
-                        }
-                    }
-                    return nil
-                }
-                if let n = n {
-                    return n
-                }
-            }
-        } else if let s = try parseBareSInt(p: &p, end: end) {
-            return s
-        }
-        throw JSONDecodingError.malformedNumber
-    }
-
-    /// Parse the next Float value, regardless of whether it
-    /// is quoted, including handling backslash escapes for
-    /// quoted strings.
-    internal mutating func nextFloat() throws -> Float {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        let c = p[0]
-        if c == asciiDoubleQuote { // "
-            let start = p
-            p = p + 1
-            if let d = try parseBareDouble(p: &p, end: end) {
-                if p == end {
-                    throw JSONDecodingError.truncated
-                }
-                if p[0] != asciiDoubleQuote {
-                    throw JSONDecodingError.malformedNumber
-                }
-                p = p + 1
-                let f = Float(d)
-                if f.isFinite {
-                    return f
-                }
-            } else {
-                // Slow Path: parseBareDouble returned nil: It might be
-                // a valid float, but had something that
-                // parseBareDouble cannot directly handle.  So we reset,
-                // try a full string parse, then examine the result:
-                p = start
-                let s = try nextQuotedString()
-                switch s {
-                case "NaN": return Float.nan
-                case "Inf": return Float.infinity
-                case "-Inf": return -Float.infinity
-                case "Infinity": return Float.infinity
-                case "-Infinity": return -Float.infinity
-                default:
-                    let raw = s.data(using: String.Encoding.utf8)!
-                    let n = try raw.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Float? in
-                        var p = bytes
-                        let end = p + raw.count
-                        if let d = try parseBareDouble(p: &p, end: end) {
-                            let f = Float(d)
-                            if p == end && f.isFinite {
-                                return f
-                            }
-                        }
-                        return nil
-                    }
-                    if let n = n {
-                        return n
-                    }
-                }
-            }
-        } else {
-            if let d = try parseBareDouble(p: &p, end: end) {
-                let f = Float(d)
-                if f.isFinite {
-                    return f
-                }
-            }
-        }
-        throw JSONDecodingError.malformedNumber
-    }
-
-    /// Parse the next Double value, regardless of whether it
-    /// is quoted, including handling backslash escapes for
-    /// quoted strings.
-    internal mutating func nextDouble() throws -> Double {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        let c = p[0]
-        if c == asciiDoubleQuote { // "
-            let start = p
-            p = p + 1
-            if let d = try parseBareDouble(p: &p, end: end) {
-                if p == end {
-                    throw JSONDecodingError.truncated
-                }
-                if p[0] != asciiDoubleQuote {
-                    throw JSONDecodingError.malformedNumber
-                }
-                p = p + 1
-                return d
-            } else {
-                // Slow Path: parseBareDouble returned nil: It might be
-                // a valid float, but had something that
-                // parseBareDouble cannot directly handle.  So we reset,
-                // try a full string parse, then examine the result:
-                p = start
-                let s = try nextQuotedString()
-                switch s {
-                case "NaN": return Double.nan
-                case "Inf": return Double.infinity
-                case "-Inf": return -Double.infinity
-                case "Infinity": return Double.infinity
-                case "-Infinity": return -Double.infinity
-                default:
-                    let raw = s.data(using: String.Encoding.utf8)!
-                    let n = try raw.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) -> Double? in
-                        var p = bytes
-                        let end = p + raw.count
-                        if let d = try parseBareDouble(p: &p, end: end), p == end {
-                            return d
-                        }
-                        return nil
-                    }
-                    if let n = n {
-                        return n
-                    }
-                }
-            }
-        } else {
-            if let d = try parseBareDouble(p: &p, end: end) {
-                return d
-            }
-        }
-        throw JSONDecodingError.malformedNumber
-    }
-
-    /// Return the contents of the following quoted string,
-    /// or throw an error if the next token is not a string.
-    internal mutating func nextQuotedString() throws -> String {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        let c = p[0]
-        if c != asciiDoubleQuote {
-            throw JSONDecodingError.malformedString
-        }
-        if let s = parseOptionalQuotedString() {
-            return s
-        } else {
-            throw JSONDecodingError.malformedString
-        }
-    }
-
-    /// Return the contents of the following quoted string,
-    /// or nil if the next token is not a string.
-    /// This will only throw an error if the next token starts
-    /// out as a string but is malformed in some way.
-    internal mutating func nextOptionalQuotedString() throws -> String? {
-        skipWhitespace()
-        if p == end {
             return nil
+          }
+          if let n = n {
+            return n
+          }
         }
-        let c = p[0]
-        if c != asciiDoubleQuote {
-            return nil
-        }
-        return try nextQuotedString()
+      }
+    } else {
+      if let s = try parseBareFloatString(p: &p, end: end), let n = Double(s) {
+        return n
+      }
     }
+    throw JSONDecodingError.malformedNumber
+  }
 
-    /// Return a Data with the decoded contents of the
-    /// following base-64 string.
-    internal mutating func nextBytesValue() throws -> Data {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        let c = p[0]
-        if c != asciiDoubleQuote {
-            throw JSONDecodingError.malformedString
-        }
-        if let s = parseOptionalQuotedString(), let b = decodeBytes(base64String: s) {
-            return b
-        } else {
-            throw JSONDecodingError.malformedString
-        }
+  /// Return the contents of the following quoted string,
+  /// or throw an error if the next token is not a string.
+  internal mutating func nextQuotedString() throws -> String {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
     }
+    let c = p[0]
+    if c != asciiDoubleQuote {
+      throw JSONDecodingError.malformedString
+    }
+    if let s = parseOptionalQuotedString() {
+      return s
+    } else {
+      throw JSONDecodingError.malformedString
+    }
+  }
 
-    /// Private function to help parse keywords.
-    private mutating func skipOptionalKeyword(bytes: [UInt8]) -> Bool {
-        let start = p
-        for b in bytes {
-            if p == end {
-                p = start
-                return false
-            }
-            let c = p[0]
-            if c != b {
-                p = start
-                return false
-            }
-            p = p + 1
-        }
-        if p != end {
-            let c = p[0]
-            if (c >= asciiUpperA && c <= asciiUpperZ) || (c >= asciiLowerA && c <= asciiLowerZ) {
-                p = start
-                return false
-            }
-        }
+  /// Return the contents of the following quoted string,
+  /// or nil if the next token is not a string.
+  /// This will only throw an error if the next token starts
+  /// out as a string but is malformed in some way.
+  internal mutating func nextOptionalQuotedString() throws -> String? {
+    skipWhitespace()
+    if p == end {
+      return nil
+    }
+    let c = p[0]
+    if c != asciiDoubleQuote {
+      return nil
+    }
+    return try nextQuotedString()
+  }
+
+  /// Return a Data with the decoded contents of the
+  /// following base-64 string.
+  internal mutating func nextBytesValue() throws -> Data {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
+    }
+    let c = p[0]
+    if c != asciiDoubleQuote {
+      throw JSONDecodingError.malformedString
+    }
+    if let s = parseOptionalQuotedString(),
+      let b = decodeBytes(base64String: s) {
+      return b
+    } else {
+      throw JSONDecodingError.malformedString
+    }
+  }
+
+  /// Private function to help parse keywords.
+  private mutating func skipOptionalKeyword(bytes: [UInt8]) -> Bool {
+    let start = p
+    for b in bytes {
+      if p == end {
+        p = start
+        return false
+      }
+      let c = p[0]
+      if c != b {
+        p = start
+        return false
+      }
+      p = p + 1
+    }
+    if p != end {
+      let c = p[0]
+      if (c >= asciiUpperA && c <= asciiUpperZ) ||
+        (c >= asciiLowerA && c <= asciiLowerZ) {
+        p = start
+        return false
+      }
+    }
+    return true
+  }
+
+  /// If the next token is the identifier "null", consume it and return true.
+  internal mutating func skipOptionalNull() -> Bool {
+    skipWhitespace()
+    if p != end && p[0] == asciiLowerN {
+      return skipOptionalKeyword(bytes: [
+        asciiLowerN, asciiLowerU, asciiLowerL, asciiLowerL
+      ])
+    }
+    return false
+  }
+
+  /// Return the following Bool "true" or "false", including
+  /// full processing of quoted boolean values.  (Used in map
+  /// keys, for instance.)
+  internal mutating func nextBool() throws -> Bool {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
+    }
+    let c = p[0]
+    switch c {
+    case asciiLowerF: // f
+      if skipOptionalKeyword(bytes: [
+        asciiLowerF, asciiLowerA, asciiLowerL, asciiLowerS, asciiLowerE
+      ]) {
+        return false
+      }
+    case asciiLowerT: // t
+      if skipOptionalKeyword(bytes: [
+        asciiLowerT, asciiLowerR, asciiLowerU, asciiLowerE
+      ]) {
         return true
+      }
+    default:
+      break
     }
+    throw JSONDecodingError.malformedBool
+  }
 
-    /// If the next token is the identifier "null", consume it and return true.
-    internal mutating func skipOptionalNull() -> Bool {
-        skipWhitespace()
-        if p != end && p[0] == asciiLowerN {
-            return skipOptionalKeyword(bytes: [asciiLowerN, asciiLowerU, asciiLowerL, asciiLowerL])
-        }
-        return false
+  /// Return the following Bool "true" or "false", including
+  /// full processing of quoted boolean values.  (Used in map
+  /// keys, for instance.)
+  internal mutating func nextQuotedBool() throws -> Bool {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
     }
-
-    /// Return the following Bool "true" or "false", including
-    /// full processing of quoted boolean values.  (Used in map
-    /// keys, for instance.)
-    internal mutating func nextBool() throws -> Bool {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        let c = p[0]
-        switch c {
-        case asciiLowerF: // f
-            if skipOptionalKeyword(bytes: [asciiLowerF, asciiLowerA, asciiLowerL, asciiLowerS, asciiLowerE]) {
-                return false
-            }
-        case asciiLowerT: // t
-            if skipOptionalKeyword(bytes: [asciiLowerT, asciiLowerR, asciiLowerU, asciiLowerE]) {
-                return true
-            }
-        default:
-            break
-        }
-        throw JSONDecodingError.malformedBool
+    if p[0] != asciiDoubleQuote {
+      throw JSONDecodingError.unquotedMapKey
     }
-
-    /// Return the following Bool "true" or "false", including
-    /// full processing of quoted boolean values.  (Used in map
-    /// keys, for instance.)
-    internal mutating func nextQuotedBool() throws -> Bool {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        if p[0] != asciiDoubleQuote {
-            throw JSONDecodingError.unquotedMapKey
-        }
-        if let s = parseOptionalQuotedString() {
-            switch s {
-            case "false": return false
-            case "true": return true
-            default: break
-            }
-        }
-        throw JSONDecodingError.malformedBool
+    if let s = parseOptionalQuotedString() {
+      switch s {
+      case "false": return false
+      case "true": return true
+      default: break
+      }
     }
+    throw JSONDecodingError.malformedBool
+  }
 
-    /// Returns pointer/count spanning the UTF8 bytes of the next regular
-    /// key or nil if the key contains a backslash (and therefore requires
-    /// the full string-parsing logic to properly parse).
-    private mutating func nextBareKey() throws -> UnsafeBufferPointer<UInt8>? {
-        skipWhitespace()
-        let stringStart = p
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        if p[0] != asciiDoubleQuote {
-            throw JSONDecodingError.malformedString
-        }
-        p = p + 1
-        let nameStart = p
-        while p != end && p[0] != asciiDoubleQuote {
-            if p[0] == asciiBackslash {
-                p = stringStart // Reset to open quote
-                return nil
-            }
-            p = p + 1
-        }
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        let buff = UnsafeBufferPointer<UInt8>(start: nameStart, count: p - nameStart)
-        p = p + 1
-        return buff
+  /// Returns pointer/count spanning the UTF8 bytes of the next regular
+  /// key or nil if the key contains a backslash (and therefore requires
+  /// the full string-parsing logic to properly parse).
+  private mutating func nextBareKey() throws -> UnsafeBufferPointer<UInt8>? {
+    skipWhitespace()
+    let stringStart = p
+    if p == end {
+      throw JSONDecodingError.truncated
     }
-
-    /// Parse a field name, look it up in the provided field name map,
-    /// and return the corresponding field number.
-    ///
-    /// Throws if field name cannot be parsed.
-    /// If it encounters an unknown field name, it silently skips
-    /// the value and looks at the following field name.
-    internal mutating func nextFieldNumber(names: _NameMap) throws -> Int? {
-        while true {
-            if let key = try nextBareKey() {
-                try skipRequiredCharacter(asciiColon) // :
-                if let fieldNumber = names.number(forJSONName: key) {
-                    return fieldNumber
-                }
-            } else {
-                let key = try nextQuotedString()
-                try skipRequiredCharacter(asciiColon) // :
-                if let fieldNumber = names.number(forJSONName: key) {
-                    return fieldNumber
-                }
-            }
-            // Unknown field, skip it and try to parse the next field name
-            try skipValue()
-            if skipOptionalObjectEnd() {
-                return nil
-            }
-            try skipRequiredComma()
-        }
+    if p[0] != asciiDoubleQuote {
+      throw JSONDecodingError.malformedString
     }
-
-    /// Helper for skipping a single-character token.
-    private mutating func skipRequiredCharacter(_ required: UInt8) throws {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        let next = p[0]
-        if next == required {
-            p = p + 1
-            return
-        }
-        throw JSONDecodingError.failure
+    p = p + 1
+    let nameStart = p
+    while p != end && p[0] != asciiDoubleQuote {
+      if p[0] == asciiBackslash {
+        p = stringStart // Reset to open quote
+        return nil
+      }
+      p = p + 1
     }
-
-    /// Skip "{", throw if that's not the next character
-    internal mutating func skipRequiredObjectStart() throws {
-        try skipRequiredCharacter(asciiOpenCurlyBracket) // {
+    if p == end {
+      throw JSONDecodingError.truncated
     }
+    let buff = UnsafeBufferPointer<UInt8>(start: nameStart,
+                                          count: p - nameStart)
+    p = p + 1
+    return buff
+  }
 
-    /// Skip ",", throw if that's not the next character
-    internal mutating func skipRequiredComma() throws {
-        try skipRequiredCharacter(asciiComma)
-    }
-
-    /// Skip ":", throw if that's not the next character
-    internal mutating func skipRequiredColon() throws {
-        try skipRequiredCharacter(asciiColon)
-    }
-
-    /// Skip "[", throw if that's not the next character
-    internal mutating func skipRequiredArrayStart() throws {
-        try skipRequiredCharacter(asciiOpenSquareBracket) // [
-    }
-
-    /// Helper for skipping optional single-character tokens
-    private mutating func skipOptionalCharacter(_ c: UInt8) -> Bool {
-        skipWhitespace()
-        if p != end && p[0] == c {
-            p = p + 1
-            return true
+  /// Parse a field name, look it up in the provided field name map,
+  /// and return the corresponding field number.
+  ///
+  /// Throws if field name cannot be parsed.
+  /// If it encounters an unknown field name, it silently skips
+  /// the value and looks at the following field name.
+  internal mutating func nextFieldNumber(names: _NameMap) throws -> Int? {
+    while true {
+      if let key = try nextBareKey() {
+        try skipRequiredCharacter(asciiColon) // :
+        if let fieldNumber = names.number(forJSONName: key) {
+          return fieldNumber
         }
-        return false
+      } else {
+        let key = try nextQuotedString()
+        try skipRequiredCharacter(asciiColon) // :
+        if let fieldNumber = names.number(forJSONName: key) {
+          return fieldNumber
+        }
+      }
+      // Unknown field, skip it and try to parse the next field name
+      try skipValue()
+      if skipOptionalObjectEnd() {
+        return nil
+      }
+      try skipRequiredComma()
     }
+  }
 
-    /// If the next non-whitespace character is "]", skip it
-    /// and return true.  Otherwise, return false.
-    internal mutating func skipOptionalArrayEnd() -> Bool {
-        return skipOptionalCharacter(asciiCloseSquareBracket) // ]
+  /// Helper for skipping a single-character token.
+  private mutating func skipRequiredCharacter(_ required: UInt8) throws {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
     }
-
-    /// If the next non-whitespace character is "}", skip it
-    /// and return true.  Otherwise, return false.
-    internal mutating func skipOptionalObjectEnd() -> Bool {
-        return skipOptionalCharacter(asciiCloseCurlyBracket) // }
+    let next = p[0]
+    if next == required {
+      p = p + 1
+      return
     }
+    throw JSONDecodingError.failure
+  }
 
-    /// Return the next complete JSON structure as a string.
-    /// For example, this might return "true", or "123.456",
-    /// or "{\"foo\": 7, \"bar\": [8, 9]}"
-    ///
-    /// Used by Any to get the upcoming JSON value as a string.
-    /// Note: The value might be an object or array.
-    internal mutating func skip() throws -> String {
-        skipWhitespace()
-        let start = p
-        try skipValue()
-        if let s = utf8ToString(bytes: start, count: p - start) {
-            return s
-        } else {
-            throw JSONDecodingError.invalidUTF8
-        }
+  /// Skip "{", throw if that's not the next character
+  internal mutating func skipRequiredObjectStart() throws {
+    try skipRequiredCharacter(asciiOpenCurlyBracket) // {
+  }
+
+  /// Skip ",", throw if that's not the next character
+  internal mutating func skipRequiredComma() throws {
+    try skipRequiredCharacter(asciiComma)
+  }
+
+  /// Skip ":", throw if that's not the next character
+  internal mutating func skipRequiredColon() throws {
+    try skipRequiredCharacter(asciiColon)
+  }
+
+  /// Skip "[", throw if that's not the next character
+  internal mutating func skipRequiredArrayStart() throws {
+    try skipRequiredCharacter(asciiOpenSquareBracket) // [
+  }
+
+  /// Helper for skipping optional single-character tokens
+  private mutating func skipOptionalCharacter(_ c: UInt8) -> Bool {
+    skipWhitespace()
+    if p != end && p[0] == c {
+      p = p + 1
+      return true
     }
+    return false
+  }
 
-    /// Advance index past the next value.  This is used
-    /// by skip() and by unknown field handling.
-    private mutating func skipValue() throws {
-        skipWhitespace()
-        if p == end {
-            throw JSONDecodingError.truncated
-        }
-        switch p[0] {
-        case asciiDoubleQuote: // " begins a string
-            try skipString()
-        case asciiOpenCurlyBracket: // { begins an object
-            try skipObject()
-        case asciiOpenSquareBracket: // [ begins an array
-            try skipArray()
-        case asciiLowerN: // n must be null
-            if !skipOptionalKeyword(bytes: [asciiLowerN, asciiLowerU, asciiLowerL, asciiLowerL]) {
-                throw JSONDecodingError.truncated
-            }
-        case asciiLowerF: // f must be false
-            if !skipOptionalKeyword(bytes: [asciiLowerF, asciiLowerA, asciiLowerL, asciiLowerS, asciiLowerE]) {
-                throw JSONDecodingError.truncated
-            }
-        case asciiLowerT: // t must be true
-            if !skipOptionalKeyword(bytes: [asciiLowerT, asciiLowerR, asciiLowerU, asciiLowerE]) {
-                throw JSONDecodingError.truncated
-            }
-        default: // everything else is a number token
-            _ = try nextDouble()
-        }
+  /// If the next non-whitespace character is "]", skip it
+  /// and return true.  Otherwise, return false.
+  internal mutating func skipOptionalArrayEnd() -> Bool {
+    return skipOptionalCharacter(asciiCloseSquareBracket) // ]
+  }
+
+  /// If the next non-whitespace character is "}", skip it
+  /// and return true.  Otherwise, return false.
+  internal mutating func skipOptionalObjectEnd() -> Bool {
+    return skipOptionalCharacter(asciiCloseCurlyBracket) // }
+  }
+
+  /// Return the next complete JSON structure as a string.
+  /// For example, this might return "true", or "123.456",
+  /// or "{\"foo\": 7, \"bar\": [8, 9]}"
+  ///
+  /// Used by Any to get the upcoming JSON value as a string.
+  /// Note: The value might be an object or array.
+  internal mutating func skip() throws -> String {
+    skipWhitespace()
+    let start = p
+    try skipValue()
+    if let s = utf8ToString(bytes: start, count: p - start) {
+      return s
+    } else {
+      throw JSONDecodingError.invalidUTF8
     }
+  }
 
-    /// Advance the index past the next complete {...} construct.
-    private mutating func skipObject() throws {
-        try skipRequiredObjectStart()
-        if skipOptionalObjectEnd() {
-            return
-        }
-        while true {
-            skipWhitespace()
-            try skipString()
-            try skipRequiredColon()
-            try skipValue()
-            if skipOptionalObjectEnd() {
-                return
-            }
-            try skipRequiredComma()
-        }
+  /// Advance index past the next value.  This is used
+  /// by skip() and by unknown field handling.
+  private mutating func skipValue() throws {
+    skipWhitespace()
+    if p == end {
+      throw JSONDecodingError.truncated
     }
-
-    /// Advance the index past the next complete [...] construct.
-    private mutating func skipArray() throws {
-        try skipRequiredArrayStart()
-        if skipOptionalArrayEnd() {
-            return
-        }
-        while true {
-            try skipValue()
-            if skipOptionalArrayEnd() {
-                return
-            }
-            try skipRequiredComma()
-        }
-    }
-
-    /// Advance the index past the next complete quoted string.
-    ///
-    // Caveat:  This does not fully validate; it will accept
-    // strings that have malformed \ escapes.
-    //
-    // It would be nice to do better, but I don't think it's critical,
-    // since there are many reasons that strings (and other tokens for
-    // that matter) may be skippable but not parseable.  For example:
-    // Old clients that don't know new field types will skip fields
-    // they don't know; newer clients may reject the same input due to
-    // schema mismatches or other issues.
-    private mutating func skipString() throws {
-        if p[0] != asciiDoubleQuote {
-            throw JSONDecodingError.malformedString
-        }
-        p = p + 1
-        while p != end {
-            let c = p[0]
-            switch c {
-            case asciiDoubleQuote:
-                p = p + 1
-                return
-            case asciiBackslash:
-                p = p + 1
-                if p == end {
-                    throw JSONDecodingError.truncated
-                }
-                p = p + 1
-            default:
-                p = p + 1
-            }
-        }
+    switch p[0] {
+    case asciiDoubleQuote: // " begins a string
+      try skipString()
+    case asciiOpenCurlyBracket: // { begins an object
+      try skipObject()
+    case asciiOpenSquareBracket: // [ begins an array
+      try skipArray()
+    case asciiLowerN: // n must be null
+      if !skipOptionalKeyword(bytes: [
+        asciiLowerN, asciiLowerU, asciiLowerL, asciiLowerL
+      ]) {
         throw JSONDecodingError.truncated
+      }
+    case asciiLowerF: // f must be false
+      if !skipOptionalKeyword(bytes: [
+        asciiLowerF, asciiLowerA, asciiLowerL, asciiLowerS, asciiLowerE
+      ]) {
+        throw JSONDecodingError.truncated
+      }
+    case asciiLowerT: // t must be true
+      if !skipOptionalKeyword(bytes: [
+        asciiLowerT, asciiLowerR, asciiLowerU, asciiLowerE
+      ]) {
+        throw JSONDecodingError.truncated
+      }
+    default: // everything else is a number token
+      _ = try nextDouble()
     }
+  }
+
+  /// Advance the index past the next complete {...} construct.
+  private mutating func skipObject() throws {
+    try skipRequiredObjectStart()
+    if skipOptionalObjectEnd() {
+      return
+    }
+    while true {
+      skipWhitespace()
+      try skipString()
+      try skipRequiredColon()
+      try skipValue()
+      if skipOptionalObjectEnd() {
+        return
+      }
+      try skipRequiredComma()
+    }
+  }
+
+  /// Advance the index past the next complete [...] construct.
+  private mutating func skipArray() throws {
+    try skipRequiredArrayStart()
+    if skipOptionalArrayEnd() {
+      return
+    }
+    while true {
+      try skipValue()
+      if skipOptionalArrayEnd() {
+        return
+      }
+      try skipRequiredComma()
+    }
+  }
+
+  /// Advance the index past the next complete quoted string.
+  ///
+  // Caveat:  This does not fully validate; it will accept
+  // strings that have malformed \ escapes.
+  //
+  // It would be nice to do better, but I don't think it's critical,
+  // since there are many reasons that strings (and other tokens for
+  // that matter) may be skippable but not parseable.  For example:
+  // Old clients that don't know new field types will skip fields
+  // they don't know; newer clients may reject the same input due to
+  // schema mismatches or other issues.
+  private mutating func skipString() throws {
+    if p[0] != asciiDoubleQuote {
+      throw JSONDecodingError.malformedString
+    }
+    p = p + 1
+    while p != end {
+      let c = p[0]
+      switch c {
+      case asciiDoubleQuote:
+        p = p + 1
+        return
+      case asciiBackslash:
+        p = p + 1
+        if p == end {
+          throw JSONDecodingError.truncated
+        }
+        p = p + 1
+      default:
+        p = p + 1
+      }
+    }
+    throw JSONDecodingError.truncated
+  }
 }

--- a/Sources/SwiftProtobuf/JSONScanner.swift
+++ b/Sources/SwiftProtobuf/JSONScanner.swift
@@ -224,24 +224,27 @@ private func decodeString(_ s: String) -> String? {
 // is used by callers that are parsing quoted numbers.  See nextSInt()
 // and nextUInt() below.
 private func parseBareUInt(
-  p: inout UnsafePointer<UInt8>,
-  end: UnsafePointer<UInt8>
+  source: UnsafeBufferPointer<UInt8>,
+  index: inout UnsafeBufferPointer<UInt8>.Index,
+  end: UnsafeBufferPointer<UInt8>.Index
 ) throws -> UInt64? {
-  let start = p
-  let c = p[0]
-  p = p + 1
+  let start = index
+  let c = source[index]
+  source.formIndex(after: &index)
   switch c {
   case asciiZero: // 0
-    if p != end {
-      let after = p[0]
+    if index != end {
+      let after = source[index]
       switch after {
       case asciiZero...asciiNine: // 0...9
         // leading '0' forbidden unless it is the only digit
         throw JSONDecodingError.leadingZero
       case asciiPeriod, asciiLowerE, asciiUpperE: // . e
         // Slow path: JSON numbers can be written in floating-point notation
-        p = start
-        if let s = try parseBareFloatString(p: &p, end: end) {
+        index = start
+        if let s = try parseBareFloatString(source: source,
+                                            index: &index,
+                                            end: end) {
           if let d = Double(s) {
             if let u = UInt64(exactly: d) {
               return u
@@ -258,8 +261,8 @@ private func parseBareUInt(
     return 0
   case asciiOne...asciiNine: // 1...9
     var n = UInt64(c - 48)
-    while p != end {
-      let digit = p[0]
+    while index != end {
+      let digit = source[index]
       switch digit {
       case asciiZero...asciiNine: // 0...9
         let val = UInt64(digit - asciiZero)
@@ -268,12 +271,14 @@ private func parseBareUInt(
             throw JSONDecodingError.numberRange
           }
         }
-        p = p + 1
+        source.formIndex(after: &index)
         n = n * 10 + val
       case asciiPeriod, asciiLowerE, asciiUpperE: // . e
         // Slow path: JSON allows floating-point notation for integers
-        p = start
-        if let s = try parseBareFloatString(p: &p, end: end) {
+        index = start
+        if let s = try parseBareFloatString(source: source,
+                                            index: &index,
+                                            end: end) {
           if let d = Double(s) {
             if let u = UInt64(exactly: d) {
               return u
@@ -306,21 +311,22 @@ private func parseBareUInt(
 // parsing quoted numbers.  See nextSInt() and nextUInt() below.
 
 private func parseBareSInt(
-  p: inout UnsafePointer<UInt8>,
-  end: UnsafePointer<UInt8>
+  source: UnsafeBufferPointer<UInt8>,
+  index: inout UnsafeBufferPointer<UInt8>.Index,
+  end: UnsafeBufferPointer<UInt8>.Index
 ) throws -> Int64? {
-  if p == end {
+  if index == end {
     throw JSONDecodingError.truncated
   }
-  let c = p[0]
+  let c = source[index]
   if c == asciiMinus { // -
-    p = p + 1
+    source.formIndex(after: &index)
     // character after '-' must be digit
-    let digit = p[0]
+    let digit = source[index]
     if digit < asciiZero || digit > asciiNine {
       throw JSONDecodingError.malformedNumber
     }
-    if let n = try parseBareUInt(p: &p, end: end) {
+    if let n = try parseBareUInt(source: source, index: &index, end: end) {
       if n >= 0x8000000000000000 { // -Int64.min
         if n > 0x8000000000000000 {
           // Too large negative number
@@ -333,7 +339,7 @@ private func parseBareSInt(
     } else {
       return nil
     }
-  } else if let n = try parseBareUInt(p: &p, end: end) {
+  } else if let n = try parseBareUInt(source: source, index: &index, end: end) {
     if n > UInt64(bitPattern: Int64.max) {
       throw JSONDecodingError.numberRange
     }
@@ -355,25 +361,26 @@ private func parseBareSInt(
 // It's also used by the slow path in parseBareSInt() and parseBareUInt()
 // above to handle integer values that are written in float-point notation.
 private func parseBareFloatString(
-  p: inout UnsafePointer<UInt8>,
-  end: UnsafePointer<UInt8>
+  source: UnsafeBufferPointer<UInt8>,
+  index: inout UnsafeBufferPointer<UInt8>.Index,
+  end: UnsafeBufferPointer<UInt8>.Index
 ) throws -> String? {
   // RFC 7159 defines the grammar for JSON numbers as:
   // number = [ minus ] int [ frac ] [ exp ]
-  let start = p
-  var c = p[0]
+  let start = index
+  var c = source[index]
   if c == asciiBackslash {
     return nil
   }
 
   // Optional leading minus sign
   if c == asciiMinus { // -
-    p += 1
-    if p == end {
-      p = start
+    source.formIndex(after: &index)
+    if index == end {
+      index = start
       throw JSONDecodingError.truncated
     }
-    c = p[0]
+    c = source[index]
     if c == asciiBackslash {
       return nil
     }
@@ -392,15 +399,15 @@ private func parseBareFloatString(
   switch c {
   case asciiZero:
     // First digit can be zero only if not followed by a digit
-    p += 1
-    if p == end {
-      if let s = utf8ToString(bytes: start, count: p - start) {
+    source.formIndex(after: &index)
+    if index == end {
+      if let s = utf8ToString(bytes: source, start: start, end: index) {
         return s
       } else {
         throw JSONDecodingError.invalidUTF8
       }
     }
-    c = p[0]
+    c = source[index]
     if c == asciiBackslash {
       return nil
     }
@@ -409,15 +416,15 @@ private func parseBareFloatString(
     }
   case asciiOne...asciiNine:
     while c >= asciiZero && c <= asciiNine {
-      p = p + 1
-      if p == end {
-        if let s = utf8ToString(bytes: start, count: p - start) {
+      source.formIndex(after: &index)
+      if index == end {
+        if let s = utf8ToString(bytes: source, start: start, end: index) {
           return s
         } else {
           throw JSONDecodingError.invalidUTF8
         }
       }
-      c = p[0]
+      c = source[index]
       if c == asciiBackslash {
         return nil
       }
@@ -429,24 +436,24 @@ private func parseBareFloatString(
 
   // frac = decimal-point 1*DIGIT
   if c == asciiPeriod {
-    p = p + 1
-    if p == end {
+    source.formIndex(after: &index)
+    if index == end {
       // decimal point must have a following digit
       throw JSONDecodingError.truncated
     }
-    c = p[0]
+    c = source[index]
     switch c {
     case asciiZero...asciiNine: // 0...9
       while c >= asciiZero && c <= asciiNine {
-        p = p + 1
-        if p == end {
-          if let s = utf8ToString(bytes: start, count: p - start) {
+        source.formIndex(after: &index)
+        if index == end {
+          if let s = utf8ToString(bytes: source, start: start, end: index) {
             return s
           } else {
             throw JSONDecodingError.invalidUTF8
           }
         }
-        c = p[0]
+        c = source[index]
         if c == asciiBackslash {
           return nil
         }
@@ -461,22 +468,22 @@ private func parseBareFloatString(
 
   // exp = e [ minus / plus ] 1*DIGIT
   if c == asciiLowerE || c == asciiUpperE {
-    p = p + 1
-    if p == end {
+    source.formIndex(after: &index)
+    if index == end {
       // "e" must be followed by +,-, or digit
       throw JSONDecodingError.truncated
     }
-    c = p[0]
+    c = source[index]
     if c == asciiBackslash {
       return nil
     }
     if c == asciiPlus || c == asciiMinus { // + -
-      p = p + 1
-      if p == end {
+      source.formIndex(after: &index)
+      if index == end {
         // must be at least one digit in exponent
         throw JSONDecodingError.truncated
       }
-      c = p[0]
+      c = source[index]
       if c == asciiBackslash {
         return nil
       }
@@ -484,15 +491,15 @@ private func parseBareFloatString(
     switch c {
     case asciiZero...asciiNine:
       while c >= asciiZero && c <= asciiNine {
-        p = p + 1
-        if p == end {
-          if let s = utf8ToString(bytes: start, count: p - start) {
+        source.formIndex(after: &index)
+        if index == end {
+          if let s = utf8ToString(bytes: source, start: start, end: index) {
             return s
           } else {
             throw JSONDecodingError.invalidUTF8
           }
         }
-        c = p[0]
+        c = source[index]
         if c == asciiBackslash {
           return nil
         }
@@ -502,7 +509,7 @@ private func parseBareFloatString(
       throw JSONDecodingError.malformedNumber
     }
   }
-  if let s = utf8ToString(bytes: start, count: p - start) {
+  if let s = utf8ToString(bytes: source, start: start, end: index) {
     return s
   } else {
     throw JSONDecodingError.invalidUTF8
@@ -515,28 +522,46 @@ private func parseBareFloatString(
 /// For performance, it works directly against UTF-8 bytes in memory.
 ///
 internal struct JSONScanner {
-  private var p: UnsafePointer<UInt8>
-  private var end: UnsafePointer<UInt8>
+  private let source: UnsafeBufferPointer<UInt8>
+  private var index: UnsafeBufferPointer<UInt8>.Index
 
+  /// True if the scanner has read all of the data from the source, with the
+  /// exception of any trailing whitespace (which is consumed by reading this
+  /// property).
   internal var complete: Bool {
     mutating get {
       skipWhitespace()
-      return p == end
+      return !hasMoreContent
     }
   }
 
-  internal init(utf8Pointer: UnsafePointer<UInt8>, count: Int) {
-    p = utf8Pointer
-    end = p + count
+  /// True if the scanner has not yet reached the end of the source.
+  private var hasMoreContent: Bool {
+    return index != source.endIndex
+  }
+
+  /// The byte (UTF-8 code unit) at the scanner's current position.
+  private var currentByte: UInt8 {
+    return source[index]
+  }
+
+  internal init(source: UnsafeBufferPointer<UInt8>) {
+    self.source = source
+    self.index = source.startIndex
+  }
+
+  /// Advances the scanner to the next position in the source.
+  private mutating func advance() {
+    source.formIndex(after: &index)
   }
 
   /// Skip whitespace
   private mutating func skipWhitespace() {
-    while p != end {
-      let u = p[0]
+    while hasMoreContent {
+      let u = currentByte
       switch u {
       case asciiSpace, asciiTab, asciiNewLine, asciiCarriageReturn:
-        p += 1
+        advance()
       default:
         return
       }
@@ -548,10 +573,10 @@ internal struct JSONScanner {
   /// example, for custom JSON parsing.
   internal mutating func peekOneCharacter() throws -> Character {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    return Character(UnicodeScalar(UInt32(p[0]))!)
+    return Character(UnicodeScalar(UInt32(currentByte))!)
   }
 
   /// Returns a fully-parsed string with all backslash escapes
@@ -559,15 +584,15 @@ internal struct JSONScanner {
   ///
   /// Assumes the leading quote has been verified (but not consumed)
   private mutating func parseOptionalQuotedString() -> String? {
-    // Caller has already asserted that p[0] == quote here
+    // Caller has already asserted that currentByte == quote here
     var sawBackslash = false
-    p = p + 1
-    let start = p
-    while p != end {
-      switch p[0] {
+    advance()
+    let start = index
+    while hasMoreContent {
+      switch currentByte {
       case asciiDoubleQuote: // "
-        let s = utf8ToString(bytes: start, count: p - start)
-        p = p + 1
+        let s = utf8ToString(bytes: source, start: start, end: index)
+        advance()
         if let t = s {
           if sawBackslash {
             return decodeString(t)
@@ -578,15 +603,15 @@ internal struct JSONScanner {
           return nil // Invalid UTF8
         }
       case asciiBackslash: //  \
-        p = p + 1
-        if p == end {
+        advance()
+        guard hasMoreContent else {
           return nil // Unterminated escape
         }
         sawBackslash = true
       default:
         break
       }
-      p = p + 1
+      advance()
     }
     return nil // Unterminated quoted string
   }
@@ -600,35 +625,40 @@ internal struct JSONScanner {
   /// case, we decode it with only Double precision.
   internal mutating func nextUInt() throws -> UInt64 {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    let c = p[0]
+    let c = currentByte
     if c == asciiDoubleQuote {
-      let start = p
-      p = p + 1
-      if let u = try parseBareUInt(p: &p, end: end) {
-        if p == end {
+      let start = index
+      advance()
+      if let u = try parseBareUInt(source: source,
+                                   index: &index,
+                                   end: source.endIndex) {
+        guard hasMoreContent else {
           throw JSONDecodingError.truncated
         }
-        if p[0] != asciiDoubleQuote {
+        if currentByte != asciiDoubleQuote {
           throw JSONDecodingError.malformedNumber
         }
-        p = p + 1
+        advance()
         return u
       } else {
         // Couldn't parse because it had a "\" in the string,
         // so parse out the quoted string and then reparse
         // the result to get a UInt
-        p = start
+        index = start
         let s = try nextQuotedString()
         let raw = s.data(using: String.Encoding.utf8)!
         let n = try raw.withUnsafeBytes {
           (bytes: UnsafePointer<UInt8>) -> UInt64? in
-          var p = bytes
-          let end = p + raw.count
-          if let u = try parseBareUInt(p: &p, end: end) {
-            if p == end {
+          let buffer = UnsafeBufferPointer(start: bytes, count: raw.count)
+          var index = buffer.startIndex
+          let end = buffer.endIndex
+          if let u = try parseBareUInt(source: buffer,
+                                       index: &index,
+                                       end: end) {
+            if index == end {
               return u
             }
           }
@@ -638,7 +668,9 @@ internal struct JSONScanner {
           return n
         }
       }
-    } else if let u = try parseBareUInt(p: &p, end: end) {
+    } else if let u = try parseBareUInt(source: source,
+                                        index: &index,
+                                        end: source.endIndex) {
       return u
     }
     throw JSONDecodingError.malformedNumber
@@ -653,35 +685,40 @@ internal struct JSONScanner {
   /// case, we decode it with only Double precision.
   internal mutating func nextSInt() throws -> Int64 {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    let c = p[0]
+    let c = currentByte
     if c == asciiDoubleQuote {
-      let start = p
-      p = p + 1
-      if let s = try parseBareSInt(p: &p, end: end) {
-        if p == end {
+      let start = index
+      advance()
+      if let s = try parseBareSInt(source: source,
+                                   index: &index,
+                                   end: source.endIndex) {
+        guard hasMoreContent else {
           throw JSONDecodingError.truncated
         }
-        if p[0] != asciiDoubleQuote {
+        if currentByte != asciiDoubleQuote {
           throw JSONDecodingError.malformedNumber
         }
-        p = p + 1
+        advance()
         return s
       } else {
         // Couldn't parse because it had a "\" in the string,
         // so parse out the quoted string and then reparse
         // the result as an SInt
-        p = start
+        index = start
         let s = try nextQuotedString()
         let raw = s.data(using: String.Encoding.utf8)!
         let n = try raw.withUnsafeBytes {
           (bytes: UnsafePointer<UInt8>) -> Int64? in
-          var p = bytes
-          let end = p + raw.count
-          if let s = try parseBareSInt(p: &p, end: end) {
-            if p == end {
+          let buffer = UnsafeBufferPointer(start: bytes, count: raw.count)
+          var index = buffer.startIndex
+          let end = buffer.endIndex
+          if let s = try parseBareSInt(source: buffer,
+                                       index: &index,
+                                       end: end) {
+            if index == end {
               return s
             }
           }
@@ -691,7 +728,9 @@ internal struct JSONScanner {
           return n
         }
       }
-    } else if let s = try parseBareSInt(p: &p, end: end) {
+    } else if let s = try parseBareSInt(source: source,
+                                        index: &index,
+                                        end: source.endIndex) {
       return s
     }
     throw JSONDecodingError.malformedNumber
@@ -702,21 +741,23 @@ internal struct JSONScanner {
   /// quoted strings.
   internal mutating func nextFloat() throws -> Float {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    let c = p[0]
+    let c = currentByte
     if c == asciiDoubleQuote { // "
-      let start = p
-      p = p + 1
-      if let s = try parseBareFloatString(p: &p, end: end) {
-        if p == end {
+      let start = index
+      advance()
+      if let s = try parseBareFloatString(source: source,
+                                          index: &index,
+                                          end: source.endIndex) {
+        guard hasMoreContent else {
           throw JSONDecodingError.truncated
         }
-        if p[0] != asciiDoubleQuote {
+        if currentByte != asciiDoubleQuote {
           throw JSONDecodingError.malformedNumber
         }
-        p = p + 1
+        advance()
         if let f = Float(s) {
           return f
         }
@@ -725,7 +766,7 @@ internal struct JSONScanner {
         // a valid float, but had something that
         // parseBareFloatString cannot directly handle.  So we reset,
         // try a full string parse, then examine the result:
-        p = start
+        index = start
         let s = try nextQuotedString()
         switch s {
         case "NaN": return Float.nan
@@ -737,10 +778,13 @@ internal struct JSONScanner {
           let raw = s.data(using: String.Encoding.utf8)!
           let n = try raw.withUnsafeBytes {
             (bytes: UnsafePointer<UInt8>) -> Float? in
-            var p = bytes
-            let end = p + raw.count
-            if let s = try parseBareFloatString(p: &p, end: end) {
-              if p == end {
+            let buffer = UnsafeBufferPointer(start: bytes, count: raw.count)
+            var index = buffer.startIndex
+            let end = buffer.endIndex
+            if let s = try parseBareFloatString(source: buffer,
+                                                index: &index,
+                                                end: end) {
+              if index == end {
                 return Float(s)
               }
             }
@@ -752,7 +796,10 @@ internal struct JSONScanner {
         }
       }
     } else {
-      if let s = try parseBareFloatString(p: &p, end: end), let n = Float(s) {
+      if let s = try parseBareFloatString(source: source,
+                                          index: &index,
+                                          end: source.endIndex),
+        let n = Float(s) {
         return n
       }
     }
@@ -764,21 +811,23 @@ internal struct JSONScanner {
   /// quoted strings.
   internal mutating func nextDouble() throws -> Double {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    let c = p[0]
+    let c = currentByte
     if c == asciiDoubleQuote { // "
-      let start = p
-      p = p + 1
-      if let s = try parseBareFloatString(p: &p, end: end) {
-        if p == end {
+      let start = index
+      advance()
+      if let s = try parseBareFloatString(source: source,
+                                          index: &index,
+                                          end: source.endIndex) {
+        guard hasMoreContent else {
           throw JSONDecodingError.truncated
         }
-        if p[0] != asciiDoubleQuote {
+        if currentByte != asciiDoubleQuote {
           throw JSONDecodingError.malformedNumber
         }
-        p = p + 1
+        advance()
         if let f = Double(s) {
           return f
         }
@@ -787,7 +836,7 @@ internal struct JSONScanner {
         // a valid float, but had something that
         // parseBareFloatString cannot directly handle.  So we reset,
         // try a full string parse, then examine the result:
-        p = start
+        index = start
         let s = try nextQuotedString()
         switch s {
         case "NaN": return Double.nan
@@ -799,10 +848,13 @@ internal struct JSONScanner {
           let raw = s.data(using: String.Encoding.utf8)!
           let n = try raw.withUnsafeBytes {
             (bytes: UnsafePointer<UInt8>) -> Double? in
-            var p = bytes
-            let end = p + raw.count
-            if let s = try parseBareFloatString(p: &p, end: end) {
-              if p == end {
+            let buffer = UnsafeBufferPointer(start: bytes, count: raw.count)
+            var index = buffer.startIndex
+            let end = buffer.endIndex
+            if let s = try parseBareFloatString(source: buffer,
+                                                index: &index,
+                                                end: end) {
+              if index == end {
                 return Double(s)
               }
             }
@@ -814,7 +866,10 @@ internal struct JSONScanner {
         }
       }
     } else {
-      if let s = try parseBareFloatString(p: &p, end: end), let n = Double(s) {
+      if let s = try parseBareFloatString(source: source,
+                                          index: &index,
+                                          end: source.endIndex),
+        let n = Double(s) {
         return n
       }
     }
@@ -825,10 +880,10 @@ internal struct JSONScanner {
   /// or throw an error if the next token is not a string.
   internal mutating func nextQuotedString() throws -> String {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    let c = p[0]
+    let c = currentByte
     if c != asciiDoubleQuote {
       throw JSONDecodingError.malformedString
     }
@@ -845,10 +900,10 @@ internal struct JSONScanner {
   /// out as a string but is malformed in some way.
   internal mutating func nextOptionalQuotedString() throws -> String? {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       return nil
     }
-    let c = p[0]
+    let c = currentByte
     if c != asciiDoubleQuote {
       return nil
     }
@@ -859,10 +914,10 @@ internal struct JSONScanner {
   /// following base-64 string.
   internal mutating func nextBytesValue() throws -> Data {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    let c = p[0]
+    let c = currentByte
     if c != asciiDoubleQuote {
       throw JSONDecodingError.malformedString
     }
@@ -876,24 +931,24 @@ internal struct JSONScanner {
 
   /// Private function to help parse keywords.
   private mutating func skipOptionalKeyword(bytes: [UInt8]) -> Bool {
-    let start = p
+    let start = index
     for b in bytes {
-      if p == end {
-        p = start
+      guard hasMoreContent else {
+        index = start
         return false
       }
-      let c = p[0]
+      let c = currentByte
       if c != b {
-        p = start
+        index = start
         return false
       }
-      p = p + 1
+      advance()
     }
-    if p != end {
-      let c = p[0]
+    if hasMoreContent {
+      let c = currentByte
       if (c >= asciiUpperA && c <= asciiUpperZ) ||
         (c >= asciiLowerA && c <= asciiLowerZ) {
-        p = start
+        index = start
         return false
       }
     }
@@ -903,7 +958,7 @@ internal struct JSONScanner {
   /// If the next token is the identifier "null", consume it and return true.
   internal mutating func skipOptionalNull() -> Bool {
     skipWhitespace()
-    if p != end && p[0] == asciiLowerN {
+    if hasMoreContent && currentByte == asciiLowerN {
       return skipOptionalKeyword(bytes: [
         asciiLowerN, asciiLowerU, asciiLowerL, asciiLowerL
       ])
@@ -916,10 +971,10 @@ internal struct JSONScanner {
   /// keys, for instance.)
   internal mutating func nextBool() throws -> Bool {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    let c = p[0]
+    let c = currentByte
     switch c {
     case asciiLowerF: // f
       if skipOptionalKeyword(bytes: [
@@ -944,10 +999,10 @@ internal struct JSONScanner {
   /// keys, for instance.)
   internal mutating func nextQuotedBool() throws -> Bool {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    if p[0] != asciiDoubleQuote {
+    if currentByte != asciiDoubleQuote {
       throw JSONDecodingError.unquotedMapKey
     }
     if let s = parseOptionalQuotedString() {
@@ -965,28 +1020,29 @@ internal struct JSONScanner {
   /// the full string-parsing logic to properly parse).
   private mutating func nextBareKey() throws -> UnsafeBufferPointer<UInt8>? {
     skipWhitespace()
-    let stringStart = p
-    if p == end {
+    let stringStart = index
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    if p[0] != asciiDoubleQuote {
+    if currentByte != asciiDoubleQuote {
       throw JSONDecodingError.malformedString
     }
-    p = p + 1
-    let nameStart = p
-    while p != end && p[0] != asciiDoubleQuote {
-      if p[0] == asciiBackslash {
-        p = stringStart // Reset to open quote
+    advance()
+    let nameStart = index
+    while hasMoreContent && currentByte != asciiDoubleQuote {
+      if currentByte == asciiBackslash {
+        index = stringStart // Reset to open quote
         return nil
       }
-      p = p + 1
+      advance()
     }
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    let buff = UnsafeBufferPointer<UInt8>(start: nameStart,
-                                          count: p - nameStart)
-    p = p + 1
+    let buff = UnsafeBufferPointer<UInt8>(
+      start: source.baseAddress! + nameStart,
+      count: index - nameStart)
+    advance()
     return buff
   }
 
@@ -1022,12 +1078,12 @@ internal struct JSONScanner {
   /// Helper for skipping a single-character token.
   private mutating func skipRequiredCharacter(_ required: UInt8) throws {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    let next = p[0]
+    let next = currentByte
     if next == required {
-      p = p + 1
+      advance()
       return
     }
     throw JSONDecodingError.failure
@@ -1056,8 +1112,8 @@ internal struct JSONScanner {
   /// Helper for skipping optional single-character tokens
   private mutating func skipOptionalCharacter(_ c: UInt8) -> Bool {
     skipWhitespace()
-    if p != end && p[0] == c {
-      p = p + 1
+    if hasMoreContent && currentByte == c {
+      advance()
       return true
     }
     return false
@@ -1083,9 +1139,9 @@ internal struct JSONScanner {
   /// Note: The value might be an object or array.
   internal mutating func skip() throws -> String {
     skipWhitespace()
-    let start = p
+    let start = index
     try skipValue()
-    if let s = utf8ToString(bytes: start, count: p - start) {
+    if let s = utf8ToString(bytes: source, start: start, end: index) {
       return s
     } else {
       throw JSONDecodingError.invalidUTF8
@@ -1096,10 +1152,10 @@ internal struct JSONScanner {
   /// by skip() and by unknown field handling.
   private mutating func skipValue() throws {
     skipWhitespace()
-    if p == end {
+    guard hasMoreContent else {
       throw JSONDecodingError.truncated
     }
-    switch p[0] {
+    switch currentByte {
     case asciiDoubleQuote: // " begins a string
       try skipString()
     case asciiOpenCurlyBracket: // { begins an object
@@ -1174,24 +1230,24 @@ internal struct JSONScanner {
   // they don't know; newer clients may reject the same input due to
   // schema mismatches or other issues.
   private mutating func skipString() throws {
-    if p[0] != asciiDoubleQuote {
+    if currentByte != asciiDoubleQuote {
       throw JSONDecodingError.malformedString
     }
-    p = p + 1
-    while p != end {
-      let c = p[0]
+    advance()
+    while hasMoreContent {
+      let c = currentByte
       switch c {
       case asciiDoubleQuote:
-        p = p + 1
+        advance()
         return
       case asciiBackslash:
-        p = p + 1
-        if p == end {
+        advance()
+        guard hasMoreContent else {
           throw JSONDecodingError.truncated
         }
-        p = p + 1
+        advance()
       default:
-        p = p + 1
+        advance()
       }
     }
     throw JSONDecodingError.truncated

--- a/Sources/SwiftProtobuf/Message+JSONAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONAdditions.swift
@@ -74,8 +74,8 @@ public extension Message {
   public init(jsonUTF8Data: Data) throws {
     self.init()
     try jsonUTF8Data.withUnsafeBytes { (bytes:UnsafePointer<UInt8>) in
-      var decoder = JSONDecoder(utf8Pointer: bytes,
-                                count: jsonUTF8Data.count)
+      let buffer = UnsafeBufferPointer(start: bytes, count: jsonUTF8Data.count)
+      var decoder = JSONDecoder(source: buffer)
       if !decoder.scanner.skipOptionalNull() {
         try decoder.decodeFullObject(message: &self)
       } else if Self.self is _CustomJSONCodable.Type {

--- a/Sources/SwiftProtobuf/StringUtils.swift
+++ b/Sources/SwiftProtobuf/StringUtils.swift
@@ -38,6 +38,14 @@ fileprivate func slowUtf8ToString(bytes: UnsafePointer<UInt8>, count: Int) -> St
 }
 #endif
 
+internal func utf8ToString(
+  bytes: UnsafeBufferPointer<UInt8>,
+  start: UnsafeBufferPointer<UInt8>.Index,
+  end: UnsafeBufferPointer<UInt8>.Index
+) -> String? {
+  return utf8ToString(bytes: bytes.baseAddress! + start, count: end - start)
+}
+
 internal func utf8ToString(bytes: UnsafePointer<UInt8>, count: Int) -> String? {
     if count == 0 {
         return ""


### PR DESCRIPTION
This has no appreciable impact on JSON decoding performance.

I tried doing the same for `TextFormatScanner`, but things got... weird. `nextFieldNumber` nearly doubled in execution time (and instruction count) and I couldn't figure out why. From looking at Hopper, the version at `master` is very nicely inlined and compact—even the call to `skipWhitespace` gets cleanly integrated into the body of the function. It's not immediately clear to me what's unique about that function that the optimizer isn't able to handle the UBP version, so I punted on it for the time being.
