### PR TITLE
Linux requires `import Dispatch` to use GCD functions

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Registry.swift
@@ -14,6 +14,7 @@
 // -----------------------------------------------------------------------------
 
 import Foundation
+import Dispatch
 
 // TODO: Should these first four be exposed as methods to go with
 // the general registry support?


### PR DESCRIPTION
Fixes the build on Linux.