### PR TITLE
	Move _ProtoNameProviding support for Enums into a Swift Extension.

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -51,18 +51,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "conformance"
 
-enum Conformance_WireFormat: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Conformance_WireFormat: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case unspecified // = 0
   case protobuf // = 1
   case json // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "UNSPECIFIED"),
-    1: .same(proto: "PROTOBUF"),
-    2: .same(proto: "JSON"),
-  ]
 
   init() {
     self = .unspecified
@@ -368,6 +362,14 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     try result?.traverse(visitor: &visitor, start: 1, end: 7)
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Conformance_WireFormat: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "UNSPECIFIED"),
+    1: .same(proto: "PROTOBUF"),
+    2: .same(proto: "JSON"),
+  ]
 }
 
 extension Conformance_ConformanceRequest: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -782,7 +782,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TypeEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// 0 is reserved for errors.
@@ -824,27 +824,6 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
 
     /// Uses ZigZag encoding.
     case sint64 // = 18
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "TYPE_DOUBLE"),
-      2: .same(proto: "TYPE_FLOAT"),
-      3: .same(proto: "TYPE_INT64"),
-      4: .same(proto: "TYPE_UINT64"),
-      5: .same(proto: "TYPE_INT32"),
-      6: .same(proto: "TYPE_FIXED64"),
-      7: .same(proto: "TYPE_FIXED32"),
-      8: .same(proto: "TYPE_BOOL"),
-      9: .same(proto: "TYPE_STRING"),
-      10: .same(proto: "TYPE_GROUP"),
-      11: .same(proto: "TYPE_MESSAGE"),
-      12: .same(proto: "TYPE_BYTES"),
-      13: .same(proto: "TYPE_UINT32"),
-      14: .same(proto: "TYPE_ENUM"),
-      15: .same(proto: "TYPE_SFIXED32"),
-      16: .same(proto: "TYPE_SFIXED64"),
-      17: .same(proto: "TYPE_SINT32"),
-      18: .same(proto: "TYPE_SINT64"),
-    ]
 
     init() {
       self = .double
@@ -899,19 +878,13 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
 
   }
 
-  enum Label: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Label: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// 0 is reserved for errors
     case `optional` // = 1
     case `required` // = 2
     case repeated // = 3
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "LABEL_OPTIONAL"),
-      2: .same(proto: "LABEL_REQUIRED"),
-      3: .same(proto: "LABEL_REPEATED"),
-    ]
 
     init() {
       self = .`optional`
@@ -1827,7 +1800,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Generated classes can be optimized for speed or code size.
-  enum OptimizeMode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum OptimizeMode: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// Generate complete code for parsing, serialization,
@@ -1838,12 +1811,6 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
 
     /// Generate code using MessageLite and the lite runtime.
     case liteRuntime // = 3
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "SPEED"),
-      2: .same(proto: "CODE_SIZE"),
-      3: .same(proto: "LITE_RUNTIME"),
-    ]
 
     init() {
       self = .speed
@@ -2248,19 +2215,13 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum CType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum CType: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// Default mode.
     case string // = 0
     case cord // = 1
     case stringPiece // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "STRING"),
-      1: .same(proto: "CORD"),
-      2: .same(proto: "STRING_PIECE"),
-    ]
 
     init() {
       self = .string
@@ -2285,7 +2246,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
 
   }
 
-  enum JSType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum JSType: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// Use the default type.
@@ -2296,12 +2257,6 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
 
     /// Use JavaScript numbers.
     case jsNumber // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "JS_NORMAL"),
-      1: .same(proto: "JS_STRING"),
-      2: .same(proto: "JS_NUMBER"),
-    ]
 
     init() {
       self = .jsNormal
@@ -2649,7 +2604,7 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.Exten
   /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
   /// or neither? HTTP based RPC implementation may choose GET verb for safe
   /// methods, and PUT verb for idempotent methods instead of the default POST.
-  enum IdempotencyLevel: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum IdempotencyLevel: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case idempotencyUnknown // = 0
 
@@ -2658,12 +2613,6 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.Exten
 
     /// idempotent, but may have side effects
     case idempotent // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "IDEMPOTENCY_UNKNOWN"),
-      1: .same(proto: "NO_SIDE_EFFECTS"),
-      2: .same(proto: "IDEMPOTENT"),
-    ]
 
     init() {
       self = .idempotencyUnknown
@@ -3405,6 +3354,37 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobuf._MessageImplementa
   }
 }
 
+extension Google_Protobuf_FieldDescriptorProto.TypeEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "TYPE_DOUBLE"),
+    2: .same(proto: "TYPE_FLOAT"),
+    3: .same(proto: "TYPE_INT64"),
+    4: .same(proto: "TYPE_UINT64"),
+    5: .same(proto: "TYPE_INT32"),
+    6: .same(proto: "TYPE_FIXED64"),
+    7: .same(proto: "TYPE_FIXED32"),
+    8: .same(proto: "TYPE_BOOL"),
+    9: .same(proto: "TYPE_STRING"),
+    10: .same(proto: "TYPE_GROUP"),
+    11: .same(proto: "TYPE_MESSAGE"),
+    12: .same(proto: "TYPE_BYTES"),
+    13: .same(proto: "TYPE_UINT32"),
+    14: .same(proto: "TYPE_ENUM"),
+    15: .same(proto: "TYPE_SFIXED32"),
+    16: .same(proto: "TYPE_SFIXED64"),
+    17: .same(proto: "TYPE_SINT32"),
+    18: .same(proto: "TYPE_SINT64"),
+  ]
+}
+
+extension Google_Protobuf_FieldDescriptorProto.Label: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "LABEL_OPTIONAL"),
+    2: .same(proto: "LABEL_REQUIRED"),
+    3: .same(proto: "LABEL_REPEATED"),
+  ]
+}
+
 extension Google_Protobuf_OneofDescriptorProto: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "name"),
@@ -3570,6 +3550,14 @@ extension Google_Protobuf_FileOptions: SwiftProtobuf._MessageImplementationBase,
   }
 }
 
+extension Google_Protobuf_FileOptions.OptimizeMode: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "SPEED"),
+    2: .same(proto: "CODE_SIZE"),
+    3: .same(proto: "LITE_RUNTIME"),
+  ]
+}
+
 extension Google_Protobuf_MessageOptions: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "message_set_wire_format"),
@@ -3614,6 +3602,22 @@ extension Google_Protobuf_FieldOptions: SwiftProtobuf._MessageImplementationBase
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
   }
+}
+
+extension Google_Protobuf_FieldOptions.CType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "STRING"),
+    1: .same(proto: "CORD"),
+    2: .same(proto: "STRING_PIECE"),
+  ]
+}
+
+extension Google_Protobuf_FieldOptions.JSType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "JS_NORMAL"),
+    1: .same(proto: "JS_STRING"),
+    2: .same(proto: "JS_NUMBER"),
+  ]
 }
 
 extension Google_Protobuf_OneofOptions: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -3691,6 +3695,14 @@ extension Google_Protobuf_MethodOptions: SwiftProtobuf._MessageImplementationBas
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
   }
+}
+
+extension Google_Protobuf_MethodOptions.IdempotencyLevel: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "IDEMPOTENCY_UNKNOWN"),
+    1: .same(proto: "NO_SIDE_EFFECTS"),
+    2: .same(proto: "IDEMPOTENT"),
+  ]
 }
 
 extension Google_Protobuf_UninterpretedOption: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/map_lite_unittest.pb.swift
+++ b/Reference/google/protobuf/map_lite_unittest.pb.swift
@@ -51,17 +51,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_Proto2MapEnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_Proto2MapEnumLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case proto2MapEnumFooLite // = 0
   case proto2MapEnumBarLite // = 1
   case proto2MapEnumBazLite // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "PROTO2_MAP_ENUM_FOO_LITE"),
-    1: .same(proto: "PROTO2_MAP_ENUM_BAR_LITE"),
-    2: .same(proto: "PROTO2_MAP_ENUM_BAZ_LITE"),
-  ]
 
   init() {
     self = .proto2MapEnumFooLite
@@ -86,19 +80,12 @@ enum ProtobufUnittest_Proto2MapEnumLite: SwiftProtobuf.Enum, SwiftProtobuf._Prot
 
 }
 
-enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case eProto2MapEnumFooLite // = 0
   case eProto2MapEnumBarLite // = 1
   case eProto2MapEnumBazLite // = 2
   case eProto2MapEnumExtraLite // = 3
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "E_PROTO2_MAP_ENUM_FOO_LITE"),
-    1: .same(proto: "E_PROTO2_MAP_ENUM_BAR_LITE"),
-    2: .same(proto: "E_PROTO2_MAP_ENUM_BAZ_LITE"),
-    3: .same(proto: "E_PROTO2_MAP_ENUM_EXTRA_LITE"),
-  ]
 
   init() {
     self = .eProto2MapEnumFooLite
@@ -125,17 +112,11 @@ enum ProtobufUnittest_Proto2MapEnumPlusExtraLite: SwiftProtobuf.Enum, SwiftProto
 
 }
 
-enum ProtobufUnittest_MapEnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_MapEnumLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case mapEnumFooLite // = 0
   case mapEnumBarLite // = 1
   case mapEnumBazLite // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "MAP_ENUM_FOO_LITE"),
-    1: .same(proto: "MAP_ENUM_BAR_LITE"),
-    2: .same(proto: "MAP_ENUM_BAZ_LITE"),
-  ]
 
   init() {
     self = .mapEnumFooLite
@@ -871,6 +852,31 @@ struct ProtobufUnittest_ForeignMessageArenaLite: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension ProtobufUnittest_Proto2MapEnumLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "PROTO2_MAP_ENUM_FOO_LITE"),
+    1: .same(proto: "PROTO2_MAP_ENUM_BAR_LITE"),
+    2: .same(proto: "PROTO2_MAP_ENUM_BAZ_LITE"),
+  ]
+}
+
+extension ProtobufUnittest_Proto2MapEnumPlusExtraLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "E_PROTO2_MAP_ENUM_FOO_LITE"),
+    1: .same(proto: "E_PROTO2_MAP_ENUM_BAR_LITE"),
+    2: .same(proto: "E_PROTO2_MAP_ENUM_BAZ_LITE"),
+    3: .same(proto: "E_PROTO2_MAP_ENUM_EXTRA_LITE"),
+  ]
+}
+
+extension ProtobufUnittest_MapEnumLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "MAP_ENUM_FOO_LITE"),
+    1: .same(proto: "MAP_ENUM_BAR_LITE"),
+    2: .same(proto: "MAP_ENUM_BAZ_LITE"),
+  ]
 }
 
 extension ProtobufUnittest_TestMapLite: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/map_proto2_unittest.pb.swift
+++ b/Reference/google/protobuf/map_proto2_unittest.pb.swift
@@ -51,17 +51,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_Proto2MapEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_Proto2MapEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "PROTO2_MAP_ENUM_FOO"),
-    1: .same(proto: "PROTO2_MAP_ENUM_BAR"),
-    2: .same(proto: "PROTO2_MAP_ENUM_BAZ"),
-  ]
 
   init() {
     self = .foo
@@ -86,19 +80,12 @@ enum ProtobufUnittest_Proto2MapEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNam
 
 }
 
-enum ProtobufUnittest_Proto2MapEnumPlusExtra: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_Proto2MapEnumPlusExtra: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case eProto2MapEnumFoo // = 0
   case eProto2MapEnumBar // = 1
   case eProto2MapEnumBaz // = 2
   case eProto2MapEnumExtra // = 3
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "E_PROTO2_MAP_ENUM_FOO"),
-    1: .same(proto: "E_PROTO2_MAP_ENUM_BAR"),
-    2: .same(proto: "E_PROTO2_MAP_ENUM_BAZ"),
-    3: .same(proto: "E_PROTO2_MAP_ENUM_EXTRA"),
-  ]
 
   init() {
     self = .eProto2MapEnumFoo
@@ -332,6 +319,23 @@ struct ProtobufUnittest_TestMaps: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension ProtobufUnittest_Proto2MapEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "PROTO2_MAP_ENUM_FOO"),
+    1: .same(proto: "PROTO2_MAP_ENUM_BAR"),
+    2: .same(proto: "PROTO2_MAP_ENUM_BAZ"),
+  ]
+}
+
+extension ProtobufUnittest_Proto2MapEnumPlusExtra: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "E_PROTO2_MAP_ENUM_FOO"),
+    1: .same(proto: "E_PROTO2_MAP_ENUM_BAR"),
+    2: .same(proto: "E_PROTO2_MAP_ENUM_BAZ"),
+    3: .same(proto: "E_PROTO2_MAP_ENUM_EXTRA"),
+  ]
 }
 
 extension ProtobufUnittest_TestEnumMap: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/map_unittest.pb.swift
+++ b/Reference/google/protobuf/map_unittest.pb.swift
@@ -51,18 +51,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_MapEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_MapEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "MAP_ENUM_FOO"),
-    1: .same(proto: "MAP_ENUM_BAR"),
-    2: .same(proto: "MAP_ENUM_BAZ"),
-  ]
 
   init() {
     self = .foo
@@ -728,14 +722,10 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TypeEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "TYPE_FOO"),
-    ]
 
     init() {
       self = .foo
@@ -827,6 +817,14 @@ struct ProtobufUnittest_TestRecursiveMapMessage: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension ProtobufUnittest_MapEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "MAP_ENUM_FOO"),
+    1: .same(proto: "MAP_ENUM_BAR"),
+    2: .same(proto: "MAP_ENUM_BAZ"),
+  ]
 }
 
 extension ProtobufUnittest_TestMap: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -999,6 +997,12 @@ extension ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf._Messa
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_MessageContainingEnumCalledType.TypeEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "TYPE_FOO"),
+  ]
 }
 
 extension ProtobufUnittest_MessageContainingMapCalledEntry: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/map_unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/map_unittest_proto3.pb.swift
@@ -58,18 +58,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum Proto3MapEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3MapEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "MAP_ENUM_FOO"),
-    1: .same(proto: "MAP_ENUM_BAR"),
-    2: .same(proto: "MAP_ENUM_BAZ"),
-  ]
 
   init() {
     self = .foo
@@ -562,14 +556,10 @@ struct Proto3MessageContainingEnumCalledType: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TypeEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "TYPE_FOO"),
-    ]
 
     init() {
       self = .foo
@@ -635,6 +625,14 @@ struct Proto3MessageContainingMapCalledEntry: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Proto3MapEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "MAP_ENUM_FOO"),
+    1: .same(proto: "MAP_ENUM_BAR"),
+    2: .same(proto: "MAP_ENUM_BAZ"),
+  ]
 }
 
 extension Proto3TestMap: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -781,6 +779,12 @@ extension Proto3MessageContainingEnumCalledType: SwiftProtobuf._MessageImplement
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Proto3MessageContainingEnumCalledType.TypeEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "TYPE_FOO"),
+  ]
 }
 
 extension Proto3MessageContainingMapCalledEntry: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -54,16 +54,12 @@ fileprivate let _protobuf_package = "google.protobuf"
 /// `Value` type union.
 ///
 ///  The JSON representation for `NullValue` is JSON `null`.
-enum Google_Protobuf_NullValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Google_Protobuf_NullValue: SwiftProtobuf.Enum {
   typealias RawValue = Int
 
   /// Null value.
   case nullValue // = 0
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "NULL_VALUE"),
-  ]
 
   init() {
     self = .nullValue
@@ -381,6 +377,12 @@ struct Google_Protobuf_ListValue: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Google_Protobuf_NullValue: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "NULL_VALUE"),
+  ]
 }
 
 extension Google_Protobuf_Struct: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -57,18 +57,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_test_messages.proto3"
 
-enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
   case foreignBaz // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_FOO"),
-    1: .same(proto: "FOREIGN_BAR"),
-    2: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignFoo
@@ -1247,7 +1241,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -1256,13 +1250,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -1852,6 +1839,14 @@ struct ProtobufTestMessages_Proto3_ForeignMessage: SwiftProtobuf.Message {
   }
 }
 
+extension ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_FOO"),
+    1: .same(proto: "FOREIGN_BAR"),
+    2: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -2096,6 +2091,15 @@ extension ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf._MessageImplem
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
 }
 
 extension ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/type.pb.swift
+++ b/Reference/google/protobuf/type.pb.swift
@@ -51,7 +51,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 fileprivate let _protobuf_package = "google.protobuf"
 
 /// The syntax in which a protocol buffer element is defined.
-enum Google_Protobuf_Syntax: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Google_Protobuf_Syntax: SwiftProtobuf.Enum {
   typealias RawValue = Int
 
   /// Syntax `proto2`.
@@ -60,11 +60,6 @@ enum Google_Protobuf_Syntax: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProvidi
   /// Syntax `proto3`.
   case proto3 // = 1
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "SYNTAX_PROTO2"),
-    1: .same(proto: "SYNTAX_PROTO3"),
-  ]
 
   init() {
     self = .proto2
@@ -248,7 +243,7 @@ struct Google_Protobuf_Field: SwiftProtobuf.Message {
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Basic field types.
-  enum Kind: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Kind: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// Field type unknown.
@@ -309,28 +304,6 @@ struct Google_Protobuf_Field: SwiftProtobuf.Message {
     case typeSint64 // = 18
     case UNRECOGNIZED(Int)
 
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "TYPE_UNKNOWN"),
-      1: .same(proto: "TYPE_DOUBLE"),
-      2: .same(proto: "TYPE_FLOAT"),
-      3: .same(proto: "TYPE_INT64"),
-      4: .same(proto: "TYPE_UINT64"),
-      5: .same(proto: "TYPE_INT32"),
-      6: .same(proto: "TYPE_FIXED64"),
-      7: .same(proto: "TYPE_FIXED32"),
-      8: .same(proto: "TYPE_BOOL"),
-      9: .same(proto: "TYPE_STRING"),
-      10: .same(proto: "TYPE_GROUP"),
-      11: .same(proto: "TYPE_MESSAGE"),
-      12: .same(proto: "TYPE_BYTES"),
-      13: .same(proto: "TYPE_UINT32"),
-      14: .same(proto: "TYPE_ENUM"),
-      15: .same(proto: "TYPE_SFIXED32"),
-      16: .same(proto: "TYPE_SFIXED64"),
-      17: .same(proto: "TYPE_SINT32"),
-      18: .same(proto: "TYPE_SINT64"),
-    ]
-
     init() {
       self = .typeUnknown
     }
@@ -388,7 +361,7 @@ struct Google_Protobuf_Field: SwiftProtobuf.Message {
   }
 
   /// Whether a field is optional, required, or repeated.
-  enum Cardinality: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Cardinality: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// For fields with unknown cardinality.
@@ -403,13 +376,6 @@ struct Google_Protobuf_Field: SwiftProtobuf.Message {
     /// For repeated fields.
     case repeated // = 3
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "CARDINALITY_UNKNOWN"),
-      1: .same(proto: "CARDINALITY_OPTIONAL"),
-      2: .same(proto: "CARDINALITY_REQUIRED"),
-      3: .same(proto: "CARDINALITY_REPEATED"),
-    ]
 
     init() {
       self = .unknown
@@ -723,6 +689,13 @@ struct Google_Protobuf_Option: SwiftProtobuf.Message {
   }
 }
 
+extension Google_Protobuf_Syntax: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "SYNTAX_PROTO2"),
+    1: .same(proto: "SYNTAX_PROTO3"),
+  ]
+}
+
 extension Google_Protobuf_Type: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "name"),
@@ -779,6 +752,39 @@ extension Google_Protobuf_Field: SwiftProtobuf._MessageImplementationBase, Swift
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Google_Protobuf_Field.Kind: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "TYPE_UNKNOWN"),
+    1: .same(proto: "TYPE_DOUBLE"),
+    2: .same(proto: "TYPE_FLOAT"),
+    3: .same(proto: "TYPE_INT64"),
+    4: .same(proto: "TYPE_UINT64"),
+    5: .same(proto: "TYPE_INT32"),
+    6: .same(proto: "TYPE_FIXED64"),
+    7: .same(proto: "TYPE_FIXED32"),
+    8: .same(proto: "TYPE_BOOL"),
+    9: .same(proto: "TYPE_STRING"),
+    10: .same(proto: "TYPE_GROUP"),
+    11: .same(proto: "TYPE_MESSAGE"),
+    12: .same(proto: "TYPE_BYTES"),
+    13: .same(proto: "TYPE_UINT32"),
+    14: .same(proto: "TYPE_ENUM"),
+    15: .same(proto: "TYPE_SFIXED32"),
+    16: .same(proto: "TYPE_SFIXED64"),
+    17: .same(proto: "TYPE_SINT32"),
+    18: .same(proto: "TYPE_SINT64"),
+  ]
+}
+
+extension Google_Protobuf_Field.Cardinality: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "CARDINALITY_UNKNOWN"),
+    1: .same(proto: "CARDINALITY_OPTIONAL"),
+    2: .same(proto: "CARDINALITY_REQUIRED"),
+    3: .same(proto: "CARDINALITY_REPEATED"),
+  ]
 }
 
 extension Google_Protobuf_Enum: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -57,17 +57,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    4: .same(proto: "FOREIGN_FOO"),
-    5: .same(proto: "FOREIGN_BAR"),
-    6: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignFoo
@@ -93,19 +87,13 @@ enum ProtobufUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameP
 }
 
 /// Test an enum that has multiple values with the same number.
-enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo1 // = 1
   case bar1 // = 2
   case baz // = 3
   static let foo2 = foo1
   static let bar2 = bar1
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
-    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
-    3: .same(proto: "BAZ"),
-  ]
 
   init() {
     self = .foo1
@@ -131,7 +119,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._P
 }
 
 /// Test an enum with large, unordered values.
-enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case sparseA // = 123
   case sparseB // = 62374
@@ -140,16 +128,6 @@ enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNa
   case sparseE // = -53452
   case sparseF // = 0
   case sparseG // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    -53452: .same(proto: "SPARSE_E"),
-    -15: .same(proto: "SPARSE_D"),
-    0: .same(proto: "SPARSE_F"),
-    2: .same(proto: "SPARSE_G"),
-    123: .same(proto: "SPARSE_A"),
-    62374: .same(proto: "SPARSE_B"),
-    12589234: .same(proto: "SPARSE_C"),
-  ]
 
   init() {
     self = .sparseA
@@ -1114,7 +1092,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -1122,13 +1100,6 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
 
     /// Intentionally negative.
     case neg // = -1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -5563,17 +5534,11 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -6309,17 +6274,11 @@ struct ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum DynamicEnumType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum DynamicEnumType: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case dynamicFoo // = 2200
     case dynamicBar // = 2201
     case dynamicBaz // = 2202
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      2200: .same(proto: "DYNAMIC_FOO"),
-      2201: .same(proto: "DYNAMIC_BAR"),
-      2202: .same(proto: "DYNAMIC_BAZ"),
-    ]
 
     init() {
       self = .dynamicFoo
@@ -9790,6 +9749,34 @@ let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext
 ]
 
+extension ProtobufUnittest_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    4: .same(proto: "FOREIGN_FOO"),
+    5: .same(proto: "FOREIGN_BAR"),
+    6: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
+extension ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
+    3: .same(proto: "BAZ"),
+  ]
+}
+
+extension ProtobufUnittest_TestSparseEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -53452: .same(proto: "SPARSE_E"),
+    -15: .same(proto: "SPARSE_D"),
+    0: .same(proto: "SPARSE_F"),
+    2: .same(proto: "SPARSE_G"),
+    123: .same(proto: "SPARSE_A"),
+    62374: .same(proto: "SPARSE_B"),
+    12589234: .same(proto: "SPARSE_C"),
+  ]
+}
+
 extension ProtobufUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -9951,6 +9938,15 @@ extension ProtobufUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBas
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension ProtobufUnittest_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -10814,6 +10810,14 @@ extension ProtobufUnittest_TestOneof2: SwiftProtobuf._MessageImplementationBase,
   }
 }
 
+extension ProtobufUnittest_TestOneof2.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
+}
+
 extension ProtobufUnittest_TestOneof2.FooGroup: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     9: .same(proto: "a"),
@@ -10998,6 +11002,14 @@ extension ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf._MessageImplemen
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_TestDynamicExtensions.DynamicEnumType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    2200: .same(proto: "DYNAMIC_FOO"),
+    2201: .same(proto: "DYNAMIC_BAR"),
+    2202: .same(proto: "DYNAMIC_BAZ"),
+  ]
 }
 
 extension ProtobufUnittest_TestDynamicExtensions.DynamicMessageType: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -57,15 +57,10 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_MethodOpt1: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_MethodOpt1: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case val1 // = 1
   case val2 // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "METHODOPT1_VAL1"),
-    2: .same(proto: "METHODOPT1_VAL2"),
-  ]
 
   init() {
     self = .val1
@@ -88,13 +83,9 @@ enum ProtobufUnittest_MethodOpt1: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePr
 
 }
 
-enum ProtobufUnittest_AggregateEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_AggregateEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case value // = 1
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "VALUE"),
-  ]
 
   init() {
     self = .value
@@ -178,15 +169,10 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
     }
   }
 
-  enum AnEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum AnEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case val1 // = 1
     case val2 // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "ANENUM_VAL1"),
-      2: .same(proto: "ANENUM_VAL2"),
-    ]
 
     init() {
       self = .val1
@@ -309,15 +295,10 @@ struct ProtobufUnittest_DummyMessageContainingEnum: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestEnumType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TestEnumType: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case testOptionEnumType1 // = 22
     case testOptionEnumType2 // = -23
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -23: .same(proto: "TEST_OPTION_ENUM_TYPE2"),
-      22: .same(proto: "TEST_OPTION_ENUM_TYPE1"),
-    ]
 
     init() {
       self = .testOptionEnumType1
@@ -1130,13 +1111,9 @@ struct ProtobufUnittest_NestedOptionType: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case value // = 1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "NESTED_ENUM_VALUE"),
-    ]
 
     init() {
       self = .value
@@ -1233,13 +1210,9 @@ struct ProtobufUnittest_OldOptionType: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TestEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case oldValue // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "OLD_VALUE"),
-    ]
 
     init() {
       self = .oldValue
@@ -1302,15 +1275,10 @@ struct ProtobufUnittest_NewOptionType: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TestEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case oldValue // = 0
     case newValue // = 1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "OLD_VALUE"),
-      1: .same(proto: "NEW_VALUE"),
-    ]
 
     init() {
       self = .oldValue
@@ -2278,6 +2246,19 @@ let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.SimpleExten
   ProtobufUnittest_NestedOptionType.Extensions.nested_extension
 ]
 
+extension ProtobufUnittest_MethodOpt1: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "METHODOPT1_VAL1"),
+    2: .same(proto: "METHODOPT1_VAL2"),
+  ]
+}
+
+extension ProtobufUnittest_AggregateEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "VALUE"),
+  ]
+}
+
 extension ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "field1"),
@@ -2290,6 +2271,13 @@ extension ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf._MessageI
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_TestMessageWithCustomOptions.AnEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ANENUM_VAL1"),
+    2: .same(proto: "ANENUM_VAL2"),
+  ]
 }
 
 extension ProtobufUnittest_CustomOptionFooRequest: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -2335,6 +2323,13 @@ extension ProtobufUnittest_DummyMessageContainingEnum: SwiftProtobuf._MessageImp
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_DummyMessageContainingEnum.TestEnumType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -23: .same(proto: "TEST_OPTION_ENUM_TYPE2"),
+    22: .same(proto: "TEST_OPTION_ENUM_TYPE1"),
+  ]
 }
 
 extension ProtobufUnittest_DummyMessageInvalidAsOptionType: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -2569,6 +2564,12 @@ extension ProtobufUnittest_NestedOptionType: SwiftProtobuf._MessageImplementatio
   }
 }
 
+extension ProtobufUnittest_NestedOptionType.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "NESTED_ENUM_VALUE"),
+  ]
+}
+
 extension ProtobufUnittest_NestedOptionType.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "nested_field"),
@@ -2593,6 +2594,12 @@ extension ProtobufUnittest_OldOptionType: SwiftProtobuf._MessageImplementationBa
   }
 }
 
+extension ProtobufUnittest_OldOptionType.TestEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "OLD_VALUE"),
+  ]
+}
+
 extension ProtobufUnittest_NewOptionType: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "value"),
@@ -2603,6 +2610,13 @@ extension ProtobufUnittest_NewOptionType: SwiftProtobuf._MessageImplementationBa
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_NewOptionType.TestEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "OLD_VALUE"),
+    1: .same(proto: "NEW_VALUE"),
+  ]
 }
 
 extension ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_drop_unknown_fields.pb.swift
+++ b/Reference/google/protobuf/unittest_drop_unknown_fields.pb.swift
@@ -60,18 +60,12 @@ struct UnittestDropUnknownFields_Foo: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -131,20 +125,13 @@ struct UnittestDropUnknownFields_FooWithExtraFields: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case qux // = 3
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-      3: .same(proto: "QUX"),
-    ]
 
     init() {
       self = .foo
@@ -213,6 +200,14 @@ extension UnittestDropUnknownFields_Foo: SwiftProtobuf._MessageImplementationBas
   }
 }
 
+extension UnittestDropUnknownFields_Foo.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
+}
+
 extension UnittestDropUnknownFields_FooWithExtraFields: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "int32_value"),
@@ -227,4 +222,13 @@ extension UnittestDropUnknownFields_FooWithExtraFields: SwiftProtobuf._MessageIm
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension UnittestDropUnknownFields_FooWithExtraFields.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+    3: .same(proto: "QUX"),
+  ]
 }

--- a/Reference/google/protobuf/unittest_import.pb.swift
+++ b/Reference/google/protobuf/unittest_import.pb.swift
@@ -57,17 +57,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest_import"
 
-enum ProtobufUnittestImport_ImportEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittestImport_ImportEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case importFoo // = 7
   case importBar // = 8
   case importBaz // = 9
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    7: .same(proto: "IMPORT_FOO"),
-    8: .same(proto: "IMPORT_BAR"),
-    9: .same(proto: "IMPORT_BAZ"),
-  ]
 
   init() {
     self = .importFoo
@@ -93,17 +87,11 @@ enum ProtobufUnittestImport_ImportEnum: SwiftProtobuf.Enum, SwiftProtobuf._Proto
 }
 
 /// To use an enum in a map, it must has the first value as 0.
-enum ProtobufUnittestImport_ImportEnumForMap: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittestImport_ImportEnumForMap: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case unknown // = 0
   case foo // = 1
   case bar // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "UNKNOWN"),
-    1: .same(proto: "FOO"),
-    2: .same(proto: "BAR"),
-  ]
 
   init() {
     self = .unknown
@@ -162,6 +150,22 @@ struct ProtobufUnittestImport_ImportMessage: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension ProtobufUnittestImport_ImportEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    7: .same(proto: "IMPORT_FOO"),
+    8: .same(proto: "IMPORT_BAR"),
+    9: .same(proto: "IMPORT_BAZ"),
+  ]
+}
+
+extension ProtobufUnittestImport_ImportEnumForMap: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "UNKNOWN"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+  ]
 }
 
 extension ProtobufUnittestImport_ImportMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_import_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_import_lite.pb.swift
@@ -55,17 +55,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest_import"
 
-enum ProtobufUnittestImport_ImportEnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittestImport_ImportEnumLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case importLiteFoo // = 7
   case importLiteBar // = 8
   case importLiteBaz // = 9
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    7: .same(proto: "IMPORT_LITE_FOO"),
-    8: .same(proto: "IMPORT_LITE_BAR"),
-    9: .same(proto: "IMPORT_LITE_BAZ"),
-  ]
 
   init() {
     self = .importLiteFoo
@@ -124,6 +118,14 @@ struct ProtobufUnittestImport_ImportMessageLite: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension ProtobufUnittestImport_ImportEnumLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    7: .same(proto: "IMPORT_LITE_FOO"),
+    8: .same(proto: "IMPORT_LITE_BAR"),
+    9: .same(proto: "IMPORT_LITE_BAZ"),
+  ]
 }
 
 extension ProtobufUnittestImport_ImportMessageLite: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_import_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_import_proto3.pb.swift
@@ -57,20 +57,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest_import"
 
-enum Proto3ImportEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3ImportEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case importEnumUnspecified // = 0
   case importFoo // = 7
   case importBar // = 8
   case importBaz // = 9
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "IMPORT_ENUM_UNSPECIFIED"),
-    7: .same(proto: "IMPORT_FOO"),
-    8: .same(proto: "IMPORT_BAR"),
-    9: .same(proto: "IMPORT_BAZ"),
-  ]
 
   init() {
     self = .importEnumUnspecified
@@ -122,6 +115,15 @@ struct Proto3ImportMessage: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Proto3ImportEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "IMPORT_ENUM_UNSPECIFIED"),
+    7: .same(proto: "IMPORT_FOO"),
+    8: .same(proto: "IMPORT_BAR"),
+    9: .same(proto: "IMPORT_BAZ"),
+  ]
 }
 
 extension Proto3ImportMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -55,17 +55,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_ForeignEnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_ForeignEnumLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignLiteFoo // = 4
   case foreignLiteBar // = 5
   case foreignLiteBaz // = 6
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    4: .same(proto: "FOREIGN_LITE_FOO"),
-    5: .same(proto: "FOREIGN_LITE_BAR"),
-    6: .same(proto: "FOREIGN_LITE_BAZ"),
-  ]
 
   init() {
     self = .foreignLiteFoo
@@ -90,13 +84,9 @@ enum ProtobufUnittest_ForeignEnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoN
 
 }
 
-enum ProtobufUnittest_V1EnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_V1EnumLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case v1First // = 1
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "V1_FIRST"),
-  ]
 
   init() {
     self = .v1First
@@ -117,15 +107,10 @@ enum ProtobufUnittest_V1EnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePr
 
 }
 
-enum ProtobufUnittest_V2EnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_V2EnumLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case v2First // = 1
   case v2Second // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "V2_FIRST"),
-    2: .same(proto: "V2_SECOND"),
-  ]
 
   init() {
     self = .v2First
@@ -1118,17 +1103,11 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -4757,6 +4736,27 @@ let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.SimpleExtensionMap =
   ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext
 ]
 
+extension ProtobufUnittest_ForeignEnumLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    4: .same(proto: "FOREIGN_LITE_FOO"),
+    5: .same(proto: "FOREIGN_LITE_BAR"),
+    6: .same(proto: "FOREIGN_LITE_BAZ"),
+  ]
+}
+
+extension ProtobufUnittest_V1EnumLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "V1_FIRST"),
+  ]
+}
+
+extension ProtobufUnittest_V2EnumLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "V2_FIRST"),
+    2: .same(proto: "V2_SECOND"),
+  ]
+}
+
 extension ProtobufUnittest_TestAllTypesLite: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -4921,6 +4921,14 @@ extension ProtobufUnittest_TestAllTypesLite: SwiftProtobuf._MessageImplementatio
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_TestAllTypesLite.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension ProtobufUnittest_TestAllTypesLite.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -59,17 +59,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest_no_arena"
 
-enum ProtobufUnittestNoArena_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittestNoArena_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    4: .same(proto: "FOREIGN_FOO"),
-    5: .same(proto: "FOREIGN_BAR"),
-    6: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignFoo
@@ -1051,7 +1045,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -1059,13 +1053,6 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
 
     /// Intentionally negative.
     case neg // = -1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -1610,6 +1597,14 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage: SwiftProtobuf.Message {
   }
 }
 
+extension ProtobufUnittestNoArena_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    4: .same(proto: "FOREIGN_FOO"),
+    5: .same(proto: "FOREIGN_BAR"),
+    6: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -1772,6 +1767,15 @@ extension ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf._MessageImplementa
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittestNoArena_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension ProtobufUnittestNoArena_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -53,18 +53,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto2_nofieldpresence_unittest"
 
-enum Proto2NofieldpresenceUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto2NofieldpresenceUnittest_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
   case foreignBaz // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_FOO"),
-    1: .same(proto: "FOREIGN_BAR"),
-    2: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignFoo
@@ -592,18 +586,12 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -959,6 +947,14 @@ struct Proto2NofieldpresenceUnittest_ForeignMessage: SwiftProtobuf.Message {
   }
 }
 
+extension Proto2NofieldpresenceUnittest_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_FOO"),
+    1: .same(proto: "FOREIGN_BAR"),
+    2: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -1070,6 +1066,14 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf._MessageImpl
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
 }
 
 extension Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -53,13 +53,9 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf.no_generic_services_test"
 
-enum Google_Protobuf_NoGenericServicesTest_TestEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Google_Protobuf_NoGenericServicesTest_TestEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 1
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "FOO"),
-  ]
 
   init() {
     self = .foo
@@ -148,6 +144,12 @@ extension Google_Protobuf_NoGenericServicesTest_TestMessage {
 let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Google_Protobuf_NoGenericServicesTest_Extensions_test_extension
 ]
+
+extension Google_Protobuf_NoGenericServicesTest_TestEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "FOO"),
+  ]
+}
 
 extension Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -51,18 +51,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto3_preserve_unknown_enum_unittest"
 
-enum Proto3PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOO"),
-    1: .same(proto: "BAR"),
-    2: .same(proto: "BAZ"),
-  ]
 
   init() {
     self = .foo
@@ -88,20 +82,13 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum, SwiftProtobuf
 
 }
 
-enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case eFoo // = 0
   case eBar // = 1
   case eBaz // = 2
   case eExtra // = 3
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "E_FOO"),
-    1: .same(proto: "E_BAR"),
-    2: .same(proto: "E_BAZ"),
-    3: .same(proto: "E_EXTRA"),
-  ]
 
   init() {
     self = .eFoo
@@ -352,6 +339,23 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     try o?.traverse(visitor: &visitor, start: 5, end: 7)
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Proto3PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
+}
+
+extension Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "E_FOO"),
+    1: .same(proto: "E_BAR"),
+    2: .same(proto: "E_BAZ"),
+    3: .same(proto: "E_EXTRA"),
+  ]
 }
 
 extension Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -51,17 +51,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto2_preserve_unknown_enum_unittest"
 
-enum Proto2PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto2PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOO"),
-    1: .same(proto: "BAR"),
-    2: .same(proto: "BAZ"),
-  ]
 
   init() {
     self = .foo
@@ -211,6 +205,14 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
     try o?.traverse(visitor: &visitor, start: 5, end: 7)
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Proto2PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
 }
 
 extension Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -57,20 +57,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum Proto3ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignUnspecified // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_UNSPECIFIED"),
-    4: .same(proto: "FOREIGN_FOO"),
-    5: .same(proto: "FOREIGN_BAR"),
-    6: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignUnspecified
@@ -99,7 +92,7 @@ enum Proto3ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
 }
 
 /// Test an enum that has multiple values with the same number.
-enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case testEnumWithDupValueUnspecified // = 0
   case foo1 // = 1
@@ -108,13 +101,6 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
   static let foo2 = foo1
   static let bar2 = bar1
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED"),
-    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
-    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
-    3: .same(proto: "BAZ"),
-  ]
 
   init() {
     self = .testEnumWithDupValueUnspecified
@@ -143,7 +129,7 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
 }
 
 /// Test an enum with large, unordered values.
-enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3TestSparseEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case testSparseEnumUnspecified // = 0
   case sparseA // = 123
@@ -156,16 +142,6 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding
   /// SPARSE_F = 0;
   case sparseG // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    -53452: .same(proto: "SPARSE_E"),
-    -15: .same(proto: "SPARSE_D"),
-    0: .same(proto: "TEST_SPARSE_ENUM_UNSPECIFIED"),
-    2: .same(proto: "SPARSE_G"),
-    123: .same(proto: "SPARSE_A"),
-    62374: .same(proto: "SPARSE_B"),
-    12589234: .same(proto: "SPARSE_C"),
-  ]
 
   init() {
     self = .testSparseEnumUnspecified
@@ -684,7 +660,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case nestedEnumUnspecified // = 0
     case foo // = 1
@@ -694,14 +670,6 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      0: .same(proto: "NESTED_ENUM_UNSPECIFIED"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .nestedEnumUnspecified
@@ -2524,6 +2492,36 @@ struct Proto3BarResponse: SwiftProtobuf.Message {
   }
 }
 
+extension Proto3ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_UNSPECIFIED"),
+    4: .same(proto: "FOREIGN_FOO"),
+    5: .same(proto: "FOREIGN_BAR"),
+    6: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
+extension Proto3TestEnumWithDupValue: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED"),
+    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
+    3: .same(proto: "BAZ"),
+  ]
+}
+
+extension Proto3TestSparseEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -53452: .same(proto: "SPARSE_E"),
+    -15: .same(proto: "SPARSE_D"),
+    0: .same(proto: "TEST_SPARSE_ENUM_UNSPECIFIED"),
+    2: .same(proto: "SPARSE_G"),
+    123: .same(proto: "SPARSE_A"),
+    62374: .same(proto: "SPARSE_B"),
+    12589234: .same(proto: "SPARSE_C"),
+  ]
+}
+
 extension Proto3TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "single_int32"),
@@ -2631,6 +2629,16 @@ extension Proto3TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftPro
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Proto3TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    0: .same(proto: "NESTED_ENUM_UNSPECIFIED"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension Proto3TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -51,20 +51,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto3_arena_unittest"
 
-enum Proto3ArenaUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3ArenaUnittest_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_ZERO"),
-    4: .same(proto: "FOREIGN_FOO"),
-    5: .same(proto: "FOREIGN_BAR"),
-    6: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignZero
@@ -603,7 +596,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case zero // = 0
     case foo // = 1
@@ -613,14 +606,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      0: .same(proto: "ZERO"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .zero
@@ -1225,6 +1210,15 @@ struct Proto3ArenaUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   }
 }
 
+extension Proto3ArenaUnittest_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_ZERO"),
+    4: .same(proto: "FOREIGN_FOO"),
+    5: .same(proto: "FOREIGN_BAR"),
+    6: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -1338,6 +1332,16 @@ extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf._MessageImplementation
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Proto3ArenaUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    0: .same(proto: "ZERO"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension Proto3ArenaUnittest_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -51,20 +51,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto3_arena_lite_unittest"
 
-enum Proto3ArenaLiteUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3ArenaLiteUnittest_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_ZERO"),
-    4: .same(proto: "FOREIGN_FOO"),
-    5: .same(proto: "FOREIGN_BAR"),
-    6: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignZero
@@ -603,7 +596,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case zero // = 0
     case foo // = 1
@@ -613,14 +606,6 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      0: .same(proto: "ZERO"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .zero
@@ -1225,6 +1210,15 @@ struct Proto3ArenaLiteUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   }
 }
 
+extension Proto3ArenaLiteUnittest_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_ZERO"),
+    4: .same(proto: "FOREIGN_FOO"),
+    5: .same(proto: "FOREIGN_BAR"),
+    6: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -1338,6 +1332,16 @@ extension Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf._MessageImplementa
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Proto3ArenaLiteUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    0: .same(proto: "ZERO"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -51,20 +51,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto3_lite_unittest"
 
-enum Proto3LiteUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3LiteUnittest_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_ZERO"),
-    4: .same(proto: "FOREIGN_FOO"),
-    5: .same(proto: "FOREIGN_BAR"),
-    6: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignZero
@@ -603,7 +596,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case zero // = 0
     case foo // = 1
@@ -613,14 +606,6 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      0: .same(proto: "ZERO"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .zero
@@ -1225,6 +1210,15 @@ struct Proto3LiteUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   }
 }
 
+extension Proto3LiteUnittest_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_ZERO"),
+    4: .same(proto: "FOREIGN_FOO"),
+    5: .same(proto: "FOREIGN_BAR"),
+    6: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension Proto3LiteUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -1338,6 +1332,16 @@ extension Proto3LiteUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationB
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Proto3LiteUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    0: .same(proto: "ZERO"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension Proto3LiteUnittest_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -807,7 +807,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -815,13 +815,6 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
 
     /// Intentionally negative.
     case neg // = -1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -1282,13 +1275,9 @@ struct ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "FOO"),
-    ]
 
     init() {
       self = .foo
@@ -1471,6 +1460,15 @@ extension ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf._MessageImplement
   }
 }
 
+extension ProtobufUnittest_TestAllRequiredTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
+}
+
 extension ProtobufUnittest_TestAllRequiredTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "bb"),
@@ -1515,4 +1513,10 @@ extension ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf._MessageImplemen
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_TestSomeRequiredTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "FOO"),
+  ]
 }

--- a/Reference/unittest_swift_enum.pb.swift
+++ b/Reference/unittest_swift_enum.pb.swift
@@ -56,15 +56,10 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum EnumTest1: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum EnumTest1: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case firstValue // = 1
     case secondValue // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "ENUM_TEST_1_FIRST_VALUE"),
-      2: .same(proto: "ENUM_TEST_1_SECOND_VALUE"),
-    ]
 
     init() {
       self = .firstValue
@@ -87,15 +82,10 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
   }
 
-  enum EnumTest2: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum EnumTest2: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case enumTest2FirstValue // = 1
     case secondValue // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "ENUM_TEST_2_FIRST_VALUE"),
-      2: .same(proto: "SECOND_VALUE"),
-    ]
 
     init() {
       self = .enumTest2FirstValue
@@ -118,15 +108,10 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
   }
 
-  enum EnumTestNoStem: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum EnumTestNoStem: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case enumTestNoStem1 // = 1
     case enumTestNoStem2 // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "ENUM_TEST_NO_STEM_1"),
-      2: .same(proto: "ENUM_TEST_NO_STEM_2"),
-    ]
 
     init() {
       self = .enumTestNoStem1
@@ -149,15 +134,10 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
   }
 
-  enum EnumTestReservedWord: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum EnumTestReservedWord: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case `var` // = 1
     case notReserved // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "ENUM_TEST_RESERVED_WORD_VAR"),
-      2: .same(proto: "ENUM_TEST_RESERVED_WORD_NOT_RESERVED"),
-    ]
 
     init() {
       self = .`var`
@@ -199,17 +179,12 @@ struct ProtobufUnittest_SwiftEnumWithAliasTest: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum EnumWithAlias: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum EnumWithAlias: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo1 // = 1
     static let foo2 = foo1
     case bar1 // = 2
     static let bar2 = bar1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
-      2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
-    ]
 
     init() {
       self = .foo1
@@ -260,6 +235,34 @@ extension ProtobufUnittest_SwiftEnumTest: SwiftProtobuf._MessageImplementationBa
   }
 }
 
+extension ProtobufUnittest_SwiftEnumTest.EnumTest1: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ENUM_TEST_1_FIRST_VALUE"),
+    2: .same(proto: "ENUM_TEST_1_SECOND_VALUE"),
+  ]
+}
+
+extension ProtobufUnittest_SwiftEnumTest.EnumTest2: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ENUM_TEST_2_FIRST_VALUE"),
+    2: .same(proto: "SECOND_VALUE"),
+  ]
+}
+
+extension ProtobufUnittest_SwiftEnumTest.EnumTestNoStem: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ENUM_TEST_NO_STEM_1"),
+    2: .same(proto: "ENUM_TEST_NO_STEM_2"),
+  ]
+}
+
+extension ProtobufUnittest_SwiftEnumTest.EnumTestReservedWord: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ENUM_TEST_RESERVED_WORD_VAR"),
+    2: .same(proto: "ENUM_TEST_RESERVED_WORD_NOT_RESERVED"),
+  ]
+}
+
 extension ProtobufUnittest_SwiftEnumWithAliasTest: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "values"),
@@ -270,4 +273,11 @@ extension ProtobufUnittest_SwiftEnumWithAliasTest: SwiftProtobuf._MessageImpleme
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_SwiftEnumWithAliasTest.EnumWithAlias: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
+  ]
 }

--- a/Reference/unittest_swift_enum_optional_default.pb.swift
+++ b/Reference/unittest_swift_enum_optional_default.pb.swift
@@ -92,13 +92,9 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: SwiftProtobuf.Message {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+    enum Enum: SwiftProtobuf.Enum {
       typealias RawValue = Int
       case foo // = 0
-
-      static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        0: .same(proto: "FOO"),
-      ]
 
       init() {
         self = .foo
@@ -164,13 +160,9 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: SwiftProtobuf.Message {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+    enum Enum: SwiftProtobuf.Enum {
       typealias RawValue = Int
       case foo // = 0
-
-      static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        0: .same(proto: "FOO"),
-      ]
 
       init() {
         self = .foo
@@ -251,6 +243,12 @@ extension ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage: SwiftProtob
   }
 }
 
+extension ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage.Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+  ]
+}
+
 extension ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     17: .standard(proto: "optional_enum"),
@@ -261,4 +259,10 @@ extension ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2: SwiftProto
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2.Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+  ]
 }

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -39,7 +39,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "swift_unittest.names"
 
-enum SwiftUnittest_Names_EnumFieldNames: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum SwiftUnittest_Names_EnumFieldNames: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case a // = 0
   case string // = 1
@@ -249,217 +249,6 @@ enum SwiftUnittest_Names_EnumFieldNames: SwiftProtobuf.Enum, SwiftProtobuf._Prot
   case timeScale // = 241
   case timeBase // = 242
   case timeRecord // = 243
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "A"),
-    1: .same(proto: "String"),
-    2: .same(proto: "Int"),
-    3: .same(proto: "Double"),
-    4: .same(proto: "Float"),
-    5: .same(proto: "UInt"),
-    6: .same(proto: "hashValue"),
-    7: .same(proto: "description"),
-    8: .same(proto: "debugDescription"),
-    9: .same(proto: "Swift"),
-    10: .same(proto: "UNRECOGNIZED"),
-    11: .same(proto: "class"),
-    12: .same(proto: "deinit"),
-    13: .same(proto: "enum"),
-    14: .same(proto: "extension"),
-    15: .same(proto: "func"),
-    16: .same(proto: "import"),
-    17: .same(proto: "init"),
-    18: .same(proto: "inout"),
-    19: .same(proto: "internal"),
-    20: .same(proto: "let"),
-    21: .same(proto: "operator"),
-    22: .same(proto: "private"),
-    23: .same(proto: "protocol"),
-    24: .same(proto: "public"),
-    25: .same(proto: "static"),
-    26: .same(proto: "struct"),
-    27: .same(proto: "subscript"),
-    28: .same(proto: "typealias"),
-    29: .same(proto: "var"),
-    30: .same(proto: "break"),
-    31: .same(proto: "case"),
-    32: .same(proto: "continue"),
-    33: .same(proto: "default"),
-    34: .same(proto: "defer"),
-    35: .same(proto: "do"),
-    36: .same(proto: "else"),
-    37: .same(proto: "fallthrough"),
-    38: .same(proto: "for"),
-    39: .same(proto: "guard"),
-    40: .same(proto: "if"),
-    41: .same(proto: "in"),
-    42: .same(proto: "repeat"),
-    43: .same(proto: "return"),
-    44: .same(proto: "switch"),
-    45: .same(proto: "where"),
-    46: .same(proto: "while"),
-    47: .same(proto: "as"),
-    48: .same(proto: "catch"),
-    49: .same(proto: "dynamicType"),
-    50: .same(proto: "false"),
-    51: .same(proto: "is"),
-    52: .same(proto: "nil"),
-    53: .same(proto: "rethrows"),
-    54: .same(proto: "super"),
-    55: .same(proto: "self"),
-    57: .same(proto: "throw"),
-    58: .same(proto: "throws"),
-    59: .same(proto: "true"),
-    60: .same(proto: "try"),
-    61: .same(proto: "__COLUMN__"),
-    62: .same(proto: "__FILE__"),
-    63: .same(proto: "__FUNCTION__"),
-    64: .same(proto: "__LINE__"),
-    65: .same(proto: "_"),
-    66: .same(proto: "associativity"),
-    67: .same(proto: "convenience"),
-    68: .same(proto: "dynamic"),
-    69: .same(proto: "didSet"),
-    70: .same(proto: "final"),
-    71: .same(proto: "get"),
-    72: .same(proto: "infix"),
-    73: .same(proto: "indirect"),
-    74: .same(proto: "lazy"),
-    75: .same(proto: "left"),
-    76: .same(proto: "mutating"),
-    77: .same(proto: "none"),
-    78: .same(proto: "nonmutating"),
-    79: .same(proto: "optional"),
-    80: .same(proto: "override"),
-    81: .same(proto: "postfix"),
-    82: .same(proto: "precedence"),
-    83: .same(proto: "prefix"),
-    85: .same(proto: "required"),
-    86: .same(proto: "right"),
-    87: .same(proto: "set"),
-    88: .same(proto: "Type"),
-    89: .same(proto: "unowned"),
-    90: .same(proto: "weak"),
-    91: .same(proto: "willSet"),
-    92: .same(proto: "id"),
-    93: .same(proto: "_cmd"),
-    96: .same(proto: "out"),
-    98: .same(proto: "bycopy"),
-    99: .same(proto: "byref"),
-    100: .same(proto: "oneway"),
-    102: .same(proto: "and"),
-    103: .same(proto: "and_eq"),
-    104: .same(proto: "alignas"),
-    105: .same(proto: "alignof"),
-    106: .same(proto: "asm"),
-    107: .same(proto: "auto"),
-    108: .same(proto: "bitand"),
-    109: .same(proto: "bitor"),
-    110: .same(proto: "bool"),
-    114: .same(proto: "char"),
-    115: .same(proto: "char16_t"),
-    116: .same(proto: "char32_t"),
-    118: .same(proto: "compl"),
-    119: .same(proto: "const"),
-    120: .same(proto: "constexpr"),
-    121: .same(proto: "const_cast"),
-    123: .same(proto: "decltype"),
-    125: .same(proto: "delete"),
-    127: .same(proto: "dynamic_cast"),
-    130: .same(proto: "explicit"),
-    131: .same(proto: "export"),
-    132: .same(proto: "extern"),
-    136: .same(proto: "friend"),
-    137: .same(proto: "goto"),
-    139: .same(proto: "inline"),
-    141: .same(proto: "long"),
-    142: .same(proto: "mutable"),
-    143: .same(proto: "namespace"),
-    144: .same(proto: "new"),
-    145: .same(proto: "noexcept"),
-    146: .same(proto: "not"),
-    147: .same(proto: "not_eq"),
-    148: .same(proto: "nullptr"),
-    150: .same(proto: "or"),
-    151: .same(proto: "or_eq"),
-    153: .same(proto: "protected"),
-    155: .same(proto: "register"),
-    156: .same(proto: "reinterpret_cast"),
-    158: .same(proto: "short"),
-    159: .same(proto: "signed"),
-    160: .same(proto: "sizeof"),
-    162: .same(proto: "static_assert"),
-    163: .same(proto: "static_cast"),
-    166: .same(proto: "template"),
-    167: .same(proto: "this"),
-    168: .same(proto: "thread_local"),
-    172: .same(proto: "typedef"),
-    173: .same(proto: "typeid"),
-    174: .same(proto: "typename"),
-    175: .same(proto: "union"),
-    176: .same(proto: "unsigned"),
-    177: .same(proto: "using"),
-    178: .same(proto: "virtual"),
-    179: .same(proto: "void"),
-    180: .same(proto: "volatile"),
-    181: .same(proto: "wchar_t"),
-    183: .same(proto: "xor"),
-    184: .same(proto: "xor_eq"),
-    185: .same(proto: "restrict"),
-    186: .same(proto: "Category"),
-    187: .same(proto: "Ivar"),
-    188: .same(proto: "Method"),
-    192: .same(proto: "finalize"),
-    193: .same(proto: "hash"),
-    194: .same(proto: "dealloc"),
-    197: .same(proto: "superclass"),
-    198: .same(proto: "retain"),
-    199: .same(proto: "release"),
-    200: .same(proto: "autorelease"),
-    201: .same(proto: "retainCount"),
-    202: .same(proto: "zone"),
-    203: .same(proto: "isProxy"),
-    204: .same(proto: "copy"),
-    205: .same(proto: "mutableCopy"),
-    206: .same(proto: "classForCoder"),
-    207: .same(proto: "clear"),
-    208: .same(proto: "data"),
-    209: .same(proto: "delimitedData"),
-    210: .same(proto: "descriptor"),
-    211: .same(proto: "extensionRegistry"),
-    212: .same(proto: "extensionsCurrentlySet"),
-    213: .same(proto: "isInitialized"),
-    214: .same(proto: "serializedSize"),
-    215: .same(proto: "sortedExtensionsInUse"),
-    216: .same(proto: "unknownFields"),
-    217: .same(proto: "Fixed"),
-    218: .same(proto: "Fract"),
-    219: .same(proto: "Size"),
-    220: .same(proto: "LogicalAddress"),
-    221: .same(proto: "PhysicalAddress"),
-    222: .same(proto: "ByteCount"),
-    223: .same(proto: "ByteOffset"),
-    224: .same(proto: "Duration"),
-    225: .same(proto: "AbsoluteTime"),
-    226: .same(proto: "OptionBits"),
-    227: .same(proto: "ItemCount"),
-    228: .same(proto: "PBVersion"),
-    229: .same(proto: "ScriptCode"),
-    230: .same(proto: "LangCode"),
-    231: .same(proto: "RegionCode"),
-    232: .same(proto: "OSType"),
-    233: .same(proto: "ProcessSerialNumber"),
-    234: .same(proto: "Point"),
-    235: .same(proto: "Rect"),
-    236: .same(proto: "FixedPoint"),
-    237: .same(proto: "FixedRect"),
-    238: .same(proto: "Style"),
-    239: .same(proto: "StyleParameter"),
-    240: .same(proto: "StyleField"),
-    241: .same(proto: "TimeScale"),
-    242: .same(proto: "TimeBase"),
-    243: .same(proto: "TimeRecord"),
-  ]
 
   init() {
     self = .a
@@ -894,7 +683,7 @@ enum SwiftUnittest_Names_EnumFieldNames: SwiftProtobuf.Enum, SwiftProtobuf._Prot
 
 }
 
-enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case aa // = 0
 
@@ -906,11 +695,6 @@ enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum, SwiftProtobuf._Pro
   /// So this is in a second enum so it won't cause issues with the '_' one;
   /// but still ensure things generator correctly.
   case ____ // = 1065
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "AA"),
-    1065: .same(proto: "__"),
-  ]
 
   init() {
     self = .aa
@@ -12193,13 +11977,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum StringEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum StringEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aString // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aString"),
-    ]
 
     init() {
       self = .aString
@@ -12220,13 +12000,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ProtocolEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ProtocolEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aProtocol // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aProtocol"),
-    ]
 
     init() {
       self = .aProtocol
@@ -12247,13 +12023,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum IntEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum IntEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aInt // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aInt"),
-    ]
 
     init() {
       self = .aInt
@@ -12274,13 +12046,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum DoubleEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum DoubleEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aDouble // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aDouble"),
-    ]
 
     init() {
       self = .aDouble
@@ -12301,13 +12069,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum FloatEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum FloatEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aFloat // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aFloat"),
-    ]
 
     init() {
       self = .aFloat
@@ -12328,13 +12092,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum UIntEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum UIntEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aUint // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aUInt"),
-    ]
 
     init() {
       self = .aUint
@@ -12355,13 +12115,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum hashValueEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum hashValueEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ahashValue // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ahashValue"),
-    ]
 
     init() {
       self = .ahashValue
@@ -12382,13 +12138,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum descriptionEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum descriptionEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adescription // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adescription"),
-    ]
 
     init() {
       self = .adescription
@@ -12409,13 +12161,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum debugDescriptionEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum debugDescriptionEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adebugDescription // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adebugDescription"),
-    ]
 
     init() {
       self = .adebugDescription
@@ -12436,13 +12184,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Swift: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Swift: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aSwift // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aSwift"),
-    ]
 
     init() {
       self = .aSwift
@@ -12463,13 +12207,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum UNRECOGNIZED: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum UNRECOGNIZED: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aUnrecognized // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aUNRECOGNIZED"),
-    ]
 
     init() {
       self = .aUnrecognized
@@ -12490,13 +12230,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum classEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum classEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aclass // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aclass"),
-    ]
 
     init() {
       self = .aclass
@@ -12517,13 +12253,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum deinitEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum deinitEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adeinit // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adeinit"),
-    ]
 
     init() {
       self = .adeinit
@@ -12544,13 +12276,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum enumEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum enumEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aenum // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aenum"),
-    ]
 
     init() {
       self = .aenum
@@ -12571,13 +12299,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum extensionEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum extensionEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aextension // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aextension"),
-    ]
 
     init() {
       self = .aextension
@@ -12598,13 +12322,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum funcEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum funcEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afunc // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afunc"),
-    ]
 
     init() {
       self = .afunc
@@ -12625,13 +12345,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum importEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum importEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aimport // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aimport"),
-    ]
 
     init() {
       self = .aimport
@@ -12652,13 +12368,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum initEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum initEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ainit // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ainit"),
-    ]
 
     init() {
       self = .ainit
@@ -12679,13 +12391,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum inoutEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum inoutEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ainout // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ainout"),
-    ]
 
     init() {
       self = .ainout
@@ -12706,13 +12414,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum internalEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum internalEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ainternal // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ainternal"),
-    ]
 
     init() {
       self = .ainternal
@@ -12733,13 +12437,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum letEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum letEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case alet // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "alet"),
-    ]
 
     init() {
       self = .alet
@@ -12760,13 +12460,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum operatorEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum operatorEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aoperator // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aoperator"),
-    ]
 
     init() {
       self = .aoperator
@@ -12787,13 +12483,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum privateEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum privateEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aprivate // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aprivate"),
-    ]
 
     init() {
       self = .aprivate
@@ -12814,13 +12506,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum protocolEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum protocolEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aprotocol // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aprotocol"),
-    ]
 
     init() {
       self = .aprotocol
@@ -12841,13 +12529,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum publicEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum publicEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case apublic // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "apublic"),
-    ]
 
     init() {
       self = .apublic
@@ -12868,13 +12552,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum staticEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum staticEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case astatic // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "astatic"),
-    ]
 
     init() {
       self = .astatic
@@ -12895,13 +12575,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum structEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum structEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case astruct // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "astruct"),
-    ]
 
     init() {
       self = .astruct
@@ -12922,13 +12598,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum subscriptEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum subscriptEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asubscript // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asubscript"),
-    ]
 
     init() {
       self = .asubscript
@@ -12949,13 +12621,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum typealiasEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum typealiasEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atypealias // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atypealias"),
-    ]
 
     init() {
       self = .atypealias
@@ -12976,13 +12644,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum varEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum varEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case avar // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "avar"),
-    ]
 
     init() {
       self = .avar
@@ -13003,13 +12667,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum breakEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum breakEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abreak // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abreak"),
-    ]
 
     init() {
       self = .abreak
@@ -13030,13 +12690,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum caseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum caseEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case acase // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "acase"),
-    ]
 
     init() {
       self = .acase
@@ -13057,13 +12713,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum continueEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum continueEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case acontinue // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "acontinue"),
-    ]
 
     init() {
       self = .acontinue
@@ -13084,13 +12736,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum defaultEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum defaultEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adefault // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adefault"),
-    ]
 
     init() {
       self = .adefault
@@ -13111,13 +12759,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum deferEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum deferEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adefer // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adefer"),
-    ]
 
     init() {
       self = .adefer
@@ -13138,13 +12782,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum doEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum doEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ado // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ado"),
-    ]
 
     init() {
       self = .ado
@@ -13165,13 +12805,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum elseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum elseEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aelse // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aelse"),
-    ]
 
     init() {
       self = .aelse
@@ -13192,13 +12828,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum fallthroughEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum fallthroughEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afallthrough // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afallthrough"),
-    ]
 
     init() {
       self = .afallthrough
@@ -13219,13 +12851,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum forEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum forEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afor // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afor"),
-    ]
 
     init() {
       self = .afor
@@ -13246,13 +12874,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum guardEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum guardEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aguard // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aguard"),
-    ]
 
     init() {
       self = .aguard
@@ -13273,13 +12897,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ifEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ifEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aif // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aif"),
-    ]
 
     init() {
       self = .aif
@@ -13300,13 +12920,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum inEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum inEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ain // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ain"),
-    ]
 
     init() {
       self = .ain
@@ -13327,13 +12943,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum repeatEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum repeatEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case arepeat // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "arepeat"),
-    ]
 
     init() {
       self = .arepeat
@@ -13354,13 +12966,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum returnEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum returnEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case areturn // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "areturn"),
-    ]
 
     init() {
       self = .areturn
@@ -13381,13 +12989,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum switchEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum switchEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aswitch // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aswitch"),
-    ]
 
     init() {
       self = .aswitch
@@ -13408,13 +13012,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum whereEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum whereEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case awhere // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "awhere"),
-    ]
 
     init() {
       self = .awhere
@@ -13435,13 +13035,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum whileEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum whileEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case awhile // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "awhile"),
-    ]
 
     init() {
       self = .awhile
@@ -13462,13 +13058,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum asEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum asEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aas // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aas"),
-    ]
 
     init() {
       self = .aas
@@ -13489,13 +13081,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum catchEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum catchEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case acatch // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "acatch"),
-    ]
 
     init() {
       self = .acatch
@@ -13516,13 +13104,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum dynamicTypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum dynamicTypeEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adynamicType // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adynamicType"),
-    ]
 
     init() {
       self = .adynamicType
@@ -13543,13 +13127,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum falseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum falseEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afalse // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afalse"),
-    ]
 
     init() {
       self = .afalse
@@ -13570,13 +13150,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum isEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum isEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ais // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ais"),
-    ]
 
     init() {
       self = .ais
@@ -13597,13 +13173,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum nilEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum nilEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anil // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anil"),
-    ]
 
     init() {
       self = .anil
@@ -13624,13 +13196,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum rethrowsEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum rethrowsEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case arethrows // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "arethrows"),
-    ]
 
     init() {
       self = .arethrows
@@ -13651,13 +13219,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum superEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum superEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asuper // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asuper"),
-    ]
 
     init() {
       self = .asuper
@@ -13678,13 +13242,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum selfEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum selfEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aself // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aself"),
-    ]
 
     init() {
       self = .aself
@@ -13705,13 +13265,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum throwEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum throwEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case athrow // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "athrow"),
-    ]
 
     init() {
       self = .athrow
@@ -13732,13 +13288,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum throwsEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum throwsEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case athrows // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "athrows"),
-    ]
 
     init() {
       self = .athrows
@@ -13759,13 +13311,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum trueEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum trueEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atrue // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atrue"),
-    ]
 
     init() {
       self = .atrue
@@ -13786,13 +13334,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum tryEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum tryEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atry // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atry"),
-    ]
 
     init() {
       self = .atry
@@ -13813,13 +13357,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum __COLUMN__Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum __COLUMN__Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a_Column__ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a__COLUMN__"),
-    ]
 
     init() {
       self = .a_Column__
@@ -13840,13 +13380,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum __FILE__Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum __FILE__Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a_File__ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a__FILE__"),
-    ]
 
     init() {
       self = .a_File__
@@ -13867,13 +13403,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum __FUNCTION__Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum __FUNCTION__Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a_Function__ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a__FUNCTION__"),
-    ]
 
     init() {
       self = .a_Function__
@@ -13894,13 +13426,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum __LINE__Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum __LINE__Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a_Line__ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a__LINE__"),
-    ]
 
     init() {
       self = .a_Line__
@@ -13921,13 +13449,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum _Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum _Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a_ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a_"),
-    ]
 
     init() {
       self = .a_
@@ -13948,13 +13472,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum __Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum __Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a__ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a__"),
-    ]
 
     init() {
       self = .a__
@@ -13975,13 +13495,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum associativity: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum associativity: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aassociativity // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aassociativity"),
-    ]
 
     init() {
       self = .aassociativity
@@ -14002,13 +13518,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum convenience: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum convenience: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aconvenience // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aconvenience"),
-    ]
 
     init() {
       self = .aconvenience
@@ -14029,13 +13541,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum dynamic: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum dynamic: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adynamic // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adynamic"),
-    ]
 
     init() {
       self = .adynamic
@@ -14056,13 +13564,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum didSet: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum didSet: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adidSet // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adidSet"),
-    ]
 
     init() {
       self = .adidSet
@@ -14083,13 +13587,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum final: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum final: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afinal // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afinal"),
-    ]
 
     init() {
       self = .afinal
@@ -14110,13 +13610,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum get: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum get: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aget // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aget"),
-    ]
 
     init() {
       self = .aget
@@ -14137,13 +13633,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum infix: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum infix: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ainfix // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ainfix"),
-    ]
 
     init() {
       self = .ainfix
@@ -14164,13 +13656,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum indirect: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum indirect: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aindirect // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aindirect"),
-    ]
 
     init() {
       self = .aindirect
@@ -14191,13 +13679,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum lazy: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum lazy: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case alazy // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "alazy"),
-    ]
 
     init() {
       self = .alazy
@@ -14218,13 +13702,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum left: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum left: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aleft // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aleft"),
-    ]
 
     init() {
       self = .aleft
@@ -14245,13 +13725,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum mutating: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum mutating: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case amutating // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "amutating"),
-    ]
 
     init() {
       self = .amutating
@@ -14272,13 +13748,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum none: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum none: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anone // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anone"),
-    ]
 
     init() {
       self = .anone
@@ -14299,13 +13771,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum nonmutating: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum nonmutating: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anonmutating // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anonmutating"),
-    ]
 
     init() {
       self = .anonmutating
@@ -14326,13 +13794,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum optional: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum optional: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aoptional // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aoptional"),
-    ]
 
     init() {
       self = .aoptional
@@ -14353,13 +13817,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum override: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum override: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aoverride // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aoverride"),
-    ]
 
     init() {
       self = .aoverride
@@ -14380,13 +13840,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum postfix: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum postfix: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case apostfix // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "apostfix"),
-    ]
 
     init() {
       self = .apostfix
@@ -14407,13 +13863,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum precedence: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum precedence: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aprecedence // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aprecedence"),
-    ]
 
     init() {
       self = .aprecedence
@@ -14434,13 +13886,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum prefix: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum prefix: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aprefix // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aprefix"),
-    ]
 
     init() {
       self = .aprefix
@@ -14461,13 +13909,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum required: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum required: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case arequired // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "arequired"),
-    ]
 
     init() {
       self = .arequired
@@ -14488,13 +13932,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum right: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum right: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aright // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aright"),
-    ]
 
     init() {
       self = .aright
@@ -14515,13 +13955,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum set: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum set: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aset // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aset"),
-    ]
 
     init() {
       self = .aset
@@ -14542,13 +13978,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TypeEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aType // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aType"),
-    ]
 
     init() {
       self = .aType
@@ -14569,13 +14001,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum unowned: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum unowned: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aunowned // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aunowned"),
-    ]
 
     init() {
       self = .aunowned
@@ -14596,13 +14024,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum weak: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum weak: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aweak // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aweak"),
-    ]
 
     init() {
       self = .aweak
@@ -14623,13 +14047,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum willSet: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum willSet: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case awillSet // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "awillSet"),
-    ]
 
     init() {
       self = .awillSet
@@ -14650,13 +14070,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum id: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum id: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aid // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aid"),
-    ]
 
     init() {
       self = .aid
@@ -14677,13 +14093,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum _cmd: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum _cmd: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aCmd // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a_cmd"),
-    ]
 
     init() {
       self = .aCmd
@@ -14704,13 +14116,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum out: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum out: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aout // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aout"),
-    ]
 
     init() {
       self = .aout
@@ -14731,13 +14139,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum bycopy: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum bycopy: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abycopy // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abycopy"),
-    ]
 
     init() {
       self = .abycopy
@@ -14758,13 +14162,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum byref: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum byref: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abyref // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abyref"),
-    ]
 
     init() {
       self = .abyref
@@ -14785,13 +14185,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum oneway: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum oneway: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aoneway // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aoneway"),
-    ]
 
     init() {
       self = .aoneway
@@ -14812,13 +14208,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum and: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum and: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aand // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aand"),
-    ]
 
     init() {
       self = .aand
@@ -14839,13 +14231,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum and_eq: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum and_eq: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aandEq // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aand_eq"),
-    ]
 
     init() {
       self = .aandEq
@@ -14866,13 +14254,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum alignas: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum alignas: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aalignas // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aalignas"),
-    ]
 
     init() {
       self = .aalignas
@@ -14893,13 +14277,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum alignof: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum alignof: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aalignof // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aalignof"),
-    ]
 
     init() {
       self = .aalignof
@@ -14920,13 +14300,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum asm: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum asm: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aasm // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aasm"),
-    ]
 
     init() {
       self = .aasm
@@ -14947,13 +14323,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum auto: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum auto: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aauto // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aauto"),
-    ]
 
     init() {
       self = .aauto
@@ -14974,13 +14346,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum bitand: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum bitand: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abitand // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abitand"),
-    ]
 
     init() {
       self = .abitand
@@ -15001,13 +14369,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum bitor: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum bitor: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abitor // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abitor"),
-    ]
 
     init() {
       self = .abitor
@@ -15028,13 +14392,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum bool: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum bool: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abool // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abool"),
-    ]
 
     init() {
       self = .abool
@@ -15055,13 +14415,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum char: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum char: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case achar // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "achar"),
-    ]
 
     init() {
       self = .achar
@@ -15082,13 +14438,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum char16_t: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum char16_t: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case achar16T // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "achar16_t"),
-    ]
 
     init() {
       self = .achar16T
@@ -15109,13 +14461,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum char32_t: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum char32_t: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case achar32T // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "achar32_t"),
-    ]
 
     init() {
       self = .achar32T
@@ -15136,13 +14484,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum compl: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum compl: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case acompl // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "acompl"),
-    ]
 
     init() {
       self = .acompl
@@ -15163,13 +14507,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum const: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum const: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aconst // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aconst"),
-    ]
 
     init() {
       self = .aconst
@@ -15190,13 +14530,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum constexpr: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum constexpr: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aconstexpr // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aconstexpr"),
-    ]
 
     init() {
       self = .aconstexpr
@@ -15217,13 +14553,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum const_cast: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum const_cast: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aconstCast // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aconst_cast"),
-    ]
 
     init() {
       self = .aconstCast
@@ -15244,13 +14576,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum decltype: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum decltype: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adecltype // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adecltype"),
-    ]
 
     init() {
       self = .adecltype
@@ -15271,13 +14599,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum delete: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum delete: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adelete // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adelete"),
-    ]
 
     init() {
       self = .adelete
@@ -15298,13 +14622,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum dynamic_cast: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum dynamic_cast: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adynamicCast // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adynamic_cast"),
-    ]
 
     init() {
       self = .adynamicCast
@@ -15325,13 +14645,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum explicit: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum explicit: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aexplicit // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aexplicit"),
-    ]
 
     init() {
       self = .aexplicit
@@ -15352,13 +14668,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum export: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum export: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aexport // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aexport"),
-    ]
 
     init() {
       self = .aexport
@@ -15379,13 +14691,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum extern: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum extern: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aextern // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aextern"),
-    ]
 
     init() {
       self = .aextern
@@ -15406,13 +14714,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum friend: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum friend: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afriend // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afriend"),
-    ]
 
     init() {
       self = .afriend
@@ -15433,13 +14737,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum goto: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum goto: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case agoto // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "agoto"),
-    ]
 
     init() {
       self = .agoto
@@ -15460,13 +14760,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum inline: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum inline: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ainline // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ainline"),
-    ]
 
     init() {
       self = .ainline
@@ -15487,13 +14783,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum long: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum long: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case along // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "along"),
-    ]
 
     init() {
       self = .along
@@ -15514,13 +14806,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum mutable: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum mutable: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case amutable // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "amutable"),
-    ]
 
     init() {
       self = .amutable
@@ -15541,13 +14829,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum namespace: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum namespace: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anamespace // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anamespace"),
-    ]
 
     init() {
       self = .anamespace
@@ -15568,13 +14852,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum new: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum new: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anew // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anew"),
-    ]
 
     init() {
       self = .anew
@@ -15595,13 +14875,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum noexcept: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum noexcept: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anoexcept // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anoexcept"),
-    ]
 
     init() {
       self = .anoexcept
@@ -15622,13 +14898,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum not: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum not: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anot // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anot"),
-    ]
 
     init() {
       self = .anot
@@ -15649,13 +14921,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum not_eq: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum not_eq: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anotEq // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anot_eq"),
-    ]
 
     init() {
       self = .anotEq
@@ -15676,13 +14944,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum nullptr: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum nullptr: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anullptr // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anullptr"),
-    ]
 
     init() {
       self = .anullptr
@@ -15703,13 +14967,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum or: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum or: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aor // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aor"),
-    ]
 
     init() {
       self = .aor
@@ -15730,13 +14990,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum or_eq: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum or_eq: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aorEq // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aor_eq"),
-    ]
 
     init() {
       self = .aorEq
@@ -15757,13 +15013,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum protected: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum protected: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aprotected // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aprotected"),
-    ]
 
     init() {
       self = .aprotected
@@ -15784,13 +15036,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum register: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum register: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aregister // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aregister"),
-    ]
 
     init() {
       self = .aregister
@@ -15811,13 +15059,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum reinterpret_cast: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum reinterpret_cast: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case areinterpretCast // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "areinterpret_cast"),
-    ]
 
     init() {
       self = .areinterpretCast
@@ -15838,13 +15082,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum short: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum short: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ashort // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ashort"),
-    ]
 
     init() {
       self = .ashort
@@ -15865,13 +15105,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum signed: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum signed: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asigned // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asigned"),
-    ]
 
     init() {
       self = .asigned
@@ -15892,13 +15128,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum sizeof: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum sizeof: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asizeof // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asizeof"),
-    ]
 
     init() {
       self = .asizeof
@@ -15919,13 +15151,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum static_assert: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum static_assert: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case astaticAssert // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "astatic_assert"),
-    ]
 
     init() {
       self = .astaticAssert
@@ -15946,13 +15174,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum static_cast: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum static_cast: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case astaticCast // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "astatic_cast"),
-    ]
 
     init() {
       self = .astaticCast
@@ -15973,13 +15197,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum template: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum template: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atemplate // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atemplate"),
-    ]
 
     init() {
       self = .atemplate
@@ -16000,13 +15220,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum this: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum this: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case athis // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "athis"),
-    ]
 
     init() {
       self = .athis
@@ -16027,13 +15243,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum thread_local: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum thread_local: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case athreadLocal // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "athread_local"),
-    ]
 
     init() {
       self = .athreadLocal
@@ -16054,13 +15266,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum typedef: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum typedef: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atypedef // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atypedef"),
-    ]
 
     init() {
       self = .atypedef
@@ -16081,13 +15289,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum typeid: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum typeid: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atypeid // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atypeid"),
-    ]
 
     init() {
       self = .atypeid
@@ -16108,13 +15312,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum typename: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum typename: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atypename // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atypename"),
-    ]
 
     init() {
       self = .atypename
@@ -16135,13 +15335,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum union: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum union: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aunion // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aunion"),
-    ]
 
     init() {
       self = .aunion
@@ -16162,13 +15358,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum unsigned: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum unsigned: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aunsigned // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aunsigned"),
-    ]
 
     init() {
       self = .aunsigned
@@ -16189,13 +15381,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum using: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum using: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ausing // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ausing"),
-    ]
 
     init() {
       self = .ausing
@@ -16216,13 +15404,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum virtual: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum virtual: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case avirtual // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "avirtual"),
-    ]
 
     init() {
       self = .avirtual
@@ -16243,13 +15427,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum void: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum void: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case avoid // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "avoid"),
-    ]
 
     init() {
       self = .avoid
@@ -16270,13 +15450,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum volatile: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum volatile: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case avolatile // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "avolatile"),
-    ]
 
     init() {
       self = .avolatile
@@ -16297,13 +15473,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum wchar_t: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum wchar_t: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case awcharT // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "awchar_t"),
-    ]
 
     init() {
       self = .awcharT
@@ -16324,13 +15496,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum xor: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum xor: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case axor // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "axor"),
-    ]
 
     init() {
       self = .axor
@@ -16351,13 +15519,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum xor_eq: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum xor_eq: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case axorEq // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "axor_eq"),
-    ]
 
     init() {
       self = .axorEq
@@ -16378,13 +15542,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum restrict: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum restrict: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case arestrict // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "arestrict"),
-    ]
 
     init() {
       self = .arestrict
@@ -16405,13 +15565,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Category: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Category: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aCategory // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aCategory"),
-    ]
 
     init() {
       self = .aCategory
@@ -16432,13 +15588,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Ivar: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Ivar: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aIvar // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aIvar"),
-    ]
 
     init() {
       self = .aIvar
@@ -16459,13 +15611,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Method: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Method: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aMethod // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aMethod"),
-    ]
 
     init() {
       self = .aMethod
@@ -16486,13 +15634,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum finalize: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum finalize: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afinalize // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afinalize"),
-    ]
 
     init() {
       self = .afinalize
@@ -16513,13 +15657,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum hash: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum hash: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ahash // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ahash"),
-    ]
 
     init() {
       self = .ahash
@@ -16540,13 +15680,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum dealloc: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum dealloc: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adealloc // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adealloc"),
-    ]
 
     init() {
       self = .adealloc
@@ -16567,13 +15703,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum superclass: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum superclass: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asuperclass // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asuperclass"),
-    ]
 
     init() {
       self = .asuperclass
@@ -16594,13 +15726,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum retain: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum retain: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aretain // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aretain"),
-    ]
 
     init() {
       self = .aretain
@@ -16621,13 +15749,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum release: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum release: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case arelease // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "arelease"),
-    ]
 
     init() {
       self = .arelease
@@ -16648,13 +15772,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum autorelease: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum autorelease: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aautorelease // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aautorelease"),
-    ]
 
     init() {
       self = .aautorelease
@@ -16675,13 +15795,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum retainCount: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum retainCount: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aretainCount // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aretainCount"),
-    ]
 
     init() {
       self = .aretainCount
@@ -16702,13 +15818,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum zone: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum zone: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case azone // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "azone"),
-    ]
 
     init() {
       self = .azone
@@ -16729,13 +15841,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum isProxy: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum isProxy: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aisProxy // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aisProxy"),
-    ]
 
     init() {
       self = .aisProxy
@@ -16756,13 +15864,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum copy: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum copy: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case acopy // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "acopy"),
-    ]
 
     init() {
       self = .acopy
@@ -16783,13 +15887,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum mutableCopy: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum mutableCopy: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case amutableCopy // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "amutableCopy"),
-    ]
 
     init() {
       self = .amutableCopy
@@ -16810,13 +15910,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum classForCoder: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum classForCoder: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aclassForCoder // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aclassForCoder"),
-    ]
 
     init() {
       self = .aclassForCoder
@@ -16837,13 +15933,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum clear: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum clear: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aclear // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aclear"),
-    ]
 
     init() {
       self = .aclear
@@ -16864,13 +15956,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum data: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum data: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adata // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adata"),
-    ]
 
     init() {
       self = .adata
@@ -16891,13 +15979,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum delimitedData: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum delimitedData: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adelimitedData // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adelimitedData"),
-    ]
 
     init() {
       self = .adelimitedData
@@ -16918,13 +16002,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum descriptor: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum descriptor: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adescriptor // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adescriptor"),
-    ]
 
     init() {
       self = .adescriptor
@@ -16945,13 +16025,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum extensionRegistry: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum extensionRegistry: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aextensionRegistry // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aextensionRegistry"),
-    ]
 
     init() {
       self = .aextensionRegistry
@@ -16972,13 +16048,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum extensionsCurrentlySet: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum extensionsCurrentlySet: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aextensionsCurrentlySet // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aextensionsCurrentlySet"),
-    ]
 
     init() {
       self = .aextensionsCurrentlySet
@@ -16999,13 +16071,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum isInitialized: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum isInitialized: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aisInitialized // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aisInitialized"),
-    ]
 
     init() {
       self = .aisInitialized
@@ -17026,13 +16094,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum serializedSize: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum serializedSize: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aserializedSize // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aserializedSize"),
-    ]
 
     init() {
       self = .aserializedSize
@@ -17053,13 +16117,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum sortedExtensionsInUse: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum sortedExtensionsInUse: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asortedExtensionsInUse // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asortedExtensionsInUse"),
-    ]
 
     init() {
       self = .asortedExtensionsInUse
@@ -17080,13 +16140,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum unknownFieldsEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum unknownFieldsEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aunknownFields // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aunknownFields"),
-    ]
 
     init() {
       self = .aunknownFields
@@ -17107,13 +16163,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Fixed: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Fixed: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aFixed // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aFixed"),
-    ]
 
     init() {
       self = .aFixed
@@ -17134,13 +16186,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Fract: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Fract: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aFract // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aFract"),
-    ]
 
     init() {
       self = .aFract
@@ -17161,13 +16209,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Size: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Size: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aSize // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aSize"),
-    ]
 
     init() {
       self = .aSize
@@ -17188,13 +16232,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum LogicalAddress: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum LogicalAddress: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aLogicalAddress // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aLogicalAddress"),
-    ]
 
     init() {
       self = .aLogicalAddress
@@ -17215,13 +16255,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum PhysicalAddress: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum PhysicalAddress: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aPhysicalAddress // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aPhysicalAddress"),
-    ]
 
     init() {
       self = .aPhysicalAddress
@@ -17242,13 +16278,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ByteCount: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ByteCount: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aByteCount // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aByteCount"),
-    ]
 
     init() {
       self = .aByteCount
@@ -17269,13 +16301,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ByteOffset: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ByteOffset: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aByteOffset // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aByteOffset"),
-    ]
 
     init() {
       self = .aByteOffset
@@ -17296,13 +16324,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Duration: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Duration: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aDuration // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aDuration"),
-    ]
 
     init() {
       self = .aDuration
@@ -17323,13 +16347,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum AbsoluteTime: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum AbsoluteTime: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aAbsoluteTime // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aAbsoluteTime"),
-    ]
 
     init() {
       self = .aAbsoluteTime
@@ -17350,13 +16370,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum OptionBits: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum OptionBits: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aOptionBits // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aOptionBits"),
-    ]
 
     init() {
       self = .aOptionBits
@@ -17377,13 +16393,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ItemCount: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ItemCount: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aItemCount // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aItemCount"),
-    ]
 
     init() {
       self = .aItemCount
@@ -17404,13 +16416,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum PBVersion: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum PBVersion: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aPbversion // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aPBVersion"),
-    ]
 
     init() {
       self = .aPbversion
@@ -17431,13 +16439,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ScriptCode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ScriptCode: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aScriptCode // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aScriptCode"),
-    ]
 
     init() {
       self = .aScriptCode
@@ -17458,13 +16462,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum LangCode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum LangCode: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aLangCode // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aLangCode"),
-    ]
 
     init() {
       self = .aLangCode
@@ -17485,13 +16485,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum RegionCode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum RegionCode: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aRegionCode // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aRegionCode"),
-    ]
 
     init() {
       self = .aRegionCode
@@ -17512,13 +16508,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum OSType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum OSType: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aOstype // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aOSType"),
-    ]
 
     init() {
       self = .aOstype
@@ -17539,13 +16531,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ProcessSerialNumber: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ProcessSerialNumber: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aProcessSerialNumber // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aProcessSerialNumber"),
-    ]
 
     init() {
       self = .aProcessSerialNumber
@@ -17566,13 +16554,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Point: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Point: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aPoint // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aPoint"),
-    ]
 
     init() {
       self = .aPoint
@@ -17593,13 +16577,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Rect: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Rect: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aRect // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aRect"),
-    ]
 
     init() {
       self = .aRect
@@ -17620,13 +16600,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum FixedPoint: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum FixedPoint: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aFixedPoint // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aFixedPoint"),
-    ]
 
     init() {
       self = .aFixedPoint
@@ -17647,13 +16623,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum FixedRect: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum FixedRect: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aFixedRect // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aFixedRect"),
-    ]
 
     init() {
       self = .aFixedRect
@@ -17674,13 +16646,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Style: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Style: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aStyle // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aStyle"),
-    ]
 
     init() {
       self = .aStyle
@@ -17701,13 +16669,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum StyleParameter: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum StyleParameter: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aStyleParameter // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aStyleParameter"),
-    ]
 
     init() {
       self = .aStyleParameter
@@ -17728,13 +16692,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum StyleField: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum StyleField: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aStyleField // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aStyleField"),
-    ]
 
     init() {
       self = .aStyleField
@@ -17755,13 +16715,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum TimeScale: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TimeScale: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aTimeScale // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aTimeScale"),
-    ]
 
     init() {
       self = .aTimeScale
@@ -17782,13 +16738,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum TimeBase: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TimeBase: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aTimeBase // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aTimeBase"),
-    ]
 
     init() {
       self = .aTimeBase
@@ -17809,13 +16761,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum TimeRecord: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TimeRecord: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aTimeRecord // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aTimeRecord"),
-    ]
 
     init() {
       self = .aTimeRecord
@@ -20171,6 +19119,226 @@ let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.SimpleExte
   SwiftUnittest_Names_WordCase.Extensions.TheUrlValue,
   SwiftUnittest_Names_WordCase.Extensions.TheUrl
 ]
+
+extension SwiftUnittest_Names_EnumFieldNames: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "A"),
+    1: .same(proto: "String"),
+    2: .same(proto: "Int"),
+    3: .same(proto: "Double"),
+    4: .same(proto: "Float"),
+    5: .same(proto: "UInt"),
+    6: .same(proto: "hashValue"),
+    7: .same(proto: "description"),
+    8: .same(proto: "debugDescription"),
+    9: .same(proto: "Swift"),
+    10: .same(proto: "UNRECOGNIZED"),
+    11: .same(proto: "class"),
+    12: .same(proto: "deinit"),
+    13: .same(proto: "enum"),
+    14: .same(proto: "extension"),
+    15: .same(proto: "func"),
+    16: .same(proto: "import"),
+    17: .same(proto: "init"),
+    18: .same(proto: "inout"),
+    19: .same(proto: "internal"),
+    20: .same(proto: "let"),
+    21: .same(proto: "operator"),
+    22: .same(proto: "private"),
+    23: .same(proto: "protocol"),
+    24: .same(proto: "public"),
+    25: .same(proto: "static"),
+    26: .same(proto: "struct"),
+    27: .same(proto: "subscript"),
+    28: .same(proto: "typealias"),
+    29: .same(proto: "var"),
+    30: .same(proto: "break"),
+    31: .same(proto: "case"),
+    32: .same(proto: "continue"),
+    33: .same(proto: "default"),
+    34: .same(proto: "defer"),
+    35: .same(proto: "do"),
+    36: .same(proto: "else"),
+    37: .same(proto: "fallthrough"),
+    38: .same(proto: "for"),
+    39: .same(proto: "guard"),
+    40: .same(proto: "if"),
+    41: .same(proto: "in"),
+    42: .same(proto: "repeat"),
+    43: .same(proto: "return"),
+    44: .same(proto: "switch"),
+    45: .same(proto: "where"),
+    46: .same(proto: "while"),
+    47: .same(proto: "as"),
+    48: .same(proto: "catch"),
+    49: .same(proto: "dynamicType"),
+    50: .same(proto: "false"),
+    51: .same(proto: "is"),
+    52: .same(proto: "nil"),
+    53: .same(proto: "rethrows"),
+    54: .same(proto: "super"),
+    55: .same(proto: "self"),
+    57: .same(proto: "throw"),
+    58: .same(proto: "throws"),
+    59: .same(proto: "true"),
+    60: .same(proto: "try"),
+    61: .same(proto: "__COLUMN__"),
+    62: .same(proto: "__FILE__"),
+    63: .same(proto: "__FUNCTION__"),
+    64: .same(proto: "__LINE__"),
+    65: .same(proto: "_"),
+    66: .same(proto: "associativity"),
+    67: .same(proto: "convenience"),
+    68: .same(proto: "dynamic"),
+    69: .same(proto: "didSet"),
+    70: .same(proto: "final"),
+    71: .same(proto: "get"),
+    72: .same(proto: "infix"),
+    73: .same(proto: "indirect"),
+    74: .same(proto: "lazy"),
+    75: .same(proto: "left"),
+    76: .same(proto: "mutating"),
+    77: .same(proto: "none"),
+    78: .same(proto: "nonmutating"),
+    79: .same(proto: "optional"),
+    80: .same(proto: "override"),
+    81: .same(proto: "postfix"),
+    82: .same(proto: "precedence"),
+    83: .same(proto: "prefix"),
+    85: .same(proto: "required"),
+    86: .same(proto: "right"),
+    87: .same(proto: "set"),
+    88: .same(proto: "Type"),
+    89: .same(proto: "unowned"),
+    90: .same(proto: "weak"),
+    91: .same(proto: "willSet"),
+    92: .same(proto: "id"),
+    93: .same(proto: "_cmd"),
+    96: .same(proto: "out"),
+    98: .same(proto: "bycopy"),
+    99: .same(proto: "byref"),
+    100: .same(proto: "oneway"),
+    102: .same(proto: "and"),
+    103: .same(proto: "and_eq"),
+    104: .same(proto: "alignas"),
+    105: .same(proto: "alignof"),
+    106: .same(proto: "asm"),
+    107: .same(proto: "auto"),
+    108: .same(proto: "bitand"),
+    109: .same(proto: "bitor"),
+    110: .same(proto: "bool"),
+    114: .same(proto: "char"),
+    115: .same(proto: "char16_t"),
+    116: .same(proto: "char32_t"),
+    118: .same(proto: "compl"),
+    119: .same(proto: "const"),
+    120: .same(proto: "constexpr"),
+    121: .same(proto: "const_cast"),
+    123: .same(proto: "decltype"),
+    125: .same(proto: "delete"),
+    127: .same(proto: "dynamic_cast"),
+    130: .same(proto: "explicit"),
+    131: .same(proto: "export"),
+    132: .same(proto: "extern"),
+    136: .same(proto: "friend"),
+    137: .same(proto: "goto"),
+    139: .same(proto: "inline"),
+    141: .same(proto: "long"),
+    142: .same(proto: "mutable"),
+    143: .same(proto: "namespace"),
+    144: .same(proto: "new"),
+    145: .same(proto: "noexcept"),
+    146: .same(proto: "not"),
+    147: .same(proto: "not_eq"),
+    148: .same(proto: "nullptr"),
+    150: .same(proto: "or"),
+    151: .same(proto: "or_eq"),
+    153: .same(proto: "protected"),
+    155: .same(proto: "register"),
+    156: .same(proto: "reinterpret_cast"),
+    158: .same(proto: "short"),
+    159: .same(proto: "signed"),
+    160: .same(proto: "sizeof"),
+    162: .same(proto: "static_assert"),
+    163: .same(proto: "static_cast"),
+    166: .same(proto: "template"),
+    167: .same(proto: "this"),
+    168: .same(proto: "thread_local"),
+    172: .same(proto: "typedef"),
+    173: .same(proto: "typeid"),
+    174: .same(proto: "typename"),
+    175: .same(proto: "union"),
+    176: .same(proto: "unsigned"),
+    177: .same(proto: "using"),
+    178: .same(proto: "virtual"),
+    179: .same(proto: "void"),
+    180: .same(proto: "volatile"),
+    181: .same(proto: "wchar_t"),
+    183: .same(proto: "xor"),
+    184: .same(proto: "xor_eq"),
+    185: .same(proto: "restrict"),
+    186: .same(proto: "Category"),
+    187: .same(proto: "Ivar"),
+    188: .same(proto: "Method"),
+    192: .same(proto: "finalize"),
+    193: .same(proto: "hash"),
+    194: .same(proto: "dealloc"),
+    197: .same(proto: "superclass"),
+    198: .same(proto: "retain"),
+    199: .same(proto: "release"),
+    200: .same(proto: "autorelease"),
+    201: .same(proto: "retainCount"),
+    202: .same(proto: "zone"),
+    203: .same(proto: "isProxy"),
+    204: .same(proto: "copy"),
+    205: .same(proto: "mutableCopy"),
+    206: .same(proto: "classForCoder"),
+    207: .same(proto: "clear"),
+    208: .same(proto: "data"),
+    209: .same(proto: "delimitedData"),
+    210: .same(proto: "descriptor"),
+    211: .same(proto: "extensionRegistry"),
+    212: .same(proto: "extensionsCurrentlySet"),
+    213: .same(proto: "isInitialized"),
+    214: .same(proto: "serializedSize"),
+    215: .same(proto: "sortedExtensionsInUse"),
+    216: .same(proto: "unknownFields"),
+    217: .same(proto: "Fixed"),
+    218: .same(proto: "Fract"),
+    219: .same(proto: "Size"),
+    220: .same(proto: "LogicalAddress"),
+    221: .same(proto: "PhysicalAddress"),
+    222: .same(proto: "ByteCount"),
+    223: .same(proto: "ByteOffset"),
+    224: .same(proto: "Duration"),
+    225: .same(proto: "AbsoluteTime"),
+    226: .same(proto: "OptionBits"),
+    227: .same(proto: "ItemCount"),
+    228: .same(proto: "PBVersion"),
+    229: .same(proto: "ScriptCode"),
+    230: .same(proto: "LangCode"),
+    231: .same(proto: "RegionCode"),
+    232: .same(proto: "OSType"),
+    233: .same(proto: "ProcessSerialNumber"),
+    234: .same(proto: "Point"),
+    235: .same(proto: "Rect"),
+    236: .same(proto: "FixedPoint"),
+    237: .same(proto: "FixedRect"),
+    238: .same(proto: "Style"),
+    239: .same(proto: "StyleParameter"),
+    240: .same(proto: "StyleField"),
+    241: .same(proto: "TimeScale"),
+    242: .same(proto: "TimeBase"),
+    243: .same(proto: "TimeRecord"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "AA"),
+    1065: .same(proto: "__"),
+  ]
+}
 
 extension SwiftUnittest_Names_FieldNames: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -23144,6 +22312,1260 @@ extension SwiftUnittest_Names_EnumNames: SwiftProtobuf._MessageImplementationBas
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension SwiftUnittest_Names_EnumNames.StringEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aString"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ProtocolEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aProtocol"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.IntEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aInt"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.DoubleEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aDouble"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.FloatEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aFloat"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.UIntEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aUInt"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.hashValueEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ahashValue"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.descriptionEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adescription"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.debugDescriptionEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adebugDescription"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Swift: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aSwift"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.UNRECOGNIZED: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aUNRECOGNIZED"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.classEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aclass"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.deinitEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adeinit"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.enumEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aenum"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.extensionEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aextension"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.funcEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afunc"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.importEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aimport"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.initEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ainit"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.inoutEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ainout"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.internalEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ainternal"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.letEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "alet"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.operatorEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aoperator"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.privateEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aprivate"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.protocolEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aprotocol"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.publicEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "apublic"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.staticEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "astatic"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.structEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "astruct"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.subscriptEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asubscript"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.typealiasEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atypealias"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.varEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "avar"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.breakEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abreak"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.caseEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "acase"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.continueEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "acontinue"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.defaultEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adefault"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.deferEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adefer"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.doEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ado"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.elseEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aelse"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.fallthroughEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afallthrough"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.forEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afor"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.guardEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aguard"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ifEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aif"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.inEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ain"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.repeatEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "arepeat"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.returnEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "areturn"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.switchEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aswitch"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.whereEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "awhere"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.whileEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "awhile"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.asEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aas"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.catchEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "acatch"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.dynamicTypeEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adynamicType"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.falseEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afalse"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.isEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ais"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.nilEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anil"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.rethrowsEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "arethrows"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.superEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asuper"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.selfEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aself"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.throwEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "athrow"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.throwsEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "athrows"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.trueEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atrue"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.tryEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atry"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.__COLUMN__Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a__COLUMN__"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.__FILE__Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a__FILE__"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.__FUNCTION__Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a__FUNCTION__"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.__LINE__Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a__LINE__"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames._Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a_"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.__Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a__"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.associativity: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aassociativity"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.convenience: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aconvenience"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.dynamic: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adynamic"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.didSet: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adidSet"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.final: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afinal"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.get: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aget"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.infix: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ainfix"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.indirect: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aindirect"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.lazy: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "alazy"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.left: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aleft"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.mutating: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "amutating"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.none: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anone"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.nonmutating: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anonmutating"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.optional: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aoptional"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.override: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aoverride"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.postfix: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "apostfix"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.precedence: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aprecedence"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.prefix: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aprefix"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.required: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "arequired"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.right: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aright"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.set: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aset"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.TypeEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aType"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.unowned: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aunowned"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.weak: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aweak"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.willSet: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "awillSet"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.id: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aid"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames._cmd: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a_cmd"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.out: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aout"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.bycopy: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abycopy"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.byref: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abyref"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.oneway: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aoneway"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.and: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aand"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.and_eq: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aand_eq"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.alignas: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aalignas"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.alignof: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aalignof"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.asm: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aasm"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.auto: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aauto"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.bitand: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abitand"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.bitor: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abitor"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.bool: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abool"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.char: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "achar"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.char16_t: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "achar16_t"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.char32_t: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "achar32_t"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.compl: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "acompl"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.const: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aconst"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.constexpr: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aconstexpr"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.const_cast: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aconst_cast"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.decltype: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adecltype"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.delete: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adelete"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.dynamic_cast: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adynamic_cast"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.explicit: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aexplicit"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.export: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aexport"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.extern: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aextern"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.friend: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afriend"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.goto: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "agoto"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.inline: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ainline"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.long: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "along"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.mutable: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "amutable"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.namespace: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anamespace"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.new: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anew"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.noexcept: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anoexcept"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.not: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anot"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.not_eq: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anot_eq"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.nullptr: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anullptr"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.or: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aor"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.or_eq: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aor_eq"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.protected: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aprotected"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.register: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aregister"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.reinterpret_cast: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "areinterpret_cast"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.short: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ashort"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.signed: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asigned"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.sizeof: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asizeof"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.static_assert: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "astatic_assert"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.static_cast: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "astatic_cast"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.template: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atemplate"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.this: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "athis"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.thread_local: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "athread_local"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.typedef: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atypedef"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.typeid: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atypeid"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.typename: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atypename"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.union: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aunion"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.unsigned: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aunsigned"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.using: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ausing"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.virtual: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "avirtual"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.void: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "avoid"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.volatile: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "avolatile"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.wchar_t: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "awchar_t"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.xor: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "axor"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.xor_eq: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "axor_eq"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.restrict: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "arestrict"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Category: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aCategory"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Ivar: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aIvar"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Method: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aMethod"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.finalize: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afinalize"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.hash: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ahash"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.dealloc: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adealloc"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.superclass: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asuperclass"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.retain: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aretain"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.release: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "arelease"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.autorelease: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aautorelease"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.retainCount: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aretainCount"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.zone: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "azone"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.isProxy: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aisProxy"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.copy: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "acopy"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.mutableCopy: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "amutableCopy"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.classForCoder: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aclassForCoder"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.clear: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aclear"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.data: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adata"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.delimitedData: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adelimitedData"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.descriptor: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adescriptor"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.extensionRegistry: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aextensionRegistry"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.extensionsCurrentlySet: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aextensionsCurrentlySet"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.isInitialized: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aisInitialized"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.serializedSize: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aserializedSize"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.sortedExtensionsInUse: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asortedExtensionsInUse"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.unknownFieldsEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aunknownFields"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Fixed: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aFixed"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Fract: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aFract"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Size: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aSize"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.LogicalAddress: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aLogicalAddress"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.PhysicalAddress: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aPhysicalAddress"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ByteCount: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aByteCount"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ByteOffset: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aByteOffset"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Duration: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aDuration"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.AbsoluteTime: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aAbsoluteTime"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.OptionBits: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aOptionBits"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ItemCount: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aItemCount"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.PBVersion: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aPBVersion"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ScriptCode: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aScriptCode"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.LangCode: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aLangCode"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.RegionCode: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aRegionCode"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.OSType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aOSType"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ProcessSerialNumber: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aProcessSerialNumber"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Point: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aPoint"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Rect: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aRect"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.FixedPoint: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aFixedPoint"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.FixedRect: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aFixedRect"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Style: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aStyle"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.StyleParameter: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aStyleParameter"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.StyleField: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aStyleField"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.TimeScale: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aTimeScale"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.TimeBase: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aTimeBase"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.TimeRecord: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aTimeRecord"),
+  ]
 }
 
 extension SwiftUnittest_Names_FieldNamingInitials: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -128,7 +128,7 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case double // = 1
     case json // = 2
@@ -136,15 +136,6 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
     case ___ // = 4
     case self_ // = 5
     case type // = 6
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "DOUBLE"),
-      2: .same(proto: "JSON"),
-      3: .same(proto: "CLASS"),
-      4: .same(proto: "_"),
-      5: .same(proto: "SELF"),
-      6: .same(proto: "TYPE"),
-    ]
 
     init() {
       self = .double
@@ -175,13 +166,9 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
 
   }
 
-  enum ProtocolEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ProtocolEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a // = 1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "a"),
-    ]
 
     init() {
       self = .a
@@ -619,6 +606,23 @@ extension ProtobufUnittest_SwiftReservedTest: SwiftProtobuf._MessageImplementati
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "DOUBLE"),
+    2: .same(proto: "JSON"),
+    3: .same(proto: "CLASS"),
+    4: .same(proto: "_"),
+    5: .same(proto: "SELF"),
+    6: .same(proto: "TYPE"),
+  ]
+}
+
+extension ProtobufUnittest_SwiftReservedTest.ProtocolEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "a"),
+  ]
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -1047,19 +1047,12 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
     }
   }
 
-  enum Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case extra2 // = 20
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-      20: .same(proto: "EXTRA_2"),
-    ]
 
     init() {
       self = .foo
@@ -1676,6 +1669,15 @@ extension ProtobufUnittest_Message2: SwiftProtobuf._MessageImplementationBase, S
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_Message2.Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+    20: .same(proto: "EXTRA_2"),
+  ]
 }
 
 extension ProtobufUnittest_Message2.OptionalGroup: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -877,20 +877,13 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     }
   }
 
-  enum Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case extra3 // = 30
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-      30: .same(proto: "EXTRA_3"),
-    ]
 
     init() {
       self = .foo
@@ -1371,6 +1364,15 @@ extension ProtobufUnittest_Message3: SwiftProtobuf._MessageImplementationBase, S
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_Message3.Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+    30: .same(proto: "EXTRA_3"),
+  ]
 }
 
 extension ProtobufUnittest_Msg3NoStorage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -51,18 +51,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "conformance"
 
-enum Conformance_WireFormat: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Conformance_WireFormat: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case unspecified // = 0
   case protobuf // = 1
   case json // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "UNSPECIFIED"),
-    1: .same(proto: "PROTOBUF"),
-    2: .same(proto: "JSON"),
-  ]
 
   init() {
     self = .unspecified
@@ -368,6 +362,14 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     try result?.traverse(visitor: &visitor, start: 1, end: 7)
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Conformance_WireFormat: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "UNSPECIFIED"),
+    1: .same(proto: "PROTOBUF"),
+    2: .same(proto: "JSON"),
+  ]
 }
 
 extension Conformance_ConformanceRequest: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -57,18 +57,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_test_messages.proto3"
 
-enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
   case foreignBaz // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_FOO"),
-    1: .same(proto: "FOREIGN_BAR"),
-    2: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignFoo
@@ -1247,7 +1241,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -1256,13 +1250,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -1852,6 +1839,14 @@ struct ProtobufTestMessages_Proto3_ForeignMessage: SwiftProtobuf.Message {
   }
 }
 
+extension ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_FOO"),
+    1: .same(proto: "FOREIGN_BAR"),
+    2: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -2096,6 +2091,15 @@ extension ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf._MessageImplem
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
 }
 
 extension ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Sources/PluginLibrary/descriptor.pb.swift
+++ b/Sources/PluginLibrary/descriptor.pb.swift
@@ -782,7 +782,7 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  public enum TypeEnum: SwiftProtobuf.Enum {
     public typealias RawValue = Int
 
     /// 0 is reserved for errors.
@@ -824,27 +824,6 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
 
     /// Uses ZigZag encoding.
     case sint64 // = 18
-
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "TYPE_DOUBLE"),
-      2: .same(proto: "TYPE_FLOAT"),
-      3: .same(proto: "TYPE_INT64"),
-      4: .same(proto: "TYPE_UINT64"),
-      5: .same(proto: "TYPE_INT32"),
-      6: .same(proto: "TYPE_FIXED64"),
-      7: .same(proto: "TYPE_FIXED32"),
-      8: .same(proto: "TYPE_BOOL"),
-      9: .same(proto: "TYPE_STRING"),
-      10: .same(proto: "TYPE_GROUP"),
-      11: .same(proto: "TYPE_MESSAGE"),
-      12: .same(proto: "TYPE_BYTES"),
-      13: .same(proto: "TYPE_UINT32"),
-      14: .same(proto: "TYPE_ENUM"),
-      15: .same(proto: "TYPE_SFIXED32"),
-      16: .same(proto: "TYPE_SFIXED64"),
-      17: .same(proto: "TYPE_SINT32"),
-      18: .same(proto: "TYPE_SINT64"),
-    ]
 
     public init() {
       self = .double
@@ -899,19 +878,13 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
 
   }
 
-  public enum Label: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  public enum Label: SwiftProtobuf.Enum {
     public typealias RawValue = Int
 
     /// 0 is reserved for errors
     case `optional` // = 1
     case `required` // = 2
     case repeated // = 3
-
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "LABEL_OPTIONAL"),
-      2: .same(proto: "LABEL_REQUIRED"),
-      3: .same(proto: "LABEL_REPEATED"),
-    ]
 
     public init() {
       self = .`optional`
@@ -1827,7 +1800,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Generated classes can be optimized for speed or code size.
-  public enum OptimizeMode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  public enum OptimizeMode: SwiftProtobuf.Enum {
     public typealias RawValue = Int
 
     /// Generate complete code for parsing, serialization,
@@ -1838,12 +1811,6 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
 
     /// Generate code using MessageLite and the lite runtime.
     case liteRuntime // = 3
-
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "SPEED"),
-      2: .same(proto: "CODE_SIZE"),
-      3: .same(proto: "LITE_RUNTIME"),
-    ]
 
     public init() {
       self = .speed
@@ -2248,19 +2215,13 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public enum CType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  public enum CType: SwiftProtobuf.Enum {
     public typealias RawValue = Int
 
     /// Default mode.
     case string // = 0
     case cord // = 1
     case stringPiece // = 2
-
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "STRING"),
-      1: .same(proto: "CORD"),
-      2: .same(proto: "STRING_PIECE"),
-    ]
 
     public init() {
       self = .string
@@ -2285,7 +2246,7 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
 
   }
 
-  public enum JSType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  public enum JSType: SwiftProtobuf.Enum {
     public typealias RawValue = Int
 
     /// Use the default type.
@@ -2296,12 +2257,6 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
 
     /// Use JavaScript numbers.
     case jsNumber // = 2
-
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "JS_NORMAL"),
-      1: .same(proto: "JS_STRING"),
-      2: .same(proto: "JS_NUMBER"),
-    ]
 
     public init() {
       self = .jsNormal
@@ -2649,7 +2604,7 @@ public struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobu
   /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
   /// or neither? HTTP based RPC implementation may choose GET verb for safe
   /// methods, and PUT verb for idempotent methods instead of the default POST.
-  public enum IdempotencyLevel: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  public enum IdempotencyLevel: SwiftProtobuf.Enum {
     public typealias RawValue = Int
     case idempotencyUnknown // = 0
 
@@ -2658,12 +2613,6 @@ public struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobu
 
     /// idempotent, but may have side effects
     case idempotent // = 2
-
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "IDEMPOTENCY_UNKNOWN"),
-      1: .same(proto: "NO_SIDE_EFFECTS"),
-      2: .same(proto: "IDEMPOTENT"),
-    ]
 
     public init() {
       self = .idempotencyUnknown
@@ -3405,6 +3354,37 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobuf._MessageImplementa
   }
 }
 
+extension Google_Protobuf_FieldDescriptorProto.TypeEnum: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "TYPE_DOUBLE"),
+    2: .same(proto: "TYPE_FLOAT"),
+    3: .same(proto: "TYPE_INT64"),
+    4: .same(proto: "TYPE_UINT64"),
+    5: .same(proto: "TYPE_INT32"),
+    6: .same(proto: "TYPE_FIXED64"),
+    7: .same(proto: "TYPE_FIXED32"),
+    8: .same(proto: "TYPE_BOOL"),
+    9: .same(proto: "TYPE_STRING"),
+    10: .same(proto: "TYPE_GROUP"),
+    11: .same(proto: "TYPE_MESSAGE"),
+    12: .same(proto: "TYPE_BYTES"),
+    13: .same(proto: "TYPE_UINT32"),
+    14: .same(proto: "TYPE_ENUM"),
+    15: .same(proto: "TYPE_SFIXED32"),
+    16: .same(proto: "TYPE_SFIXED64"),
+    17: .same(proto: "TYPE_SINT32"),
+    18: .same(proto: "TYPE_SINT64"),
+  ]
+}
+
+extension Google_Protobuf_FieldDescriptorProto.Label: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "LABEL_OPTIONAL"),
+    2: .same(proto: "LABEL_REQUIRED"),
+    3: .same(proto: "LABEL_REPEATED"),
+  ]
+}
+
 extension Google_Protobuf_OneofDescriptorProto: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "name"),
@@ -3570,6 +3550,14 @@ extension Google_Protobuf_FileOptions: SwiftProtobuf._MessageImplementationBase,
   }
 }
 
+extension Google_Protobuf_FileOptions.OptimizeMode: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "SPEED"),
+    2: .same(proto: "CODE_SIZE"),
+    3: .same(proto: "LITE_RUNTIME"),
+  ]
+}
+
 extension Google_Protobuf_MessageOptions: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "message_set_wire_format"),
@@ -3614,6 +3602,22 @@ extension Google_Protobuf_FieldOptions: SwiftProtobuf._MessageImplementationBase
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
   }
+}
+
+extension Google_Protobuf_FieldOptions.CType: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "STRING"),
+    1: .same(proto: "CORD"),
+    2: .same(proto: "STRING_PIECE"),
+  ]
+}
+
+extension Google_Protobuf_FieldOptions.JSType: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "JS_NORMAL"),
+    1: .same(proto: "JS_STRING"),
+    2: .same(proto: "JS_NUMBER"),
+  ]
 }
 
 extension Google_Protobuf_OneofOptions: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -3691,6 +3695,14 @@ extension Google_Protobuf_MethodOptions: SwiftProtobuf._MessageImplementationBas
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
   }
+}
+
+extension Google_Protobuf_MethodOptions.IdempotencyLevel: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "IDEMPOTENCY_UNKNOWN"),
+    1: .same(proto: "NO_SIDE_EFFECTS"),
+    2: .same(proto: "IDEMPOTENT"),
+  ]
 }
 
 extension Google_Protobuf_UninterpretedOption: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -54,16 +54,12 @@ fileprivate let _protobuf_package = "google.protobuf"
 /// `Value` type union.
 ///
 ///  The JSON representation for `NullValue` is JSON `null`.
-public enum Google_Protobuf_NullValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+public enum Google_Protobuf_NullValue: SwiftProtobuf.Enum {
   public typealias RawValue = Int
 
   /// Null value.
   case nullValue // = 0
   case UNRECOGNIZED(Int)
-
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "NULL_VALUE"),
-  ]
 
   public init() {
     self = .nullValue
@@ -381,6 +377,12 @@ public struct Google_Protobuf_ListValue: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Google_Protobuf_NullValue: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "NULL_VALUE"),
+  ]
 }
 
 extension Google_Protobuf_Struct: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Sources/SwiftProtobuf/type.pb.swift
+++ b/Sources/SwiftProtobuf/type.pb.swift
@@ -51,7 +51,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 fileprivate let _protobuf_package = "google.protobuf"
 
 /// The syntax in which a protocol buffer element is defined.
-public enum Google_Protobuf_Syntax: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+public enum Google_Protobuf_Syntax: SwiftProtobuf.Enum {
   public typealias RawValue = Int
 
   /// Syntax `proto2`.
@@ -60,11 +60,6 @@ public enum Google_Protobuf_Syntax: SwiftProtobuf.Enum, SwiftProtobuf._ProtoName
   /// Syntax `proto3`.
   case proto3 // = 1
   case UNRECOGNIZED(Int)
-
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "SYNTAX_PROTO2"),
-    1: .same(proto: "SYNTAX_PROTO3"),
-  ]
 
   public init() {
     self = .proto2
@@ -248,7 +243,7 @@ public struct Google_Protobuf_Field: SwiftProtobuf.Message {
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Basic field types.
-  public enum Kind: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  public enum Kind: SwiftProtobuf.Enum {
     public typealias RawValue = Int
 
     /// Field type unknown.
@@ -309,28 +304,6 @@ public struct Google_Protobuf_Field: SwiftProtobuf.Message {
     case typeSint64 // = 18
     case UNRECOGNIZED(Int)
 
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "TYPE_UNKNOWN"),
-      1: .same(proto: "TYPE_DOUBLE"),
-      2: .same(proto: "TYPE_FLOAT"),
-      3: .same(proto: "TYPE_INT64"),
-      4: .same(proto: "TYPE_UINT64"),
-      5: .same(proto: "TYPE_INT32"),
-      6: .same(proto: "TYPE_FIXED64"),
-      7: .same(proto: "TYPE_FIXED32"),
-      8: .same(proto: "TYPE_BOOL"),
-      9: .same(proto: "TYPE_STRING"),
-      10: .same(proto: "TYPE_GROUP"),
-      11: .same(proto: "TYPE_MESSAGE"),
-      12: .same(proto: "TYPE_BYTES"),
-      13: .same(proto: "TYPE_UINT32"),
-      14: .same(proto: "TYPE_ENUM"),
-      15: .same(proto: "TYPE_SFIXED32"),
-      16: .same(proto: "TYPE_SFIXED64"),
-      17: .same(proto: "TYPE_SINT32"),
-      18: .same(proto: "TYPE_SINT64"),
-    ]
-
     public init() {
       self = .typeUnknown
     }
@@ -388,7 +361,7 @@ public struct Google_Protobuf_Field: SwiftProtobuf.Message {
   }
 
   /// Whether a field is optional, required, or repeated.
-  public enum Cardinality: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  public enum Cardinality: SwiftProtobuf.Enum {
     public typealias RawValue = Int
 
     /// For fields with unknown cardinality.
@@ -403,13 +376,6 @@ public struct Google_Protobuf_Field: SwiftProtobuf.Message {
     /// For repeated fields.
     case repeated // = 3
     case UNRECOGNIZED(Int)
-
-    public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "CARDINALITY_UNKNOWN"),
-      1: .same(proto: "CARDINALITY_OPTIONAL"),
-      2: .same(proto: "CARDINALITY_REQUIRED"),
-      3: .same(proto: "CARDINALITY_REPEATED"),
-    ]
 
     public init() {
       self = .unknown
@@ -723,6 +689,13 @@ public struct Google_Protobuf_Option: SwiftProtobuf.Message {
   }
 }
 
+extension Google_Protobuf_Syntax: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "SYNTAX_PROTO2"),
+    1: .same(proto: "SYNTAX_PROTO3"),
+  ]
+}
+
 extension Google_Protobuf_Type: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "name"),
@@ -779,6 +752,39 @@ extension Google_Protobuf_Field: SwiftProtobuf._MessageImplementationBase, Swift
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Google_Protobuf_Field.Kind: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "TYPE_UNKNOWN"),
+    1: .same(proto: "TYPE_DOUBLE"),
+    2: .same(proto: "TYPE_FLOAT"),
+    3: .same(proto: "TYPE_INT64"),
+    4: .same(proto: "TYPE_UINT64"),
+    5: .same(proto: "TYPE_INT32"),
+    6: .same(proto: "TYPE_FIXED64"),
+    7: .same(proto: "TYPE_FIXED32"),
+    8: .same(proto: "TYPE_BOOL"),
+    9: .same(proto: "TYPE_STRING"),
+    10: .same(proto: "TYPE_GROUP"),
+    11: .same(proto: "TYPE_MESSAGE"),
+    12: .same(proto: "TYPE_BYTES"),
+    13: .same(proto: "TYPE_UINT32"),
+    14: .same(proto: "TYPE_ENUM"),
+    15: .same(proto: "TYPE_SFIXED32"),
+    16: .same(proto: "TYPE_SFIXED64"),
+    17: .same(proto: "TYPE_SINT32"),
+    18: .same(proto: "TYPE_SINT64"),
+  ]
+}
+
+extension Google_Protobuf_Field.Cardinality: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "CARDINALITY_UNKNOWN"),
+    1: .same(proto: "CARDINALITY_OPTIONAL"),
+    2: .same(proto: "CARDINALITY_REQUIRED"),
+    3: .same(proto: "CARDINALITY_REPEATED"),
+  ]
 }
 
 extension Google_Protobuf_Enum: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Sources/protoc-gen-swift/EnumGenerator.swift
+++ b/Sources/protoc-gen-swift/EnumGenerator.swift
@@ -83,10 +83,10 @@ class EnumGenerator {
     self.comments = file.commentsFor(path: path)
   }
 
-  func generateNested(printer p: inout CodePrinter) {
+  func generateMainEnum(printer p: inout CodePrinter) {
     p.print("\n")
     p.print(comments)
-    p.print("\(visibility)enum \(swiftRelativeName): SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {\n")
+    p.print("\(visibility)enum \(swiftRelativeName): SwiftProtobuf.Enum {\n")
     p.indent()
     p.print("\(visibility)typealias RawValue = Int\n")
 
@@ -97,10 +97,6 @@ class EnumGenerator {
     if isProto3 {
       p.print("case \(unrecognizedCaseName)(Int)\n")
     }
-
-    // Map the enum case names to their numbers.
-    p.print("\n")
-    generateNameMap(printer: &p)
 
     // Generate the default initializer.
     p.print("\n")
@@ -121,10 +117,19 @@ class EnumGenerator {
     p.print("}\n")
   }
 
+  func generateRuntimeSupport(printer p: inout CodePrinter) {
+    p.print("\n")
+    p.print("extension \(swiftFullName): SwiftProtobuf._ProtoNameProviding {\n")
+    p.indent()
+    generateProtoNameProviding(printer: &p)
+    p.outdent()
+    p.print("}\n")
+  }
+
   /// Generates the mapping from case numbers to their text/JSON names.
   ///
   /// - Parameter p: The code printer.
-  private func generateNameMap(printer p: inout CodePrinter) {
+  private func generateProtoNameProviding(printer p: inout CodePrinter) {
     if enumCases.isEmpty {
       p.print("\(visibility)static let _protobuf_nameMap = SwiftProtobuf._NameMap()\n")
     } else {

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -338,7 +338,7 @@ class FileGenerator {
         }
 
         for e in enums {
-            e.generateNested(printer: &p)
+            e.generateMainEnum(printer: &p)
         }
 
         for m in messages {
@@ -378,6 +378,10 @@ class FileGenerator {
             p.print("\n")
             p.outdent()
             p.print("]\n")
+        }
+
+        for e in enums {
+            e.generateRuntimeSupport(printer: &p)
         }
 
         for m in messages {

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -229,7 +229,7 @@ class MessageGenerator {
 
     // Nested enums
     for e in enums {
-      e.generateNested(printer: &p)
+      e.generateMainEnum(printer: &p)
     }
 
     // Nested messages
@@ -305,8 +305,10 @@ class MessageGenerator {
     p.outdent()
     p.print("}\n")
 
-
-    // Nested messages
+    // Nested enums and messages
+    for e in enums {
+      e.generateRuntimeSupport(printer: &p)
+    }
     for m in messages {
       m.generateRuntimeSupport(printer: &p, file: file, parent: self)
     }

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -51,18 +51,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "conformance"
 
-enum Conformance_WireFormat: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Conformance_WireFormat: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case unspecified // = 0
   case protobuf // = 1
   case json // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "UNSPECIFIED"),
-    1: .same(proto: "PROTOBUF"),
-    2: .same(proto: "JSON"),
-  ]
 
   init() {
     self = .unspecified
@@ -368,6 +362,14 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     try result?.traverse(visitor: &visitor, start: 1, end: 7)
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Conformance_WireFormat: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "UNSPECIFIED"),
+    1: .same(proto: "PROTOBUF"),
+    2: .same(proto: "JSON"),
+  ]
 }
 
 extension Conformance_ConformanceRequest: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/descriptor.pb.swift
+++ b/Tests/SwiftProtobufTests/descriptor.pb.swift
@@ -782,7 +782,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TypeEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// 0 is reserved for errors.
@@ -824,27 +824,6 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
 
     /// Uses ZigZag encoding.
     case sint64 // = 18
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "TYPE_DOUBLE"),
-      2: .same(proto: "TYPE_FLOAT"),
-      3: .same(proto: "TYPE_INT64"),
-      4: .same(proto: "TYPE_UINT64"),
-      5: .same(proto: "TYPE_INT32"),
-      6: .same(proto: "TYPE_FIXED64"),
-      7: .same(proto: "TYPE_FIXED32"),
-      8: .same(proto: "TYPE_BOOL"),
-      9: .same(proto: "TYPE_STRING"),
-      10: .same(proto: "TYPE_GROUP"),
-      11: .same(proto: "TYPE_MESSAGE"),
-      12: .same(proto: "TYPE_BYTES"),
-      13: .same(proto: "TYPE_UINT32"),
-      14: .same(proto: "TYPE_ENUM"),
-      15: .same(proto: "TYPE_SFIXED32"),
-      16: .same(proto: "TYPE_SFIXED64"),
-      17: .same(proto: "TYPE_SINT32"),
-      18: .same(proto: "TYPE_SINT64"),
-    ]
 
     init() {
       self = .double
@@ -899,19 +878,13 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
 
   }
 
-  enum Label: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Label: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// 0 is reserved for errors
     case `optional` // = 1
     case `required` // = 2
     case repeated // = 3
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "LABEL_OPTIONAL"),
-      2: .same(proto: "LABEL_REQUIRED"),
-      3: .same(proto: "LABEL_REPEATED"),
-    ]
 
     init() {
       self = .`optional`
@@ -1827,7 +1800,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Generated classes can be optimized for speed or code size.
-  enum OptimizeMode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum OptimizeMode: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// Generate complete code for parsing, serialization,
@@ -1838,12 +1811,6 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
 
     /// Generate code using MessageLite and the lite runtime.
     case liteRuntime // = 3
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "SPEED"),
-      2: .same(proto: "CODE_SIZE"),
-      3: .same(proto: "LITE_RUNTIME"),
-    ]
 
     init() {
       self = .speed
@@ -2248,19 +2215,13 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum CType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum CType: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// Default mode.
     case string // = 0
     case cord // = 1
     case stringPiece // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "STRING"),
-      1: .same(proto: "CORD"),
-      2: .same(proto: "STRING_PIECE"),
-    ]
 
     init() {
       self = .string
@@ -2285,7 +2246,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
 
   }
 
-  enum JSType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum JSType: SwiftProtobuf.Enum {
     typealias RawValue = Int
 
     /// Use the default type.
@@ -2296,12 +2257,6 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
 
     /// Use JavaScript numbers.
     case jsNumber // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "JS_NORMAL"),
-      1: .same(proto: "JS_STRING"),
-      2: .same(proto: "JS_NUMBER"),
-    ]
 
     init() {
       self = .jsNormal
@@ -2649,7 +2604,7 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.Exten
   /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
   /// or neither? HTTP based RPC implementation may choose GET verb for safe
   /// methods, and PUT verb for idempotent methods instead of the default POST.
-  enum IdempotencyLevel: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum IdempotencyLevel: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case idempotencyUnknown // = 0
 
@@ -2658,12 +2613,6 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.Exten
 
     /// idempotent, but may have side effects
     case idempotent // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "IDEMPOTENCY_UNKNOWN"),
-      1: .same(proto: "NO_SIDE_EFFECTS"),
-      2: .same(proto: "IDEMPOTENT"),
-    ]
 
     init() {
       self = .idempotencyUnknown
@@ -3405,6 +3354,37 @@ extension Google_Protobuf_FieldDescriptorProto: SwiftProtobuf._MessageImplementa
   }
 }
 
+extension Google_Protobuf_FieldDescriptorProto.TypeEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "TYPE_DOUBLE"),
+    2: .same(proto: "TYPE_FLOAT"),
+    3: .same(proto: "TYPE_INT64"),
+    4: .same(proto: "TYPE_UINT64"),
+    5: .same(proto: "TYPE_INT32"),
+    6: .same(proto: "TYPE_FIXED64"),
+    7: .same(proto: "TYPE_FIXED32"),
+    8: .same(proto: "TYPE_BOOL"),
+    9: .same(proto: "TYPE_STRING"),
+    10: .same(proto: "TYPE_GROUP"),
+    11: .same(proto: "TYPE_MESSAGE"),
+    12: .same(proto: "TYPE_BYTES"),
+    13: .same(proto: "TYPE_UINT32"),
+    14: .same(proto: "TYPE_ENUM"),
+    15: .same(proto: "TYPE_SFIXED32"),
+    16: .same(proto: "TYPE_SFIXED64"),
+    17: .same(proto: "TYPE_SINT32"),
+    18: .same(proto: "TYPE_SINT64"),
+  ]
+}
+
+extension Google_Protobuf_FieldDescriptorProto.Label: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "LABEL_OPTIONAL"),
+    2: .same(proto: "LABEL_REQUIRED"),
+    3: .same(proto: "LABEL_REPEATED"),
+  ]
+}
+
 extension Google_Protobuf_OneofDescriptorProto: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "name"),
@@ -3570,6 +3550,14 @@ extension Google_Protobuf_FileOptions: SwiftProtobuf._MessageImplementationBase,
   }
 }
 
+extension Google_Protobuf_FileOptions.OptimizeMode: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "SPEED"),
+    2: .same(proto: "CODE_SIZE"),
+    3: .same(proto: "LITE_RUNTIME"),
+  ]
+}
+
 extension Google_Protobuf_MessageOptions: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "message_set_wire_format"),
@@ -3614,6 +3602,22 @@ extension Google_Protobuf_FieldOptions: SwiftProtobuf._MessageImplementationBase
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
   }
+}
+
+extension Google_Protobuf_FieldOptions.CType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "STRING"),
+    1: .same(proto: "CORD"),
+    2: .same(proto: "STRING_PIECE"),
+  ]
+}
+
+extension Google_Protobuf_FieldOptions.JSType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "JS_NORMAL"),
+    1: .same(proto: "JS_STRING"),
+    2: .same(proto: "JS_NUMBER"),
+  ]
 }
 
 extension Google_Protobuf_OneofOptions: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -3691,6 +3695,14 @@ extension Google_Protobuf_MethodOptions: SwiftProtobuf._MessageImplementationBas
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
   }
+}
+
+extension Google_Protobuf_MethodOptions.IdempotencyLevel: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "IDEMPOTENCY_UNKNOWN"),
+    1: .same(proto: "NO_SIDE_EFFECTS"),
+    2: .same(proto: "IDEMPOTENT"),
+  ]
 }
 
 extension Google_Protobuf_UninterpretedOption: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/map_proto2_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_proto2_unittest.pb.swift
@@ -51,17 +51,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_Proto2MapEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_Proto2MapEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "PROTO2_MAP_ENUM_FOO"),
-    1: .same(proto: "PROTO2_MAP_ENUM_BAR"),
-    2: .same(proto: "PROTO2_MAP_ENUM_BAZ"),
-  ]
 
   init() {
     self = .foo
@@ -86,19 +80,12 @@ enum ProtobufUnittest_Proto2MapEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNam
 
 }
 
-enum ProtobufUnittest_Proto2MapEnumPlusExtra: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_Proto2MapEnumPlusExtra: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case eProto2MapEnumFoo // = 0
   case eProto2MapEnumBar // = 1
   case eProto2MapEnumBaz // = 2
   case eProto2MapEnumExtra // = 3
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "E_PROTO2_MAP_ENUM_FOO"),
-    1: .same(proto: "E_PROTO2_MAP_ENUM_BAR"),
-    2: .same(proto: "E_PROTO2_MAP_ENUM_BAZ"),
-    3: .same(proto: "E_PROTO2_MAP_ENUM_EXTRA"),
-  ]
 
   init() {
     self = .eProto2MapEnumFoo
@@ -332,6 +319,23 @@ struct ProtobufUnittest_TestMaps: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension ProtobufUnittest_Proto2MapEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "PROTO2_MAP_ENUM_FOO"),
+    1: .same(proto: "PROTO2_MAP_ENUM_BAR"),
+    2: .same(proto: "PROTO2_MAP_ENUM_BAZ"),
+  ]
+}
+
+extension ProtobufUnittest_Proto2MapEnumPlusExtra: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "E_PROTO2_MAP_ENUM_FOO"),
+    1: .same(proto: "E_PROTO2_MAP_ENUM_BAR"),
+    2: .same(proto: "E_PROTO2_MAP_ENUM_BAZ"),
+    3: .same(proto: "E_PROTO2_MAP_ENUM_EXTRA"),
+  ]
 }
 
 extension ProtobufUnittest_TestEnumMap: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/map_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest.pb.swift
@@ -51,18 +51,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_MapEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_MapEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "MAP_ENUM_FOO"),
-    1: .same(proto: "MAP_ENUM_BAR"),
-    2: .same(proto: "MAP_ENUM_BAZ"),
-  ]
 
   init() {
     self = .foo
@@ -728,14 +722,10 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TypeEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "TYPE_FOO"),
-    ]
 
     init() {
       self = .foo
@@ -827,6 +817,14 @@ struct ProtobufUnittest_TestRecursiveMapMessage: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension ProtobufUnittest_MapEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "MAP_ENUM_FOO"),
+    1: .same(proto: "MAP_ENUM_BAR"),
+    2: .same(proto: "MAP_ENUM_BAZ"),
+  ]
 }
 
 extension ProtobufUnittest_TestMap: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -999,6 +997,12 @@ extension ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf._Messa
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_MessageContainingEnumCalledType.TypeEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "TYPE_FOO"),
+  ]
 }
 
 extension ProtobufUnittest_MessageContainingMapCalledEntry: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -57,18 +57,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_test_messages.proto3"
 
-enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
   case foreignBaz // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_FOO"),
-    1: .same(proto: "FOREIGN_BAR"),
-    2: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignFoo
@@ -1247,7 +1241,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
@@ -1256,13 +1250,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -1852,6 +1839,14 @@ struct ProtobufTestMessages_Proto3_ForeignMessage: SwiftProtobuf.Message {
   }
 }
 
+extension ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_FOO"),
+    1: .same(proto: "FOREIGN_BAR"),
+    2: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -2096,6 +2091,15 @@ extension ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf._MessageImplem
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
 }
 
 extension ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -57,17 +57,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    4: .same(proto: "FOREIGN_FOO"),
-    5: .same(proto: "FOREIGN_BAR"),
-    6: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignFoo
@@ -93,19 +87,13 @@ enum ProtobufUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameP
 }
 
 /// Test an enum that has multiple values with the same number.
-enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo1 // = 1
   case bar1 // = 2
   case baz // = 3
   static let foo2 = foo1
   static let bar2 = bar1
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
-    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
-    3: .same(proto: "BAZ"),
-  ]
 
   init() {
     self = .foo1
@@ -131,7 +119,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._P
 }
 
 /// Test an enum with large, unordered values.
-enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case sparseA // = 123
   case sparseB // = 62374
@@ -140,16 +128,6 @@ enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNa
   case sparseE // = -53452
   case sparseF // = 0
   case sparseG // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    -53452: .same(proto: "SPARSE_E"),
-    -15: .same(proto: "SPARSE_D"),
-    0: .same(proto: "SPARSE_F"),
-    2: .same(proto: "SPARSE_G"),
-    123: .same(proto: "SPARSE_A"),
-    62374: .same(proto: "SPARSE_B"),
-    12589234: .same(proto: "SPARSE_C"),
-  ]
 
   init() {
     self = .sparseA
@@ -1114,7 +1092,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -1122,13 +1100,6 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
 
     /// Intentionally negative.
     case neg // = -1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -5563,17 +5534,11 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -6309,17 +6274,11 @@ struct ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum DynamicEnumType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum DynamicEnumType: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case dynamicFoo // = 2200
     case dynamicBar // = 2201
     case dynamicBaz // = 2202
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      2200: .same(proto: "DYNAMIC_FOO"),
-      2201: .same(proto: "DYNAMIC_BAR"),
-      2202: .same(proto: "DYNAMIC_BAZ"),
-    ]
 
     init() {
       self = .dynamicFoo
@@ -9790,6 +9749,34 @@ let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext
 ]
 
+extension ProtobufUnittest_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    4: .same(proto: "FOREIGN_FOO"),
+    5: .same(proto: "FOREIGN_BAR"),
+    6: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
+extension ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
+    3: .same(proto: "BAZ"),
+  ]
+}
+
+extension ProtobufUnittest_TestSparseEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -53452: .same(proto: "SPARSE_E"),
+    -15: .same(proto: "SPARSE_D"),
+    0: .same(proto: "SPARSE_F"),
+    2: .same(proto: "SPARSE_G"),
+    123: .same(proto: "SPARSE_A"),
+    62374: .same(proto: "SPARSE_B"),
+    12589234: .same(proto: "SPARSE_C"),
+  ]
+}
+
 extension ProtobufUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -9951,6 +9938,15 @@ extension ProtobufUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBas
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension ProtobufUnittest_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -10814,6 +10810,14 @@ extension ProtobufUnittest_TestOneof2: SwiftProtobuf._MessageImplementationBase,
   }
 }
 
+extension ProtobufUnittest_TestOneof2.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
+}
+
 extension ProtobufUnittest_TestOneof2.FooGroup: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     9: .same(proto: "a"),
@@ -10998,6 +11002,14 @@ extension ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf._MessageImplemen
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_TestDynamicExtensions.DynamicEnumType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    2200: .same(proto: "DYNAMIC_FOO"),
+    2201: .same(proto: "DYNAMIC_BAR"),
+    2202: .same(proto: "DYNAMIC_BAZ"),
+  ]
 }
 
 extension ProtobufUnittest_TestDynamicExtensions.DynamicMessageType: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -57,15 +57,10 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_MethodOpt1: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_MethodOpt1: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case val1 // = 1
   case val2 // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "METHODOPT1_VAL1"),
-    2: .same(proto: "METHODOPT1_VAL2"),
-  ]
 
   init() {
     self = .val1
@@ -88,13 +83,9 @@ enum ProtobufUnittest_MethodOpt1: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePr
 
 }
 
-enum ProtobufUnittest_AggregateEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_AggregateEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case value // = 1
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "VALUE"),
-  ]
 
   init() {
     self = .value
@@ -178,15 +169,10 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
     }
   }
 
-  enum AnEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum AnEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case val1 // = 1
     case val2 // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "ANENUM_VAL1"),
-      2: .same(proto: "ANENUM_VAL2"),
-    ]
 
     init() {
       self = .val1
@@ -309,15 +295,10 @@ struct ProtobufUnittest_DummyMessageContainingEnum: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestEnumType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TestEnumType: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case testOptionEnumType1 // = 22
     case testOptionEnumType2 // = -23
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -23: .same(proto: "TEST_OPTION_ENUM_TYPE2"),
-      22: .same(proto: "TEST_OPTION_ENUM_TYPE1"),
-    ]
 
     init() {
       self = .testOptionEnumType1
@@ -1130,13 +1111,9 @@ struct ProtobufUnittest_NestedOptionType: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case value // = 1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "NESTED_ENUM_VALUE"),
-    ]
 
     init() {
       self = .value
@@ -1233,13 +1210,9 @@ struct ProtobufUnittest_OldOptionType: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TestEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case oldValue // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "OLD_VALUE"),
-    ]
 
     init() {
       self = .oldValue
@@ -1302,15 +1275,10 @@ struct ProtobufUnittest_NewOptionType: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum TestEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TestEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case oldValue // = 0
     case newValue // = 1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "OLD_VALUE"),
-      1: .same(proto: "NEW_VALUE"),
-    ]
 
     init() {
       self = .oldValue
@@ -2278,6 +2246,19 @@ let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.SimpleExten
   ProtobufUnittest_NestedOptionType.Extensions.nested_extension
 ]
 
+extension ProtobufUnittest_MethodOpt1: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "METHODOPT1_VAL1"),
+    2: .same(proto: "METHODOPT1_VAL2"),
+  ]
+}
+
+extension ProtobufUnittest_AggregateEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "VALUE"),
+  ]
+}
+
 extension ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "field1"),
@@ -2290,6 +2271,13 @@ extension ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf._MessageI
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_TestMessageWithCustomOptions.AnEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ANENUM_VAL1"),
+    2: .same(proto: "ANENUM_VAL2"),
+  ]
 }
 
 extension ProtobufUnittest_CustomOptionFooRequest: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -2335,6 +2323,13 @@ extension ProtobufUnittest_DummyMessageContainingEnum: SwiftProtobuf._MessageImp
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_DummyMessageContainingEnum.TestEnumType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -23: .same(proto: "TEST_OPTION_ENUM_TYPE2"),
+    22: .same(proto: "TEST_OPTION_ENUM_TYPE1"),
+  ]
 }
 
 extension ProtobufUnittest_DummyMessageInvalidAsOptionType: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -2569,6 +2564,12 @@ extension ProtobufUnittest_NestedOptionType: SwiftProtobuf._MessageImplementatio
   }
 }
 
+extension ProtobufUnittest_NestedOptionType.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "NESTED_ENUM_VALUE"),
+  ]
+}
+
 extension ProtobufUnittest_NestedOptionType.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "nested_field"),
@@ -2593,6 +2594,12 @@ extension ProtobufUnittest_OldOptionType: SwiftProtobuf._MessageImplementationBa
   }
 }
 
+extension ProtobufUnittest_OldOptionType.TestEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "OLD_VALUE"),
+  ]
+}
+
 extension ProtobufUnittest_NewOptionType: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "value"),
@@ -2603,6 +2610,13 @@ extension ProtobufUnittest_NewOptionType: SwiftProtobuf._MessageImplementationBa
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_NewOptionType.TestEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "OLD_VALUE"),
+    1: .same(proto: "NEW_VALUE"),
+  ]
 }
 
 extension ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_drop_unknown_fields.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_drop_unknown_fields.pb.swift
@@ -60,18 +60,12 @@ struct UnittestDropUnknownFields_Foo: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -131,20 +125,13 @@ struct UnittestDropUnknownFields_FooWithExtraFields: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case qux // = 3
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-      3: .same(proto: "QUX"),
-    ]
 
     init() {
       self = .foo
@@ -213,6 +200,14 @@ extension UnittestDropUnknownFields_Foo: SwiftProtobuf._MessageImplementationBas
   }
 }
 
+extension UnittestDropUnknownFields_Foo.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
+}
+
 extension UnittestDropUnknownFields_FooWithExtraFields: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "int32_value"),
@@ -227,4 +222,13 @@ extension UnittestDropUnknownFields_FooWithExtraFields: SwiftProtobuf._MessageIm
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension UnittestDropUnknownFields_FooWithExtraFields.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+    3: .same(proto: "QUX"),
+  ]
 }

--- a/Tests/SwiftProtobufTests/unittest_import.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import.pb.swift
@@ -57,17 +57,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest_import"
 
-enum ProtobufUnittestImport_ImportEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittestImport_ImportEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case importFoo // = 7
   case importBar // = 8
   case importBaz // = 9
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    7: .same(proto: "IMPORT_FOO"),
-    8: .same(proto: "IMPORT_BAR"),
-    9: .same(proto: "IMPORT_BAZ"),
-  ]
 
   init() {
     self = .importFoo
@@ -93,17 +87,11 @@ enum ProtobufUnittestImport_ImportEnum: SwiftProtobuf.Enum, SwiftProtobuf._Proto
 }
 
 /// To use an enum in a map, it must has the first value as 0.
-enum ProtobufUnittestImport_ImportEnumForMap: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittestImport_ImportEnumForMap: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case unknown // = 0
   case foo // = 1
   case bar // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "UNKNOWN"),
-    1: .same(proto: "FOO"),
-    2: .same(proto: "BAR"),
-  ]
 
   init() {
     self = .unknown
@@ -162,6 +150,22 @@ struct ProtobufUnittestImport_ImportMessage: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension ProtobufUnittestImport_ImportEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    7: .same(proto: "IMPORT_FOO"),
+    8: .same(proto: "IMPORT_BAR"),
+    9: .same(proto: "IMPORT_BAZ"),
+  ]
+}
+
+extension ProtobufUnittestImport_ImportEnumForMap: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "UNKNOWN"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+  ]
 }
 
 extension ProtobufUnittestImport_ImportMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_import_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_lite.pb.swift
@@ -55,17 +55,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest_import"
 
-enum ProtobufUnittestImport_ImportEnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittestImport_ImportEnumLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case importLiteFoo // = 7
   case importLiteBar // = 8
   case importLiteBaz // = 9
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    7: .same(proto: "IMPORT_LITE_FOO"),
-    8: .same(proto: "IMPORT_LITE_BAR"),
-    9: .same(proto: "IMPORT_LITE_BAZ"),
-  ]
 
   init() {
     self = .importLiteFoo
@@ -124,6 +118,14 @@ struct ProtobufUnittestImport_ImportMessageLite: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension ProtobufUnittestImport_ImportEnumLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    7: .same(proto: "IMPORT_LITE_FOO"),
+    8: .same(proto: "IMPORT_LITE_BAR"),
+    9: .same(proto: "IMPORT_LITE_BAZ"),
+  ]
 }
 
 extension ProtobufUnittestImport_ImportMessageLite: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_import_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_proto3.pb.swift
@@ -57,20 +57,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest_import"
 
-enum Proto3ImportEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3ImportEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case importEnumUnspecified // = 0
   case importFoo // = 7
   case importBar // = 8
   case importBaz // = 9
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "IMPORT_ENUM_UNSPECIFIED"),
-    7: .same(proto: "IMPORT_FOO"),
-    8: .same(proto: "IMPORT_BAR"),
-    9: .same(proto: "IMPORT_BAZ"),
-  ]
 
   init() {
     self = .importEnumUnspecified
@@ -122,6 +115,15 @@ struct Proto3ImportMessage: SwiftProtobuf.Message {
     }
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Proto3ImportEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "IMPORT_ENUM_UNSPECIFIED"),
+    7: .same(proto: "IMPORT_FOO"),
+    8: .same(proto: "IMPORT_BAR"),
+    9: .same(proto: "IMPORT_BAZ"),
+  ]
 }
 
 extension Proto3ImportMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -55,17 +55,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum ProtobufUnittest_ForeignEnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_ForeignEnumLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignLiteFoo // = 4
   case foreignLiteBar // = 5
   case foreignLiteBaz // = 6
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    4: .same(proto: "FOREIGN_LITE_FOO"),
-    5: .same(proto: "FOREIGN_LITE_BAR"),
-    6: .same(proto: "FOREIGN_LITE_BAZ"),
-  ]
 
   init() {
     self = .foreignLiteFoo
@@ -90,13 +84,9 @@ enum ProtobufUnittest_ForeignEnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoN
 
 }
 
-enum ProtobufUnittest_V1EnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_V1EnumLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case v1First // = 1
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "V1_FIRST"),
-  ]
 
   init() {
     self = .v1First
@@ -117,15 +107,10 @@ enum ProtobufUnittest_V1EnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePr
 
 }
 
-enum ProtobufUnittest_V2EnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittest_V2EnumLite: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case v2First // = 1
   case v2Second // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "V2_FIRST"),
-    2: .same(proto: "V2_SECOND"),
-  ]
 
   init() {
     self = .v2First
@@ -1118,17 +1103,11 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
     case bar // = 2
     case baz // = 3
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -4757,6 +4736,27 @@ let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.SimpleExtensionMap =
   ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext
 ]
 
+extension ProtobufUnittest_ForeignEnumLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    4: .same(proto: "FOREIGN_LITE_FOO"),
+    5: .same(proto: "FOREIGN_LITE_BAR"),
+    6: .same(proto: "FOREIGN_LITE_BAZ"),
+  ]
+}
+
+extension ProtobufUnittest_V1EnumLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "V1_FIRST"),
+  ]
+}
+
+extension ProtobufUnittest_V2EnumLite: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "V2_FIRST"),
+    2: .same(proto: "V2_SECOND"),
+  ]
+}
+
 extension ProtobufUnittest_TestAllTypesLite: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -4921,6 +4921,14 @@ extension ProtobufUnittest_TestAllTypesLite: SwiftProtobuf._MessageImplementatio
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_TestAllTypesLite.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension ProtobufUnittest_TestAllTypesLite.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -59,17 +59,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest_no_arena"
 
-enum ProtobufUnittestNoArena_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum ProtobufUnittestNoArena_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    4: .same(proto: "FOREIGN_FOO"),
-    5: .same(proto: "FOREIGN_BAR"),
-    6: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignFoo
@@ -1051,7 +1045,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -1059,13 +1053,6 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
 
     /// Intentionally negative.
     case neg // = -1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -1610,6 +1597,14 @@ struct ProtobufUnittestNoArena_TestNoArenaMessage: SwiftProtobuf.Message {
   }
 }
 
+extension ProtobufUnittestNoArena_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    4: .same(proto: "FOREIGN_FOO"),
+    5: .same(proto: "FOREIGN_BAR"),
+    6: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -1772,6 +1767,15 @@ extension ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf._MessageImplementa
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittestNoArena_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension ProtobufUnittestNoArena_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -53,18 +53,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto2_nofieldpresence_unittest"
 
-enum Proto2NofieldpresenceUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto2NofieldpresenceUnittest_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignFoo // = 0
   case foreignBar // = 1
   case foreignBaz // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_FOO"),
-    1: .same(proto: "FOREIGN_BAR"),
-    2: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignFoo
@@ -592,18 +586,12 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -959,6 +947,14 @@ struct Proto2NofieldpresenceUnittest_ForeignMessage: SwiftProtobuf.Message {
   }
 }
 
+extension Proto2NofieldpresenceUnittest_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_FOO"),
+    1: .same(proto: "FOREIGN_BAR"),
+    2: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -1070,6 +1066,14 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf._MessageImpl
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
 }
 
 extension Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -53,13 +53,9 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf.no_generic_services_test"
 
-enum Google_Protobuf_NoGenericServicesTest_TestEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Google_Protobuf_NoGenericServicesTest_TestEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 1
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "FOO"),
-  ]
 
   init() {
     self = .foo
@@ -148,6 +144,12 @@ extension Google_Protobuf_NoGenericServicesTest_TestMessage {
 let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Google_Protobuf_NoGenericServicesTest_Extensions_test_extension
 ]
+
+extension Google_Protobuf_NoGenericServicesTest_TestEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "FOO"),
+  ]
+}
 
 extension Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -51,18 +51,12 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto3_preserve_unknown_enum_unittest"
 
-enum Proto3PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOO"),
-    1: .same(proto: "BAR"),
-    2: .same(proto: "BAZ"),
-  ]
 
   init() {
     self = .foo
@@ -88,20 +82,13 @@ enum Proto3PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum, SwiftProtobuf
 
 }
 
-enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case eFoo // = 0
   case eBar // = 1
   case eBaz // = 2
   case eExtra // = 3
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "E_FOO"),
-    1: .same(proto: "E_BAR"),
-    2: .same(proto: "E_BAZ"),
-    3: .same(proto: "E_EXTRA"),
-  ]
 
   init() {
     self = .eFoo
@@ -352,6 +339,23 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     try o?.traverse(visitor: &visitor, start: 5, end: 7)
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Proto3PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
+}
+
+extension Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "E_FOO"),
+    1: .same(proto: "E_BAR"),
+    2: .same(proto: "E_BAZ"),
+    3: .same(proto: "E_EXTRA"),
+  ]
 }
 
 extension Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -51,17 +51,11 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto2_preserve_unknown_enum_unittest"
 
-enum Proto2PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto2PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foo // = 0
   case bar // = 1
   case baz // = 2
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOO"),
-    1: .same(proto: "BAR"),
-    2: .same(proto: "BAZ"),
-  ]
 
   init() {
     self = .foo
@@ -211,6 +205,14 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
     try o?.traverse(visitor: &visitor, start: 5, end: 7)
     try unknownFields.traverse(visitor: &visitor)
   }
+}
+
+extension Proto2PreserveUnknownEnumUnittest_MyEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+  ]
 }
 
 extension Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -57,20 +57,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-enum Proto3ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignUnspecified // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_UNSPECIFIED"),
-    4: .same(proto: "FOREIGN_FOO"),
-    5: .same(proto: "FOREIGN_BAR"),
-    6: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignUnspecified
@@ -99,7 +92,7 @@ enum Proto3ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
 }
 
 /// Test an enum that has multiple values with the same number.
-enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case testEnumWithDupValueUnspecified // = 0
   case foo1 // = 1
@@ -108,13 +101,6 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
   static let foo2 = foo1
   static let bar2 = bar1
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED"),
-    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
-    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
-    3: .same(proto: "BAZ"),
-  ]
 
   init() {
     self = .testEnumWithDupValueUnspecified
@@ -143,7 +129,7 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
 }
 
 /// Test an enum with large, unordered values.
-enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3TestSparseEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case testSparseEnumUnspecified // = 0
   case sparseA // = 123
@@ -156,16 +142,6 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding
   /// SPARSE_F = 0;
   case sparseG // = 2
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    -53452: .same(proto: "SPARSE_E"),
-    -15: .same(proto: "SPARSE_D"),
-    0: .same(proto: "TEST_SPARSE_ENUM_UNSPECIFIED"),
-    2: .same(proto: "SPARSE_G"),
-    123: .same(proto: "SPARSE_A"),
-    62374: .same(proto: "SPARSE_B"),
-    12589234: .same(proto: "SPARSE_C"),
-  ]
 
   init() {
     self = .testSparseEnumUnspecified
@@ -684,7 +660,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case nestedEnumUnspecified // = 0
     case foo // = 1
@@ -694,14 +670,6 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      0: .same(proto: "NESTED_ENUM_UNSPECIFIED"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .nestedEnumUnspecified
@@ -2524,6 +2492,36 @@ struct Proto3BarResponse: SwiftProtobuf.Message {
   }
 }
 
+extension Proto3ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_UNSPECIFIED"),
+    4: .same(proto: "FOREIGN_FOO"),
+    5: .same(proto: "FOREIGN_BAR"),
+    6: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
+extension Proto3TestEnumWithDupValue: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "TEST_ENUM_WITH_DUP_VALUE_UNSPECIFIED"),
+    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
+    3: .same(proto: "BAZ"),
+  ]
+}
+
+extension Proto3TestSparseEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -53452: .same(proto: "SPARSE_E"),
+    -15: .same(proto: "SPARSE_D"),
+    0: .same(proto: "TEST_SPARSE_ENUM_UNSPECIFIED"),
+    2: .same(proto: "SPARSE_G"),
+    123: .same(proto: "SPARSE_A"),
+    62374: .same(proto: "SPARSE_B"),
+    12589234: .same(proto: "SPARSE_C"),
+  ]
+}
+
 extension Proto3TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "single_int32"),
@@ -2631,6 +2629,16 @@ extension Proto3TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftPro
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Proto3TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    0: .same(proto: "NESTED_ENUM_UNSPECIFIED"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension Proto3TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -51,20 +51,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto3_arena_unittest"
 
-enum Proto3ArenaUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum Proto3ArenaUnittest_ForeignEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case foreignZero // = 0
   case foreignFoo // = 4
   case foreignBar // = 5
   case foreignBaz // = 6
   case UNRECOGNIZED(Int)
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "FOREIGN_ZERO"),
-    4: .same(proto: "FOREIGN_FOO"),
-    5: .same(proto: "FOREIGN_BAR"),
-    6: .same(proto: "FOREIGN_BAZ"),
-  ]
 
   init() {
     self = .foreignZero
@@ -603,7 +596,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case zero // = 0
     case foo // = 1
@@ -613,14 +606,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      0: .same(proto: "ZERO"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .zero
@@ -1225,6 +1210,15 @@ struct Proto3ArenaUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   }
 }
 
+extension Proto3ArenaUnittest_ForeignEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOREIGN_ZERO"),
+    4: .same(proto: "FOREIGN_FOO"),
+    5: .same(proto: "FOREIGN_BAR"),
+    6: .same(proto: "FOREIGN_BAZ"),
+  ]
+}
+
 extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "optional_int32"),
@@ -1338,6 +1332,16 @@ extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf._MessageImplementation
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension Proto3ArenaUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    0: .same(proto: "ZERO"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
 }
 
 extension Proto3ArenaUnittest_TestAllTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -807,7 +807,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
     }
   }
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
     case bar // = 2
@@ -815,13 +815,6 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
 
     /// Intentionally negative.
     case neg // = -1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      -1: .same(proto: "NEG"),
-      1: .same(proto: "FOO"),
-      2: .same(proto: "BAR"),
-      3: .same(proto: "BAZ"),
-    ]
 
     init() {
       self = .foo
@@ -1282,13 +1275,9 @@ struct ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum NestedEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "FOO"),
-    ]
 
     init() {
       self = .foo
@@ -1471,6 +1460,15 @@ extension ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf._MessageImplement
   }
 }
 
+extension ProtobufUnittest_TestAllRequiredTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    -1: .same(proto: "NEG"),
+    1: .same(proto: "FOO"),
+    2: .same(proto: "BAR"),
+    3: .same(proto: "BAZ"),
+  ]
+}
+
 extension ProtobufUnittest_TestAllRequiredTypes.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "bb"),
@@ -1515,4 +1513,10 @@ extension ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf._MessageImplemen
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_TestSomeRequiredTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "FOO"),
+  ]
 }

--- a/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
@@ -56,15 +56,10 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum EnumTest1: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum EnumTest1: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case firstValue // = 1
     case secondValue // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "ENUM_TEST_1_FIRST_VALUE"),
-      2: .same(proto: "ENUM_TEST_1_SECOND_VALUE"),
-    ]
 
     init() {
       self = .firstValue
@@ -87,15 +82,10 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
   }
 
-  enum EnumTest2: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum EnumTest2: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case enumTest2FirstValue // = 1
     case secondValue // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "ENUM_TEST_2_FIRST_VALUE"),
-      2: .same(proto: "SECOND_VALUE"),
-    ]
 
     init() {
       self = .enumTest2FirstValue
@@ -118,15 +108,10 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
   }
 
-  enum EnumTestNoStem: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum EnumTestNoStem: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case enumTestNoStem1 // = 1
     case enumTestNoStem2 // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "ENUM_TEST_NO_STEM_1"),
-      2: .same(proto: "ENUM_TEST_NO_STEM_2"),
-    ]
 
     init() {
       self = .enumTestNoStem1
@@ -149,15 +134,10 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
   }
 
-  enum EnumTestReservedWord: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum EnumTestReservedWord: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case `var` // = 1
     case notReserved // = 2
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "ENUM_TEST_RESERVED_WORD_VAR"),
-      2: .same(proto: "ENUM_TEST_RESERVED_WORD_NOT_RESERVED"),
-    ]
 
     init() {
       self = .`var`
@@ -199,17 +179,12 @@ struct ProtobufUnittest_SwiftEnumWithAliasTest: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum EnumWithAlias: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum EnumWithAlias: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo1 // = 1
     static let foo2 = foo1
     case bar1 // = 2
     static let bar2 = bar1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
-      2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
-    ]
 
     init() {
       self = .foo1
@@ -260,6 +235,34 @@ extension ProtobufUnittest_SwiftEnumTest: SwiftProtobuf._MessageImplementationBa
   }
 }
 
+extension ProtobufUnittest_SwiftEnumTest.EnumTest1: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ENUM_TEST_1_FIRST_VALUE"),
+    2: .same(proto: "ENUM_TEST_1_SECOND_VALUE"),
+  ]
+}
+
+extension ProtobufUnittest_SwiftEnumTest.EnumTest2: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ENUM_TEST_2_FIRST_VALUE"),
+    2: .same(proto: "SECOND_VALUE"),
+  ]
+}
+
+extension ProtobufUnittest_SwiftEnumTest.EnumTestNoStem: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ENUM_TEST_NO_STEM_1"),
+    2: .same(proto: "ENUM_TEST_NO_STEM_2"),
+  ]
+}
+
+extension ProtobufUnittest_SwiftEnumTest.EnumTestReservedWord: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "ENUM_TEST_RESERVED_WORD_VAR"),
+    2: .same(proto: "ENUM_TEST_RESERVED_WORD_NOT_RESERVED"),
+  ]
+}
+
 extension ProtobufUnittest_SwiftEnumWithAliasTest: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "values"),
@@ -270,4 +273,11 @@ extension ProtobufUnittest_SwiftEnumWithAliasTest: SwiftProtobuf._MessageImpleme
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_SwiftEnumWithAliasTest.EnumWithAlias: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .aliased(proto: "FOO1", aliases: ["FOO2"]),
+    2: .aliased(proto: "BAR1", aliases: ["BAR2"]),
+  ]
 }

--- a/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
@@ -92,13 +92,9 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: SwiftProtobuf.Message {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+    enum Enum: SwiftProtobuf.Enum {
       typealias RawValue = Int
       case foo // = 0
-
-      static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        0: .same(proto: "FOO"),
-      ]
 
       init() {
         self = .foo
@@ -164,13 +160,9 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: SwiftProtobuf.Message {
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    enum Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+    enum Enum: SwiftProtobuf.Enum {
       typealias RawValue = Int
       case foo // = 0
-
-      static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-        0: .same(proto: "FOO"),
-      ]
 
       init() {
         self = .foo
@@ -251,6 +243,12 @@ extension ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage: SwiftProtob
   }
 }
 
+extension ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage.Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+  ]
+}
+
 extension ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     17: .standard(proto: "optional_enum"),
@@ -261,4 +259,10 @@ extension ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2: SwiftProto
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage2.Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+  ]
 }

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -39,7 +39,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "swift_unittest.names"
 
-enum SwiftUnittest_Names_EnumFieldNames: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum SwiftUnittest_Names_EnumFieldNames: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case a // = 0
   case string // = 1
@@ -249,217 +249,6 @@ enum SwiftUnittest_Names_EnumFieldNames: SwiftProtobuf.Enum, SwiftProtobuf._Prot
   case timeScale // = 241
   case timeBase // = 242
   case timeRecord // = 243
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "A"),
-    1: .same(proto: "String"),
-    2: .same(proto: "Int"),
-    3: .same(proto: "Double"),
-    4: .same(proto: "Float"),
-    5: .same(proto: "UInt"),
-    6: .same(proto: "hashValue"),
-    7: .same(proto: "description"),
-    8: .same(proto: "debugDescription"),
-    9: .same(proto: "Swift"),
-    10: .same(proto: "UNRECOGNIZED"),
-    11: .same(proto: "class"),
-    12: .same(proto: "deinit"),
-    13: .same(proto: "enum"),
-    14: .same(proto: "extension"),
-    15: .same(proto: "func"),
-    16: .same(proto: "import"),
-    17: .same(proto: "init"),
-    18: .same(proto: "inout"),
-    19: .same(proto: "internal"),
-    20: .same(proto: "let"),
-    21: .same(proto: "operator"),
-    22: .same(proto: "private"),
-    23: .same(proto: "protocol"),
-    24: .same(proto: "public"),
-    25: .same(proto: "static"),
-    26: .same(proto: "struct"),
-    27: .same(proto: "subscript"),
-    28: .same(proto: "typealias"),
-    29: .same(proto: "var"),
-    30: .same(proto: "break"),
-    31: .same(proto: "case"),
-    32: .same(proto: "continue"),
-    33: .same(proto: "default"),
-    34: .same(proto: "defer"),
-    35: .same(proto: "do"),
-    36: .same(proto: "else"),
-    37: .same(proto: "fallthrough"),
-    38: .same(proto: "for"),
-    39: .same(proto: "guard"),
-    40: .same(proto: "if"),
-    41: .same(proto: "in"),
-    42: .same(proto: "repeat"),
-    43: .same(proto: "return"),
-    44: .same(proto: "switch"),
-    45: .same(proto: "where"),
-    46: .same(proto: "while"),
-    47: .same(proto: "as"),
-    48: .same(proto: "catch"),
-    49: .same(proto: "dynamicType"),
-    50: .same(proto: "false"),
-    51: .same(proto: "is"),
-    52: .same(proto: "nil"),
-    53: .same(proto: "rethrows"),
-    54: .same(proto: "super"),
-    55: .same(proto: "self"),
-    57: .same(proto: "throw"),
-    58: .same(proto: "throws"),
-    59: .same(proto: "true"),
-    60: .same(proto: "try"),
-    61: .same(proto: "__COLUMN__"),
-    62: .same(proto: "__FILE__"),
-    63: .same(proto: "__FUNCTION__"),
-    64: .same(proto: "__LINE__"),
-    65: .same(proto: "_"),
-    66: .same(proto: "associativity"),
-    67: .same(proto: "convenience"),
-    68: .same(proto: "dynamic"),
-    69: .same(proto: "didSet"),
-    70: .same(proto: "final"),
-    71: .same(proto: "get"),
-    72: .same(proto: "infix"),
-    73: .same(proto: "indirect"),
-    74: .same(proto: "lazy"),
-    75: .same(proto: "left"),
-    76: .same(proto: "mutating"),
-    77: .same(proto: "none"),
-    78: .same(proto: "nonmutating"),
-    79: .same(proto: "optional"),
-    80: .same(proto: "override"),
-    81: .same(proto: "postfix"),
-    82: .same(proto: "precedence"),
-    83: .same(proto: "prefix"),
-    85: .same(proto: "required"),
-    86: .same(proto: "right"),
-    87: .same(proto: "set"),
-    88: .same(proto: "Type"),
-    89: .same(proto: "unowned"),
-    90: .same(proto: "weak"),
-    91: .same(proto: "willSet"),
-    92: .same(proto: "id"),
-    93: .same(proto: "_cmd"),
-    96: .same(proto: "out"),
-    98: .same(proto: "bycopy"),
-    99: .same(proto: "byref"),
-    100: .same(proto: "oneway"),
-    102: .same(proto: "and"),
-    103: .same(proto: "and_eq"),
-    104: .same(proto: "alignas"),
-    105: .same(proto: "alignof"),
-    106: .same(proto: "asm"),
-    107: .same(proto: "auto"),
-    108: .same(proto: "bitand"),
-    109: .same(proto: "bitor"),
-    110: .same(proto: "bool"),
-    114: .same(proto: "char"),
-    115: .same(proto: "char16_t"),
-    116: .same(proto: "char32_t"),
-    118: .same(proto: "compl"),
-    119: .same(proto: "const"),
-    120: .same(proto: "constexpr"),
-    121: .same(proto: "const_cast"),
-    123: .same(proto: "decltype"),
-    125: .same(proto: "delete"),
-    127: .same(proto: "dynamic_cast"),
-    130: .same(proto: "explicit"),
-    131: .same(proto: "export"),
-    132: .same(proto: "extern"),
-    136: .same(proto: "friend"),
-    137: .same(proto: "goto"),
-    139: .same(proto: "inline"),
-    141: .same(proto: "long"),
-    142: .same(proto: "mutable"),
-    143: .same(proto: "namespace"),
-    144: .same(proto: "new"),
-    145: .same(proto: "noexcept"),
-    146: .same(proto: "not"),
-    147: .same(proto: "not_eq"),
-    148: .same(proto: "nullptr"),
-    150: .same(proto: "or"),
-    151: .same(proto: "or_eq"),
-    153: .same(proto: "protected"),
-    155: .same(proto: "register"),
-    156: .same(proto: "reinterpret_cast"),
-    158: .same(proto: "short"),
-    159: .same(proto: "signed"),
-    160: .same(proto: "sizeof"),
-    162: .same(proto: "static_assert"),
-    163: .same(proto: "static_cast"),
-    166: .same(proto: "template"),
-    167: .same(proto: "this"),
-    168: .same(proto: "thread_local"),
-    172: .same(proto: "typedef"),
-    173: .same(proto: "typeid"),
-    174: .same(proto: "typename"),
-    175: .same(proto: "union"),
-    176: .same(proto: "unsigned"),
-    177: .same(proto: "using"),
-    178: .same(proto: "virtual"),
-    179: .same(proto: "void"),
-    180: .same(proto: "volatile"),
-    181: .same(proto: "wchar_t"),
-    183: .same(proto: "xor"),
-    184: .same(proto: "xor_eq"),
-    185: .same(proto: "restrict"),
-    186: .same(proto: "Category"),
-    187: .same(proto: "Ivar"),
-    188: .same(proto: "Method"),
-    192: .same(proto: "finalize"),
-    193: .same(proto: "hash"),
-    194: .same(proto: "dealloc"),
-    197: .same(proto: "superclass"),
-    198: .same(proto: "retain"),
-    199: .same(proto: "release"),
-    200: .same(proto: "autorelease"),
-    201: .same(proto: "retainCount"),
-    202: .same(proto: "zone"),
-    203: .same(proto: "isProxy"),
-    204: .same(proto: "copy"),
-    205: .same(proto: "mutableCopy"),
-    206: .same(proto: "classForCoder"),
-    207: .same(proto: "clear"),
-    208: .same(proto: "data"),
-    209: .same(proto: "delimitedData"),
-    210: .same(proto: "descriptor"),
-    211: .same(proto: "extensionRegistry"),
-    212: .same(proto: "extensionsCurrentlySet"),
-    213: .same(proto: "isInitialized"),
-    214: .same(proto: "serializedSize"),
-    215: .same(proto: "sortedExtensionsInUse"),
-    216: .same(proto: "unknownFields"),
-    217: .same(proto: "Fixed"),
-    218: .same(proto: "Fract"),
-    219: .same(proto: "Size"),
-    220: .same(proto: "LogicalAddress"),
-    221: .same(proto: "PhysicalAddress"),
-    222: .same(proto: "ByteCount"),
-    223: .same(proto: "ByteOffset"),
-    224: .same(proto: "Duration"),
-    225: .same(proto: "AbsoluteTime"),
-    226: .same(proto: "OptionBits"),
-    227: .same(proto: "ItemCount"),
-    228: .same(proto: "PBVersion"),
-    229: .same(proto: "ScriptCode"),
-    230: .same(proto: "LangCode"),
-    231: .same(proto: "RegionCode"),
-    232: .same(proto: "OSType"),
-    233: .same(proto: "ProcessSerialNumber"),
-    234: .same(proto: "Point"),
-    235: .same(proto: "Rect"),
-    236: .same(proto: "FixedPoint"),
-    237: .same(proto: "FixedRect"),
-    238: .same(proto: "Style"),
-    239: .same(proto: "StyleParameter"),
-    240: .same(proto: "StyleField"),
-    241: .same(proto: "TimeScale"),
-    242: .same(proto: "TimeBase"),
-    243: .same(proto: "TimeRecord"),
-  ]
 
   init() {
     self = .a
@@ -894,7 +683,7 @@ enum SwiftUnittest_Names_EnumFieldNames: SwiftProtobuf.Enum, SwiftProtobuf._Prot
 
 }
 
-enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum {
   typealias RawValue = Int
   case aa // = 0
 
@@ -906,11 +695,6 @@ enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum, SwiftProtobuf._Pro
   /// So this is in a second enum so it won't cause issues with the '_' one;
   /// but still ensure things generator correctly.
   case ____ // = 1065
-
-  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "AA"),
-    1065: .same(proto: "__"),
-  ]
 
   init() {
     self = .aa
@@ -12193,13 +11977,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum StringEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum StringEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aString // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aString"),
-    ]
 
     init() {
       self = .aString
@@ -12220,13 +12000,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ProtocolEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ProtocolEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aProtocol // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aProtocol"),
-    ]
 
     init() {
       self = .aProtocol
@@ -12247,13 +12023,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum IntEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum IntEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aInt // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aInt"),
-    ]
 
     init() {
       self = .aInt
@@ -12274,13 +12046,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum DoubleEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum DoubleEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aDouble // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aDouble"),
-    ]
 
     init() {
       self = .aDouble
@@ -12301,13 +12069,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum FloatEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum FloatEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aFloat // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aFloat"),
-    ]
 
     init() {
       self = .aFloat
@@ -12328,13 +12092,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum UIntEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum UIntEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aUint // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aUInt"),
-    ]
 
     init() {
       self = .aUint
@@ -12355,13 +12115,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum hashValueEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum hashValueEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ahashValue // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ahashValue"),
-    ]
 
     init() {
       self = .ahashValue
@@ -12382,13 +12138,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum descriptionEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum descriptionEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adescription // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adescription"),
-    ]
 
     init() {
       self = .adescription
@@ -12409,13 +12161,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum debugDescriptionEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum debugDescriptionEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adebugDescription // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adebugDescription"),
-    ]
 
     init() {
       self = .adebugDescription
@@ -12436,13 +12184,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Swift: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Swift: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aSwift // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aSwift"),
-    ]
 
     init() {
       self = .aSwift
@@ -12463,13 +12207,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum UNRECOGNIZED: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum UNRECOGNIZED: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aUnrecognized // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aUNRECOGNIZED"),
-    ]
 
     init() {
       self = .aUnrecognized
@@ -12490,13 +12230,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum classEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum classEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aclass // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aclass"),
-    ]
 
     init() {
       self = .aclass
@@ -12517,13 +12253,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum deinitEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum deinitEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adeinit // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adeinit"),
-    ]
 
     init() {
       self = .adeinit
@@ -12544,13 +12276,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum enumEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum enumEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aenum // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aenum"),
-    ]
 
     init() {
       self = .aenum
@@ -12571,13 +12299,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum extensionEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum extensionEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aextension // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aextension"),
-    ]
 
     init() {
       self = .aextension
@@ -12598,13 +12322,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum funcEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum funcEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afunc // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afunc"),
-    ]
 
     init() {
       self = .afunc
@@ -12625,13 +12345,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum importEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum importEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aimport // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aimport"),
-    ]
 
     init() {
       self = .aimport
@@ -12652,13 +12368,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum initEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum initEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ainit // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ainit"),
-    ]
 
     init() {
       self = .ainit
@@ -12679,13 +12391,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum inoutEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum inoutEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ainout // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ainout"),
-    ]
 
     init() {
       self = .ainout
@@ -12706,13 +12414,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum internalEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum internalEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ainternal // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ainternal"),
-    ]
 
     init() {
       self = .ainternal
@@ -12733,13 +12437,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum letEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum letEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case alet // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "alet"),
-    ]
 
     init() {
       self = .alet
@@ -12760,13 +12460,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum operatorEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum operatorEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aoperator // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aoperator"),
-    ]
 
     init() {
       self = .aoperator
@@ -12787,13 +12483,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum privateEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum privateEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aprivate // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aprivate"),
-    ]
 
     init() {
       self = .aprivate
@@ -12814,13 +12506,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum protocolEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum protocolEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aprotocol // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aprotocol"),
-    ]
 
     init() {
       self = .aprotocol
@@ -12841,13 +12529,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum publicEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum publicEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case apublic // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "apublic"),
-    ]
 
     init() {
       self = .apublic
@@ -12868,13 +12552,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum staticEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum staticEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case astatic // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "astatic"),
-    ]
 
     init() {
       self = .astatic
@@ -12895,13 +12575,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum structEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum structEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case astruct // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "astruct"),
-    ]
 
     init() {
       self = .astruct
@@ -12922,13 +12598,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum subscriptEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum subscriptEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asubscript // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asubscript"),
-    ]
 
     init() {
       self = .asubscript
@@ -12949,13 +12621,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum typealiasEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum typealiasEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atypealias // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atypealias"),
-    ]
 
     init() {
       self = .atypealias
@@ -12976,13 +12644,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum varEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum varEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case avar // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "avar"),
-    ]
 
     init() {
       self = .avar
@@ -13003,13 +12667,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum breakEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum breakEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abreak // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abreak"),
-    ]
 
     init() {
       self = .abreak
@@ -13030,13 +12690,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum caseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum caseEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case acase // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "acase"),
-    ]
 
     init() {
       self = .acase
@@ -13057,13 +12713,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum continueEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum continueEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case acontinue // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "acontinue"),
-    ]
 
     init() {
       self = .acontinue
@@ -13084,13 +12736,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum defaultEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum defaultEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adefault // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adefault"),
-    ]
 
     init() {
       self = .adefault
@@ -13111,13 +12759,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum deferEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum deferEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adefer // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adefer"),
-    ]
 
     init() {
       self = .adefer
@@ -13138,13 +12782,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum doEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum doEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ado // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ado"),
-    ]
 
     init() {
       self = .ado
@@ -13165,13 +12805,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum elseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum elseEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aelse // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aelse"),
-    ]
 
     init() {
       self = .aelse
@@ -13192,13 +12828,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum fallthroughEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum fallthroughEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afallthrough // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afallthrough"),
-    ]
 
     init() {
       self = .afallthrough
@@ -13219,13 +12851,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum forEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum forEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afor // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afor"),
-    ]
 
     init() {
       self = .afor
@@ -13246,13 +12874,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum guardEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum guardEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aguard // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aguard"),
-    ]
 
     init() {
       self = .aguard
@@ -13273,13 +12897,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ifEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ifEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aif // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aif"),
-    ]
 
     init() {
       self = .aif
@@ -13300,13 +12920,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum inEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum inEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ain // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ain"),
-    ]
 
     init() {
       self = .ain
@@ -13327,13 +12943,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum repeatEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum repeatEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case arepeat // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "arepeat"),
-    ]
 
     init() {
       self = .arepeat
@@ -13354,13 +12966,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum returnEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum returnEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case areturn // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "areturn"),
-    ]
 
     init() {
       self = .areturn
@@ -13381,13 +12989,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum switchEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum switchEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aswitch // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aswitch"),
-    ]
 
     init() {
       self = .aswitch
@@ -13408,13 +13012,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum whereEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum whereEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case awhere // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "awhere"),
-    ]
 
     init() {
       self = .awhere
@@ -13435,13 +13035,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum whileEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum whileEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case awhile // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "awhile"),
-    ]
 
     init() {
       self = .awhile
@@ -13462,13 +13058,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum asEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum asEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aas // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aas"),
-    ]
 
     init() {
       self = .aas
@@ -13489,13 +13081,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum catchEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum catchEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case acatch // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "acatch"),
-    ]
 
     init() {
       self = .acatch
@@ -13516,13 +13104,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum dynamicTypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum dynamicTypeEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adynamicType // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adynamicType"),
-    ]
 
     init() {
       self = .adynamicType
@@ -13543,13 +13127,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum falseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum falseEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afalse // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afalse"),
-    ]
 
     init() {
       self = .afalse
@@ -13570,13 +13150,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum isEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum isEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ais // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ais"),
-    ]
 
     init() {
       self = .ais
@@ -13597,13 +13173,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum nilEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum nilEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anil // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anil"),
-    ]
 
     init() {
       self = .anil
@@ -13624,13 +13196,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum rethrowsEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum rethrowsEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case arethrows // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "arethrows"),
-    ]
 
     init() {
       self = .arethrows
@@ -13651,13 +13219,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum superEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum superEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asuper // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asuper"),
-    ]
 
     init() {
       self = .asuper
@@ -13678,13 +13242,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum selfEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum selfEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aself // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aself"),
-    ]
 
     init() {
       self = .aself
@@ -13705,13 +13265,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum throwEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum throwEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case athrow // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "athrow"),
-    ]
 
     init() {
       self = .athrow
@@ -13732,13 +13288,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum throwsEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum throwsEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case athrows // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "athrows"),
-    ]
 
     init() {
       self = .athrows
@@ -13759,13 +13311,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum trueEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum trueEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atrue // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atrue"),
-    ]
 
     init() {
       self = .atrue
@@ -13786,13 +13334,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum tryEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum tryEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atry // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atry"),
-    ]
 
     init() {
       self = .atry
@@ -13813,13 +13357,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum __COLUMN__Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum __COLUMN__Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a_Column__ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a__COLUMN__"),
-    ]
 
     init() {
       self = .a_Column__
@@ -13840,13 +13380,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum __FILE__Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum __FILE__Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a_File__ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a__FILE__"),
-    ]
 
     init() {
       self = .a_File__
@@ -13867,13 +13403,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum __FUNCTION__Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum __FUNCTION__Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a_Function__ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a__FUNCTION__"),
-    ]
 
     init() {
       self = .a_Function__
@@ -13894,13 +13426,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum __LINE__Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum __LINE__Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a_Line__ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a__LINE__"),
-    ]
 
     init() {
       self = .a_Line__
@@ -13921,13 +13449,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum _Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum _Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a_ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a_"),
-    ]
 
     init() {
       self = .a_
@@ -13948,13 +13472,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum __Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum __Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a__ // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a__"),
-    ]
 
     init() {
       self = .a__
@@ -13975,13 +13495,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum associativity: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum associativity: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aassociativity // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aassociativity"),
-    ]
 
     init() {
       self = .aassociativity
@@ -14002,13 +13518,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum convenience: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum convenience: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aconvenience // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aconvenience"),
-    ]
 
     init() {
       self = .aconvenience
@@ -14029,13 +13541,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum dynamic: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum dynamic: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adynamic // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adynamic"),
-    ]
 
     init() {
       self = .adynamic
@@ -14056,13 +13564,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum didSet: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum didSet: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adidSet // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adidSet"),
-    ]
 
     init() {
       self = .adidSet
@@ -14083,13 +13587,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum final: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum final: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afinal // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afinal"),
-    ]
 
     init() {
       self = .afinal
@@ -14110,13 +13610,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum get: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum get: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aget // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aget"),
-    ]
 
     init() {
       self = .aget
@@ -14137,13 +13633,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum infix: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum infix: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ainfix // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ainfix"),
-    ]
 
     init() {
       self = .ainfix
@@ -14164,13 +13656,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum indirect: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum indirect: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aindirect // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aindirect"),
-    ]
 
     init() {
       self = .aindirect
@@ -14191,13 +13679,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum lazy: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum lazy: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case alazy // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "alazy"),
-    ]
 
     init() {
       self = .alazy
@@ -14218,13 +13702,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum left: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum left: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aleft // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aleft"),
-    ]
 
     init() {
       self = .aleft
@@ -14245,13 +13725,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum mutating: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum mutating: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case amutating // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "amutating"),
-    ]
 
     init() {
       self = .amutating
@@ -14272,13 +13748,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum none: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum none: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anone // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anone"),
-    ]
 
     init() {
       self = .anone
@@ -14299,13 +13771,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum nonmutating: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum nonmutating: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anonmutating // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anonmutating"),
-    ]
 
     init() {
       self = .anonmutating
@@ -14326,13 +13794,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum optional: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum optional: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aoptional // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aoptional"),
-    ]
 
     init() {
       self = .aoptional
@@ -14353,13 +13817,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum override: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum override: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aoverride // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aoverride"),
-    ]
 
     init() {
       self = .aoverride
@@ -14380,13 +13840,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum postfix: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum postfix: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case apostfix // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "apostfix"),
-    ]
 
     init() {
       self = .apostfix
@@ -14407,13 +13863,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum precedence: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum precedence: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aprecedence // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aprecedence"),
-    ]
 
     init() {
       self = .aprecedence
@@ -14434,13 +13886,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum prefix: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum prefix: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aprefix // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aprefix"),
-    ]
 
     init() {
       self = .aprefix
@@ -14461,13 +13909,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum required: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum required: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case arequired // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "arequired"),
-    ]
 
     init() {
       self = .arequired
@@ -14488,13 +13932,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum right: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum right: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aright // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aright"),
-    ]
 
     init() {
       self = .aright
@@ -14515,13 +13955,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum set: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum set: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aset // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aset"),
-    ]
 
     init() {
       self = .aset
@@ -14542,13 +13978,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TypeEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aType // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aType"),
-    ]
 
     init() {
       self = .aType
@@ -14569,13 +14001,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum unowned: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum unowned: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aunowned // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aunowned"),
-    ]
 
     init() {
       self = .aunowned
@@ -14596,13 +14024,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum weak: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum weak: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aweak // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aweak"),
-    ]
 
     init() {
       self = .aweak
@@ -14623,13 +14047,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum willSet: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum willSet: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case awillSet // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "awillSet"),
-    ]
 
     init() {
       self = .awillSet
@@ -14650,13 +14070,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum id: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum id: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aid // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aid"),
-    ]
 
     init() {
       self = .aid
@@ -14677,13 +14093,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum _cmd: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum _cmd: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aCmd // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "a_cmd"),
-    ]
 
     init() {
       self = .aCmd
@@ -14704,13 +14116,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum out: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum out: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aout // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aout"),
-    ]
 
     init() {
       self = .aout
@@ -14731,13 +14139,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum bycopy: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum bycopy: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abycopy // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abycopy"),
-    ]
 
     init() {
       self = .abycopy
@@ -14758,13 +14162,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum byref: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum byref: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abyref // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abyref"),
-    ]
 
     init() {
       self = .abyref
@@ -14785,13 +14185,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum oneway: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum oneway: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aoneway // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aoneway"),
-    ]
 
     init() {
       self = .aoneway
@@ -14812,13 +14208,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum and: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum and: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aand // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aand"),
-    ]
 
     init() {
       self = .aand
@@ -14839,13 +14231,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum and_eq: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum and_eq: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aandEq // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aand_eq"),
-    ]
 
     init() {
       self = .aandEq
@@ -14866,13 +14254,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum alignas: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum alignas: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aalignas // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aalignas"),
-    ]
 
     init() {
       self = .aalignas
@@ -14893,13 +14277,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum alignof: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum alignof: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aalignof // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aalignof"),
-    ]
 
     init() {
       self = .aalignof
@@ -14920,13 +14300,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum asm: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum asm: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aasm // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aasm"),
-    ]
 
     init() {
       self = .aasm
@@ -14947,13 +14323,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum auto: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum auto: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aauto // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aauto"),
-    ]
 
     init() {
       self = .aauto
@@ -14974,13 +14346,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum bitand: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum bitand: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abitand // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abitand"),
-    ]
 
     init() {
       self = .abitand
@@ -15001,13 +14369,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum bitor: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum bitor: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abitor // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abitor"),
-    ]
 
     init() {
       self = .abitor
@@ -15028,13 +14392,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum bool: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum bool: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case abool // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "abool"),
-    ]
 
     init() {
       self = .abool
@@ -15055,13 +14415,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum char: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum char: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case achar // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "achar"),
-    ]
 
     init() {
       self = .achar
@@ -15082,13 +14438,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum char16_t: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum char16_t: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case achar16T // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "achar16_t"),
-    ]
 
     init() {
       self = .achar16T
@@ -15109,13 +14461,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum char32_t: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum char32_t: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case achar32T // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "achar32_t"),
-    ]
 
     init() {
       self = .achar32T
@@ -15136,13 +14484,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum compl: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum compl: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case acompl // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "acompl"),
-    ]
 
     init() {
       self = .acompl
@@ -15163,13 +14507,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum const: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum const: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aconst // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aconst"),
-    ]
 
     init() {
       self = .aconst
@@ -15190,13 +14530,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum constexpr: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum constexpr: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aconstexpr // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aconstexpr"),
-    ]
 
     init() {
       self = .aconstexpr
@@ -15217,13 +14553,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum const_cast: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum const_cast: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aconstCast // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aconst_cast"),
-    ]
 
     init() {
       self = .aconstCast
@@ -15244,13 +14576,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum decltype: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum decltype: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adecltype // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adecltype"),
-    ]
 
     init() {
       self = .adecltype
@@ -15271,13 +14599,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum delete: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum delete: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adelete // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adelete"),
-    ]
 
     init() {
       self = .adelete
@@ -15298,13 +14622,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum dynamic_cast: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum dynamic_cast: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adynamicCast // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adynamic_cast"),
-    ]
 
     init() {
       self = .adynamicCast
@@ -15325,13 +14645,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum explicit: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum explicit: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aexplicit // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aexplicit"),
-    ]
 
     init() {
       self = .aexplicit
@@ -15352,13 +14668,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum export: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum export: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aexport // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aexport"),
-    ]
 
     init() {
       self = .aexport
@@ -15379,13 +14691,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum extern: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum extern: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aextern // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aextern"),
-    ]
 
     init() {
       self = .aextern
@@ -15406,13 +14714,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum friend: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum friend: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afriend // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afriend"),
-    ]
 
     init() {
       self = .afriend
@@ -15433,13 +14737,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum goto: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum goto: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case agoto // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "agoto"),
-    ]
 
     init() {
       self = .agoto
@@ -15460,13 +14760,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum inline: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum inline: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ainline // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ainline"),
-    ]
 
     init() {
       self = .ainline
@@ -15487,13 +14783,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum long: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum long: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case along // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "along"),
-    ]
 
     init() {
       self = .along
@@ -15514,13 +14806,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum mutable: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum mutable: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case amutable // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "amutable"),
-    ]
 
     init() {
       self = .amutable
@@ -15541,13 +14829,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum namespace: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum namespace: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anamespace // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anamespace"),
-    ]
 
     init() {
       self = .anamespace
@@ -15568,13 +14852,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum new: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum new: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anew // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anew"),
-    ]
 
     init() {
       self = .anew
@@ -15595,13 +14875,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum noexcept: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum noexcept: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anoexcept // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anoexcept"),
-    ]
 
     init() {
       self = .anoexcept
@@ -15622,13 +14898,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum not: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum not: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anot // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anot"),
-    ]
 
     init() {
       self = .anot
@@ -15649,13 +14921,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum not_eq: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum not_eq: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anotEq // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anot_eq"),
-    ]
 
     init() {
       self = .anotEq
@@ -15676,13 +14944,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum nullptr: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum nullptr: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case anullptr // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "anullptr"),
-    ]
 
     init() {
       self = .anullptr
@@ -15703,13 +14967,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum or: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum or: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aor // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aor"),
-    ]
 
     init() {
       self = .aor
@@ -15730,13 +14990,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum or_eq: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum or_eq: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aorEq // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aor_eq"),
-    ]
 
     init() {
       self = .aorEq
@@ -15757,13 +15013,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum protected: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum protected: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aprotected // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aprotected"),
-    ]
 
     init() {
       self = .aprotected
@@ -15784,13 +15036,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum register: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum register: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aregister // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aregister"),
-    ]
 
     init() {
       self = .aregister
@@ -15811,13 +15059,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum reinterpret_cast: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum reinterpret_cast: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case areinterpretCast // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "areinterpret_cast"),
-    ]
 
     init() {
       self = .areinterpretCast
@@ -15838,13 +15082,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum short: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum short: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ashort // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ashort"),
-    ]
 
     init() {
       self = .ashort
@@ -15865,13 +15105,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum signed: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum signed: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asigned // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asigned"),
-    ]
 
     init() {
       self = .asigned
@@ -15892,13 +15128,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum sizeof: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum sizeof: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asizeof // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asizeof"),
-    ]
 
     init() {
       self = .asizeof
@@ -15919,13 +15151,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum static_assert: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum static_assert: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case astaticAssert // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "astatic_assert"),
-    ]
 
     init() {
       self = .astaticAssert
@@ -15946,13 +15174,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum static_cast: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum static_cast: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case astaticCast // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "astatic_cast"),
-    ]
 
     init() {
       self = .astaticCast
@@ -15973,13 +15197,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum template: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum template: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atemplate // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atemplate"),
-    ]
 
     init() {
       self = .atemplate
@@ -16000,13 +15220,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum this: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum this: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case athis // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "athis"),
-    ]
 
     init() {
       self = .athis
@@ -16027,13 +15243,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum thread_local: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum thread_local: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case athreadLocal // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "athread_local"),
-    ]
 
     init() {
       self = .athreadLocal
@@ -16054,13 +15266,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum typedef: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum typedef: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atypedef // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atypedef"),
-    ]
 
     init() {
       self = .atypedef
@@ -16081,13 +15289,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum typeid: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum typeid: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atypeid // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atypeid"),
-    ]
 
     init() {
       self = .atypeid
@@ -16108,13 +15312,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum typename: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum typename: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case atypename // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "atypename"),
-    ]
 
     init() {
       self = .atypename
@@ -16135,13 +15335,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum union: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum union: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aunion // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aunion"),
-    ]
 
     init() {
       self = .aunion
@@ -16162,13 +15358,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum unsigned: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum unsigned: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aunsigned // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aunsigned"),
-    ]
 
     init() {
       self = .aunsigned
@@ -16189,13 +15381,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum using: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum using: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ausing // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ausing"),
-    ]
 
     init() {
       self = .ausing
@@ -16216,13 +15404,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum virtual: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum virtual: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case avirtual // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "avirtual"),
-    ]
 
     init() {
       self = .avirtual
@@ -16243,13 +15427,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum void: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum void: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case avoid // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "avoid"),
-    ]
 
     init() {
       self = .avoid
@@ -16270,13 +15450,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum volatile: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum volatile: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case avolatile // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "avolatile"),
-    ]
 
     init() {
       self = .avolatile
@@ -16297,13 +15473,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum wchar_t: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum wchar_t: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case awcharT // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "awchar_t"),
-    ]
 
     init() {
       self = .awcharT
@@ -16324,13 +15496,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum xor: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum xor: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case axor // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "axor"),
-    ]
 
     init() {
       self = .axor
@@ -16351,13 +15519,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum xor_eq: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum xor_eq: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case axorEq // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "axor_eq"),
-    ]
 
     init() {
       self = .axorEq
@@ -16378,13 +15542,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum restrict: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum restrict: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case arestrict // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "arestrict"),
-    ]
 
     init() {
       self = .arestrict
@@ -16405,13 +15565,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Category: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Category: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aCategory // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aCategory"),
-    ]
 
     init() {
       self = .aCategory
@@ -16432,13 +15588,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Ivar: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Ivar: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aIvar // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aIvar"),
-    ]
 
     init() {
       self = .aIvar
@@ -16459,13 +15611,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Method: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Method: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aMethod // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aMethod"),
-    ]
 
     init() {
       self = .aMethod
@@ -16486,13 +15634,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum finalize: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum finalize: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case afinalize // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "afinalize"),
-    ]
 
     init() {
       self = .afinalize
@@ -16513,13 +15657,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum hash: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum hash: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case ahash // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "ahash"),
-    ]
 
     init() {
       self = .ahash
@@ -16540,13 +15680,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum dealloc: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum dealloc: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adealloc // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adealloc"),
-    ]
 
     init() {
       self = .adealloc
@@ -16567,13 +15703,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum superclass: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum superclass: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asuperclass // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asuperclass"),
-    ]
 
     init() {
       self = .asuperclass
@@ -16594,13 +15726,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum retain: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum retain: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aretain // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aretain"),
-    ]
 
     init() {
       self = .aretain
@@ -16621,13 +15749,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum release: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum release: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case arelease // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "arelease"),
-    ]
 
     init() {
       self = .arelease
@@ -16648,13 +15772,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum autorelease: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum autorelease: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aautorelease // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aautorelease"),
-    ]
 
     init() {
       self = .aautorelease
@@ -16675,13 +15795,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum retainCount: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum retainCount: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aretainCount // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aretainCount"),
-    ]
 
     init() {
       self = .aretainCount
@@ -16702,13 +15818,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum zone: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum zone: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case azone // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "azone"),
-    ]
 
     init() {
       self = .azone
@@ -16729,13 +15841,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum isProxy: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum isProxy: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aisProxy // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aisProxy"),
-    ]
 
     init() {
       self = .aisProxy
@@ -16756,13 +15864,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum copy: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum copy: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case acopy // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "acopy"),
-    ]
 
     init() {
       self = .acopy
@@ -16783,13 +15887,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum mutableCopy: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum mutableCopy: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case amutableCopy // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "amutableCopy"),
-    ]
 
     init() {
       self = .amutableCopy
@@ -16810,13 +15910,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum classForCoder: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum classForCoder: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aclassForCoder // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aclassForCoder"),
-    ]
 
     init() {
       self = .aclassForCoder
@@ -16837,13 +15933,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum clear: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum clear: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aclear // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aclear"),
-    ]
 
     init() {
       self = .aclear
@@ -16864,13 +15956,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum data: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum data: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adata // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adata"),
-    ]
 
     init() {
       self = .adata
@@ -16891,13 +15979,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum delimitedData: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum delimitedData: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adelimitedData // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adelimitedData"),
-    ]
 
     init() {
       self = .adelimitedData
@@ -16918,13 +16002,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum descriptor: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum descriptor: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case adescriptor // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "adescriptor"),
-    ]
 
     init() {
       self = .adescriptor
@@ -16945,13 +16025,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum extensionRegistry: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum extensionRegistry: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aextensionRegistry // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aextensionRegistry"),
-    ]
 
     init() {
       self = .aextensionRegistry
@@ -16972,13 +16048,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum extensionsCurrentlySet: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum extensionsCurrentlySet: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aextensionsCurrentlySet // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aextensionsCurrentlySet"),
-    ]
 
     init() {
       self = .aextensionsCurrentlySet
@@ -16999,13 +16071,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum isInitialized: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum isInitialized: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aisInitialized // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aisInitialized"),
-    ]
 
     init() {
       self = .aisInitialized
@@ -17026,13 +16094,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum serializedSize: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum serializedSize: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aserializedSize // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aserializedSize"),
-    ]
 
     init() {
       self = .aserializedSize
@@ -17053,13 +16117,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum sortedExtensionsInUse: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum sortedExtensionsInUse: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case asortedExtensionsInUse // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "asortedExtensionsInUse"),
-    ]
 
     init() {
       self = .asortedExtensionsInUse
@@ -17080,13 +16140,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum unknownFieldsEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum unknownFieldsEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aunknownFields // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aunknownFields"),
-    ]
 
     init() {
       self = .aunknownFields
@@ -17107,13 +16163,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Fixed: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Fixed: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aFixed // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aFixed"),
-    ]
 
     init() {
       self = .aFixed
@@ -17134,13 +16186,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Fract: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Fract: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aFract // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aFract"),
-    ]
 
     init() {
       self = .aFract
@@ -17161,13 +16209,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Size: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Size: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aSize // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aSize"),
-    ]
 
     init() {
       self = .aSize
@@ -17188,13 +16232,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum LogicalAddress: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum LogicalAddress: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aLogicalAddress // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aLogicalAddress"),
-    ]
 
     init() {
       self = .aLogicalAddress
@@ -17215,13 +16255,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum PhysicalAddress: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum PhysicalAddress: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aPhysicalAddress // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aPhysicalAddress"),
-    ]
 
     init() {
       self = .aPhysicalAddress
@@ -17242,13 +16278,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ByteCount: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ByteCount: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aByteCount // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aByteCount"),
-    ]
 
     init() {
       self = .aByteCount
@@ -17269,13 +16301,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ByteOffset: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ByteOffset: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aByteOffset // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aByteOffset"),
-    ]
 
     init() {
       self = .aByteOffset
@@ -17296,13 +16324,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Duration: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Duration: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aDuration // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aDuration"),
-    ]
 
     init() {
       self = .aDuration
@@ -17323,13 +16347,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum AbsoluteTime: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum AbsoluteTime: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aAbsoluteTime // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aAbsoluteTime"),
-    ]
 
     init() {
       self = .aAbsoluteTime
@@ -17350,13 +16370,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum OptionBits: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum OptionBits: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aOptionBits // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aOptionBits"),
-    ]
 
     init() {
       self = .aOptionBits
@@ -17377,13 +16393,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ItemCount: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ItemCount: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aItemCount // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aItemCount"),
-    ]
 
     init() {
       self = .aItemCount
@@ -17404,13 +16416,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum PBVersion: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum PBVersion: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aPbversion // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aPBVersion"),
-    ]
 
     init() {
       self = .aPbversion
@@ -17431,13 +16439,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ScriptCode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ScriptCode: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aScriptCode // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aScriptCode"),
-    ]
 
     init() {
       self = .aScriptCode
@@ -17458,13 +16462,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum LangCode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum LangCode: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aLangCode // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aLangCode"),
-    ]
 
     init() {
       self = .aLangCode
@@ -17485,13 +16485,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum RegionCode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum RegionCode: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aRegionCode // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aRegionCode"),
-    ]
 
     init() {
       self = .aRegionCode
@@ -17512,13 +16508,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum OSType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum OSType: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aOstype // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aOSType"),
-    ]
 
     init() {
       self = .aOstype
@@ -17539,13 +16531,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum ProcessSerialNumber: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ProcessSerialNumber: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aProcessSerialNumber // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aProcessSerialNumber"),
-    ]
 
     init() {
       self = .aProcessSerialNumber
@@ -17566,13 +16554,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Point: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Point: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aPoint // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aPoint"),
-    ]
 
     init() {
       self = .aPoint
@@ -17593,13 +16577,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Rect: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Rect: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aRect // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aRect"),
-    ]
 
     init() {
       self = .aRect
@@ -17620,13 +16600,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum FixedPoint: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum FixedPoint: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aFixedPoint // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aFixedPoint"),
-    ]
 
     init() {
       self = .aFixedPoint
@@ -17647,13 +16623,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum FixedRect: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum FixedRect: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aFixedRect // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aFixedRect"),
-    ]
 
     init() {
       self = .aFixedRect
@@ -17674,13 +16646,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum Style: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Style: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aStyle // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aStyle"),
-    ]
 
     init() {
       self = .aStyle
@@ -17701,13 +16669,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum StyleParameter: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum StyleParameter: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aStyleParameter // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aStyleParameter"),
-    ]
 
     init() {
       self = .aStyleParameter
@@ -17728,13 +16692,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum StyleField: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum StyleField: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aStyleField // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aStyleField"),
-    ]
 
     init() {
       self = .aStyleField
@@ -17755,13 +16715,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum TimeScale: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TimeScale: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aTimeScale // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aTimeScale"),
-    ]
 
     init() {
       self = .aTimeScale
@@ -17782,13 +16738,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum TimeBase: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TimeBase: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aTimeBase // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aTimeBase"),
-    ]
 
     init() {
       self = .aTimeBase
@@ -17809,13 +16761,9 @@ struct SwiftUnittest_Names_EnumNames: SwiftProtobuf.Message {
 
   }
 
-  enum TimeRecord: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum TimeRecord: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case aTimeRecord // = 0
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "aTimeRecord"),
-    ]
 
     init() {
       self = .aTimeRecord
@@ -20171,6 +19119,226 @@ let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.SimpleExte
   SwiftUnittest_Names_WordCase.Extensions.TheUrlValue,
   SwiftUnittest_Names_WordCase.Extensions.TheUrl
 ]
+
+extension SwiftUnittest_Names_EnumFieldNames: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "A"),
+    1: .same(proto: "String"),
+    2: .same(proto: "Int"),
+    3: .same(proto: "Double"),
+    4: .same(proto: "Float"),
+    5: .same(proto: "UInt"),
+    6: .same(proto: "hashValue"),
+    7: .same(proto: "description"),
+    8: .same(proto: "debugDescription"),
+    9: .same(proto: "Swift"),
+    10: .same(proto: "UNRECOGNIZED"),
+    11: .same(proto: "class"),
+    12: .same(proto: "deinit"),
+    13: .same(proto: "enum"),
+    14: .same(proto: "extension"),
+    15: .same(proto: "func"),
+    16: .same(proto: "import"),
+    17: .same(proto: "init"),
+    18: .same(proto: "inout"),
+    19: .same(proto: "internal"),
+    20: .same(proto: "let"),
+    21: .same(proto: "operator"),
+    22: .same(proto: "private"),
+    23: .same(proto: "protocol"),
+    24: .same(proto: "public"),
+    25: .same(proto: "static"),
+    26: .same(proto: "struct"),
+    27: .same(proto: "subscript"),
+    28: .same(proto: "typealias"),
+    29: .same(proto: "var"),
+    30: .same(proto: "break"),
+    31: .same(proto: "case"),
+    32: .same(proto: "continue"),
+    33: .same(proto: "default"),
+    34: .same(proto: "defer"),
+    35: .same(proto: "do"),
+    36: .same(proto: "else"),
+    37: .same(proto: "fallthrough"),
+    38: .same(proto: "for"),
+    39: .same(proto: "guard"),
+    40: .same(proto: "if"),
+    41: .same(proto: "in"),
+    42: .same(proto: "repeat"),
+    43: .same(proto: "return"),
+    44: .same(proto: "switch"),
+    45: .same(proto: "where"),
+    46: .same(proto: "while"),
+    47: .same(proto: "as"),
+    48: .same(proto: "catch"),
+    49: .same(proto: "dynamicType"),
+    50: .same(proto: "false"),
+    51: .same(proto: "is"),
+    52: .same(proto: "nil"),
+    53: .same(proto: "rethrows"),
+    54: .same(proto: "super"),
+    55: .same(proto: "self"),
+    57: .same(proto: "throw"),
+    58: .same(proto: "throws"),
+    59: .same(proto: "true"),
+    60: .same(proto: "try"),
+    61: .same(proto: "__COLUMN__"),
+    62: .same(proto: "__FILE__"),
+    63: .same(proto: "__FUNCTION__"),
+    64: .same(proto: "__LINE__"),
+    65: .same(proto: "_"),
+    66: .same(proto: "associativity"),
+    67: .same(proto: "convenience"),
+    68: .same(proto: "dynamic"),
+    69: .same(proto: "didSet"),
+    70: .same(proto: "final"),
+    71: .same(proto: "get"),
+    72: .same(proto: "infix"),
+    73: .same(proto: "indirect"),
+    74: .same(proto: "lazy"),
+    75: .same(proto: "left"),
+    76: .same(proto: "mutating"),
+    77: .same(proto: "none"),
+    78: .same(proto: "nonmutating"),
+    79: .same(proto: "optional"),
+    80: .same(proto: "override"),
+    81: .same(proto: "postfix"),
+    82: .same(proto: "precedence"),
+    83: .same(proto: "prefix"),
+    85: .same(proto: "required"),
+    86: .same(proto: "right"),
+    87: .same(proto: "set"),
+    88: .same(proto: "Type"),
+    89: .same(proto: "unowned"),
+    90: .same(proto: "weak"),
+    91: .same(proto: "willSet"),
+    92: .same(proto: "id"),
+    93: .same(proto: "_cmd"),
+    96: .same(proto: "out"),
+    98: .same(proto: "bycopy"),
+    99: .same(proto: "byref"),
+    100: .same(proto: "oneway"),
+    102: .same(proto: "and"),
+    103: .same(proto: "and_eq"),
+    104: .same(proto: "alignas"),
+    105: .same(proto: "alignof"),
+    106: .same(proto: "asm"),
+    107: .same(proto: "auto"),
+    108: .same(proto: "bitand"),
+    109: .same(proto: "bitor"),
+    110: .same(proto: "bool"),
+    114: .same(proto: "char"),
+    115: .same(proto: "char16_t"),
+    116: .same(proto: "char32_t"),
+    118: .same(proto: "compl"),
+    119: .same(proto: "const"),
+    120: .same(proto: "constexpr"),
+    121: .same(proto: "const_cast"),
+    123: .same(proto: "decltype"),
+    125: .same(proto: "delete"),
+    127: .same(proto: "dynamic_cast"),
+    130: .same(proto: "explicit"),
+    131: .same(proto: "export"),
+    132: .same(proto: "extern"),
+    136: .same(proto: "friend"),
+    137: .same(proto: "goto"),
+    139: .same(proto: "inline"),
+    141: .same(proto: "long"),
+    142: .same(proto: "mutable"),
+    143: .same(proto: "namespace"),
+    144: .same(proto: "new"),
+    145: .same(proto: "noexcept"),
+    146: .same(proto: "not"),
+    147: .same(proto: "not_eq"),
+    148: .same(proto: "nullptr"),
+    150: .same(proto: "or"),
+    151: .same(proto: "or_eq"),
+    153: .same(proto: "protected"),
+    155: .same(proto: "register"),
+    156: .same(proto: "reinterpret_cast"),
+    158: .same(proto: "short"),
+    159: .same(proto: "signed"),
+    160: .same(proto: "sizeof"),
+    162: .same(proto: "static_assert"),
+    163: .same(proto: "static_cast"),
+    166: .same(proto: "template"),
+    167: .same(proto: "this"),
+    168: .same(proto: "thread_local"),
+    172: .same(proto: "typedef"),
+    173: .same(proto: "typeid"),
+    174: .same(proto: "typename"),
+    175: .same(proto: "union"),
+    176: .same(proto: "unsigned"),
+    177: .same(proto: "using"),
+    178: .same(proto: "virtual"),
+    179: .same(proto: "void"),
+    180: .same(proto: "volatile"),
+    181: .same(proto: "wchar_t"),
+    183: .same(proto: "xor"),
+    184: .same(proto: "xor_eq"),
+    185: .same(proto: "restrict"),
+    186: .same(proto: "Category"),
+    187: .same(proto: "Ivar"),
+    188: .same(proto: "Method"),
+    192: .same(proto: "finalize"),
+    193: .same(proto: "hash"),
+    194: .same(proto: "dealloc"),
+    197: .same(proto: "superclass"),
+    198: .same(proto: "retain"),
+    199: .same(proto: "release"),
+    200: .same(proto: "autorelease"),
+    201: .same(proto: "retainCount"),
+    202: .same(proto: "zone"),
+    203: .same(proto: "isProxy"),
+    204: .same(proto: "copy"),
+    205: .same(proto: "mutableCopy"),
+    206: .same(proto: "classForCoder"),
+    207: .same(proto: "clear"),
+    208: .same(proto: "data"),
+    209: .same(proto: "delimitedData"),
+    210: .same(proto: "descriptor"),
+    211: .same(proto: "extensionRegistry"),
+    212: .same(proto: "extensionsCurrentlySet"),
+    213: .same(proto: "isInitialized"),
+    214: .same(proto: "serializedSize"),
+    215: .same(proto: "sortedExtensionsInUse"),
+    216: .same(proto: "unknownFields"),
+    217: .same(proto: "Fixed"),
+    218: .same(proto: "Fract"),
+    219: .same(proto: "Size"),
+    220: .same(proto: "LogicalAddress"),
+    221: .same(proto: "PhysicalAddress"),
+    222: .same(proto: "ByteCount"),
+    223: .same(proto: "ByteOffset"),
+    224: .same(proto: "Duration"),
+    225: .same(proto: "AbsoluteTime"),
+    226: .same(proto: "OptionBits"),
+    227: .same(proto: "ItemCount"),
+    228: .same(proto: "PBVersion"),
+    229: .same(proto: "ScriptCode"),
+    230: .same(proto: "LangCode"),
+    231: .same(proto: "RegionCode"),
+    232: .same(proto: "OSType"),
+    233: .same(proto: "ProcessSerialNumber"),
+    234: .same(proto: "Point"),
+    235: .same(proto: "Rect"),
+    236: .same(proto: "FixedPoint"),
+    237: .same(proto: "FixedRect"),
+    238: .same(proto: "Style"),
+    239: .same(proto: "StyleParameter"),
+    240: .same(proto: "StyleField"),
+    241: .same(proto: "TimeScale"),
+    242: .same(proto: "TimeBase"),
+    243: .same(proto: "TimeRecord"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "AA"),
+    1065: .same(proto: "__"),
+  ]
+}
 
 extension SwiftUnittest_Names_FieldNames: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -23144,6 +22312,1260 @@ extension SwiftUnittest_Names_EnumNames: SwiftProtobuf._MessageImplementationBas
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension SwiftUnittest_Names_EnumNames.StringEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aString"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ProtocolEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aProtocol"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.IntEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aInt"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.DoubleEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aDouble"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.FloatEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aFloat"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.UIntEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aUInt"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.hashValueEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ahashValue"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.descriptionEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adescription"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.debugDescriptionEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adebugDescription"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Swift: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aSwift"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.UNRECOGNIZED: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aUNRECOGNIZED"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.classEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aclass"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.deinitEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adeinit"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.enumEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aenum"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.extensionEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aextension"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.funcEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afunc"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.importEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aimport"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.initEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ainit"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.inoutEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ainout"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.internalEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ainternal"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.letEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "alet"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.operatorEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aoperator"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.privateEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aprivate"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.protocolEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aprotocol"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.publicEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "apublic"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.staticEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "astatic"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.structEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "astruct"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.subscriptEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asubscript"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.typealiasEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atypealias"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.varEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "avar"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.breakEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abreak"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.caseEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "acase"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.continueEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "acontinue"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.defaultEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adefault"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.deferEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adefer"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.doEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ado"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.elseEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aelse"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.fallthroughEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afallthrough"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.forEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afor"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.guardEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aguard"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ifEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aif"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.inEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ain"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.repeatEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "arepeat"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.returnEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "areturn"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.switchEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aswitch"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.whereEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "awhere"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.whileEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "awhile"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.asEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aas"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.catchEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "acatch"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.dynamicTypeEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adynamicType"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.falseEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afalse"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.isEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ais"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.nilEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anil"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.rethrowsEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "arethrows"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.superEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asuper"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.selfEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aself"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.throwEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "athrow"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.throwsEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "athrows"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.trueEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atrue"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.tryEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atry"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.__COLUMN__Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a__COLUMN__"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.__FILE__Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a__FILE__"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.__FUNCTION__Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a__FUNCTION__"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.__LINE__Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a__LINE__"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames._Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a_"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.__Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a__"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.associativity: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aassociativity"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.convenience: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aconvenience"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.dynamic: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adynamic"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.didSet: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adidSet"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.final: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afinal"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.get: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aget"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.infix: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ainfix"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.indirect: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aindirect"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.lazy: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "alazy"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.left: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aleft"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.mutating: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "amutating"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.none: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anone"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.nonmutating: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anonmutating"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.optional: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aoptional"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.override: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aoverride"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.postfix: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "apostfix"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.precedence: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aprecedence"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.prefix: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aprefix"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.required: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "arequired"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.right: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aright"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.set: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aset"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.TypeEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aType"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.unowned: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aunowned"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.weak: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aweak"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.willSet: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "awillSet"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.id: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aid"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames._cmd: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "a_cmd"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.out: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aout"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.bycopy: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abycopy"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.byref: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abyref"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.oneway: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aoneway"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.and: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aand"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.and_eq: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aand_eq"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.alignas: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aalignas"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.alignof: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aalignof"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.asm: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aasm"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.auto: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aauto"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.bitand: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abitand"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.bitor: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abitor"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.bool: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "abool"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.char: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "achar"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.char16_t: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "achar16_t"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.char32_t: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "achar32_t"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.compl: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "acompl"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.const: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aconst"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.constexpr: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aconstexpr"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.const_cast: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aconst_cast"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.decltype: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adecltype"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.delete: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adelete"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.dynamic_cast: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adynamic_cast"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.explicit: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aexplicit"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.export: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aexport"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.extern: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aextern"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.friend: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afriend"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.goto: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "agoto"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.inline: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ainline"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.long: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "along"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.mutable: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "amutable"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.namespace: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anamespace"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.new: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anew"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.noexcept: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anoexcept"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.not: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anot"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.not_eq: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anot_eq"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.nullptr: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "anullptr"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.or: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aor"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.or_eq: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aor_eq"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.protected: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aprotected"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.register: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aregister"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.reinterpret_cast: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "areinterpret_cast"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.short: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ashort"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.signed: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asigned"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.sizeof: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asizeof"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.static_assert: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "astatic_assert"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.static_cast: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "astatic_cast"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.template: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atemplate"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.this: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "athis"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.thread_local: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "athread_local"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.typedef: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atypedef"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.typeid: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atypeid"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.typename: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "atypename"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.union: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aunion"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.unsigned: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aunsigned"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.using: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ausing"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.virtual: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "avirtual"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.void: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "avoid"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.volatile: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "avolatile"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.wchar_t: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "awchar_t"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.xor: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "axor"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.xor_eq: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "axor_eq"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.restrict: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "arestrict"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Category: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aCategory"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Ivar: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aIvar"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Method: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aMethod"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.finalize: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "afinalize"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.hash: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "ahash"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.dealloc: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adealloc"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.superclass: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asuperclass"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.retain: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aretain"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.release: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "arelease"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.autorelease: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aautorelease"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.retainCount: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aretainCount"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.zone: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "azone"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.isProxy: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aisProxy"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.copy: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "acopy"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.mutableCopy: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "amutableCopy"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.classForCoder: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aclassForCoder"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.clear: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aclear"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.data: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adata"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.delimitedData: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adelimitedData"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.descriptor: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "adescriptor"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.extensionRegistry: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aextensionRegistry"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.extensionsCurrentlySet: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aextensionsCurrentlySet"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.isInitialized: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aisInitialized"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.serializedSize: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aserializedSize"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.sortedExtensionsInUse: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "asortedExtensionsInUse"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.unknownFieldsEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aunknownFields"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Fixed: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aFixed"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Fract: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aFract"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Size: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aSize"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.LogicalAddress: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aLogicalAddress"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.PhysicalAddress: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aPhysicalAddress"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ByteCount: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aByteCount"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ByteOffset: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aByteOffset"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Duration: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aDuration"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.AbsoluteTime: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aAbsoluteTime"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.OptionBits: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aOptionBits"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ItemCount: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aItemCount"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.PBVersion: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aPBVersion"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ScriptCode: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aScriptCode"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.LangCode: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aLangCode"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.RegionCode: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aRegionCode"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.OSType: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aOSType"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.ProcessSerialNumber: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aProcessSerialNumber"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Point: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aPoint"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Rect: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aRect"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.FixedPoint: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aFixedPoint"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.FixedRect: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aFixedRect"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.Style: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aStyle"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.StyleParameter: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aStyleParameter"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.StyleField: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aStyleField"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.TimeScale: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aTimeScale"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.TimeBase: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aTimeBase"),
+  ]
+}
+
+extension SwiftUnittest_Names_EnumNames.TimeRecord: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "aTimeRecord"),
+  ]
 }
 
 extension SwiftUnittest_Names_FieldNamingInitials: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -128,7 +128,7 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  enum Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case double // = 1
     case json // = 2
@@ -136,15 +136,6 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
     case ___ // = 4
     case self_ // = 5
     case type // = 6
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "DOUBLE"),
-      2: .same(proto: "JSON"),
-      3: .same(proto: "CLASS"),
-      4: .same(proto: "_"),
-      5: .same(proto: "SELF"),
-      6: .same(proto: "TYPE"),
-    ]
 
     init() {
       self = .double
@@ -175,13 +166,9 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
 
   }
 
-  enum ProtocolEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum ProtocolEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case a // = 1
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      1: .same(proto: "a"),
-    ]
 
     init() {
       self = .a
@@ -619,6 +606,23 @@ extension ProtobufUnittest_SwiftReservedTest: SwiftProtobuf._MessageImplementati
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "DOUBLE"),
+    2: .same(proto: "JSON"),
+    3: .same(proto: "CLASS"),
+    4: .same(proto: "_"),
+    5: .same(proto: "SELF"),
+    6: .same(proto: "TYPE"),
+  ]
+}
+
+extension ProtobufUnittest_SwiftReservedTest.ProtocolEnum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "a"),
+  ]
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -1047,19 +1047,12 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
     }
   }
 
-  enum Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case extra2 // = 20
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-      20: .same(proto: "EXTRA_2"),
-    ]
 
     init() {
       self = .foo
@@ -1676,6 +1669,15 @@ extension ProtobufUnittest_Message2: SwiftProtobuf._MessageImplementationBase, S
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_Message2.Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+    20: .same(proto: "EXTRA_2"),
+  ]
 }
 
 extension ProtobufUnittest_Message2.OptionalGroup: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -877,20 +877,13 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     }
   }
 
-  enum Enum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
+  enum Enum: SwiftProtobuf.Enum {
     typealias RawValue = Int
     case foo // = 0
     case bar // = 1
     case baz // = 2
     case extra3 // = 30
     case UNRECOGNIZED(Int)
-
-    static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-      0: .same(proto: "FOO"),
-      1: .same(proto: "BAR"),
-      2: .same(proto: "BAZ"),
-      30: .same(proto: "EXTRA_3"),
-    ]
 
     init() {
       self = .foo
@@ -1371,6 +1364,15 @@ extension ProtobufUnittest_Message3: SwiftProtobuf._MessageImplementationBase, S
     if unknownFields != other.unknownFields {return false}
     return true
   }
+}
+
+extension ProtobufUnittest_Message3.Enum: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    0: .same(proto: "FOO"),
+    1: .same(proto: "BAR"),
+    2: .same(proto: "BAZ"),
+    30: .same(proto: "EXTRA_3"),
+  ]
 }
 
 extension ProtobufUnittest_Msg3NoStorage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {


### PR DESCRIPTION
Helps get some of the library overhead out of the way of someone reading the
source for their generated messages/enums.