### PR TITLE
FLT_DIG and DBL_DIG need to be Int32 to match other C imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ install: build
 clean:
 	swift build --clean
 	rm -rf .build _test ${PROTOC_GEN_SWIFT}
-	find . -name '*~' | xargs rm
+	find . -name '*~' | xargs rm -f
 
 # Build a local copy of the API documentation, using the same process used
 # by cocoadocs.org.

--- a/Sources/SwiftProtobuf/DoubleFormatter.swift
+++ b/Sources/SwiftProtobuf/DoubleFormatter.swift
@@ -17,8 +17,8 @@ import Foundation
 #if os(Linux)
 // Linux doesn't seem to define these by default.
 // https://bugs.swift.org/browse/SR-4198
-internal let FLT_DIG=6
-internal let DBL_DIG=15
+internal let FLT_DIG: Int32 = 6
+internal let DBL_DIG: Int32 = 15
 #endif
 
 // TODO: Experiment with other approaches for formatting float/double.


### PR DESCRIPTION
Fixes build warning on Linux