### PR TITLE
Add jsonUTF8Data() for symmetry with init(jsonUTF8Data:)

### DIFF
--- a/Performance/generators/swift.sh
+++ b/Performance/generators/swift.sh
@@ -77,10 +77,10 @@ extension Harness {
 
       // Exercise JSON serialization.
       let json = try measureSubtask("Encode JSON") {
-        return try message.jsonString()
+        return try message.jsonUTF8Data()
       }
       let jsonDecodedMessage = try measureSubtask("Decode JSON") {
-        return try PerfMessage(jsonString: json)
+        return try PerfMessage(jsonUTF8Data: json)
       }
 
       // Exercise text serialization.

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -141,8 +141,8 @@ internal struct JSONEncodingVisitor: Visitor {
 
   mutating func visitSingularMessageField<M: Message>(value: M, fieldNumber: Int) throws {
     try startField(for: fieldNumber)
-    let json = try value.jsonString()
-    encoder.append(text: json)
+    let json = try value.jsonUTF8Data()
+    encoder.append(utf8Data: json)
   }
 
   mutating func visitSingularGroupField<G: Message>(value: G, fieldNumber: Int) throws {
@@ -249,8 +249,8 @@ internal struct JSONEncodingVisitor: Visitor {
     encoder.append(text: "[")
     for v in value {
       encoder.append(text: arraySeparator)
-      let json = try v.jsonString()
-      encoder.append(text: json)
+      let json = try v.jsonUTF8Data()
+      encoder.append(utf8Data: json)
       arraySeparator = ","
     }
     encoder.append(text: "]")

--- a/Sources/SwiftProtobuf/Message+JSONAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONAdditions.swift
@@ -34,6 +34,26 @@ public extension Message {
     return visitor.stringResult
   }
 
+  /// Returns a Data containing the UTF-8 JSON serialization of the message.
+  ///
+  /// Unlike binary encoding, presence of required fields is not enforced when
+  /// serializing to JSON.
+  ///
+  /// - Returns: A Data containing the JSON serialization of the message.
+  /// - Throws: `JSONEncodingError` if encoding fails.
+  func jsonUTF8Data() throws -> Data {
+    if let m = self as? _CustomJSONCodable {
+      let string = try m.encodedJSONString()
+      let data = string.data(using: String.Encoding.utf8)! // Cannot fail!
+      return data
+    }
+    var visitor = try JSONEncodingVisitor(message: self)
+    visitor.startObject()
+    try traverse(visitor: &visitor)
+    visitor.endObject()
+    return visitor.dataResult
+  }
+
   /// Creates a new message by decoding the given string containing a
   /// serialized message in JSON format.
   ///

--- a/Sources/SwiftProtobuf/Message+JSONAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONAdditions.swift
@@ -24,14 +24,8 @@ public extension Message {
   /// - Returns: A string containing the JSON serialization of the message.
   /// - Throws: `JSONEncodingError` if encoding fails.
   func jsonString() throws -> String {
-    if let m = self as? _CustomJSONCodable {
-      return try m.encodedJSONString()
-    }
-    var visitor = try JSONEncodingVisitor(message: self)
-    visitor.startObject()
-    try traverse(visitor: &visitor)
-    visitor.endObject()
-    return visitor.stringResult
+    let data = try jsonUTF8Data()
+    return String(data: data, encoding: String.Encoding.utf8)!
   }
 
   /// Returns a Data containing the UTF-8 JSON serialization of the message.


### PR DESCRIPTION
This fills an obvious hole in the JSON API.

It also gives a noticable performance bump encoding JSON objects with
many subobjects, since appending Data is faster than appending String.