### PR TITLE
Don't add spaces before the comments pulled from proto file.

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -88,11 +88,11 @@ enum Conformance_WireFormat: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProvidi
 
 }
 
-///   Represents a single test case's input.  The testee should:
-///  
-///     1. parse this proto (which should always succeed)
-///     2. parse the protobuf or JSON payload in "payload" (which may fail)
-///     3. if the parse succeeded, serialize the message in the requested format.
+/// Represents a single test case's input.  The testee should:
+///
+///   1. parse this proto (which should always succeed)
+///   2. parse the protobuf or JSON payload in "payload" (which may fail)
+///   3. if the parse succeeded, serialize the message in the requested format.
 struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ConformanceRequest"
 
@@ -122,7 +122,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
     }
   }
 
-  ///   Which format should the testee serialize its message to?
+  /// Which format should the testee serialize its message to?
   var requestedOutputFormat: Conformance_WireFormat = Conformance_WireFormat.unspecified
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -196,15 +196,15 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   }
 }
 
-///   Represents a single test case's output.
+/// Represents a single test case's output.
 struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ConformanceResponse"
 
-  ///   This string should be set to indicate parsing failed.  The string can
-  ///   provide more information about the parse error if it is available.
-  ///  
-  ///   Setting this string does not necessarily mean the testee failed the
-  ///   test.  Some of the test cases are intentionally invalid input.
+  /// This string should be set to indicate parsing failed.  The string can
+  /// provide more information about the parse error if it is available.
+  ///
+  /// Setting this string does not necessarily mean the testee failed the
+  /// test.  Some of the test cases are intentionally invalid input.
   var parseError: String {
     get {
       if case .parseError(let v)? = result {
@@ -219,9 +219,9 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
 
   var result: Conformance_ConformanceResponse.OneOf_Result? = nil
 
-  ///   If the input was successfully parsed but errors occurred when
-  ///   serializing it to the requested output format, set the error message in
-  ///   this field.
+  /// If the input was successfully parsed but errors occurred when
+  /// serializing it to the requested output format, set the error message in
+  /// this field.
   var serializeError: String {
     get {
       if case .serializeError(let v)? = result {
@@ -234,9 +234,9 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   This should be set if some other error occurred.  This will always
-  ///   indicate that the test failed.  The string can provide more information
-  ///   about the failure.
+  /// This should be set if some other error occurred.  This will always
+  /// indicate that the test failed.  The string can provide more information
+  /// about the failure.
   var runtimeError: String {
     get {
       if case .runtimeError(let v)? = result {
@@ -249,8 +249,8 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   If the input was successfully parsed and the requested output was
-  ///   protobuf, serialize it to protobuf and set it in this field.
+  /// If the input was successfully parsed and the requested output was
+  /// protobuf, serialize it to protobuf and set it in this field.
   var protobufPayload: Data {
     get {
       if case .protobufPayload(let v)? = result {
@@ -263,8 +263,8 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   If the input was successfully parsed and the requested output was JSON,
-  ///   serialize to JSON and set it in this field.
+  /// If the input was successfully parsed and the requested output was JSON,
+  /// serialize to JSON and set it in this field.
   var jsonPayload: String {
     get {
       if case .jsonPayload(let v)? = result {
@@ -277,8 +277,8 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   For when the testee skipped the test, likely because a certain feature
-  ///   wasn't supported, like JSON input/output.
+  /// For when the testee skipped the test, likely because a certain feature
+  /// wasn't supported, like JSON input/output.
   var skipped: String {
     get {
       if case .skipped(let v)? = result {

--- a/Reference/google/protobuf/any.pb.swift
+++ b/Reference/google/protobuf/any.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,75 +50,75 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   `Any` contains an arbitrary serialized protocol buffer message along with a
-///   URL that describes the type of the serialized message.
-///  
-///   Protobuf library provides support to pack/unpack Any values in the form
-///   of utility functions or additional generated methods of the Any type.
-///  
-///   Example 1: Pack and unpack a message in C++.
-///  
-///       Foo foo = ...;
-///       Any any;
-///       any.PackFrom(foo);
+/// `Any` contains an arbitrary serialized protocol buffer message along with a
+/// URL that describes the type of the serialized message.
+///
+/// Protobuf library provides support to pack/unpack Any values in the form
+/// of utility functions or additional generated methods of the Any type.
+///
+/// Example 1: Pack and unpack a message in C++.
+///
+///     Foo foo = ...;
+///     Any any;
+///     any.PackFrom(foo);
+///     ...
+///     if (any.UnpackTo(&foo)) {
 ///       ...
-///       if (any.UnpackTo(&foo)) {
-///         ...
-///       }
-///  
-///   Example 2: Pack and unpack a message in Java.
-///  
-///       Foo foo = ...;
-///       Any any = Any.pack(foo);
+///     }
+///
+/// Example 2: Pack and unpack a message in Java.
+///
+///     Foo foo = ...;
+///     Any any = Any.pack(foo);
+///     ...
+///     if (any.is(Foo.class)) {
+///       foo = any.unpack(Foo.class);
+///     }
+///
+///  Example 3: Pack and unpack a message in Python.
+///
+///     foo = Foo(...)
+///     any = Any()
+///     any.Pack(foo)
+///     ...
+///     if any.Is(Foo.DESCRIPTOR):
+///       any.Unpack(foo)
 ///       ...
-///       if (any.is(Foo.class)) {
-///         foo = any.unpack(Foo.class);
-///       }
-///  
-///    Example 3: Pack and unpack a message in Python.
-///  
-///       foo = Foo(...)
-///       any = Any()
-///       any.Pack(foo)
-///       ...
-///       if any.Is(Foo.DESCRIPTOR):
-///         any.Unpack(foo)
-///         ...
-///  
-///   The pack methods provided by protobuf library will by default use
-///   'type.googleapis.com/full.type.name' as the type URL and the unpack
-///   methods only use the fully qualified type name after the last '/'
-///   in the type URL, for example "foo.bar.com/x/y.z" will yield type
-///   name "y.z".
-///  
-///  
-///   JSON
-///   ====
-///   The JSON representation of an `Any` value uses the regular
-///   representation of the deserialized, embedded message, with an
-///   additional field `@type` which contains the type URL. Example:
-///  
-///       package google.profile;
-///       message Person {
-///         string first_name = 1;
-///         string last_name = 2;
-///       }
-///  
-///       {
-///         "@type": "type.googleapis.com/google.profile.Person",
-///         "firstName": <string>,
-///         "lastName": <string>
-///       }
-///  
-///   If the embedded message type is well-known and has a custom JSON
-///   representation, that representation will be embedded adding a field
-///   `value` which holds the custom JSON in addition to the `@type`
-///   field. Example (for message [google.protobuf.Duration][]):
-///  
-///       {
-///         "@type": "type.googleapis.com/google.protobuf.Duration",
-///         "value": "1.212s"
-///       }
+///
+/// The pack methods provided by protobuf library will by default use
+/// 'type.googleapis.com/full.type.name' as the type URL and the unpack
+/// methods only use the fully qualified type name after the last '/'
+/// in the type URL, for example "foo.bar.com/x/y.z" will yield type
+/// name "y.z".
+///
+///
+/// JSON
+/// ====
+/// The JSON representation of an `Any` value uses the regular
+/// representation of the deserialized, embedded message, with an
+/// additional field `@type` which contains the type URL. Example:
+///
+///     package google.profile;
+///     message Person {
+///       string first_name = 1;
+///       string last_name = 2;
+///     }
+///
+///     {
+///       "@type": "type.googleapis.com/google.profile.Person",
+///       "firstName": <string>,
+///       "lastName": <string>
+///     }
+///
+/// If the embedded message type is well-known and has a custom JSON
+/// representation, that representation will be embedded adding a field
+/// `value` which holds the custom JSON in addition to the `@type`
+/// field. Example (for message [google.protobuf.Duration][]):
+///
+///     {
+///       "@type": "type.googleapis.com/google.protobuf.Duration",
+///       "value": "1.212s"
+///     }
 struct Google_Protobuf_Any: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Any"
 
@@ -133,33 +133,33 @@ struct Google_Protobuf_Any: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   A URL/resource name whose content describes the type of the
-  ///   serialized protocol buffer message.
-  ///  
-  ///   For URLs which use the scheme `http`, `https`, or no scheme, the
-  ///   following restrictions and interpretations apply:
-  ///  
-  ///   * If no scheme is provided, `https` is assumed.
-  ///   * The last segment of the URL's path must represent the fully
-  ///     qualified name of the type (as in `path/google.protobuf.Duration`).
-  ///     The name should be in a canonical form (e.g., leading "." is
-  ///     not accepted).
-  ///   * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-  ///     value in binary format, or produce an error.
-  ///   * Applications are allowed to cache lookup results based on the
-  ///     URL, or have them precompiled into a binary to avoid any
-  ///     lookup. Therefore, binary compatibility needs to be preserved
-  ///     on changes to types. (Use versioned type names to manage
-  ///     breaking changes.)
-  ///  
-  ///   Schemes other than `http`, `https` (or the empty scheme) might be
-  ///   used with implementation specific semantics.
+  /// A URL/resource name whose content describes the type of the
+  /// serialized protocol buffer message.
+  ///
+  /// For URLs which use the scheme `http`, `https`, or no scheme, the
+  /// following restrictions and interpretations apply:
+  ///
+  /// * If no scheme is provided, `https` is assumed.
+  /// * The last segment of the URL's path must represent the fully
+  ///   qualified name of the type (as in `path/google.protobuf.Duration`).
+  ///   The name should be in a canonical form (e.g., leading "." is
+  ///   not accepted).
+  /// * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+  ///   value in binary format, or produce an error.
+  /// * Applications are allowed to cache lookup results based on the
+  ///   URL, or have them precompiled into a binary to avoid any
+  ///   lookup. Therefore, binary compatibility needs to be preserved
+  ///   on changes to types. (Use versioned type names to manage
+  ///   breaking changes.)
+  ///
+  /// Schemes other than `http`, `https` (or the empty scheme) might be
+  /// used with implementation specific semantics.
   var typeURL: String {
     get {return _storage._typeURL}
     set {_uniqueStorage()._typeURL = newValue}
   }
 
-  ///   Must be a valid serialized protocol buffer of the above specified type.
+  /// Must be a valid serialized protocol buffer of the above specified type.
   var value: Data {
     get {return _storage._value}
     set {_uniqueStorage()._value = newValue}

--- a/Reference/google/protobuf/any_test.pb.swift
+++ b/Reference/google/protobuf/any_test.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/api.pb.swift
+++ b/Reference/google/protobuf/api.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,7 +50,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   Api is a light-weight descriptor for a protocol buffer service.
+/// Api is a light-weight descriptor for a protocol buffer service.
 struct Google_Protobuf_Api: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Api"
 
@@ -85,52 +85,52 @@ struct Google_Protobuf_Api: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   The fully qualified name of this api, including package name
-  ///   followed by the api's simple name.
+  /// The fully qualified name of this api, including package name
+  /// followed by the api's simple name.
   var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
-  ///   The methods of this api, in unspecified order.
+  /// The methods of this api, in unspecified order.
   var methods: [Google_Protobuf_Method] {
     get {return _storage._methods}
     set {_uniqueStorage()._methods = newValue}
   }
 
-  ///   Any metadata attached to the API.
+  /// Any metadata attached to the API.
   var options: [Google_Protobuf_Option] {
     get {return _storage._options}
     set {_uniqueStorage()._options = newValue}
   }
 
-  ///   A version string for this api. If specified, must have the form
-  ///   `major-version.minor-version`, as in `1.10`. If the minor version
-  ///   is omitted, it defaults to zero. If the entire version field is
-  ///   empty, the major version is derived from the package name, as
-  ///   outlined below. If the field is not empty, the version in the
-  ///   package name will be verified to be consistent with what is
-  ///   provided here.
-  ///  
-  ///   The versioning schema uses [semantic
-  ///   versioning](http://semver.org) where the major version number
-  ///   indicates a breaking change and the minor version an additive,
-  ///   non-breaking change. Both version numbers are signals to users
-  ///   what to expect from different versions, and should be carefully
-  ///   chosen based on the product plan.
-  ///  
-  ///   The major version is also reflected in the package name of the
-  ///   API, which must end in `v<major-version>`, as in
-  ///   `google.feature.v1`. For major versions 0 and 1, the suffix can
-  ///   be omitted. Zero major versions must only be used for
-  ///   experimental, none-GA apis.
+  /// A version string for this api. If specified, must have the form
+  /// `major-version.minor-version`, as in `1.10`. If the minor version
+  /// is omitted, it defaults to zero. If the entire version field is
+  /// empty, the major version is derived from the package name, as
+  /// outlined below. If the field is not empty, the version in the
+  /// package name will be verified to be consistent with what is
+  /// provided here.
+  ///
+  /// The versioning schema uses [semantic
+  /// versioning](http://semver.org) where the major version number
+  /// indicates a breaking change and the minor version an additive,
+  /// non-breaking change. Both version numbers are signals to users
+  /// what to expect from different versions, and should be carefully
+  /// chosen based on the product plan.
+  ///
+  /// The major version is also reflected in the package name of the
+  /// API, which must end in `v<major-version>`, as in
+  /// `google.feature.v1`. For major versions 0 and 1, the suffix can
+  /// be omitted. Zero major versions must only be used for
+  /// experimental, none-GA apis.
   var version: String {
     get {return _storage._version}
     set {_uniqueStorage()._version = newValue}
   }
 
-  ///   Source context for the protocol buffer service represented by this
-  ///   message.
+  /// Source context for the protocol buffer service represented by this
+  /// message.
   var sourceContext: Google_Protobuf_SourceContext {
     get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContext = newValue}
@@ -142,13 +142,13 @@ struct Google_Protobuf_Api: SwiftProtobuf.Message {
     return _storage._sourceContext = nil
   }
 
-  ///   Included APIs. See [Mixin][].
+  /// Included APIs. See [Mixin][].
   var mixins: [Google_Protobuf_Mixin] {
     get {return _storage._mixins}
     set {_uniqueStorage()._mixins = newValue}
   }
 
-  ///   The source syntax of the service.
+  /// The source syntax of the service.
   var syntax: Google_Protobuf_Syntax {
     get {return _storage._syntax}
     set {_uniqueStorage()._syntax = newValue}
@@ -204,29 +204,29 @@ struct Google_Protobuf_Api: SwiftProtobuf.Message {
   }
 }
 
-///   Method represents a method of an api.
+/// Method represents a method of an api.
 struct Google_Protobuf_Method: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Method"
 
-  ///   The simple name of this method.
+  /// The simple name of this method.
   var name: String = ""
 
-  ///   A URL of the input message type.
+  /// A URL of the input message type.
   var requestTypeURL: String = ""
 
-  ///   If true, the request is streamed.
+  /// If true, the request is streamed.
   var requestStreaming: Bool = false
 
-  ///   The URL of the output message type.
+  /// The URL of the output message type.
   var responseTypeURL: String = ""
 
-  ///   If true, the response is streamed.
+  /// If true, the response is streamed.
   var responseStreaming: Bool = false
 
-  ///   Any metadata attached to the method.
+  /// Any metadata attached to the method.
   var options: [Google_Protobuf_Option] = []
 
-  ///   The source syntax of this method.
+  /// The source syntax of this method.
   var syntax: Google_Protobuf_Syntax = Google_Protobuf_Syntax.proto2
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -274,91 +274,91 @@ struct Google_Protobuf_Method: SwiftProtobuf.Message {
   }
 }
 
-///   Declares an API to be included in this API. The including API must
-///   redeclare all the methods from the included API, but documentation
-///   and options are inherited as follows:
-///  
-///   - If after comment and whitespace stripping, the documentation
-///     string of the redeclared method is empty, it will be inherited
-///     from the original method.
-///  
-///   - Each annotation belonging to the service config (http,
-///     visibility) which is not set in the redeclared method will be
-///     inherited.
-///  
-///   - If an http annotation is inherited, the path pattern will be
-///     modified as follows. Any version prefix will be replaced by the
-///     version of the including API plus the [root][] path if specified.
-///  
-///   Example of a simple mixin:
-///  
-///       package google.acl.v1;
-///       service AccessControl {
-///         // Get the underlying ACL object.
-///         rpc GetAcl(GetAclRequest) returns (Acl) {
-///           option (google.api.http).get = "/v1/{resource=**}:getAcl";
-///         }
+/// Declares an API to be included in this API. The including API must
+/// redeclare all the methods from the included API, but documentation
+/// and options are inherited as follows:
+///
+/// - If after comment and whitespace stripping, the documentation
+///   string of the redeclared method is empty, it will be inherited
+///   from the original method.
+///
+/// - Each annotation belonging to the service config (http,
+///   visibility) which is not set in the redeclared method will be
+///   inherited.
+///
+/// - If an http annotation is inherited, the path pattern will be
+///   modified as follows. Any version prefix will be replaced by the
+///   version of the including API plus the [root][] path if specified.
+///
+/// Example of a simple mixin:
+///
+///     package google.acl.v1;
+///     service AccessControl {
+///       // Get the underlying ACL object.
+///       rpc GetAcl(GetAclRequest) returns (Acl) {
+///         option (google.api.http).get = "/v1/{resource=**}:getAcl";
 ///       }
-///  
-///       package google.storage.v2;
-///       service Storage {
-///         rpc GetAcl(GetAclRequest) returns (Acl);
-///  
-///         // Get a data record.
-///         rpc GetData(GetDataRequest) returns (Data) {
-///           option (google.api.http).get = "/v2/{resource=**}";
-///         }
+///     }
+///
+///     package google.storage.v2;
+///     service Storage {
+///       rpc GetAcl(GetAclRequest) returns (Acl);
+///
+///       // Get a data record.
+///       rpc GetData(GetDataRequest) returns (Data) {
+///         option (google.api.http).get = "/v2/{resource=**}";
 ///       }
-///  
-///   Example of a mixin configuration:
-///  
-///       apis:
-///       - name: google.storage.v2.Storage
-///         mixins:
-///         - name: google.acl.v1.AccessControl
-///  
-///   The mixin construct implies that all methods in `AccessControl` are
-///   also declared with same name and request/response types in
-///   `Storage`. A documentation generator or annotation processor will
-///   see the effective `Storage.GetAcl` method after inherting
-///   documentation and annotations as follows:
-///  
-///       service Storage {
-///         // Get the underlying ACL object.
-///         rpc GetAcl(GetAclRequest) returns (Acl) {
-///           option (google.api.http).get = "/v2/{resource=**}:getAcl";
-///         }
-///         ...
+///     }
+///
+/// Example of a mixin configuration:
+///
+///     apis:
+///     - name: google.storage.v2.Storage
+///       mixins:
+///       - name: google.acl.v1.AccessControl
+///
+/// The mixin construct implies that all methods in `AccessControl` are
+/// also declared with same name and request/response types in
+/// `Storage`. A documentation generator or annotation processor will
+/// see the effective `Storage.GetAcl` method after inherting
+/// documentation and annotations as follows:
+///
+///     service Storage {
+///       // Get the underlying ACL object.
+///       rpc GetAcl(GetAclRequest) returns (Acl) {
+///         option (google.api.http).get = "/v2/{resource=**}:getAcl";
 ///       }
-///  
-///   Note how the version in the path pattern changed from `v1` to `v2`.
-///  
-///   If the `root` field in the mixin is specified, it should be a
-///   relative path under which inherited HTTP paths are placed. Example:
-///  
-///       apis:
-///       - name: google.storage.v2.Storage
-///         mixins:
-///         - name: google.acl.v1.AccessControl
-///           root: acls
-///  
-///   This implies the following inherited HTTP annotation:
-///  
-///       service Storage {
-///         // Get the underlying ACL object.
-///         rpc GetAcl(GetAclRequest) returns (Acl) {
-///           option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";
-///         }
-///         ...
+///       ...
+///     }
+///
+/// Note how the version in the path pattern changed from `v1` to `v2`.
+///
+/// If the `root` field in the mixin is specified, it should be a
+/// relative path under which inherited HTTP paths are placed. Example:
+///
+///     apis:
+///     - name: google.storage.v2.Storage
+///       mixins:
+///       - name: google.acl.v1.AccessControl
+///         root: acls
+///
+/// This implies the following inherited HTTP annotation:
+///
+///     service Storage {
+///       // Get the underlying ACL object.
+///       rpc GetAcl(GetAclRequest) returns (Acl) {
+///         option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";
 ///       }
+///       ...
+///     }
 struct Google_Protobuf_Mixin: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Mixin"
 
-  ///   The fully qualified name of the API which is included.
+  /// The fully qualified name of the API which is included.
   var name: String = ""
 
-  ///   If non-empty specifies a path under which inherited HTTP paths
-  ///   are rooted.
+  /// If non-empty specifies a path under which inherited HTTP paths
+  /// are rooted.
   var root: String = ""
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/compiler/plugin.pb.swift
+++ b/Reference/google/protobuf/compiler/plugin.pb.swift
@@ -6,51 +6,51 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-// 
-//  WARNING:  The plugin interface is currently EXPERIMENTAL and is subject to
-//    change.
-// 
-//  protoc (aka the Protocol Compiler) can be extended via plugins.  A plugin is
-//  just a program that reads a CodeGeneratorRequest from stdin and writes a
-//  CodeGeneratorResponse to stdout.
-// 
-//  Plugins written using C++ can use google/protobuf/compiler/plugin.h instead
-//  of dealing with the raw protocol defined here.
-// 
-//  A plugin executable needs only to be placed somewhere in the path.  The
-//  plugin should be named "protoc-gen-$NAME", and will then be used when the
-//  flag "--${NAME}_out" is passed to protoc.
+// Author: kenton@google.com (Kenton Varda)
+//
+// WARNING:  The plugin interface is currently EXPERIMENTAL and is subject to
+//   change.
+//
+// protoc (aka the Protocol Compiler) can be extended via plugins.  A plugin is
+// just a program that reads a CodeGeneratorRequest from stdin and writes a
+// CodeGeneratorResponse to stdout.
+//
+// Plugins written using C++ can use google/protobuf/compiler/plugin.h instead
+// of dealing with the raw protocol defined here.
+//
+// A plugin executable needs only to be placed somewhere in the path.  The
+// plugin should be named "protoc-gen-$NAME", and will then be used when the
+// flag "--${NAME}_out" is passed to protoc.
 
 import Foundation
 import SwiftProtobuf
@@ -67,7 +67,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf.compiler"
 
-///   The version number of protocol compiler.
+/// The version number of protocol compiler.
 struct Google_Protobuf_Compiler_Version: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Version"
 
@@ -107,8 +107,8 @@ struct Google_Protobuf_Compiler_Version: SwiftProtobuf.Message {
     return _patch = nil
   }
 
-  ///   A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
-  ///   be empty for mainline stable releases.
+  /// A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+  /// be empty for mainline stable releases.
   fileprivate var _suffix: String? = nil
   var suffix: String {
     get {return _suffix ?? ""}
@@ -154,7 +154,7 @@ struct Google_Protobuf_Compiler_Version: SwiftProtobuf.Message {
   }
 }
 
-///   An encoded CodeGeneratorRequest is written to the plugin's stdin.
+/// An encoded CodeGeneratorRequest is written to the plugin's stdin.
 struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".CodeGeneratorRequest"
 
@@ -183,15 +183,15 @@ struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   The .proto files that were explicitly listed on the command-line.  The
-  ///   code generator should generate code only for these files.  Each file's
-  ///   descriptor will be included in proto_file, below.
+  /// The .proto files that were explicitly listed on the command-line.  The
+  /// code generator should generate code only for these files.  Each file's
+  /// descriptor will be included in proto_file, below.
   var fileToGenerate: [String] {
     get {return _storage._fileToGenerate}
     set {_uniqueStorage()._fileToGenerate = newValue}
   }
 
-  ///   The generator parameter passed on the command-line.
+  /// The generator parameter passed on the command-line.
   var parameter: String {
     get {return _storage._parameter ?? ""}
     set {_uniqueStorage()._parameter = newValue}
@@ -203,23 +203,23 @@ struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message {
     return _storage._parameter = nil
   }
 
-  ///   FileDescriptorProtos for all files in files_to_generate and everything
-  ///   they import.  The files will appear in topological order, so each file
-  ///   appears before any file that imports it.
-  ///  
-  ///   protoc guarantees that all proto_files will be written after
-  ///   the fields above, even though this is not technically guaranteed by the
-  ///   protobuf wire format.  This theoretically could allow a plugin to stream
-  ///   in the FileDescriptorProtos and handle them one by one rather than read
-  ///   the entire set into memory at once.  However, as of this writing, this
-  ///   is not similarly optimized on protoc's end -- it will store all fields in
-  ///   memory at once before sending them to the plugin.
+  /// FileDescriptorProtos for all files in files_to_generate and everything
+  /// they import.  The files will appear in topological order, so each file
+  /// appears before any file that imports it.
+  ///
+  /// protoc guarantees that all proto_files will be written after
+  /// the fields above, even though this is not technically guaranteed by the
+  /// protobuf wire format.  This theoretically could allow a plugin to stream
+  /// in the FileDescriptorProtos and handle them one by one rather than read
+  /// the entire set into memory at once.  However, as of this writing, this
+  /// is not similarly optimized on protoc's end -- it will store all fields in
+  /// memory at once before sending them to the plugin.
   var protoFile: [Google_Protobuf_FileDescriptorProto] {
     get {return _storage._protoFile}
     set {_uniqueStorage()._protoFile = newValue}
   }
 
-  ///   The version number of protocol compiler.
+  /// The version number of protocol compiler.
   var compilerVersion: Google_Protobuf_Compiler_Version {
     get {return _storage._compilerVersion ?? Google_Protobuf_Compiler_Version()}
     set {_uniqueStorage()._compilerVersion = newValue}
@@ -276,18 +276,18 @@ struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message {
   }
 }
 
-///   The plugin writes an encoded CodeGeneratorResponse to stdout.
+/// The plugin writes an encoded CodeGeneratorResponse to stdout.
 struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".CodeGeneratorResponse"
 
-  ///   Error message.  If non-empty, code generation failed.  The plugin process
-  ///   should exit with status code zero even if it reports an error in this way.
-  ///  
-  ///   This should be used to indicate errors in .proto files which prevent the
-  ///   code generator from generating correct code.  Errors which indicate a
-  ///   problem in protoc itself -- such as the input CodeGeneratorRequest being
-  ///   unparseable -- should be reported by writing a message to stderr and
-  ///   exiting with a non-zero status code.
+  /// Error message.  If non-empty, code generation failed.  The plugin process
+  /// should exit with status code zero even if it reports an error in this way.
+  ///
+  /// This should be used to indicate errors in .proto files which prevent the
+  /// code generator from generating correct code.  Errors which indicate a
+  /// problem in protoc itself -- such as the input CodeGeneratorRequest being
+  /// unparseable -- should be reported by writing a message to stderr and
+  /// exiting with a non-zero status code.
   fileprivate var _error: String? = nil
   var error: String {
     get {return _error ?? ""}
@@ -304,21 +304,21 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   Represents a single generated file.
+  /// Represents a single generated file.
   struct File: SwiftProtobuf.Message {
     static let protoMessageName: String = Google_Protobuf_Compiler_CodeGeneratorResponse.protoMessageName + ".File"
 
-    ///   The file name, relative to the output directory.  The name must not
-    ///   contain "." or ".." components and must be relative, not be absolute (so,
-    ///   the file cannot lie outside the output directory).  "/" must be used as
-    ///   the path separator, not "\".
-    ///  
-    ///   If the name is omitted, the content will be appended to the previous
-    ///   file.  This allows the generator to break large files into small chunks,
-    ///   and allows the generated text to be streamed back to protoc so that large
-    ///   files need not reside completely in memory at one time.  Note that as of
-    ///   this writing protoc does not optimize for this -- it will read the entire
-    ///   CodeGeneratorResponse before writing files to disk.
+    /// The file name, relative to the output directory.  The name must not
+    /// contain "." or ".." components and must be relative, not be absolute (so,
+    /// the file cannot lie outside the output directory).  "/" must be used as
+    /// the path separator, not "\".
+    ///
+    /// If the name is omitted, the content will be appended to the previous
+    /// file.  This allows the generator to break large files into small chunks,
+    /// and allows the generated text to be streamed back to protoc so that large
+    /// files need not reside completely in memory at one time.  Note that as of
+    /// this writing protoc does not optimize for this -- it will read the entire
+    /// CodeGeneratorResponse before writing files to disk.
     fileprivate var _name: String? = nil
     var name: String {
       get {return _name ?? ""}
@@ -331,43 +331,43 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message {
       return _name = nil
     }
 
-    ///   If non-empty, indicates that the named file should already exist, and the
-    ///   content here is to be inserted into that file at a defined insertion
-    ///   point.  This feature allows a code generator to extend the output
-    ///   produced by another code generator.  The original generator may provide
-    ///   insertion points by placing special annotations in the file that look
-    ///   like:
-    ///     @@protoc_insertion_point(NAME)
-    ///   The annotation can have arbitrary text before and after it on the line,
-    ///   which allows it to be placed in a comment.  NAME should be replaced with
-    ///   an identifier naming the point -- this is what other generators will use
-    ///   as the insertion_point.  Code inserted at this point will be placed
-    ///   immediately above the line containing the insertion point (thus multiple
-    ///   insertions to the same point will come out in the order they were added).
-    ///   The double-@ is intended to make it unlikely that the generated code
-    ///   could contain things that look like insertion points by accident.
-    ///  
-    ///   For example, the C++ code generator places the following line in the
-    ///   .pb.h files that it generates:
-    ///     // @@protoc_insertion_point(namespace_scope)
-    ///   This line appears within the scope of the file's package namespace, but
-    ///   outside of any particular class.  Another plugin can then specify the
-    ///   insertion_point "namespace_scope" to generate additional classes or
-    ///   other declarations that should be placed in this scope.
-    ///  
-    ///   Note that if the line containing the insertion point begins with
-    ///   whitespace, the same whitespace will be added to every line of the
-    ///   inserted text.  This is useful for languages like Python, where
-    ///   indentation matters.  In these languages, the insertion point comment
-    ///   should be indented the same amount as any inserted code will need to be
-    ///   in order to work correctly in that context.
-    ///  
-    ///   The code generator that generates the initial file and the one which
-    ///   inserts into it must both run as part of a single invocation of protoc.
-    ///   Code generators are executed in the order in which they appear on the
-    ///   command line.
-    ///  
-    ///   If |insertion_point| is present, |name| must also be present.
+    /// If non-empty, indicates that the named file should already exist, and the
+    /// content here is to be inserted into that file at a defined insertion
+    /// point.  This feature allows a code generator to extend the output
+    /// produced by another code generator.  The original generator may provide
+    /// insertion points by placing special annotations in the file that look
+    /// like:
+    ///   @@protoc_insertion_point(NAME)
+    /// The annotation can have arbitrary text before and after it on the line,
+    /// which allows it to be placed in a comment.  NAME should be replaced with
+    /// an identifier naming the point -- this is what other generators will use
+    /// as the insertion_point.  Code inserted at this point will be placed
+    /// immediately above the line containing the insertion point (thus multiple
+    /// insertions to the same point will come out in the order they were added).
+    /// The double-@ is intended to make it unlikely that the generated code
+    /// could contain things that look like insertion points by accident.
+    ///
+    /// For example, the C++ code generator places the following line in the
+    /// .pb.h files that it generates:
+    ///   // @@protoc_insertion_point(namespace_scope)
+    /// This line appears within the scope of the file's package namespace, but
+    /// outside of any particular class.  Another plugin can then specify the
+    /// insertion_point "namespace_scope" to generate additional classes or
+    /// other declarations that should be placed in this scope.
+    ///
+    /// Note that if the line containing the insertion point begins with
+    /// whitespace, the same whitespace will be added to every line of the
+    /// inserted text.  This is useful for languages like Python, where
+    /// indentation matters.  In these languages, the insertion point comment
+    /// should be indented the same amount as any inserted code will need to be
+    /// in order to work correctly in that context.
+    ///
+    /// The code generator that generates the initial file and the one which
+    /// inserts into it must both run as part of a single invocation of protoc.
+    /// Code generators are executed in the order in which they appear on the
+    /// command line.
+    ///
+    /// If |insertion_point| is present, |name| must also be present.
     fileprivate var _insertionPoint: String? = nil
     var insertionPoint: String {
       get {return _insertionPoint ?? ""}
@@ -380,7 +380,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message {
       return _insertionPoint = nil
     }
 
-    ///   The file contents.
+    /// The file contents.
     fileprivate var _content: String? = nil
     var content: String {
       get {return _content ?? ""}

--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -6,43 +6,43 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  The messages in this file describe the definitions found in .proto files.
-//  A valid .proto file can be translated directly to a FileDescriptorProto
-//  without any other information (e.g. without reading its imports).
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// The messages in this file describe the definitions found in .proto files.
+// A valid .proto file can be translated directly to a FileDescriptorProto
+// without any other information (e.g. without reading its imports).
 
 import Foundation
 import SwiftProtobuf
@@ -59,8 +59,8 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   The protocol compiler can output a FileDescriptorSet containing the .proto
-///   files it parses.
+/// The protocol compiler can output a FileDescriptorSet containing the .proto
+/// files it parses.
 struct Google_Protobuf_FileDescriptorSet: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FileDescriptorSet"
 
@@ -92,7 +92,7 @@ struct Google_Protobuf_FileDescriptorSet: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a complete .proto file.
+/// Describes a complete .proto file.
 struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FileDescriptorProto"
 
@@ -137,7 +137,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   file name, relative to root of source tree
+  /// file name, relative to root of source tree
   var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
@@ -149,7 +149,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._name = nil
   }
 
-  ///   e.g. "foo", "foo.bar", etc.
+  /// e.g. "foo", "foo.bar", etc.
   var package: String {
     get {return _storage._package ?? ""}
     set {_uniqueStorage()._package = newValue}
@@ -161,26 +161,26 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._package = nil
   }
 
-  ///   Names of files imported by this file.
+  /// Names of files imported by this file.
   var dependency: [String] {
     get {return _storage._dependency}
     set {_uniqueStorage()._dependency = newValue}
   }
 
-  ///   Indexes of the public imported files in the dependency list above.
+  /// Indexes of the public imported files in the dependency list above.
   var publicDependency: [Int32] {
     get {return _storage._publicDependency}
     set {_uniqueStorage()._publicDependency = newValue}
   }
 
-  ///   Indexes of the weak imported files in the dependency list.
-  ///   For Google-internal migration only. Do not use.
+  /// Indexes of the weak imported files in the dependency list.
+  /// For Google-internal migration only. Do not use.
   var weakDependency: [Int32] {
     get {return _storage._weakDependency}
     set {_uniqueStorage()._weakDependency = newValue}
   }
 
-  ///   All top-level definitions in this file.
+  /// All top-level definitions in this file.
   var messageType: [Google_Protobuf_DescriptorProto] {
     get {return _storage._messageType}
     set {_uniqueStorage()._messageType = newValue}
@@ -212,10 +212,10 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._options = nil
   }
 
-  ///   This field contains optional information about the original source code.
-  ///   You may safely remove this entire field without harming runtime
-  ///   functionality of the descriptors -- the information is needed only by
-  ///   development tools.
+  /// This field contains optional information about the original source code.
+  /// You may safely remove this entire field without harming runtime
+  /// functionality of the descriptors -- the information is needed only by
+  /// development tools.
   var sourceCodeInfo: Google_Protobuf_SourceCodeInfo {
     get {return _storage._sourceCodeInfo ?? Google_Protobuf_SourceCodeInfo()}
     set {_uniqueStorage()._sourceCodeInfo = newValue}
@@ -227,8 +227,8 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._sourceCodeInfo = nil
   }
 
-  ///   The syntax of the proto file.
-  ///   The supported values are "proto2" and "proto3".
+  /// The syntax of the proto file.
+  /// The supported values are "proto2" and "proto3".
   var syntax: String {
     get {return _storage._syntax ?? ""}
     set {_uniqueStorage()._syntax = newValue}
@@ -321,7 +321,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a message type.
+/// Describes a message type.
 struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".DescriptorProto"
 
@@ -419,8 +419,8 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
     set {_uniqueStorage()._reservedRange = newValue}
   }
 
-  ///   Reserved field names, which may not be used by fields in the same message.
-  ///   A given name may only be reserved once.
+  /// Reserved field names, which may not be used by fields in the same message.
+  /// A given name may only be reserved once.
   var reservedName: [String] {
     get {return _storage._reservedName}
     set {_uniqueStorage()._reservedName = newValue}
@@ -480,13 +480,13 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
     }
   }
 
-  ///   Range of reserved tag numbers. Reserved tag numbers may not be used by
-  ///   fields or extension ranges in the same message. Reserved ranges may
-  ///   not overlap.
+  /// Range of reserved tag numbers. Reserved tag numbers may not be used by
+  /// fields or extension ranges in the same message. Reserved ranges may
+  /// not overlap.
   struct ReservedRange: SwiftProtobuf.Message {
     static let protoMessageName: String = Google_Protobuf_DescriptorProto.protoMessageName + ".ReservedRange"
 
-    ///   Inclusive.
+    /// Inclusive.
     fileprivate var _start: Int32? = nil
     var start: Int32 {
       get {return _start ?? 0}
@@ -499,7 +499,7 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
       return _start = nil
     }
 
-    ///   Exclusive.
+    /// Exclusive.
     fileprivate var _end: Int32? = nil
     var end: Int32 {
       get {return _end ?? 0}
@@ -609,7 +609,7 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a field within a message.
+/// Describes a field within a message.
 struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FieldDescriptorProto"
 
@@ -683,8 +683,8 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._label = nil
   }
 
-  ///   If type_name is set, this need not be set.  If both this and type_name
-  ///   are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
+  /// If type_name is set, this need not be set.  If both this and type_name
+  /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
   var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
     get {return _storage._type ?? Google_Protobuf_FieldDescriptorProto.TypeEnum.double}
     set {_uniqueStorage()._type = newValue}
@@ -696,11 +696,11 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._type = nil
   }
 
-  ///   For message and enum types, this is the name of the type.  If the name
-  ///   starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-  ///   rules are used to find the type (i.e. first the nested types within this
-  ///   message are searched, then within the parent, on up to the root
-  ///   namespace).
+  /// For message and enum types, this is the name of the type.  If the name
+  /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+  /// rules are used to find the type (i.e. first the nested types within this
+  /// message are searched, then within the parent, on up to the root
+  /// namespace).
   var typeName: String {
     get {return _storage._typeName ?? ""}
     set {_uniqueStorage()._typeName = newValue}
@@ -712,8 +712,8 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._typeName = nil
   }
 
-  ///   For extensions, this is the name of the type being extended.  It is
-  ///   resolved in the same manner as type_name.
+  /// For extensions, this is the name of the type being extended.  It is
+  /// resolved in the same manner as type_name.
   var extendee: String {
     get {return _storage._extendee ?? ""}
     set {_uniqueStorage()._extendee = newValue}
@@ -725,11 +725,11 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._extendee = nil
   }
 
-  ///   For numeric types, contains the original text representation of the value.
-  ///   For booleans, "true" or "false".
-  ///   For strings, contains the default text contents (not escaped in any way).
-  ///   For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-  ///   TODO(kenton):  Base-64 encode?
+  /// For numeric types, contains the original text representation of the value.
+  /// For booleans, "true" or "false".
+  /// For strings, contains the default text contents (not escaped in any way).
+  /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+  /// TODO(kenton):  Base-64 encode?
   var defaultValue: String {
     get {return _storage._defaultValue ?? ""}
     set {_uniqueStorage()._defaultValue = newValue}
@@ -741,8 +741,8 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._defaultValue = nil
   }
 
-  ///   If set, gives the index of a oneof in the containing type's oneof_decl
-  ///   list.  This field is a member of that oneof.
+  /// If set, gives the index of a oneof in the containing type's oneof_decl
+  /// list.  This field is a member of that oneof.
   var oneofIndex: Int32 {
     get {return _storage._oneofIndex ?? 0}
     set {_uniqueStorage()._oneofIndex = newValue}
@@ -754,10 +754,10 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._oneofIndex = nil
   }
 
-  ///   JSON name of this field. The value is set by protocol compiler. If the
-  ///   user has set a "json_name" option on this field, that option's value
-  ///   will be used. Otherwise, it's deduced from the field's name by converting
-  ///   it to camelCase.
+  /// JSON name of this field. The value is set by protocol compiler. If the
+  /// user has set a "json_name" option on this field, that option's value
+  /// will be used. Otherwise, it's deduced from the field's name by converting
+  /// it to camelCase.
   var jsonName: String {
     get {return _storage._jsonName ?? ""}
     set {_uniqueStorage()._jsonName = newValue}
@@ -785,44 +785,44 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   0 is reserved for errors.
-    ///   Order is weird for historical reasons.
+    /// 0 is reserved for errors.
+    /// Order is weird for historical reasons.
     case double // = 1
     case float // = 2
 
-    ///   Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-    ///   negative values are likely.
+    /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+    /// negative values are likely.
     case int64 // = 3
     case uint64 // = 4
 
-    ///   Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-    ///   negative values are likely.
+    /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+    /// negative values are likely.
     case int32 // = 5
     case fixed64 // = 6
     case fixed32 // = 7
     case bool // = 8
     case string // = 9
 
-    ///   Tag-delimited aggregate.
-    ///   Group type is deprecated and not supported in proto3. However, Proto3
-    ///   implementations should still be able to parse the group wire format and
-    ///   treat group fields as unknown fields.
+    /// Tag-delimited aggregate.
+    /// Group type is deprecated and not supported in proto3. However, Proto3
+    /// implementations should still be able to parse the group wire format and
+    /// treat group fields as unknown fields.
     case group // = 10
 
-    ///   Length-delimited aggregate.
+    /// Length-delimited aggregate.
     case message // = 11
 
-    ///   New in version 2.
+    /// New in version 2.
     case bytes // = 12
     case uint32 // = 13
     case `enum` // = 14
     case sfixed32 // = 15
     case sfixed64 // = 16
 
-    ///   Uses ZigZag encoding.
+    /// Uses ZigZag encoding.
     case sint32 // = 17
 
-    ///   Uses ZigZag encoding.
+    /// Uses ZigZag encoding.
     case sint64 // = 18
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -902,7 +902,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   enum Label: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   0 is reserved for errors
+    /// 0 is reserved for errors
     case `optional` // = 1
     case `required` // = 2
     case repeated // = 3
@@ -1003,7 +1003,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a oneof.
+/// Describes a oneof.
 struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OneofDescriptorProto"
 
@@ -1087,7 +1087,7 @@ struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes an enum type.
+/// Describes an enum type.
 struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".EnumDescriptorProto"
 
@@ -1183,7 +1183,7 @@ struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a value within an enum.
+/// Describes a value within an enum.
 struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".EnumValueDescriptorProto"
 
@@ -1284,7 +1284,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a service.
+/// Describes a service.
 struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ServiceDescriptorProto"
 
@@ -1380,7 +1380,7 @@ struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a method of a service.
+/// Describes a method of a service.
 struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MethodDescriptorProto"
 
@@ -1424,8 +1424,8 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
     return _storage._name = nil
   }
 
-  ///   Input and output type names.  These are resolved in the same way as
-  ///   FieldDescriptorProto.type_name, but must refer to a message type.
+  /// Input and output type names.  These are resolved in the same way as
+  /// FieldDescriptorProto.type_name, but must refer to a message type.
   var inputType: String {
     get {return _storage._inputType ?? ""}
     set {_uniqueStorage()._inputType = newValue}
@@ -1459,7 +1459,7 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
     return _storage._options = nil
   }
 
-  ///   Identifies if client streams multiple client messages
+  /// Identifies if client streams multiple client messages
   var clientStreaming: Bool {
     get {return _storage._clientStreaming ?? false}
     set {_uniqueStorage()._clientStreaming = newValue}
@@ -1471,7 +1471,7 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
     return _storage._clientStreaming = nil
   }
 
-  ///   Identifies if server streams multiple server messages
+  /// Identifies if server streams multiple server messages
   var serverStreaming: Bool {
     get {return _storage._serverStreaming ?? false}
     set {_uniqueStorage()._serverStreaming = newValue}
@@ -1590,10 +1590,10 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage
   }
 
-  ///   Sets the Java package where classes generated from this .proto will be
-  ///   placed.  By default, the proto package is used, but this is often
-  ///   inappropriate because proto packages do not normally start with backwards
-  ///   domain names.
+  /// Sets the Java package where classes generated from this .proto will be
+  /// placed.  By default, the proto package is used, but this is often
+  /// inappropriate because proto packages do not normally start with backwards
+  /// domain names.
   var javaPackage: String {
     get {return _storage._javaPackage ?? ""}
     set {_uniqueStorage()._javaPackage = newValue}
@@ -1605,11 +1605,11 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._javaPackage = nil
   }
 
-  ///   If set, all the classes from the .proto file are wrapped in a single
-  ///   outer class with the given name.  This applies to both Proto1
-  ///   (equivalent to the old "--one_java_file" option) and Proto2 (where
-  ///   a .proto always translates to a single class, but you may want to
-  ///   explicitly choose the class name).
+  /// If set, all the classes from the .proto file are wrapped in a single
+  /// outer class with the given name.  This applies to both Proto1
+  /// (equivalent to the old "--one_java_file" option) and Proto2 (where
+  /// a .proto always translates to a single class, but you may want to
+  /// explicitly choose the class name).
   var javaOuterClassname: String {
     get {return _storage._javaOuterClassname ?? ""}
     set {_uniqueStorage()._javaOuterClassname = newValue}
@@ -1621,12 +1621,12 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._javaOuterClassname = nil
   }
 
-  ///   If set true, then the Java code generator will generate a separate .java
-  ///   file for each top-level message, enum, and service defined in the .proto
-  ///   file.  Thus, these types will *not* be nested inside the outer class
-  ///   named by java_outer_classname.  However, the outer class will still be
-  ///   generated to contain the file's getDescriptor() method as well as any
-  ///   top-level extensions defined in the file.
+  /// If set true, then the Java code generator will generate a separate .java
+  /// file for each top-level message, enum, and service defined in the .proto
+  /// file.  Thus, these types will *not* be nested inside the outer class
+  /// named by java_outer_classname.  However, the outer class will still be
+  /// generated to contain the file's getDescriptor() method as well as any
+  /// top-level extensions defined in the file.
   var javaMultipleFiles: Bool {
     get {return _storage._javaMultipleFiles ?? false}
     set {_uniqueStorage()._javaMultipleFiles = newValue}
@@ -1638,7 +1638,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._javaMultipleFiles = nil
   }
 
-  ///   This option does nothing.
+  /// This option does nothing.
   var javaGenerateEqualsAndHash: Bool {
     get {return _storage._javaGenerateEqualsAndHash ?? false}
     set {_uniqueStorage()._javaGenerateEqualsAndHash = newValue}
@@ -1650,12 +1650,12 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._javaGenerateEqualsAndHash = nil
   }
 
-  ///   If set true, then the Java2 code generator will generate code that
-  ///   throws an exception whenever an attempt is made to assign a non-UTF-8
-  ///   byte sequence to a string field.
-  ///   Message reflection will do the same.
-  ///   However, an extension field still accepts non-UTF-8 byte sequences.
-  ///   This option has no effect on when used with the lite runtime.
+  /// If set true, then the Java2 code generator will generate code that
+  /// throws an exception whenever an attempt is made to assign a non-UTF-8
+  /// byte sequence to a string field.
+  /// Message reflection will do the same.
+  /// However, an extension field still accepts non-UTF-8 byte sequences.
+  /// This option has no effect on when used with the lite runtime.
   var javaStringCheckUtf8: Bool {
     get {return _storage._javaStringCheckUtf8 ?? false}
     set {_uniqueStorage()._javaStringCheckUtf8 = newValue}
@@ -1678,11 +1678,11 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._optimizeFor = nil
   }
 
-  ///   Sets the Go package where structs generated from this .proto will be
-  ///   placed. If omitted, the Go package will be derived from the following:
-  ///     - The basename of the package import path, if provided.
-  ///     - Otherwise, the package statement in the .proto file, if present.
-  ///     - Otherwise, the basename of the .proto file, without extension.
+  /// Sets the Go package where structs generated from this .proto will be
+  /// placed. If omitted, the Go package will be derived from the following:
+  ///   - The basename of the package import path, if provided.
+  ///   - Otherwise, the package statement in the .proto file, if present.
+  ///   - Otherwise, the basename of the .proto file, without extension.
   var goPackage: String {
     get {return _storage._goPackage ?? ""}
     set {_uniqueStorage()._goPackage = newValue}
@@ -1694,16 +1694,16 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._goPackage = nil
   }
 
-  ///   Should generic services be generated in each language?  "Generic" services
-  ///   are not specific to any particular RPC system.  They are generated by the
-  ///   main code generators in each language (without additional plugins).
-  ///   Generic services were the only kind of service generation supported by
-  ///   early versions of google.protobuf.
-  ///  
-  ///   Generic services are now considered deprecated in favor of using plugins
-  ///   that generate code specific to your particular RPC system.  Therefore,
-  ///   these default to false.  Old code which depends on generic services should
-  ///   explicitly set them to true.
+  /// Should generic services be generated in each language?  "Generic" services
+  /// are not specific to any particular RPC system.  They are generated by the
+  /// main code generators in each language (without additional plugins).
+  /// Generic services were the only kind of service generation supported by
+  /// early versions of google.protobuf.
+  ///
+  /// Generic services are now considered deprecated in favor of using plugins
+  /// that generate code specific to your particular RPC system.  Therefore,
+  /// these default to false.  Old code which depends on generic services should
+  /// explicitly set them to true.
   var ccGenericServices: Bool {
     get {return _storage._ccGenericServices ?? false}
     set {_uniqueStorage()._ccGenericServices = newValue}
@@ -1737,10 +1737,10 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._pyGenericServices = nil
   }
 
-  ///   Is this file deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for everything in the file, or it will be completely ignored; in the very
-  ///   least, this is a formalization for deprecating files.
+  /// Is this file deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for everything in the file, or it will be completely ignored; in the very
+  /// least, this is a formalization for deprecating files.
   var deprecated: Bool {
     get {return _storage._deprecated ?? false}
     set {_uniqueStorage()._deprecated = newValue}
@@ -1752,8 +1752,8 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._deprecated = nil
   }
 
-  ///   Enables the use of arenas for the proto messages in this file. This applies
-  ///   only to generated classes for C++.
+  /// Enables the use of arenas for the proto messages in this file. This applies
+  /// only to generated classes for C++.
   var ccEnableArenas: Bool {
     get {return _storage._ccEnableArenas ?? false}
     set {_uniqueStorage()._ccEnableArenas = newValue}
@@ -1765,8 +1765,8 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._ccEnableArenas = nil
   }
 
-  ///   Sets the objective c class prefix which is prepended to all objective c
-  ///   generated classes from this .proto. There is no default.
+  /// Sets the objective c class prefix which is prepended to all objective c
+  /// generated classes from this .proto. There is no default.
   var objcClassPrefix: String {
     get {return _storage._objcClassPrefix ?? ""}
     set {_uniqueStorage()._objcClassPrefix = newValue}
@@ -1778,7 +1778,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._objcClassPrefix = nil
   }
 
-  ///   Namespace for generated classes; defaults to the package.
+  /// Namespace for generated classes; defaults to the package.
   var csharpNamespace: String {
     get {return _storage._csharpNamespace ?? ""}
     set {_uniqueStorage()._csharpNamespace = newValue}
@@ -1790,10 +1790,10 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._csharpNamespace = nil
   }
 
-  ///   By default Swift generators will take the proto package and CamelCase it
-  ///   replacing '.' with underscore and use that to prefix the types/symbols
-  ///   defined. When this options is provided, they will use this value instead
-  ///   to prefix the types/symbols defined.
+  /// By default Swift generators will take the proto package and CamelCase it
+  /// replacing '.' with underscore and use that to prefix the types/symbols
+  /// defined. When this options is provided, they will use this value instead
+  /// to prefix the types/symbols defined.
   var swiftPrefix: String {
     get {return _storage._swiftPrefix ?? ""}
     set {_uniqueStorage()._swiftPrefix = newValue}
@@ -1805,8 +1805,8 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._swiftPrefix = nil
   }
 
-  ///   Sets the php class prefix which is prepended to all php generated classes
-  ///   from this .proto. Default is empty.
+  /// Sets the php class prefix which is prepended to all php generated classes
+  /// from this .proto. Default is empty.
   var phpClassPrefix: String {
     get {return _storage._phpClassPrefix ?? ""}
     set {_uniqueStorage()._phpClassPrefix = newValue}
@@ -1818,7 +1818,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._phpClassPrefix = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] {
     get {return _storage._uninterpretedOption}
     set {_uniqueStorage()._uninterpretedOption = newValue}
@@ -1826,17 +1826,17 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   Generated classes can be optimized for speed or code size.
+  /// Generated classes can be optimized for speed or code size.
   enum OptimizeMode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   Generate complete code for parsing, serialization,
+    /// Generate complete code for parsing, serialization,
     case speed // = 1
 
-    ///   etc.
+    /// etc.
     case codeSize // = 2
 
-    ///   Generate code using MessageLite and the lite runtime.
+    /// Generate code using MessageLite and the lite runtime.
     case liteRuntime // = 3
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -1972,24 +1972,24 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
 struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".MessageOptions"
 
-  ///   Set true to use the old proto1 MessageSet wire format for extensions.
-  ///   This is provided for backwards-compatibility with the MessageSet wire
-  ///   format.  You should not use this for any other reason:  It's less
-  ///   efficient, has fewer features, and is more complicated.
-  ///  
-  ///   The message must be defined exactly as follows:
-  ///     message Foo {
-  ///       option message_set_wire_format = true;
-  ///       extensions 4 to max;
-  ///     }
-  ///   Note that the message cannot have any defined fields; MessageSets only
-  ///   have extensions.
-  ///  
-  ///   All extensions of your type must be singular messages; e.g. they cannot
-  ///   be int32s, enums, or repeated messages.
-  ///  
-  ///   Because this is an option, the above two restrictions are not enforced by
-  ///   the protocol compiler.
+  /// Set true to use the old proto1 MessageSet wire format for extensions.
+  /// This is provided for backwards-compatibility with the MessageSet wire
+  /// format.  You should not use this for any other reason:  It's less
+  /// efficient, has fewer features, and is more complicated.
+  ///
+  /// The message must be defined exactly as follows:
+  ///   message Foo {
+  ///     option message_set_wire_format = true;
+  ///     extensions 4 to max;
+  ///   }
+  /// Note that the message cannot have any defined fields; MessageSets only
+  /// have extensions.
+  ///
+  /// All extensions of your type must be singular messages; e.g. they cannot
+  /// be int32s, enums, or repeated messages.
+  ///
+  /// Because this is an option, the above two restrictions are not enforced by
+  /// the protocol compiler.
   fileprivate var _messageSetWireFormat: Bool? = nil
   var messageSetWireFormat: Bool {
     get {return _messageSetWireFormat ?? false}
@@ -2002,9 +2002,9 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     return _messageSetWireFormat = nil
   }
 
-  ///   Disables the generation of the standard "descriptor()" accessor, which can
-  ///   conflict with a field of the same name.  This is meant to make migration
-  ///   from proto1 easier; new code should avoid fields named "descriptor".
+  /// Disables the generation of the standard "descriptor()" accessor, which can
+  /// conflict with a field of the same name.  This is meant to make migration
+  /// from proto1 easier; new code should avoid fields named "descriptor".
   fileprivate var _noStandardDescriptorAccessor: Bool? = nil
   var noStandardDescriptorAccessor: Bool {
     get {return _noStandardDescriptorAccessor ?? false}
@@ -2017,10 +2017,10 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     return _noStandardDescriptorAccessor = nil
   }
 
-  ///   Is this message deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the message, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating messages.
+  /// Is this message deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the message, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating messages.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2033,27 +2033,27 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     return _deprecated = nil
   }
 
-  ///   Whether the message is an automatically generated map entry type for the
-  ///   maps field.
-  ///  
-  ///   For maps fields:
-  ///       map<KeyType, ValueType> map_field = 1;
-  ///   The parsed descriptor looks like:
-  ///       message MapFieldEntry {
-  ///           option map_entry = true;
-  ///           optional KeyType key = 1;
-  ///           optional ValueType value = 2;
-  ///       }
-  ///       repeated MapFieldEntry map_field = 1;
-  ///  
-  ///   Implementations may choose not to generate the map_entry=true message, but
-  ///   use a native map in the target language to hold the keys and values.
-  ///   The reflection APIs in such implementions still need to work as
-  ///   if the field is a repeated message field.
-  ///  
-  ///   NOTE: Do not set the option in .proto files. Always use the maps syntax
-  ///   instead. The option should only be implicitly set by the proto compiler
-  ///   parser.
+  /// Whether the message is an automatically generated map entry type for the
+  /// maps field.
+  ///
+  /// For maps fields:
+  ///     map<KeyType, ValueType> map_field = 1;
+  /// The parsed descriptor looks like:
+  ///     message MapFieldEntry {
+  ///         option map_entry = true;
+  ///         optional KeyType key = 1;
+  ///         optional ValueType value = 2;
+  ///     }
+  ///     repeated MapFieldEntry map_field = 1;
+  ///
+  /// Implementations may choose not to generate the map_entry=true message, but
+  /// use a native map in the target language to hold the keys and values.
+  /// The reflection APIs in such implementions still need to work as
+  /// if the field is a repeated message field.
+  ///
+  /// NOTE: Do not set the option in .proto files. Always use the maps syntax
+  /// instead. The option should only be implicitly set by the proto compiler
+  /// parser.
   fileprivate var _mapEntry: Bool? = nil
   var mapEntry: Bool {
     get {return _mapEntry ?? false}
@@ -2066,7 +2066,7 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     return _mapEntry = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2120,10 +2120,10 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
 struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".FieldOptions"
 
-  ///   The ctype option instructs the C++ code generator to use a different
-  ///   representation of the field than it normally would.  See the specific
-  ///   options below.  This option is not yet implemented in the open source
-  ///   release -- sorry, we'll try to include it in a future version!
+  /// The ctype option instructs the C++ code generator to use a different
+  /// representation of the field than it normally would.  See the specific
+  /// options below.  This option is not yet implemented in the open source
+  /// release -- sorry, we'll try to include it in a future version!
   fileprivate var _ctype: Google_Protobuf_FieldOptions.CType? = nil
   var ctype: Google_Protobuf_FieldOptions.CType {
     get {return _ctype ?? Google_Protobuf_FieldOptions.CType.string}
@@ -2136,11 +2136,11 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _ctype = nil
   }
 
-  ///   The packed option can be enabled for repeated primitive fields to enable
-  ///   a more efficient representation on the wire. Rather than repeatedly
-  ///   writing the tag and type for each element, the entire array is encoded as
-  ///   a single length-delimited blob. In proto3, only explicit setting it to
-  ///   false will avoid using packed encoding.
+  /// The packed option can be enabled for repeated primitive fields to enable
+  /// a more efficient representation on the wire. Rather than repeatedly
+  /// writing the tag and type for each element, the entire array is encoded as
+  /// a single length-delimited blob. In proto3, only explicit setting it to
+  /// false will avoid using packed encoding.
   fileprivate var _packed: Bool? = nil
   var packed: Bool {
     get {return _packed ?? false}
@@ -2153,15 +2153,15 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _packed = nil
   }
 
-  ///   The jstype option determines the JavaScript type used for values of the
-  ///   field.  The option is permitted only for 64 bit integral and fixed types
-  ///   (int64, uint64, sint64, fixed64, sfixed64).  By default these types are
-  ///   represented as JavaScript strings.  This avoids loss of precision that can
-  ///   happen when a large value is converted to a floating point JavaScript
-  ///   numbers.  Specifying JS_NUMBER for the jstype causes the generated
-  ///   JavaScript code to use the JavaScript "number" type instead of strings.
-  ///   This option is an enum to permit additional types to be added,
-  ///   e.g. goog.math.Integer.
+  /// The jstype option determines the JavaScript type used for values of the
+  /// field.  The option is permitted only for 64 bit integral and fixed types
+  /// (int64, uint64, sint64, fixed64, sfixed64).  By default these types are
+  /// represented as JavaScript strings.  This avoids loss of precision that can
+  /// happen when a large value is converted to a floating point JavaScript
+  /// numbers.  Specifying JS_NUMBER for the jstype causes the generated
+  /// JavaScript code to use the JavaScript "number" type instead of strings.
+  /// This option is an enum to permit additional types to be added,
+  /// e.g. goog.math.Integer.
   fileprivate var _jstype: Google_Protobuf_FieldOptions.JSType? = nil
   var jstype: Google_Protobuf_FieldOptions.JSType {
     get {return _jstype ?? Google_Protobuf_FieldOptions.JSType.jsNormal}
@@ -2174,34 +2174,34 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _jstype = nil
   }
 
-  ///   Should this field be parsed lazily?  Lazy applies only to message-type
-  ///   fields.  It means that when the outer message is initially parsed, the
-  ///   inner message's contents will not be parsed but instead stored in encoded
-  ///   form.  The inner message will actually be parsed when it is first accessed.
-  ///  
-  ///   This is only a hint.  Implementations are free to choose whether to use
-  ///   eager or lazy parsing regardless of the value of this option.  However,
-  ///   setting this option true suggests that the protocol author believes that
-  ///   using lazy parsing on this field is worth the additional bookkeeping
-  ///   overhead typically needed to implement it.
-  ///  
-  ///   This option does not affect the public interface of any generated code;
-  ///   all method signatures remain the same.  Furthermore, thread-safety of the
-  ///   interface is not affected by this option; const methods remain safe to
-  ///   call from multiple threads concurrently, while non-const methods continue
-  ///   to require exclusive access.
-  ///  
-  ///  
-  ///   Note that implementations may choose not to check required fields within
-  ///   a lazy sub-message.  That is, calling IsInitialized() on the outer message
-  ///   may return true even if the inner message has missing required fields.
-  ///   This is necessary because otherwise the inner message would have to be
-  ///   parsed in order to perform the check, defeating the purpose of lazy
-  ///   parsing.  An implementation which chooses not to check required fields
-  ///   must be consistent about it.  That is, for any particular sub-message, the
-  ///   implementation must either *always* check its required fields, or *never*
-  ///   check its required fields, regardless of whether or not the message has
-  ///   been parsed.
+  /// Should this field be parsed lazily?  Lazy applies only to message-type
+  /// fields.  It means that when the outer message is initially parsed, the
+  /// inner message's contents will not be parsed but instead stored in encoded
+  /// form.  The inner message will actually be parsed when it is first accessed.
+  ///
+  /// This is only a hint.  Implementations are free to choose whether to use
+  /// eager or lazy parsing regardless of the value of this option.  However,
+  /// setting this option true suggests that the protocol author believes that
+  /// using lazy parsing on this field is worth the additional bookkeeping
+  /// overhead typically needed to implement it.
+  ///
+  /// This option does not affect the public interface of any generated code;
+  /// all method signatures remain the same.  Furthermore, thread-safety of the
+  /// interface is not affected by this option; const methods remain safe to
+  /// call from multiple threads concurrently, while non-const methods continue
+  /// to require exclusive access.
+  ///
+  ///
+  /// Note that implementations may choose not to check required fields within
+  /// a lazy sub-message.  That is, calling IsInitialized() on the outer message
+  /// may return true even if the inner message has missing required fields.
+  /// This is necessary because otherwise the inner message would have to be
+  /// parsed in order to perform the check, defeating the purpose of lazy
+  /// parsing.  An implementation which chooses not to check required fields
+  /// must be consistent about it.  That is, for any particular sub-message, the
+  /// implementation must either *always* check its required fields, or *never*
+  /// check its required fields, regardless of whether or not the message has
+  /// been parsed.
   fileprivate var _lazy: Bool? = nil
   var lazy: Bool {
     get {return _lazy ?? false}
@@ -2214,10 +2214,10 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _lazy = nil
   }
 
-  ///   Is this field deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for accessors, or it will be completely ignored; in the very least, this
-  ///   is a formalization for deprecating fields.
+  /// Is this field deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for accessors, or it will be completely ignored; in the very least, this
+  /// is a formalization for deprecating fields.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2230,7 +2230,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _deprecated = nil
   }
 
-  ///   For Google-internal migration only. Do not use.
+  /// For Google-internal migration only. Do not use.
   fileprivate var _weak: Bool? = nil
   var weak: Bool {
     get {return _weak ?? false}
@@ -2243,7 +2243,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _weak = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2251,7 +2251,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
   enum CType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   Default mode.
+    /// Default mode.
     case string // = 0
     case cord // = 1
     case stringPiece // = 2
@@ -2288,13 +2288,13 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
   enum JSType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   Use the default type.
+    /// Use the default type.
     case jsNormal // = 0
 
-    ///   Use JavaScript strings.
+    /// Use JavaScript strings.
     case jsString // = 1
 
-    ///   Use JavaScript numbers.
+    /// Use JavaScript numbers.
     case jsNumber // = 2
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -2383,7 +2383,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
 struct Google_Protobuf_OneofOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".OneofOptions"
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2421,8 +2421,8 @@ struct Google_Protobuf_OneofOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
 struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".EnumOptions"
 
-  ///   Set this option to true to allow mapping different tag names to the same
-  ///   value.
+  /// Set this option to true to allow mapping different tag names to the same
+  /// value.
   fileprivate var _allowAlias: Bool? = nil
   var allowAlias: Bool {
     get {return _allowAlias ?? false}
@@ -2435,10 +2435,10 @@ struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _allowAlias = nil
   }
 
-  ///   Is this enum deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the enum, or it will be completely ignored; in the very least, this
-  ///   is a formalization for deprecating enums.
+  /// Is this enum deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the enum, or it will be completely ignored; in the very least, this
+  /// is a formalization for deprecating enums.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2451,7 +2451,7 @@ struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _deprecated = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2497,10 +2497,10 @@ struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
 struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".EnumValueOptions"
 
-  ///   Is this enum value deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the enum value, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating enum values.
+  /// Is this enum value deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the enum value, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating enum values.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2513,7 +2513,7 @@ struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Message, SwiftProtobuf.Ex
     return _deprecated = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2555,10 +2555,10 @@ struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Message, SwiftProtobuf.Ex
 struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".ServiceOptions"
 
-  ///   Is this service deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the service, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating services.
+  /// Is this service deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the service, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating services.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2571,7 +2571,7 @@ struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     return _deprecated = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2613,10 +2613,10 @@ struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
 struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".MethodOptions"
 
-  ///   Is this method deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the method, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating methods.
+  /// Is this method deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the method, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating methods.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2641,22 +2641,22 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.Exten
     return _idempotencyLevel = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
-  ///   or neither? HTTP based RPC implementation may choose GET verb for safe
-  ///   methods, and PUT verb for idempotent methods instead of the default POST.
+  /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+  /// or neither? HTTP based RPC implementation may choose GET verb for safe
+  /// methods, and PUT verb for idempotent methods instead of the default POST.
   enum IdempotencyLevel: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
     case idempotencyUnknown // = 0
 
-    ///   implies idempotent
+    /// implies idempotent
     case noSideEffects // = 1
 
-    ///   idempotent, but may have side effects
+    /// idempotent, but may have side effects
     case idempotent // = 2
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -2726,19 +2726,19 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.Exten
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   A message representing a option the parser does not recognize. This only
-///   appears in options protos created by the compiler::Parser class.
-///   DescriptorPool resolves these when building Descriptor objects. Therefore,
-///   options protos in descriptor objects (e.g. returned by Descriptor::options(),
-///   or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
-///   in them.
+/// A message representing a option the parser does not recognize. This only
+/// appears in options protos created by the compiler::Parser class.
+/// DescriptorPool resolves these when building Descriptor objects. Therefore,
+/// options protos in descriptor objects (e.g. returned by Descriptor::options(),
+/// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+/// in them.
 struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".UninterpretedOption"
 
   var name: [Google_Protobuf_UninterpretedOption.NamePart] = []
 
-  ///   The value of the uninterpreted option, in whatever type the tokenizer
-  ///   identified it as during parsing. Exactly one of these should be set.
+  /// The value of the uninterpreted option, in whatever type the tokenizer
+  /// identified it as during parsing. Exactly one of these should be set.
   fileprivate var _identifierValue: String? = nil
   var identifierValue: String {
     get {return _identifierValue ?? ""}
@@ -2813,11 +2813,11 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   The name of the uninterpreted option.  Each string represents a segment in
-  ///   a dot-separated name.  is_extension is true iff a segment represents an
-  ///   extension (denoted with parentheses in options specs in .proto files).
-  ///   E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
-  ///   "foo.(bar.baz).qux".
+  /// The name of the uninterpreted option.  Each string represents a segment in
+  /// a dot-separated name.  is_extension is true iff a segment represents an
+  /// extension (denoted with parentheses in options specs in .proto files).
+  /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+  /// "foo.(bar.baz).qux".
   struct NamePart: SwiftProtobuf.Message {
     static let protoMessageName: String = Google_Protobuf_UninterpretedOption.protoMessageName + ".NamePart"
 
@@ -2924,54 +2924,54 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
   }
 }
 
-///   Encapsulates information about the original source file from which a
-///   FileDescriptorProto was generated.
+/// Encapsulates information about the original source file from which a
+/// FileDescriptorProto was generated.
 struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SourceCodeInfo"
 
-  ///   A Location identifies a piece of source code in a .proto file which
-  ///   corresponds to a particular definition.  This information is intended
-  ///   to be useful to IDEs, code indexers, documentation generators, and similar
-  ///   tools.
-  ///  
-  ///   For example, say we have a file like:
-  ///     message Foo {
-  ///       optional string foo = 1;
-  ///     }
-  ///   Let's look at just the field definition:
+  /// A Location identifies a piece of source code in a .proto file which
+  /// corresponds to a particular definition.  This information is intended
+  /// to be useful to IDEs, code indexers, documentation generators, and similar
+  /// tools.
+  ///
+  /// For example, say we have a file like:
+  ///   message Foo {
   ///     optional string foo = 1;
-  ///     ^       ^^     ^^  ^  ^^^
-  ///     a       bc     de  f  ghi
-  ///   We have the following locations:
-  ///     span   path               represents
-  ///     [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
-  ///     [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
-  ///     [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
-  ///     [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
-  ///     [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
-  ///  
-  ///   Notes:
-  ///   - A location may refer to a repeated field itself (i.e. not to any
-  ///     particular index within it).  This is used whenever a set of elements are
-  ///     logically enclosed in a single code segment.  For example, an entire
-  ///     extend block (possibly containing multiple extension definitions) will
-  ///     have an outer location whose path refers to the "extensions" repeated
-  ///     field without an index.
-  ///   - Multiple locations may have the same path.  This happens when a single
-  ///     logical declaration is spread out across multiple places.  The most
-  ///     obvious example is the "extend" block again -- there may be multiple
-  ///     extend blocks in the same scope, each of which will have the same path.
-  ///   - A location's span is not always a subset of its parent's span.  For
-  ///     example, the "extendee" of an extension declaration appears at the
-  ///     beginning of the "extend" block and is shared by all extensions within
-  ///     the block.
-  ///   - Just because a location's span is a subset of some other location's span
-  ///     does not mean that it is a descendent.  For example, a "group" defines
-  ///     both a type and a field in a single declaration.  Thus, the locations
-  ///     corresponding to the type and field and their components will overlap.
-  ///   - Code which tries to interpret locations should probably be designed to
-  ///     ignore those that it doesn't understand, as more types of locations could
-  ///     be recorded in the future.
+  ///   }
+  /// Let's look at just the field definition:
+  ///   optional string foo = 1;
+  ///   ^       ^^     ^^  ^  ^^^
+  ///   a       bc     de  f  ghi
+  /// We have the following locations:
+  ///   span   path               represents
+  ///   [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+  ///   [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+  ///   [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+  ///   [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+  ///   [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+  ///
+  /// Notes:
+  /// - A location may refer to a repeated field itself (i.e. not to any
+  ///   particular index within it).  This is used whenever a set of elements are
+  ///   logically enclosed in a single code segment.  For example, an entire
+  ///   extend block (possibly containing multiple extension definitions) will
+  ///   have an outer location whose path refers to the "extensions" repeated
+  ///   field without an index.
+  /// - Multiple locations may have the same path.  This happens when a single
+  ///   logical declaration is spread out across multiple places.  The most
+  ///   obvious example is the "extend" block again -- there may be multiple
+  ///   extend blocks in the same scope, each of which will have the same path.
+  /// - A location's span is not always a subset of its parent's span.  For
+  ///   example, the "extendee" of an extension declaration appears at the
+  ///   beginning of the "extend" block and is shared by all extensions within
+  ///   the block.
+  /// - Just because a location's span is a subset of some other location's span
+  ///   does not mean that it is a descendent.  For example, a "group" defines
+  ///   both a type and a field in a single declaration.  Thus, the locations
+  ///   corresponding to the type and field and their components will overlap.
+  /// - Code which tries to interpret locations should probably be designed to
+  ///   ignore those that it doesn't understand, as more types of locations could
+  ///   be recorded in the future.
   var location: [Google_Protobuf_SourceCodeInfo.Location] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2979,85 +2979,85 @@ struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
   struct Location: SwiftProtobuf.Message {
     static let protoMessageName: String = Google_Protobuf_SourceCodeInfo.protoMessageName + ".Location"
 
-    ///   Identifies which part of the FileDescriptorProto was defined at this
-    ///   location.
-    ///  
-    ///   Each element is a field number or an index.  They form a path from
-    ///   the root FileDescriptorProto to the place where the definition.  For
-    ///   example, this path:
-    ///     [ 4, 3, 2, 7, 1 ]
-    ///   refers to:
-    ///     file.message_type(3)  // 4, 3
-    ///         .field(7)         // 2, 7
-    ///         .name()           // 1
-    ///   This is because FileDescriptorProto.message_type has field number 4:
-    ///     repeated DescriptorProto message_type = 4;
-    ///   and DescriptorProto.field has field number 2:
-    ///     repeated FieldDescriptorProto field = 2;
-    ///   and FieldDescriptorProto.name has field number 1:
-    ///     optional string name = 1;
-    ///  
-    ///   Thus, the above path gives the location of a field name.  If we removed
-    ///   the last element:
-    ///     [ 4, 3, 2, 7 ]
-    ///   this path refers to the whole field declaration (from the beginning
-    ///   of the label to the terminating semicolon).
+    /// Identifies which part of the FileDescriptorProto was defined at this
+    /// location.
+    ///
+    /// Each element is a field number or an index.  They form a path from
+    /// the root FileDescriptorProto to the place where the definition.  For
+    /// example, this path:
+    ///   [ 4, 3, 2, 7, 1 ]
+    /// refers to:
+    ///   file.message_type(3)  // 4, 3
+    ///       .field(7)         // 2, 7
+    ///       .name()           // 1
+    /// This is because FileDescriptorProto.message_type has field number 4:
+    ///   repeated DescriptorProto message_type = 4;
+    /// and DescriptorProto.field has field number 2:
+    ///   repeated FieldDescriptorProto field = 2;
+    /// and FieldDescriptorProto.name has field number 1:
+    ///   optional string name = 1;
+    ///
+    /// Thus, the above path gives the location of a field name.  If we removed
+    /// the last element:
+    ///   [ 4, 3, 2, 7 ]
+    /// this path refers to the whole field declaration (from the beginning
+    /// of the label to the terminating semicolon).
     var path: [Int32] = []
 
-    ///   Always has exactly three or four elements: start line, start column,
-    ///   end line (optional, otherwise assumed same as start line), end column.
-    ///   These are packed into a single field for efficiency.  Note that line
-    ///   and column numbers are zero-based -- typically you will want to add
-    ///   1 to each before displaying to a user.
+    /// Always has exactly three or four elements: start line, start column,
+    /// end line (optional, otherwise assumed same as start line), end column.
+    /// These are packed into a single field for efficiency.  Note that line
+    /// and column numbers are zero-based -- typically you will want to add
+    /// 1 to each before displaying to a user.
     var span: [Int32] = []
 
-    ///   If this SourceCodeInfo represents a complete declaration, these are any
-    ///   comments appearing before and after the declaration which appear to be
-    ///   attached to the declaration.
-    ///  
-    ///   A series of line comments appearing on consecutive lines, with no other
-    ///   tokens appearing on those lines, will be treated as a single comment.
-    ///  
-    ///   leading_detached_comments will keep paragraphs of comments that appear
-    ///   before (but not connected to) the current element. Each paragraph,
-    ///   separated by empty lines, will be one comment element in the repeated
-    ///   field.
-    ///  
-    ///   Only the comment content is provided; comment markers (e.g. //) are
-    ///   stripped out.  For block comments, leading whitespace and an asterisk
-    ///   will be stripped from the beginning of each line other than the first.
-    ///   Newlines are included in the output.
-    ///  
-    ///   Examples:
-    ///  
-    ///     optional int32 foo = 1;  // Comment attached to foo.
-    ///     // Comment attached to bar.
-    ///     optional int32 bar = 2;
-    ///  
-    ///     optional string baz = 3;
-    ///     // Comment attached to baz.
-    ///     // Another line attached to baz.
-    ///  
-    ///     // Comment attached to qux.
-    ///     //
-    ///     // Another line attached to qux.
-    ///     optional double qux = 4;
-    ///  
-    ///     // Detached comment for corge. This is not leading or trailing comments
-    ///     // to qux or corge because there are blank lines separating it from
-    ///     // both.
-    ///  
-    ///     // Detached comment for corge paragraph 2.
-    ///  
-    ///     optional string corge = 5;
-    ///     /* Block comment attached
-    ///      * to corge.  Leading asterisks
-    ///      * will be removed. */
-    ///     /* Block comment attached to
-    ///      * grault. */
-    ///     optional int32 grault = 6;
-    ///  
-    ///     // ignored detached comments.
+    /// If this SourceCodeInfo represents a complete declaration, these are any
+    /// comments appearing before and after the declaration which appear to be
+    /// attached to the declaration.
+    ///
+    /// A series of line comments appearing on consecutive lines, with no other
+    /// tokens appearing on those lines, will be treated as a single comment.
+    ///
+    /// leading_detached_comments will keep paragraphs of comments that appear
+    /// before (but not connected to) the current element. Each paragraph,
+    /// separated by empty lines, will be one comment element in the repeated
+    /// field.
+    ///
+    /// Only the comment content is provided; comment markers (e.g. //) are
+    /// stripped out.  For block comments, leading whitespace and an asterisk
+    /// will be stripped from the beginning of each line other than the first.
+    /// Newlines are included in the output.
+    ///
+    /// Examples:
+    ///
+    ///   optional int32 foo = 1;  // Comment attached to foo.
+    ///   // Comment attached to bar.
+    ///   optional int32 bar = 2;
+    ///
+    ///   optional string baz = 3;
+    ///   // Comment attached to baz.
+    ///   // Another line attached to baz.
+    ///
+    ///   // Comment attached to qux.
+    ///   //
+    ///   // Another line attached to qux.
+    ///   optional double qux = 4;
+    ///
+    ///   // Detached comment for corge. This is not leading or trailing comments
+    ///   // to qux or corge because there are blank lines separating it from
+    ///   // both.
+    ///
+    ///   // Detached comment for corge paragraph 2.
+    ///
+    ///   optional string corge = 5;
+    ///   /* Block comment attached
+    ///    * to corge.  Leading asterisks
+    ///    * will be removed. */
+    ///   /* Block comment attached to
+    ///    * grault. */
+    ///   optional int32 grault = 6;
+    ///
+    ///   // ignored detached comments.
     fileprivate var _leadingComments: String? = nil
     var leadingComments: String {
       get {return _leadingComments ?? ""}
@@ -3140,14 +3140,14 @@ struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
   }
 }
 
-///   Describes the relationship between generated code and its original source
-///   file. A GeneratedCodeInfo message is associated with only one generated
-///   source file, but may contain references to different source .proto files.
+/// Describes the relationship between generated code and its original source
+/// file. A GeneratedCodeInfo message is associated with only one generated
+/// source file, but may contain references to different source .proto files.
 struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".GeneratedCodeInfo"
 
-  ///   An Annotation connects some span of text in generated code to an element
-  ///   of its generating .proto file.
+  /// An Annotation connects some span of text in generated code to an element
+  /// of its generating .proto file.
   var annotation: [Google_Protobuf_GeneratedCodeInfo.Annotation] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -3155,11 +3155,11 @@ struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
   struct Annotation: SwiftProtobuf.Message {
     static let protoMessageName: String = Google_Protobuf_GeneratedCodeInfo.protoMessageName + ".Annotation"
 
-    ///   Identifies the element in the original source .proto file. This field
-    ///   is formatted the same as SourceCodeInfo.Location.path.
+    /// Identifies the element in the original source .proto file. This field
+    /// is formatted the same as SourceCodeInfo.Location.path.
     var path: [Int32] = []
 
-    ///   Identifies the filesystem path to the original source .proto.
+    /// Identifies the filesystem path to the original source .proto.
     fileprivate var _sourceFile: String? = nil
     var sourceFile: String {
       get {return _sourceFile ?? ""}
@@ -3172,8 +3172,8 @@ struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
       return _sourceFile = nil
     }
 
-    ///   Identifies the starting offset in bytes in the generated code
-    ///   that relates to the identified object.
+    /// Identifies the starting offset in bytes in the generated code
+    /// that relates to the identified object.
     fileprivate var _begin: Int32? = nil
     var begin: Int32 {
       get {return _begin ?? 0}
@@ -3186,9 +3186,9 @@ struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
       return _begin = nil
     }
 
-    ///   Identifies the ending offset in bytes in the generated code that
-    ///   relates to the identified offset. The end offset should be one past
-    ///   the last relevant byte (so the length of the text = end - begin).
+    /// Identifies the ending offset in bytes in the generated code that
+    /// relates to the identified offset. The end offset should be one past
+    /// the last relevant byte (so the length of the text = end - begin).
     fileprivate var _end: Int32? = nil
     var end: Int32 {
       get {return _end ?? 0}

--- a/Reference/google/protobuf/duration.pb.swift
+++ b/Reference/google/protobuf/duration.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,65 +50,65 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   A Duration represents a signed, fixed-length span of time represented
-///   as a count of seconds and fractions of seconds at nanosecond
-///   resolution. It is independent of any calendar and concepts like "day"
-///   or "month". It is related to Timestamp in that the difference between
-///   two Timestamp values is a Duration and it can be added or subtracted
-///   from a Timestamp. Range is approximately +-10,000 years.
-///  
-///   Example 1: Compute Duration from two Timestamps in pseudo code.
-///  
-///       Timestamp start = ...;
-///       Timestamp end = ...;
-///       Duration duration = ...;
-///  
-///       duration.seconds = end.seconds - start.seconds;
-///       duration.nanos = end.nanos - start.nanos;
-///  
-///       if (duration.seconds < 0 && duration.nanos > 0) {
-///         duration.seconds += 1;
-///         duration.nanos -= 1000000000;
-///       } else if (durations.seconds > 0 && duration.nanos < 0) {
-///         duration.seconds -= 1;
-///         duration.nanos += 1000000000;
-///       }
-///  
-///   Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
-///  
-///       Timestamp start = ...;
-///       Duration duration = ...;
-///       Timestamp end = ...;
-///  
-///       end.seconds = start.seconds + duration.seconds;
-///       end.nanos = start.nanos + duration.nanos;
-///  
-///       if (end.nanos < 0) {
-///         end.seconds -= 1;
-///         end.nanos += 1000000000;
-///       } else if (end.nanos >= 1000000000) {
-///         end.seconds += 1;
-///         end.nanos -= 1000000000;
-///       }
-///  
-///   Example 3: Compute Duration from datetime.timedelta in Python.
-///  
-///       td = datetime.timedelta(days=3, minutes=10)
-///       duration = Duration()
-///       duration.FromTimedelta(td)
+/// A Duration represents a signed, fixed-length span of time represented
+/// as a count of seconds and fractions of seconds at nanosecond
+/// resolution. It is independent of any calendar and concepts like "day"
+/// or "month". It is related to Timestamp in that the difference between
+/// two Timestamp values is a Duration and it can be added or subtracted
+/// from a Timestamp. Range is approximately +-10,000 years.
+///
+/// Example 1: Compute Duration from two Timestamps in pseudo code.
+///
+///     Timestamp start = ...;
+///     Timestamp end = ...;
+///     Duration duration = ...;
+///
+///     duration.seconds = end.seconds - start.seconds;
+///     duration.nanos = end.nanos - start.nanos;
+///
+///     if (duration.seconds < 0 && duration.nanos > 0) {
+///       duration.seconds += 1;
+///       duration.nanos -= 1000000000;
+///     } else if (durations.seconds > 0 && duration.nanos < 0) {
+///       duration.seconds -= 1;
+///       duration.nanos += 1000000000;
+///     }
+///
+/// Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+///
+///     Timestamp start = ...;
+///     Duration duration = ...;
+///     Timestamp end = ...;
+///
+///     end.seconds = start.seconds + duration.seconds;
+///     end.nanos = start.nanos + duration.nanos;
+///
+///     if (end.nanos < 0) {
+///       end.seconds -= 1;
+///       end.nanos += 1000000000;
+///     } else if (end.nanos >= 1000000000) {
+///       end.seconds += 1;
+///       end.nanos -= 1000000000;
+///     }
+///
+/// Example 3: Compute Duration from datetime.timedelta in Python.
+///
+///     td = datetime.timedelta(days=3, minutes=10)
+///     duration = Duration()
+///     duration.FromTimedelta(td)
 struct Google_Protobuf_Duration: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Duration"
 
-  ///   Signed seconds of the span of time. Must be from -315,576,000,000
-  ///   to +315,576,000,000 inclusive.
+  /// Signed seconds of the span of time. Must be from -315,576,000,000
+  /// to +315,576,000,000 inclusive.
   var seconds: Int64 = 0
 
-  ///   Signed fractions of a second at nanosecond resolution of the span
-  ///   of time. Durations less than one second are represented with a 0
-  ///   `seconds` field and a positive or negative `nanos` field. For durations
-  ///   of one second or more, a non-zero value for the `nanos` field must be
-  ///   of the same sign as the `seconds` field. Must be from -999,999,999
-  ///   to +999,999,999 inclusive.
+  /// Signed fractions of a second at nanosecond resolution of the span
+  /// of time. Durations less than one second are represented with a 0
+  /// `seconds` field and a positive or negative `nanos` field. For durations
+  /// of one second or more, a non-zero value for the `nanos` field must be
+  /// of the same sign as the `seconds` field. Must be from -999,999,999
+  /// to +999,999,999 inclusive.
   var nanos: Int32 = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/empty.pb.swift
+++ b/Reference/google/protobuf/empty.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,15 +50,15 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   A generic empty message that you can re-use to avoid defining duplicated
-///   empty messages in your APIs. A typical example is to use it as the request
-///   or the response type of an API method. For instance:
-///  
-///       service Foo {
-///         rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-///       }
-///  
-///   The JSON representation for `Empty` is empty JSON object `{}`.
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+///
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+///
+/// The JSON representation for `Empty` is empty JSON object `{}`.
 struct Google_Protobuf_Empty: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Empty"
 

--- a/Reference/google/protobuf/field_mask.pb.swift
+++ b/Reference/google/protobuf/field_mask.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,211 +50,211 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   `FieldMask` represents a set of symbolic field paths, for example:
-///  
-///       paths: "f.a"
-///       paths: "f.b.d"
-///  
-///   Here `f` represents a field in some root message, `a` and `b`
-///   fields in the message found in `f`, and `d` a field found in the
-///   message in `f.b`.
-///  
-///   Field masks are used to specify a subset of fields that should be
-///   returned by a get operation or modified by an update operation.
-///   Field masks also have a custom JSON encoding (see below).
-///  
-///   # Field Masks in Projections
-///  
-///   When used in the context of a projection, a response message or
-///   sub-message is filtered by the API to only contain those fields as
-///   specified in the mask. For example, if the mask in the previous
-///   example is applied to a response message as follows:
-///  
-///       f {
-///         a : 22
-///         b {
-///           d : 1
-///           x : 2
-///         }
-///         y : 13
+/// `FieldMask` represents a set of symbolic field paths, for example:
+///
+///     paths: "f.a"
+///     paths: "f.b.d"
+///
+/// Here `f` represents a field in some root message, `a` and `b`
+/// fields in the message found in `f`, and `d` a field found in the
+/// message in `f.b`.
+///
+/// Field masks are used to specify a subset of fields that should be
+/// returned by a get operation or modified by an update operation.
+/// Field masks also have a custom JSON encoding (see below).
+///
+/// # Field Masks in Projections
+///
+/// When used in the context of a projection, a response message or
+/// sub-message is filtered by the API to only contain those fields as
+/// specified in the mask. For example, if the mask in the previous
+/// example is applied to a response message as follows:
+///
+///     f {
+///       a : 22
+///       b {
+///         d : 1
+///         x : 2
 ///       }
-///       z: 8
-///  
-///   The result will not contain specific values for fields x,y and z
-///   (their value will be set to the default, and omitted in proto text
-///   output):
-///  
-///  
-///       f {
-///         a : 22
-///         b {
-///           d : 1
-///         }
+///       y : 13
+///     }
+///     z: 8
+///
+/// The result will not contain specific values for fields x,y and z
+/// (their value will be set to the default, and omitted in proto text
+/// output):
+///
+///
+///     f {
+///       a : 22
+///       b {
+///         d : 1
 ///       }
-///  
-///   A repeated field is not allowed except at the last position of a
-///   paths string.
-///  
-///   If a FieldMask object is not present in a get operation, the
-///   operation applies to all fields (as if a FieldMask of all fields
-///   had been specified).
-///  
-///   Note that a field mask does not necessarily apply to the
-///   top-level response message. In case of a REST get operation, the
-///   field mask applies directly to the response, but in case of a REST
-///   list operation, the mask instead applies to each individual message
-///   in the returned resource list. In case of a REST custom method,
-///   other definitions may be used. Where the mask applies will be
-///   clearly documented together with its declaration in the API.  In
-///   any case, the effect on the returned resource/resources is required
-///   behavior for APIs.
-///  
-///   # Field Masks in Update Operations
-///  
-///   A field mask in update operations specifies which fields of the
-///   targeted resource are going to be updated. The API is required
-///   to only change the values of the fields as specified in the mask
-///   and leave the others untouched. If a resource is passed in to
-///   describe the updated values, the API ignores the values of all
-///   fields not covered by the mask.
-///  
-///   If a repeated field is specified for an update operation, the existing
-///   repeated values in the target resource will be overwritten by the new values.
-///   Note that a repeated field is only allowed in the last position of a `paths`
-///   string.
-///  
-///   If a sub-message is specified in the last position of the field mask for an
-///   update operation, then the existing sub-message in the target resource is
-///   overwritten. Given the target message:
-///  
-///       f {
-///         b {
-///           d : 1
-///           x : 2
-///         }
-///         c : 1
+///     }
+///
+/// A repeated field is not allowed except at the last position of a
+/// paths string.
+///
+/// If a FieldMask object is not present in a get operation, the
+/// operation applies to all fields (as if a FieldMask of all fields
+/// had been specified).
+///
+/// Note that a field mask does not necessarily apply to the
+/// top-level response message. In case of a REST get operation, the
+/// field mask applies directly to the response, but in case of a REST
+/// list operation, the mask instead applies to each individual message
+/// in the returned resource list. In case of a REST custom method,
+/// other definitions may be used. Where the mask applies will be
+/// clearly documented together with its declaration in the API.  In
+/// any case, the effect on the returned resource/resources is required
+/// behavior for APIs.
+///
+/// # Field Masks in Update Operations
+///
+/// A field mask in update operations specifies which fields of the
+/// targeted resource are going to be updated. The API is required
+/// to only change the values of the fields as specified in the mask
+/// and leave the others untouched. If a resource is passed in to
+/// describe the updated values, the API ignores the values of all
+/// fields not covered by the mask.
+///
+/// If a repeated field is specified for an update operation, the existing
+/// repeated values in the target resource will be overwritten by the new values.
+/// Note that a repeated field is only allowed in the last position of a `paths`
+/// string.
+///
+/// If a sub-message is specified in the last position of the field mask for an
+/// update operation, then the existing sub-message in the target resource is
+/// overwritten. Given the target message:
+///
+///     f {
+///       b {
+///         d : 1
+///         x : 2
 ///       }
-///  
-///   And an update message:
-///  
-///       f {
-///         b {
-///           d : 10
-///         }
+///       c : 1
+///     }
+///
+/// And an update message:
+///
+///     f {
+///       b {
+///         d : 10
 ///       }
-///  
-///   then if the field mask is:
-///  
-///    paths: "f.b"
-///  
-///   then the result will be:
-///  
-///       f {
-///         b {
-///           d : 10
-///         }
-///         c : 1
+///     }
+///
+/// then if the field mask is:
+///
+///  paths: "f.b"
+///
+/// then the result will be:
+///
+///     f {
+///       b {
+///         d : 10
 ///       }
-///  
-///   However, if the update mask was:
-///  
-///    paths: "f.b.d"
-///  
-///   then the result would be:
-///  
-///       f {
-///         b {
-///           d : 10
-///           x : 2
-///         }
-///         c : 1
+///       c : 1
+///     }
+///
+/// However, if the update mask was:
+///
+///  paths: "f.b.d"
+///
+/// then the result would be:
+///
+///     f {
+///       b {
+///         d : 10
+///         x : 2
 ///       }
-///  
-///   In order to reset a field's value to the default, the field must
-///   be in the mask and set to the default value in the provided resource.
-///   Hence, in order to reset all fields of a resource, provide a default
-///   instance of the resource and set all fields in the mask, or do
-///   not provide a mask as described below.
-///  
-///   If a field mask is not present on update, the operation applies to
-///   all fields (as if a field mask of all fields has been specified).
-///   Note that in the presence of schema evolution, this may mean that
-///   fields the client does not know and has therefore not filled into
-///   the request will be reset to their default. If this is unwanted
-///   behavior, a specific service may require a client to always specify
-///   a field mask, producing an error if not.
-///  
-///   As with get operations, the location of the resource which
-///   describes the updated values in the request message depends on the
-///   operation kind. In any case, the effect of the field mask is
-///   required to be honored by the API.
-///  
-///   ## Considerations for HTTP REST
-///  
-///   The HTTP kind of an update operation which uses a field mask must
-///   be set to PATCH instead of PUT in order to satisfy HTTP semantics
-///   (PUT must only be used for full updates).
-///  
-///   # JSON Encoding of Field Masks
-///  
-///   In JSON, a field mask is encoded as a single string where paths are
-///   separated by a comma. Fields name in each path are converted
-///   to/from lower-camel naming conventions.
-///  
-///   As an example, consider the following message declarations:
-///  
-///       message Profile {
-///         User user = 1;
-///         Photo photo = 2;
+///       c : 1
+///     }
+///
+/// In order to reset a field's value to the default, the field must
+/// be in the mask and set to the default value in the provided resource.
+/// Hence, in order to reset all fields of a resource, provide a default
+/// instance of the resource and set all fields in the mask, or do
+/// not provide a mask as described below.
+///
+/// If a field mask is not present on update, the operation applies to
+/// all fields (as if a field mask of all fields has been specified).
+/// Note that in the presence of schema evolution, this may mean that
+/// fields the client does not know and has therefore not filled into
+/// the request will be reset to their default. If this is unwanted
+/// behavior, a specific service may require a client to always specify
+/// a field mask, producing an error if not.
+///
+/// As with get operations, the location of the resource which
+/// describes the updated values in the request message depends on the
+/// operation kind. In any case, the effect of the field mask is
+/// required to be honored by the API.
+///
+/// ## Considerations for HTTP REST
+///
+/// The HTTP kind of an update operation which uses a field mask must
+/// be set to PATCH instead of PUT in order to satisfy HTTP semantics
+/// (PUT must only be used for full updates).
+///
+/// # JSON Encoding of Field Masks
+///
+/// In JSON, a field mask is encoded as a single string where paths are
+/// separated by a comma. Fields name in each path are converted
+/// to/from lower-camel naming conventions.
+///
+/// As an example, consider the following message declarations:
+///
+///     message Profile {
+///       User user = 1;
+///       Photo photo = 2;
+///     }
+///     message User {
+///       string display_name = 1;
+///       string address = 2;
+///     }
+///
+/// In proto a field mask for `Profile` may look as such:
+///
+///     mask {
+///       paths: "user.display_name"
+///       paths: "photo"
+///     }
+///
+/// In JSON, the same mask is represented as below:
+///
+///     {
+///       mask: "user.displayName,photo"
+///     }
+///
+/// # Field Masks and Oneof Fields
+///
+/// Field masks treat fields in oneofs just as regular fields. Consider the
+/// following message:
+///
+///     message SampleMessage {
+///       oneof test_oneof {
+///         string name = 4;
+///         SubMessage sub_message = 9;
 ///       }
-///       message User {
-///         string display_name = 1;
-///         string address = 2;
-///       }
-///  
-///   In proto a field mask for `Profile` may look as such:
-///  
-///       mask {
-///         paths: "user.display_name"
-///         paths: "photo"
-///       }
-///  
-///   In JSON, the same mask is represented as below:
-///  
-///       {
-///         mask: "user.displayName,photo"
-///       }
-///  
-///   # Field Masks and Oneof Fields
-///  
-///   Field masks treat fields in oneofs just as regular fields. Consider the
-///   following message:
-///  
-///       message SampleMessage {
-///         oneof test_oneof {
-///           string name = 4;
-///           SubMessage sub_message = 9;
-///         }
-///       }
-///  
-///   The field mask can be:
-///  
-///       mask {
-///         paths: "name"
-///       }
-///  
-///   Or:
-///  
-///       mask {
-///         paths: "sub_message"
-///       }
-///  
-///   Note that oneof type names ("test_oneof" in this case) cannot be used in
-///   paths.
+///     }
+///
+/// The field mask can be:
+///
+///     mask {
+///       paths: "name"
+///     }
+///
+/// Or:
+///
+///     mask {
+///       paths: "sub_message"
+///     }
+///
+/// Note that oneof type names ("test_oneof" in this case) cannot be used in
+/// paths.
 struct Google_Protobuf_FieldMask: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FieldMask"
 
-  ///   The set of field mask paths.
+  /// The set of field mask paths.
   var paths: [String] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/map_lite_unittest.pb.swift
+++ b/Reference/google/protobuf/map_lite_unittest.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -640,7 +640,7 @@ struct ProtobufUnittest_TestArenaMapLite: SwiftProtobuf.Message {
   }
 }
 
-///   Test embedded message with required fields
+/// Test embedded message with required fields
 struct ProtobufUnittest_TestRequiredMessageMapLite: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRequiredMessageMapLite"
 

--- a/Reference/google/protobuf/map_proto2_unittest.pb.swift
+++ b/Reference/google/protobuf/map_proto2_unittest.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -241,7 +241,7 @@ struct ProtobufUnittest_TestIntIntMap: SwiftProtobuf.Message {
   }
 }
 
-///   Test all key types: string, plus the non-floating-point scalars.
+/// Test all key types: string, plus the non-floating-point scalars.
 struct ProtobufUnittest_TestMaps: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMaps"
 

--- a/Reference/google/protobuf/map_unittest.pb.swift
+++ b/Reference/google/protobuf/map_unittest.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -88,7 +88,7 @@ enum ProtobufUnittest_MapEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProvi
 
 }
 
-///   Tests maps.
+/// Tests maps.
 struct ProtobufUnittest_TestMap: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMap"
 
@@ -414,7 +414,7 @@ struct ProtobufUnittest_TestMessageMap: SwiftProtobuf.Message {
   }
 }
 
-///   Two map fields share the same entry default instance.
+/// Two map fields share the same entry default instance.
 struct ProtobufUnittest_TestSameTypeMap: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestSameTypeMap"
 
@@ -447,7 +447,7 @@ struct ProtobufUnittest_TestSameTypeMap: SwiftProtobuf.Message {
   }
 }
 
-///   Test embedded message with required fields
+/// Test embedded message with required fields
 struct ProtobufUnittest_TestRequiredMessageMap: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRequiredMessageMap"
 
@@ -719,8 +719,8 @@ struct ProtobufUnittest_TestArenaMap: SwiftProtobuf.Message {
   }
 }
 
-///   Previously, message containing enum called Type cannot be used as value of
-///   map field.
+/// Previously, message containing enum called Type cannot be used as value of
+/// map field.
 struct ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MessageContainingEnumCalledType"
 
@@ -776,7 +776,7 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf.Message {
   }
 }
 
-///   Previously, message cannot contain map field called "entry".
+/// Previously, message cannot contain map field called "entry".
 struct ProtobufUnittest_MessageContainingMapCalledEntry: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MessageContainingMapCalledEntry"
 

--- a/Reference/google/protobuf/map_unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/map_unittest_proto3.pb.swift
@@ -6,42 +6,42 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-///   This file is mostly equivalent to map_unittest.proto, but imports
-///   unittest_proto3.proto instead of unittest.proto, so that it only
-///   uses proto3 messages. This makes it suitable for testing
-///   implementations which only support proto3.
-///   The TestRequiredMessageMap message has been removed as there are no
-///   required fields in proto3.
+/// This file is mostly equivalent to map_unittest.proto, but imports
+/// unittest_proto3.proto instead of unittest.proto, so that it only
+/// uses proto3 messages. This makes it suitable for testing
+/// implementations which only support proto3.
+/// The TestRequiredMessageMap message has been removed as there are no
+/// required fields in proto3.
 
 import Foundation
 import SwiftProtobuf
@@ -95,7 +95,7 @@ enum Proto3MapEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
 
 }
 
-///   Tests maps.
+/// Tests maps.
 struct Proto3TestMap: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMap"
 
@@ -410,7 +410,7 @@ struct Proto3TestMessageMap: SwiftProtobuf.Message {
   }
 }
 
-///   Two map fields share the same entry default instance.
+/// Two map fields share the same entry default instance.
 struct Proto3TestSameTypeMap: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestSameTypeMap"
 
@@ -553,8 +553,8 @@ struct Proto3TestArenaMap: SwiftProtobuf.Message {
   }
 }
 
-///   Previously, message containing enum called Type cannot be used as value of
-///   map field.
+/// Previously, message containing enum called Type cannot be used as value of
+/// map field.
 struct Proto3MessageContainingEnumCalledType: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MessageContainingEnumCalledType"
 
@@ -610,7 +610,7 @@ struct Proto3MessageContainingEnumCalledType: SwiftProtobuf.Message {
   }
 }
 
-///   Previously, message cannot contain map field called "entry".
+/// Previously, message cannot contain map field called "entry".
 struct Proto3MessageContainingMapCalledEntry: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MessageContainingMapCalledEntry"
 

--- a/Reference/google/protobuf/source_context.pb.swift
+++ b/Reference/google/protobuf/source_context.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,13 +50,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   `SourceContext` represents information about the source of a
-///   protobuf element, like the file in which it is defined.
+/// `SourceContext` represents information about the source of a
+/// protobuf element, like the file in which it is defined.
 struct Google_Protobuf_SourceContext: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SourceContext"
 
-  ///   The path-qualified name of the .proto file that contained the associated
-  ///   protobuf element.  For example: `"google/protobuf/source_context.proto"`.
+  /// The path-qualified name of the .proto file that contained the associated
+  /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
   var fileName: String = ""
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,14 +50,14 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   `NullValue` is a singleton enumeration to represent the null value for the
-///   `Value` type union.
-///  
-///    The JSON representation for `NullValue` is JSON `null`.
+/// `NullValue` is a singleton enumeration to represent the null value for the
+/// `Value` type union.
+///
+///  The JSON representation for `NullValue` is JSON `null`.
 enum Google_Protobuf_NullValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
 
-  ///   Null value.
+  /// Null value.
   case nullValue // = 0
   case UNRECOGNIZED(Int)
 
@@ -85,18 +85,18 @@ enum Google_Protobuf_NullValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProv
 
 }
 
-///   `Struct` represents a structured data value, consisting of fields
-///   which map to dynamically typed values. In some languages, `Struct`
-///   might be supported by a native representation. For example, in
-///   scripting languages like JS a struct is represented as an
-///   object. The details of that representation are described together
-///   with the proto support for the language.
-///  
-///   The JSON representation for `Struct` is JSON object.
+/// `Struct` represents a structured data value, consisting of fields
+/// which map to dynamically typed values. In some languages, `Struct`
+/// might be supported by a native representation. For example, in
+/// scripting languages like JS a struct is represented as an
+/// object. The details of that representation are described together
+/// with the proto support for the language.
+///
+/// The JSON representation for `Struct` is JSON object.
 struct Google_Protobuf_Struct: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Struct"
 
-  ///   Unordered map of dynamically typed values.
+  /// Unordered map of dynamically typed values.
   var fields: Dictionary<String,Google_Protobuf_Value> = [:]
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -120,12 +120,12 @@ struct Google_Protobuf_Struct: SwiftProtobuf.Message {
   }
 }
 
-///   `Value` represents a dynamically typed value which can be either
-///   null, a number, a string, a boolean, a recursive struct value, or a
-///   list of values. A producer of value is expected to set one of that
-///   variants, absence of any variant indicates an error.
-///  
-///   The JSON representation for `Value` is JSON value.
+/// `Value` represents a dynamically typed value which can be either
+/// null, a number, a string, a boolean, a recursive struct value, or a
+/// list of values. A producer of value is expected to set one of that
+/// variants, absence of any variant indicates an error.
+///
+/// The JSON representation for `Value` is JSON value.
 struct Google_Protobuf_Value: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Value"
 
@@ -148,7 +148,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Represents a null value.
+  /// Represents a null value.
   var nullValue: Google_Protobuf_NullValue {
     get {
       if case .nullValue(let v)? = _storage._kind {
@@ -161,7 +161,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
     }
   }
 
-  ///   Represents a double value.
+  /// Represents a double value.
   var numberValue: Double {
     get {
       if case .numberValue(let v)? = _storage._kind {
@@ -174,7 +174,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
     }
   }
 
-  ///   Represents a string value.
+  /// Represents a string value.
   var stringValue: String {
     get {
       if case .stringValue(let v)? = _storage._kind {
@@ -187,7 +187,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
     }
   }
 
-  ///   Represents a boolean value.
+  /// Represents a boolean value.
   var boolValue: Bool {
     get {
       if case .boolValue(let v)? = _storage._kind {
@@ -200,7 +200,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
     }
   }
 
-  ///   Represents a structured value.
+  /// Represents a structured value.
   var structValue: Google_Protobuf_Struct {
     get {
       if case .structValue(let v)? = _storage._kind {
@@ -213,7 +213,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
     }
   }
 
-  ///   Represents a repeated `Value`.
+  /// Represents a repeated `Value`.
   var listValue: Google_Protobuf_ListValue {
     get {
       if case .listValue(let v)? = _storage._kind {
@@ -353,13 +353,13 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
   }
 }
 
-///   `ListValue` is a wrapper around a repeated field of values.
-///  
-///   The JSON representation for `ListValue` is JSON array.
+/// `ListValue` is a wrapper around a repeated field of values.
+///
+/// The JSON representation for `ListValue` is JSON array.
 struct Google_Protobuf_ListValue: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ListValue"
 
-  ///   Repeated field of dynamically typed values.
+  /// Repeated field of dynamically typed values.
   var values: [Google_Protobuf_Value] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-//  Test schema for proto3 messages.  This test schema is used by:
-// 
-//  - benchmarks
-//  - fuzz tests
-//  - conformance tests
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Test schema for proto3 messages.  This test schema is used by:
+//
+// - benchmarks
+// - fuzz tests
+// - conformance tests
 
 import Foundation
 import SwiftProtobuf
@@ -94,13 +94,13 @@ enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf.
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
-///  
-///   Also, crucially, all messages and enums in this file are eventually
-///   submessages of this message.  So for example, a fuzz test of TestAllTypes
-///   could trigger bugs that occur in any message type in this file.  We verify
-///   this stays true in a unit test.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
+///
+/// Also, crucially, all messages and enums in this file are eventually
+/// submessages of this message.  So for example, a fuzz test of TestAllTypes
+/// could trigger bugs that occur in any message type in this file.  We verify
+/// this stays true in a unit test.
 struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -343,7 +343,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -472,7 +472,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     return _storage._recursiveMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -578,7 +578,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  ///   Map
+  /// Map
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
@@ -782,7 +782,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  ///   Well-known types
+  /// Well-known types
   var optionalBoolWrapper: Google_Protobuf_BoolValue {
     get {return _storage._optionalBoolWrapper ?? Google_Protobuf_BoolValue()}
     set {_uniqueStorage()._optionalBoolWrapper = newValue}
@@ -1023,8 +1023,8 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedValue = newValue}
   }
 
-  ///   Test field-name-to-JSON-name convention.
-  ///   (protobuf says names can be any valid C/C++ identifier.)
+  /// Test field-name-to-JSON-name convention.
+  /// (protobuf says names can be any valid C/C++ identifier.)
   var fieldname1: Int32 {
     get {return _storage._fieldname1}
     set {_uniqueStorage()._fieldname1 = newValue}
@@ -1253,7 +1253,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 1
     case baz // = 2
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
 

--- a/Reference/google/protobuf/timestamp.pb.swift
+++ b/Reference/google/protobuf/timestamp.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,69 +50,69 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   A Timestamp represents a point in time independent of any time zone
-///   or calendar, represented as seconds and fractions of seconds at
-///   nanosecond resolution in UTC Epoch time. It is encoded using the
-///   Proleptic Gregorian Calendar which extends the Gregorian calendar
-///   backwards to year one. It is encoded assuming all minutes are 60
-///   seconds long, i.e. leap seconds are "smeared" so that no leap second
-///   table is needed for interpretation. Range is from
-///   0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
-///   By restricting to that range, we ensure that we can convert to
-///   and from  RFC 3339 date strings.
-///   See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
-///  
-///   Example 1: Compute Timestamp from POSIX `time()`.
-///  
-///       Timestamp timestamp;
-///       timestamp.set_seconds(time(NULL));
-///       timestamp.set_nanos(0);
-///  
-///   Example 2: Compute Timestamp from POSIX `gettimeofday()`.
-///  
-///       struct timeval tv;
-///       gettimeofday(&tv, NULL);
-///  
-///       Timestamp timestamp;
-///       timestamp.set_seconds(tv.tv_sec);
-///       timestamp.set_nanos(tv.tv_usec * 1000);
-///  
-///   Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
-///  
-///       FILETIME ft;
-///       GetSystemTimeAsFileTime(&ft);
-///       UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
-///  
-///       // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
-///       // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
-///       Timestamp timestamp;
-///       timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
-///       timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
-///  
-///   Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
-///  
-///       long millis = System.currentTimeMillis();
-///  
-///       Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
-///           .setNanos((int) ((millis % 1000) * 1000000)).build();
-///  
-///  
-///   Example 5: Compute Timestamp from current time in Python.
-///  
-///       timestamp = Timestamp()
-///       timestamp.GetCurrentTime()
+/// A Timestamp represents a point in time independent of any time zone
+/// or calendar, represented as seconds and fractions of seconds at
+/// nanosecond resolution in UTC Epoch time. It is encoded using the
+/// Proleptic Gregorian Calendar which extends the Gregorian calendar
+/// backwards to year one. It is encoded assuming all minutes are 60
+/// seconds long, i.e. leap seconds are "smeared" so that no leap second
+/// table is needed for interpretation. Range is from
+/// 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
+/// By restricting to that range, we ensure that we can convert to
+/// and from  RFC 3339 date strings.
+/// See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+///
+/// Example 1: Compute Timestamp from POSIX `time()`.
+///
+///     Timestamp timestamp;
+///     timestamp.set_seconds(time(NULL));
+///     timestamp.set_nanos(0);
+///
+/// Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+///
+///     struct timeval tv;
+///     gettimeofday(&tv, NULL);
+///
+///     Timestamp timestamp;
+///     timestamp.set_seconds(tv.tv_sec);
+///     timestamp.set_nanos(tv.tv_usec * 1000);
+///
+/// Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+///
+///     FILETIME ft;
+///     GetSystemTimeAsFileTime(&ft);
+///     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+///
+///     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+///     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+///     Timestamp timestamp;
+///     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+///     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+///
+/// Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+///
+///     long millis = System.currentTimeMillis();
+///
+///     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+///         .setNanos((int) ((millis % 1000) * 1000000)).build();
+///
+///
+/// Example 5: Compute Timestamp from current time in Python.
+///
+///     timestamp = Timestamp()
+///     timestamp.GetCurrentTime()
 struct Google_Protobuf_Timestamp: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Timestamp"
 
-  ///   Represents seconds of UTC time since Unix epoch
-  ///   1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-  ///   9999-12-31T23:59:59Z inclusive.
+  /// Represents seconds of UTC time since Unix epoch
+  /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+  /// 9999-12-31T23:59:59Z inclusive.
   var seconds: Int64 = 0
 
-  ///   Non-negative fractions of a second at nanosecond resolution. Negative
-  ///   second values with fractions must still have non-negative nanos values
-  ///   that count forward in time. Must be from 0 to 999,999,999
-  ///   inclusive.
+  /// Non-negative fractions of a second at nanosecond resolution. Negative
+  /// second values with fractions must still have non-negative nanos values
+  /// that count forward in time. Must be from 0 to 999,999,999
+  /// inclusive.
   var nanos: Int32 = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/type.pb.swift
+++ b/Reference/google/protobuf/type.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,14 +50,14 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   The syntax in which a protocol buffer element is defined.
+/// The syntax in which a protocol buffer element is defined.
 enum Google_Protobuf_Syntax: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
 
-  ///   Syntax `proto2`.
+  /// Syntax `proto2`.
   case proto2 // = 0
 
-  ///   Syntax `proto3`.
+  /// Syntax `proto3`.
   case proto3 // = 1
   case UNRECOGNIZED(Int)
 
@@ -88,7 +88,7 @@ enum Google_Protobuf_Syntax: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProvidi
 
 }
 
-///   A protocol buffer message type.
+/// A protocol buffer message type.
 struct Google_Protobuf_Type: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Type"
 
@@ -121,31 +121,31 @@ struct Google_Protobuf_Type: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   The fully qualified message name.
+  /// The fully qualified message name.
   var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
-  ///   The list of fields.
+  /// The list of fields.
   var fields: [Google_Protobuf_Field] {
     get {return _storage._fields}
     set {_uniqueStorage()._fields = newValue}
   }
 
-  ///   The list of types appearing in `oneof` definitions in this type.
+  /// The list of types appearing in `oneof` definitions in this type.
   var oneofs: [String] {
     get {return _storage._oneofs}
     set {_uniqueStorage()._oneofs = newValue}
   }
 
-  ///   The protocol buffer options.
+  /// The protocol buffer options.
   var options: [Google_Protobuf_Option] {
     get {return _storage._options}
     set {_uniqueStorage()._options = newValue}
   }
 
-  ///   The source context.
+  /// The source context.
   var sourceContext: Google_Protobuf_SourceContext {
     get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContext = newValue}
@@ -157,7 +157,7 @@ struct Google_Protobuf_Type: SwiftProtobuf.Message {
     return _storage._sourceContext = nil
   }
 
-  ///   The source syntax.
+  /// The source syntax.
   var syntax: Google_Protobuf_Syntax {
     get {return _storage._syntax}
     set {_uniqueStorage()._syntax = newValue}
@@ -209,103 +209,103 @@ struct Google_Protobuf_Type: SwiftProtobuf.Message {
   }
 }
 
-///   A single field of a message type.
+/// A single field of a message type.
 struct Google_Protobuf_Field: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Field"
 
-  ///   The field type.
+  /// The field type.
   var kind: Google_Protobuf_Field.Kind = Google_Protobuf_Field.Kind.typeUnknown
 
-  ///   The field cardinality.
+  /// The field cardinality.
   var cardinality: Google_Protobuf_Field.Cardinality = Google_Protobuf_Field.Cardinality.unknown
 
-  ///   The field number.
+  /// The field number.
   var number: Int32 = 0
 
-  ///   The field name.
+  /// The field name.
   var name: String = ""
 
-  ///   The field type URL, without the scheme, for message or enumeration
-  ///   types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
+  /// The field type URL, without the scheme, for message or enumeration
+  /// types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
   var typeURL: String = ""
 
-  ///   The index of the field type in `Type.oneofs`, for message or enumeration
-  ///   types. The first type has index 1; zero means the type is not in the list.
+  /// The index of the field type in `Type.oneofs`, for message or enumeration
+  /// types. The first type has index 1; zero means the type is not in the list.
   var oneofIndex: Int32 = 0
 
-  ///   Whether to use alternative packed wire representation.
+  /// Whether to use alternative packed wire representation.
   var packed: Bool = false
 
-  ///   The protocol buffer options.
+  /// The protocol buffer options.
   var options: [Google_Protobuf_Option] = []
 
-  ///   The field JSON name.
+  /// The field JSON name.
   var jsonName: String = ""
 
-  ///   The string value of the default value of this field. Proto2 syntax only.
+  /// The string value of the default value of this field. Proto2 syntax only.
   var defaultValue: String = ""
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   Basic field types.
+  /// Basic field types.
   enum Kind: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   Field type unknown.
+    /// Field type unknown.
     case typeUnknown // = 0
 
-    ///   Field type double.
+    /// Field type double.
     case typeDouble // = 1
 
-    ///   Field type float.
+    /// Field type float.
     case typeFloat // = 2
 
-    ///   Field type int64.
+    /// Field type int64.
     case typeInt64 // = 3
 
-    ///   Field type uint64.
+    /// Field type uint64.
     case typeUint64 // = 4
 
-    ///   Field type int32.
+    /// Field type int32.
     case typeInt32 // = 5
 
-    ///   Field type fixed64.
+    /// Field type fixed64.
     case typeFixed64 // = 6
 
-    ///   Field type fixed32.
+    /// Field type fixed32.
     case typeFixed32 // = 7
 
-    ///   Field type bool.
+    /// Field type bool.
     case typeBool // = 8
 
-    ///   Field type string.
+    /// Field type string.
     case typeString // = 9
 
-    ///   Field type group. Proto2 syntax only, and deprecated.
+    /// Field type group. Proto2 syntax only, and deprecated.
     case typeGroup // = 10
 
-    ///   Field type message.
+    /// Field type message.
     case typeMessage // = 11
 
-    ///   Field type bytes.
+    /// Field type bytes.
     case typeBytes // = 12
 
-    ///   Field type uint32.
+    /// Field type uint32.
     case typeUint32 // = 13
 
-    ///   Field type enum.
+    /// Field type enum.
     case typeEnum // = 14
 
-    ///   Field type sfixed32.
+    /// Field type sfixed32.
     case typeSfixed32 // = 15
 
-    ///   Field type sfixed64.
+    /// Field type sfixed64.
     case typeSfixed64 // = 16
 
-    ///   Field type sint32.
+    /// Field type sint32.
     case typeSint32 // = 17
 
-    ///   Field type sint64.
+    /// Field type sint64.
     case typeSint64 // = 18
     case UNRECOGNIZED(Int)
 
@@ -387,20 +387,20 @@ struct Google_Protobuf_Field: SwiftProtobuf.Message {
 
   }
 
-  ///   Whether a field is optional, required, or repeated.
+  /// Whether a field is optional, required, or repeated.
   enum Cardinality: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   For fields with unknown cardinality.
+    /// For fields with unknown cardinality.
     case unknown // = 0
 
-    ///   For optional fields.
+    /// For optional fields.
     case `optional` // = 1
 
-    ///   For required fields. Proto2 syntax only.
+    /// For required fields. Proto2 syntax only.
     case `required` // = 2
 
-    ///   For repeated fields.
+    /// For repeated fields.
     case repeated // = 3
     case UNRECOGNIZED(Int)
 
@@ -492,7 +492,7 @@ struct Google_Protobuf_Field: SwiftProtobuf.Message {
   }
 }
 
-///   Enum type definition.
+/// Enum type definition.
 struct Google_Protobuf_Enum: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Enum"
 
@@ -523,25 +523,25 @@ struct Google_Protobuf_Enum: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Enum type name.
+  /// Enum type name.
   var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
-  ///   Enum value definitions.
+  /// Enum value definitions.
   var enumvalue: [Google_Protobuf_EnumValue] {
     get {return _storage._enumvalue}
     set {_uniqueStorage()._enumvalue = newValue}
   }
 
-  ///   Protocol buffer options.
+  /// Protocol buffer options.
   var options: [Google_Protobuf_Option] {
     get {return _storage._options}
     set {_uniqueStorage()._options = newValue}
   }
 
-  ///   The source context.
+  /// The source context.
   var sourceContext: Google_Protobuf_SourceContext {
     get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContext = newValue}
@@ -553,7 +553,7 @@ struct Google_Protobuf_Enum: SwiftProtobuf.Message {
     return _storage._sourceContext = nil
   }
 
-  ///   The source syntax.
+  /// The source syntax.
   var syntax: Google_Protobuf_Syntax {
     get {return _storage._syntax}
     set {_uniqueStorage()._syntax = newValue}
@@ -601,17 +601,17 @@ struct Google_Protobuf_Enum: SwiftProtobuf.Message {
   }
 }
 
-///   Enum value definition.
+/// Enum value definition.
 struct Google_Protobuf_EnumValue: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".EnumValue"
 
-  ///   Enum value name.
+  /// Enum value name.
   var name: String = ""
 
-  ///   Enum value number.
+  /// Enum value number.
   var number: Int32 = 0
 
-  ///   Protocol buffer options.
+  /// Protocol buffer options.
   var options: [Google_Protobuf_Option] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -643,8 +643,8 @@ struct Google_Protobuf_EnumValue: SwiftProtobuf.Message {
   }
 }
 
-///   A protocol buffer option, which can be attached to a message, field,
-///   enumeration, etc.
+/// A protocol buffer option, which can be attached to a message, field,
+/// enumeration, etc.
 struct Google_Protobuf_Option: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Option"
 
@@ -669,19 +669,19 @@ struct Google_Protobuf_Option: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   The option's name. For protobuf built-in options (options defined in
-  ///   descriptor.proto), this is the short name. For example, `"map_entry"`.
-  ///   For custom options, it should be the fully-qualified name. For example,
-  ///   `"google.api.http"`.
+  /// The option's name. For protobuf built-in options (options defined in
+  /// descriptor.proto), this is the short name. For example, `"map_entry"`.
+  /// For custom options, it should be the fully-qualified name. For example,
+  /// `"google.api.http"`.
   var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
-  ///   The option's value packed in an Any message. If the value is a primitive,
-  ///   the corresponding wrapper type defined in google/protobuf/wrappers.proto
-  ///   should be used. If the value is an enum, it should be stored as an int32
-  ///   value using the google.protobuf.Int32Value type.
+  /// The option's value packed in an Any message. If the value is a primitive,
+  /// the corresponding wrapper type defined in google/protobuf/wrappers.proto
+  /// should be used. If the value is an enum, it should be stored as an int32
+  /// value using the google.protobuf.Int32Value type.
   var value: Google_Protobuf_Any {
     get {return _storage._value ?? Google_Protobuf_Any()}
     set {_uniqueStorage()._value = newValue}

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file we will use for unit testing.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file we will use for unit testing.
 
 import Foundation
 import SwiftProtobuf
@@ -92,7 +92,7 @@ enum ProtobufUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameP
 
 }
 
-///   Test an enum that has multiple values with the same number.
+/// Test an enum that has multiple values with the same number.
 enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case foo1 // = 1
@@ -130,7 +130,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._P
 
 }
 
-///   Test an enum with large, unordered values.
+/// Test an enum with large, unordered values.
 enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case sparseA // = 123
@@ -182,8 +182,8 @@ enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNa
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -348,7 +348,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -613,7 +613,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalCord = nil
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
@@ -636,7 +636,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalLazyMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -762,7 +762,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  ///   Singular with defaults
+  /// Singular with defaults
   var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
@@ -1120,7 +1120,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -1158,9 +1158,9 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = ProtobufUnittest_TestAllTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     fileprivate var _bb: Int32? = nil
     var bb: Int32 {
       get {return _bb ?? 0}
@@ -1576,7 +1576,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   }
 }
 
-///   This proto includes a recusively nested message.
+/// This proto includes a recusively nested message.
 struct ProtobufUnittest_NestedTestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedTestAllTypes"
 
@@ -1717,8 +1717,8 @@ struct ProtobufUnittest_TestDeprecatedMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct ProtobufUnittest_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 
@@ -1895,16 +1895,16 @@ struct ProtobufUnittest_TestNestedExtension: SwiftProtobuf.Message {
 
   struct Extensions {
 
-    ///   Check for bug where string extensions declared in tested scope did not
-    ///   compile.
+    /// Check for bug where string extensions declared in tested scope did not
+    /// compile.
     static let test = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
       _protobuf_fieldNumber: 1002,
       fieldName: "protobuf_unittest.TestNestedExtension.test",
       defaultValue: "test"
     )
 
-    ///   Used to test if generated extension name is correct when there are
-    ///   underscores.
+    /// Used to test if generated extension name is correct when there are
+    /// underscores.
     static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
       _protobuf_fieldNumber: 1003,
       fieldName: "protobuf_unittest.TestNestedExtension.nested_string_extension",
@@ -1924,11 +1924,11 @@ struct ProtobufUnittest_TestNestedExtension: SwiftProtobuf.Message {
   }
 }
 
-///   We have separate messages for testing required fields because it's
-///   annoying to have to fill in required fields in TestProto in order to
-///   do anything with it.  Note that we don't need to test every type of
-///   required filed because the code output is basically identical to
-///   optional fields for all types.
+/// We have separate messages for testing required fields because it's
+/// annoying to have to fill in required fields in TestProto in order to
+/// do anything with it.  Note that we don't need to test every type of
+/// required filed because the code output is basically identical to
+/// optional fields for all types.
 struct ProtobufUnittest_TestRequired: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRequired"
 
@@ -2048,8 +2048,8 @@ struct ProtobufUnittest_TestRequired: SwiftProtobuf.Message {
     return _storage._b = nil
   }
 
-  ///   Pad the field count to 32 so that we can test that IsInitialized()
-  ///   properly checks multiple elements of has_bits_.
+  /// Pad the field count to 32 so that we can test that IsInitialized()
+  /// properly checks multiple elements of has_bits_.
   var dummy4: Int32 {
     get {return _storage._dummy4 ?? 0}
     set {_uniqueStorage()._dummy4 = newValue}
@@ -2653,7 +2653,7 @@ struct ProtobufUnittest_TestRequiredForeign: SwiftProtobuf.Message {
   }
 }
 
-///   Test that we can use NestedMessage from outside TestAllTypes.
+/// Test that we can use NestedMessage from outside TestAllTypes.
 struct ProtobufUnittest_TestForeignNested: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestForeignNested"
 
@@ -2713,7 +2713,7 @@ struct ProtobufUnittest_TestForeignNested: SwiftProtobuf.Message {
   }
 }
 
-///   TestEmptyMessage is used to test unknown field support.
+/// TestEmptyMessage is used to test unknown field support.
 struct ProtobufUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessage"
 
@@ -2731,8 +2731,8 @@ struct ProtobufUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Like above, but declare all field numbers as potential extensions.  No
-///   actual extensions should ever be defined for this type.
+/// Like above, but declare all field numbers as potential extensions.  No
+/// actual extensions should ever be defined for this type.
 struct ProtobufUnittest_TestEmptyMessageWithExtensions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessageWithExtensions"
 
@@ -2791,12 +2791,12 @@ struct ProtobufUnittest_TestMultipleExtensionRanges: SwiftProtobuf.Message, Swif
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   Test that really large tag numbers don't break anything.
+/// Test that really large tag numbers don't break anything.
 struct ProtobufUnittest_TestReallyLargeTagNumber: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestReallyLargeTagNumber"
 
-  ///   The largest possible tag number is 2^28 - 1, since the wire format uses
-  ///   three bits to communicate wire type.
+  /// The largest possible tag number is 2^28 - 1, since the wire format uses
+  /// three bits to communicate wire type.
   fileprivate var _a: Int32? = nil
   var a: Int32 {
     get {return _a ?? 0}
@@ -2922,7 +2922,7 @@ struct ProtobufUnittest_TestRecursiveMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test that mutual recursion works.
+/// Test that mutual recursion works.
 struct ProtobufUnittest_TestMutualRecursionA: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMutualRecursionA"
 
@@ -3058,10 +3058,10 @@ struct ProtobufUnittest_TestMutualRecursionB: SwiftProtobuf.Message {
   }
 }
 
-///   Test that groups have disjoint field numbers from their siblings and
-///   parents.  This is NOT possible in proto1; only google.protobuf.  When attempting
-///   to compile with proto1, this will emit an error; so we only include it
-///   in protobuf_unittest_proto.
+/// Test that groups have disjoint field numbers from their siblings and
+/// parents.  This is NOT possible in proto1; only google.protobuf.  When attempting
+/// to compile with proto1, this will emit an error; so we only include it
+/// in protobuf_unittest_proto.
 struct ProtobufUnittest_TestDupFieldNumber: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestDupFieldNumber"
 
@@ -3088,7 +3088,7 @@ struct ProtobufUnittest_TestDupFieldNumber: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   NO_PROTO1
+  /// NO_PROTO1
   var a: Int32 {
     get {return _storage._a ?? 0}
     set {_uniqueStorage()._a = newValue}
@@ -3228,7 +3228,7 @@ struct ProtobufUnittest_TestDupFieldNumber: SwiftProtobuf.Message {
   }
 }
 
-///   Additional messages for testing lazy fields.
+/// Additional messages for testing lazy fields.
 struct ProtobufUnittest_TestEagerMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEagerMessage"
 
@@ -3347,7 +3347,7 @@ struct ProtobufUnittest_TestLazyMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Needed for a Python test.
+/// Needed for a Python test.
 struct ProtobufUnittest_TestNestedMessageHasBits: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestNestedMessageHasBits"
 
@@ -3439,8 +3439,8 @@ struct ProtobufUnittest_TestNestedMessageHasBits: SwiftProtobuf.Message {
   }
 }
 
-///   Test message with CamelCase field names.  This violates Protocol Buffer
-///   standard style.
+/// Test message with CamelCase field names.  This violates Protocol Buffer
+/// standard style.
 struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestCamelCaseFieldNames"
 
@@ -3651,8 +3651,8 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message {
   }
 }
 
-///   We list fields out of order, to ensure that we're using field number and not
-///   field index to determine serialization order.
+/// We list fields out of order, to ensure that we're using field number and not
+/// field index to determine serialization order.
 struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestFieldOrderings"
 
@@ -3742,9 +3742,9 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf
       return _oo = nil
     }
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     fileprivate var _bb: Int32? = nil
     var bb: Int32 {
       get {return _bb ?? 0}
@@ -3980,9 +3980,9 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._reallySmallInt64 = nil
   }
 
-  ///   The default value here is UTF-8 for "\u1234".  (We could also just type
-  ///   the UTF-8 text directly into this text file rather than escape it, but
-  ///   lots of people use editors that would be confused by this.)
+  /// The default value here is UTF-8 for "\u1234".  (We could also just type
+  /// the UTF-8 text directly into this text file rather than escape it, but
+  /// lots of people use editors that would be confused by this.)
   var utf8String: String {
     get {return _storage._utf8String ?? "ሴ"}
     set {_uniqueStorage()._utf8String = newValue}
@@ -3994,7 +3994,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._utf8String = nil
   }
 
-  ///   Tests for single-precision floating-point values.
+  /// Tests for single-precision floating-point values.
   var zeroFloat: Float {
     get {return _storage._zeroFloat ?? 0}
     set {_uniqueStorage()._zeroFloat = newValue}
@@ -4050,7 +4050,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._negativeFloat = nil
   }
 
-  ///   Using exponents
+  /// Using exponents
   var largeFloat: Float {
     get {return _storage._largeFloat ?? 2e+08}
     set {_uniqueStorage()._largeFloat = newValue}
@@ -4073,7 +4073,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._smallNegativeFloat = nil
   }
 
-  ///   Text for nonfinite floating-point values.
+  /// Text for nonfinite floating-point values.
   var infDouble: Double {
     get {return _storage._infDouble ?? Double.infinity}
     set {_uniqueStorage()._infDouble = newValue}
@@ -4140,11 +4140,11 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._nanFloat = nil
   }
 
-  ///   Tests for C++ trigraphs.
-  ///   Trigraphs should be escaped in C++ generated files, but they should not be
-  ///   escaped for other languages.
-  ///   Note that in .proto file, "\?" is a valid way to escape ? in string
-  ///   literals.
+  /// Tests for C++ trigraphs.
+  /// Trigraphs should be escaped in C++ generated files, but they should not be
+  /// escaped for other languages.
+  /// Note that in .proto file, "\?" is a valid way to escape ? in string
+  /// literals.
   var cppTrigraph: String {
     get {return _storage._cppTrigraph ?? "? ? ?? ?? ??? ??/ ??-"}
     set {_uniqueStorage()._cppTrigraph = newValue}
@@ -4156,7 +4156,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._cppTrigraph = nil
   }
 
-  ///   String defaults containing the character '\000'
+  /// String defaults containing the character '\000'
   var stringWithZero: String {
     get {return _storage._stringWithZero ?? "hel\0lo"}
     set {_uniqueStorage()._stringWithZero = newValue}
@@ -4378,7 +4378,7 @@ struct ProtobufUnittest_SparseEnumMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test String and Bytes: string is for valid UTF-8 strings
+/// Test String and Bytes: string is for valid UTF-8 strings
 struct ProtobufUnittest_OneString: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OneString"
 
@@ -4503,7 +4503,7 @@ struct ProtobufUnittest_MoreBytes: SwiftProtobuf.Message {
   }
 }
 
-///   Test int32, uint32, int64, uint64, and bool are all compatible
+/// Test int32, uint32, int64, uint64, and bool are all compatible
 struct ProtobufUnittest_Int32Message: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Int32Message"
 
@@ -4684,7 +4684,7 @@ struct ProtobufUnittest_BoolMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test oneofs.
+/// Test oneofs.
 struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestOneof"
 
@@ -6043,8 +6043,8 @@ struct ProtobufUnittest_TestPackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   A message with the same fields as TestPackedTypes, but without packing. Used
-///   to test packed <-> unpacked wire compatibility.
+/// A message with the same fields as TestPackedTypes, but without packing. Used
+/// to test packed <-> unpacked wire compatibility.
 struct ProtobufUnittest_TestUnpackedTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestUnpackedTypes"
 
@@ -6205,9 +6205,9 @@ struct ProtobufUnittest_TestUnpackedExtensions: SwiftProtobuf.Message, SwiftProt
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   Used by ExtensionSetTest/DynamicExtensions.  The test actually builds
-///   a set of extensions to TestAllExtensions dynamically, based on the fields
-///   of this message type.
+/// Used by ExtensionSetTest/DynamicExtensions.  The test actually builds
+/// a set of extensions to TestAllExtensions dynamically, based on the fields
+/// of this message type.
 struct ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestDynamicExtensions"
 
@@ -6431,20 +6431,20 @@ struct ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf.Message {
 struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRepeatedScalarDifferentTagSizes"
 
-  ///   Parsing repeated fixed size values used to fail. This message needs to be
-  ///   used in order to get a tag of the right size; all of the repeated fields
-  ///   in TestAllTypes didn't trigger the check.
+  /// Parsing repeated fixed size values used to fail. This message needs to be
+  /// used in order to get a tag of the right size; all of the repeated fields
+  /// in TestAllTypes didn't trigger the check.
   var repeatedFixed32: [UInt32] = []
 
-  ///   Check for a varint type, just for good measure.
+  /// Check for a varint type, just for good measure.
   var repeatedInt32: [Int32] = []
 
-  ///   These have two-byte tags.
+  /// These have two-byte tags.
   var repeatedFixed64: [UInt64] = []
 
   var repeatedInt64: [Int64] = []
 
-  ///   Three byte tags.
+  /// Three byte tags.
   var repeatedFloat: [Float] = []
 
   var repeatedUint64: [UInt64] = []
@@ -6490,8 +6490,8 @@ struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: SwiftProtobuf.Messa
   }
 }
 
-///   Test that if an optional or required message/group field appears multiple
-///   times in the input, they need to be merged.
+/// Test that if an optional or required message/group field appears multiple
+/// times in the input, they need to be merged.
 struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestParsingMerge"
 
@@ -6567,11 +6567,11 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.E
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   RepeatedFieldsGenerator defines matching field types as TestParsingMerge,
-  ///   except that all fields are repeated. In the tests, we will serialize the
-  ///   RepeatedFieldsGenerator to bytes, and parse the bytes to TestParsingMerge.
-  ///   Repeated fields in RepeatedFieldsGenerator are expected to be merged into
-  ///   the corresponding required/optional fields in TestParsingMerge.
+  /// RepeatedFieldsGenerator defines matching field types as TestParsingMerge,
+  /// except that all fields are repeated. In the tests, we will serialize the
+  /// RepeatedFieldsGenerator to bytes, and parse the bytes to TestParsingMerge.
+  /// Repeated fields in RepeatedFieldsGenerator are expected to be merged into
+  /// the corresponding required/optional fields in TestParsingMerge.
   struct RepeatedFieldsGenerator: SwiftProtobuf.Message {
     static let protoMessageName: String = ProtobufUnittest_TestParsingMerge.protoMessageName + ".RepeatedFieldsGenerator"
 
@@ -6941,7 +6941,7 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.E
 struct ProtobufUnittest_TestCommentInjectionMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestCommentInjectionMessage"
 
-  ///   */ <- This should not close the generated doc comment
+  /// */ <- This should not close the generated doc comment
   fileprivate var _a: String? = nil
   var a: String {
     get {return _a ?? "*/ <- Neither should this."}
@@ -6975,7 +6975,7 @@ struct ProtobufUnittest_TestCommentInjectionMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test that RPC services work.
+/// Test that RPC services work.
 struct ProtobufUnittest_FooRequest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FooRequest"
 
@@ -7571,7 +7571,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   Singular
+/// Singular
 let ProtobufUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 1,
   fieldName: "protobuf_unittest.optional_int32_extension",
@@ -7728,7 +7728,7 @@ let ProtobufUnittest_Extensions_optional_lazy_message_extension = SwiftProtobuf.
   defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
 )
 
-///   Repeated
+/// Repeated
 let ProtobufUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 31,
   fieldName: "protobuf_unittest.repeated_int32_extension",
@@ -7879,7 +7879,7 @@ let ProtobufUnittest_Extensions_repeated_lazy_message_extension = SwiftProtobuf.
   defaultValue: []
 )
 
-///   Singular with defaults
+/// Singular with defaults
 let ProtobufUnittest_Extensions_default_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 61,
   fieldName: "protobuf_unittest.default_int32_extension",
@@ -8000,7 +8000,7 @@ let ProtobufUnittest_Extensions_default_cord_extension = SwiftProtobuf.MessageEx
   defaultValue: "123"
 )
 
-///   For oneof test
+/// For oneof test
 let ProtobufUnittest_Extensions_oneof_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 111,
   fieldName: "protobuf_unittest.oneof_uint32_extension",
@@ -8212,8 +8212,8 @@ let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<
 )
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   Check for bug where string extensions declared in tested scope did not
-  ///   compile.
+  /// Check for bug where string extensions declared in tested scope did not
+  /// compile.
   var ProtobufUnittest_TestNestedExtension_test: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test) ?? "test"}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test, value: newValue)}
@@ -8227,8 +8227,8 @@ extension ProtobufUnittest_TestAllExtensions {
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   Used to test if generated extension name is correct when there are
-  ///   underscores.
+  /// Used to test if generated extension name is correct when there are
+  /// underscores.
   var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension, value: newValue)}
@@ -8294,7 +8294,7 @@ extension ProtobufUnittest_TestParsingMerge {
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   Singular
+  /// Singular
   var ProtobufUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension, value: newValue)}
@@ -8633,7 +8633,7 @@ extension ProtobufUnittest_TestAllExtensions {
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   Repeated
+  /// Repeated
   var ProtobufUnittest_repeatedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension)}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension, value: newValue)}
@@ -8959,7 +8959,7 @@ extension ProtobufUnittest_TestAllExtensions {
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   Singular with defaults
+  /// Singular with defaults
   var ProtobufUnittest_defaultInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension) ?? 41}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension, value: newValue)}
@@ -9220,7 +9220,7 @@ extension ProtobufUnittest_TestAllExtensions {
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   For oneof test
+  /// For oneof test
   var ProtobufUnittest_oneofUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension, value: newValue)}

--- a/Reference/google/protobuf/unittest_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_arena.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: benjy@google.com (Benjy Weinberger)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file used to test the "custom options" feature of google.protobuf.
+// Author: benjy@google.com (Benjy Weinberger)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file used to test the "custom options" feature of google.protobuf.
 
 import Foundation
 import SwiftProtobuf
@@ -115,8 +115,8 @@ enum ProtobufUnittest_AggregateEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNam
 
 }
 
-///   A test message with custom options at all possible locations (and also some
-///   regular options, to make sure they interact nicely).
+/// A test message with custom options at all possible locations (and also some
+/// regular options, to make sure they interact nicely).
 struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMessageWithCustomOptions"
 
@@ -238,8 +238,8 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
   }
 }
 
-///   A test RPC service with custom options at all possible locations (and also
-///   some regular options, to make sure they interact nicely).
+/// A test RPC service with custom options at all possible locations (and also
+/// some regular options, to make sure they interact nicely).
 struct ProtobufUnittest_CustomOptionFooRequest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".CustomOptionFooRequest"
 
@@ -852,7 +852,7 @@ struct ProtobufUnittest_ComplexOpt6: SwiftProtobuf.Message {
   }
 }
 
-///   Note that we try various different ways of naming the same extension.
+/// Note that we try various different ways of naming the same extension.
 struct ProtobufUnittest_VariousComplexOptions: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".VariousComplexOptions"
 
@@ -943,7 +943,7 @@ struct ProtobufUnittest_AggregateMessageSetElement: SwiftProtobuf.Message {
   }
 }
 
-///   A helper type used to test aggregate option parsing
+/// A helper type used to test aggregate option parsing
 struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Aggregate"
 
@@ -996,7 +996,7 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
     return _storage._s = nil
   }
 
-  ///   A nested object
+  /// A nested object
   var sub: ProtobufUnittest_Aggregate {
     get {return _storage._sub ?? ProtobufUnittest_Aggregate()}
     set {_uniqueStorage()._sub = newValue}
@@ -1008,7 +1008,7 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
     return _storage._sub = nil
   }
 
-  ///   To test the parsing of extensions inside aggregate values
+  /// To test the parsing of extensions inside aggregate values
   var file: Google_Protobuf_FileOptions {
     get {return _storage._file ?? Google_Protobuf_FileOptions()}
     set {_uniqueStorage()._file = newValue}
@@ -1020,7 +1020,7 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
     return _storage._file = nil
   }
 
-  ///   An embedded message set
+  /// An embedded message set
   var mset: ProtobufUnittest_AggregateMessageSet {
     get {return _storage._mset ?? ProtobufUnittest_AggregateMessageSet()}
     set {_uniqueStorage()._mset = newValue}
@@ -1128,7 +1128,7 @@ struct ProtobufUnittest_AggregateMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test custom options for nested type.
+/// Test custom options for nested type.
 struct ProtobufUnittest_NestedOptionType: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedOptionType"
 
@@ -1218,8 +1218,8 @@ struct ProtobufUnittest_NestedOptionType: SwiftProtobuf.Message {
   }
 }
 
-///   Custom message option that has a required enum field.
-///   WARNING: this is strongly discouraged!
+/// Custom message option that has a required enum field.
+/// WARNING: this is strongly discouraged!
 struct ProtobufUnittest_OldOptionType: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OldOptionType"
 
@@ -1288,7 +1288,7 @@ struct ProtobufUnittest_OldOptionType: SwiftProtobuf.Message {
   }
 }
 
-///   Updated version of the custom option above.
+/// Updated version of the custom option above.
 struct ProtobufUnittest_NewOptionType: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NewOptionType"
 
@@ -1361,7 +1361,7 @@ struct ProtobufUnittest_NewOptionType: SwiftProtobuf.Message {
   }
 }
 
-///   Test message using the "required_enum_opt" option defined above.
+/// Test message using the "required_enum_opt" option defined above.
 struct ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMessageWithRequiredEnumOption"
 
@@ -1397,8 +1397,8 @@ let ProtobufUnittest_Extensions_field_opt1 = SwiftProtobuf.MessageExtension<Opti
   defaultValue: 0
 )
 
-///   This is useful for testing that we correctly register default values for
-///   extension options.
+/// This is useful for testing that we correctly register default values for
+/// extension options.
 let ProtobufUnittest_Extensions_field_opt2 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FieldOptions>(
   _protobuf_fieldNumber: 7753913,
   fieldName: "protobuf_unittest.field_opt2",
@@ -1725,8 +1725,8 @@ extension Google_Protobuf_FieldOptions {
 }
 
 extension Google_Protobuf_FieldOptions {
-  ///   This is useful for testing that we correctly register default values for
-  ///   extension options.
+  /// This is useful for testing that we correctly register default values for
+  /// extension options.
   var ProtobufUnittest_fieldOpt2: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2) ?? 42}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2, value: newValue)}

--- a/Reference/google/protobuf/unittest_drop_unknown_fields.pb.swift
+++ b/Reference/google/protobuf/unittest_drop_unknown_fields.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_embed_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_embed_optimize_for.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file which imports a proto file that uses optimize_for = CODE_SIZE.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file which imports a proto file that uses optimize_for = CODE_SIZE.
 
 import Foundation
 import SwiftProtobuf
@@ -81,8 +81,8 @@ struct ProtobufUnittest_TestEmbedOptimizedForSize: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Test that embedding a message which has optimize_for = CODE_SIZE into
-  ///   one optimized for speed works.
+  /// Test that embedding a message which has optimize_for = CODE_SIZE into
+  /// one optimized for speed works.
   var optionalMessage: ProtobufUnittest_TestOptimizedForSize {
     get {return _storage._optionalMessage ?? ProtobufUnittest_TestOptimizedForSize()}
     set {_uniqueStorage()._optionalMessage = newValue}

--- a/Reference/google/protobuf/unittest_empty.pb.swift
+++ b/Reference/google/protobuf/unittest_empty.pb.swift
@@ -6,42 +6,42 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  This file intentionally left blank.  (At one point this wouldn't compile
-//  correctly.)
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// This file intentionally left blank.  (At one point this wouldn't compile
+// correctly.)
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_enormous_descriptor.pb.swift
+++ b/Reference/google/protobuf/unittest_enormous_descriptor.pb.swift
@@ -6,43 +6,43 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file that has an extremely large descriptor.  Used to test that
-//  descriptors over 64k don't break language-specific limits in generated code,
-//  such as the string literal length limit in Java.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file that has an extremely large descriptor.  Used to test that
+// descriptors over 64k don't break language-specific limits in generated code,
+// such as the string literal length limit in Java.
 
 import Foundation
 

--- a/Reference/google/protobuf/unittest_import.pb.swift
+++ b/Reference/google/protobuf/unittest_import.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file which is imported by unittest.proto to test importing.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file which is imported by unittest.proto to test importing.
 
 import Foundation
 import SwiftProtobuf
@@ -92,7 +92,7 @@ enum ProtobufUnittestImport_ImportEnum: SwiftProtobuf.Enum, SwiftProtobuf._Proto
 
 }
 
-///   To use an enum in a map, it must has the first value as 0.
+/// To use an enum in a map, it must has the first value as 0.
 enum ProtobufUnittestImport_ImportEnumForMap: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case unknown // = 0

--- a/Reference/google/protobuf/unittest_import_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_import_lite.pb.swift
@@ -6,39 +6,39 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-// 
-//  This is like unittest_import.proto but with optimize_for = LITE_RUNTIME.
+// Author: kenton@google.com (Kenton Varda)
+//
+// This is like unittest_import.proto but with optimize_for = LITE_RUNTIME.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_import_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_import_proto3.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file which is imported by unittest_proto3.proto to test importing.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file which is imported by unittest_proto3.proto to test importing.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_import_public.pb.swift
+++ b/Reference/google/protobuf/unittest_import_public.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: liujisi@google.com (Pherl Liu)
+// Author: liujisi@google.com (Pherl Liu)
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_import_public_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_import_public_lite.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: liujisi@google.com (Pherl Liu)
+// Author: liujisi@google.com (Pherl Liu)
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_import_public_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_import_public_proto3.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: liujisi@google.com (Pherl Liu)
+// Author: liujisi@google.com (Pherl Liu)
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -6,39 +6,39 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-// 
-//  This is like unittest.proto but with optimize_for = LITE_RUNTIME.
+// Author: kenton@google.com (Kenton Varda)
+//
+// This is like unittest.proto but with optimize_for = LITE_RUNTIME.
 
 import Foundation
 import SwiftProtobuf
@@ -148,7 +148,7 @@ enum ProtobufUnittest_V2EnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePr
 
 }
 
-///   Same as TestAllTypes but with the lite runtime.
+/// Same as TestAllTypes but with the lite runtime.
 struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypesLite"
 
@@ -315,7 +315,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -580,7 +580,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     return _storage._optionalCord = nil
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessageLite {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessageLite()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
@@ -603,7 +603,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     return _storage._optionalLazyMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -729,7 +729,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  ///   Singular with defaults
+  /// Singular with defaults
   var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
@@ -1010,7 +1010,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     }
   }
 
-  ///   Tests toString for non-repeated fields with a list suffix
+  /// Tests toString for non-repeated fields with a list suffix
   var deceptivelyNamedList: Int32 {
     get {return _storage._deceptivelyNamedList ?? 0}
     set {_uniqueStorage()._deceptivelyNamedList = newValue}
@@ -1885,8 +1885,8 @@ struct ProtobufUnittest_TestNestedExtensionLite: SwiftProtobuf.Message {
   }
 }
 
-///   Test that deprecated fields work.  We only verify that they compile (at one
-///   point this failed).
+/// Test that deprecated fields work.  We only verify that they compile (at one
+/// point this failed).
 struct ProtobufUnittest_TestDeprecatedLite: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestDeprecatedLite"
 
@@ -1923,7 +1923,7 @@ struct ProtobufUnittest_TestDeprecatedLite: SwiftProtobuf.Message {
   }
 }
 
-///   See the comments of the same type in unittest.proto.
+/// See the comments of the same type in unittest.proto.
 struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestParsingMergeLite"
 
@@ -2365,7 +2365,7 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   TestEmptyMessageLite is used to test unknown fields support in lite mode.
+/// TestEmptyMessageLite is used to test unknown fields support in lite mode.
 struct ProtobufUnittest_TestEmptyMessageLite: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessageLite"
 
@@ -2383,8 +2383,8 @@ struct ProtobufUnittest_TestEmptyMessageLite: SwiftProtobuf.Message {
   }
 }
 
-///   Like above, but declare all field numbers as potential extensions.  No
-///   actual extensions should ever be defined for this type.
+/// Like above, but declare all field numbers as potential extensions.  No
+/// actual extensions should ever be defined for this type.
 struct ProtobufUnittest_TestEmptyMessageWithExtensionsLite: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessageWithExtensionsLite"
 
@@ -2904,7 +2904,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   Singular
+/// Singular
 let ProtobufUnittest_Extensions_optional_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 1,
   fieldName: "protobuf_unittest.optional_int32_extension_lite",
@@ -3061,7 +3061,7 @@ let ProtobufUnittest_Extensions_optional_lazy_message_extension_lite = SwiftProt
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
 )
 
-///   Repeated
+/// Repeated
 let ProtobufUnittest_Extensions_repeated_int32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 31,
   fieldName: "protobuf_unittest.repeated_int32_extension_lite",
@@ -3212,7 +3212,7 @@ let ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite = SwiftProt
   defaultValue: []
 )
 
-///   Singular with defaults
+/// Singular with defaults
 let ProtobufUnittest_Extensions_default_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 61,
   fieldName: "protobuf_unittest.default_int32_extension_lite",
@@ -3333,7 +3333,7 @@ let ProtobufUnittest_Extensions_default_cord_extension_lite = SwiftProtobuf.Mess
   defaultValue: "123"
 )
 
-///   For oneof test
+/// For oneof test
 let ProtobufUnittest_Extensions_oneof_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 111,
   fieldName: "protobuf_unittest.oneof_uint32_extension_lite",
@@ -3488,7 +3488,7 @@ extension ProtobufUnittest_TestParsingMergeLite {
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  ///   Singular
+  /// Singular
   var ProtobufUnittest_optionalInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite, value: newValue)}
@@ -3827,7 +3827,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  ///   Repeated
+  /// Repeated
   var ProtobufUnittest_repeatedInt32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite)}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite, value: newValue)}
@@ -4153,7 +4153,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  ///   Singular with defaults
+  /// Singular with defaults
   var ProtobufUnittest_defaultInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite) ?? 41}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite, value: newValue)}
@@ -4414,7 +4414,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  ///   For oneof test
+  /// For oneof test
   var ProtobufUnittest_oneofUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite, value: newValue)}

--- a/Reference/google/protobuf/unittest_lite_imports_nonlite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite_imports_nonlite.pb.swift
@@ -6,39 +6,39 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-// 
-//  Tests that a "lite" message can import a regular message.
+// Author: kenton@google.com (Kenton Varda)
+//
+// Tests that a "lite" message can import a regular message.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -6,42 +6,42 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  This file is similar to unittest_mset_wire_format.proto, but does not
-//  have a TestMessageSet, so it can be downgraded to proto1.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// This file is similar to unittest_mset_wire_format.proto, but does not
+// have a TestMessageSet, so it can be downgraded to proto1.
 
 import Foundation
 import SwiftProtobuf
@@ -214,7 +214,7 @@ struct ProtobufUnittest_TestMessageSetExtension2: SwiftProtobuf.Message {
   }
 }
 
-///   MessageSet wire format is equivalent to this.
+/// MessageSet wire format is equivalent to this.
 struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".RawMessageSet"
 

--- a/Reference/google/protobuf/unittest_mset_wire_format.pb.swift
+++ b/Reference/google/protobuf/unittest_mset_wire_format.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  This file contains messages for testing message_set_wire_format.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// This file contains messages for testing message_set_wire_format.
 
 import Foundation
 import SwiftProtobuf
@@ -57,7 +57,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto2_wireformat_unittest"
 
-///   A message with message_set_wire_format.
+/// A message with message_set_wire_format.
 struct Proto2WireformatUnittest_TestMessageSet: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestMessageSet"
 

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -6,43 +6,43 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  This proto file contains copies of TestAllTypes and friends, but with arena
-//  support disabled in code generation. It allows us to test the performance
-//  impact against baseline (non-arena) google.protobuf.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// This proto file contains copies of TestAllTypes and friends, but with arena
+// support disabled in code generation. It allows us to test the performance
+// impact against baseline (non-arena) google.protobuf.
 
 import Foundation
 import SwiftProtobuf
@@ -94,8 +94,8 @@ enum ProtobufUnittestNoArena_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._Pro
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -260,7 +260,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -525,7 +525,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalCord = nil
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
@@ -548,7 +548,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -674,7 +674,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  ///   Singular with defaults
+  /// Singular with defaults
   var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
@@ -1057,7 +1057,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -1095,9 +1095,9 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = ProtobufUnittestNoArena_TestAllTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     fileprivate var _bb: Int32? = nil
     var bb: Int32 {
       get {return _bb ?? 0}
@@ -1513,8 +1513,8 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct ProtobufUnittestNoArena_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 

--- a/Reference/google/protobuf/unittest_no_arena_import.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena_import.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_no_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena_lite.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  A proto file used to test a message type with no explicit field presence.
+// A proto file used to test a message type with no explicit field presence.
 
 import Foundation
 import SwiftProtobuf
@@ -90,8 +90,8 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobu
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -206,9 +206,9 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
-  ///   TODO: remove 'optional' labels as soon as CL 69188077 is LGTM'd to make
-  ///   'optional' optional.
+  /// Singular
+  /// TODO: remove 'optional' labels as soon as CL 69188077 is LGTM'd to make
+  /// 'optional' optional.
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -322,9 +322,9 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
 
-  ///   N.B.: proto2-enum-type fields not allowed, because their default values
-  ///   might not be zero.
-  ///  optional protobuf_unittest.ForeignEnum          optional_proto2_enum     = 23;
+  /// N.B.: proto2-enum-type fields not allowed, because their default values
+  /// might not be zero.
+  ///optional protobuf_unittest.ForeignEnum          optional_proto2_enum     = 23;
   var optionalForeignEnum: Proto2NofieldpresenceUnittest_ForeignEnum {
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
@@ -351,7 +351,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalLazyMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -931,8 +931,8 @@ struct Proto2NofieldpresenceUnittest_TestProto2Required: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct Proto2NofieldpresenceUnittest_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
+// Author: kenton@google.com (Kenton Varda)
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file which uses optimize_for = CODE_SIZE.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file which uses optimize_for = CODE_SIZE.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -138,7 +138,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
 
   var repeatedPackedE: [Proto3PreserveUnknownEnumUnittest_MyEnum] = []
 
-  ///   not packed
+  /// not packed
   var repeatedPackedUnexpectedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
 
   var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnum {

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -105,7 +105,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
 
   var repeatedPackedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
 
-  ///   not packed
+  /// not packed
   var repeatedPackedUnexpectedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
 
   var oneofE1: Proto2PreserveUnknownEnumUnittest_MyEnum {

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file we will use for unit testing.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file we will use for unit testing.
 
 import Foundation
 import SwiftProtobuf
@@ -98,7 +98,7 @@ enum Proto3ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
 
 }
 
-///   Test an enum that has multiple values with the same number.
+/// Test an enum that has multiple values with the same number.
 enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case testEnumWithDupValueUnspecified // = 0
@@ -142,7 +142,7 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
 
 }
 
-///   Test an enum with large, unordered values.
+/// Test an enum with large, unordered values.
 enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case testSparseEnumUnspecified // = 0
@@ -152,8 +152,8 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding
   case sparseD // = -15
   case sparseE // = -53452
 
-  ///   In proto3, value 0 must be the first one specified
-  ///   SPARSE_F = 0;
+  /// In proto3, value 0 must be the first one specified
+  /// SPARSE_F = 0;
   case sparseG // = 2
   case UNRECOGNIZED(Int)
 
@@ -199,8 +199,8 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct Proto3TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -311,7 +311,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var singleInt32: Int32 {
     get {return _storage._singleInt32}
     set {_uniqueStorage()._singleInt32 = newValue}
@@ -435,7 +435,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._singleImportEnum = newValue}
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var singlePublicImportMessage: Proto3PublicImportMessage {
     get {return _storage._singlePublicImportMessage ?? Proto3PublicImportMessage()}
     set {_uniqueStorage()._singlePublicImportMessage = newValue}
@@ -447,7 +447,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     return _storage._singlePublicImportMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -553,7 +553,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedImportEnum = newValue}
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var repeatedPublicImportMessage: [Proto3PublicImportMessage] {
     get {return _storage._repeatedPublicImportMessage}
     set {_uniqueStorage()._repeatedPublicImportMessage = newValue}
@@ -691,7 +691,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
 
@@ -734,9 +734,9 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = Proto3TestAllTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     var bb: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -962,7 +962,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
   }
 }
 
-///   This proto includes a recusively nested message.
+/// This proto includes a recusively nested message.
 struct Proto3NestedTestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedTestAllTypes"
 
@@ -1076,8 +1076,8 @@ struct Proto3TestDeprecatedFields: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct Proto3ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 
@@ -1121,7 +1121,7 @@ struct Proto3TestReservedFields: SwiftProtobuf.Message {
   }
 }
 
-///   Test that we can use NestedMessage from outside TestAllTypes.
+/// Test that we can use NestedMessage from outside TestAllTypes.
 struct Proto3TestForeignNested: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestForeignNested"
 
@@ -1181,12 +1181,12 @@ struct Proto3TestForeignNested: SwiftProtobuf.Message {
   }
 }
 
-///   Test that really large tag numbers don't break anything.
+/// Test that really large tag numbers don't break anything.
 struct Proto3TestReallyLargeTagNumber: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestReallyLargeTagNumber"
 
-  ///   The largest possible tag number is 2^28 - 1, since the wire format uses
-  ///   three bits to communicate wire type.
+  /// The largest possible tag number is 2^28 - 1, since the wire format uses
+  /// three bits to communicate wire type.
   var a: Int32 = 0
 
   var bb: Int32 = 0
@@ -1286,7 +1286,7 @@ struct Proto3TestRecursiveMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test that mutual recursion works.
+/// Test that mutual recursion works.
 struct Proto3TestMutualRecursionA: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMutualRecursionA"
 
@@ -1442,8 +1442,8 @@ struct Proto3TestEnumAllowAlias: SwiftProtobuf.Message {
   }
 }
 
-///   Test message with CamelCase field names.  This violates Protocol Buffer
-///   standard style.
+/// Test message with CamelCase field names.  This violates Protocol Buffer
+/// standard style.
 struct Proto3TestCamelCaseFieldNames: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestCamelCaseFieldNames"
 
@@ -1580,8 +1580,8 @@ struct Proto3TestCamelCaseFieldNames: SwiftProtobuf.Message {
   }
 }
 
-///   We list fields out of order, to ensure that we're using field number and not
-///   field index to determine serialization order.
+/// We list fields out of order, to ensure that we're using field number and not
+/// field index to determine serialization order.
 struct Proto3TestFieldOrderings: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestFieldOrderings"
 
@@ -1643,9 +1643,9 @@ struct Proto3TestFieldOrderings: SwiftProtobuf.Message {
 
     var oo: Int64 = 0
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     var bb: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -1735,7 +1735,7 @@ struct Proto3SparseEnumMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test String and Bytes: string is for valid UTF-8 strings
+/// Test String and Bytes: string is for valid UTF-8 strings
 struct Proto3OneString: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OneString"
 
@@ -1840,7 +1840,7 @@ struct Proto3MoreBytes: SwiftProtobuf.Message {
   }
 }
 
-///   Test int32, uint32, int64, uint64, and bool are all compatible
+/// Test int32, uint32, int64, uint64, and bool are all compatible
 struct Proto3Int32Message: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Int32Message"
 
@@ -1971,7 +1971,7 @@ struct Proto3BoolMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test oneofs.
+/// Test oneofs.
 struct Proto3TestOneof: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestOneof"
 
@@ -2226,8 +2226,8 @@ struct Proto3TestPackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   A message with the same fields as TestPackedTypes, but without packing. Used
-///   to test packed <-> unpacked wire compatibility.
+/// A message with the same fields as TestPackedTypes, but without packing. Used
+/// to test packed <-> unpacked wire compatibility.
 struct Proto3TestUnpackedTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestUnpackedTypes"
 
@@ -2335,20 +2335,20 @@ struct Proto3TestUnpackedTypes: SwiftProtobuf.Message {
 struct Proto3TestRepeatedScalarDifferentTagSizes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRepeatedScalarDifferentTagSizes"
 
-  ///   Parsing repeated fixed size values used to fail. This message needs to be
-  ///   used in order to get a tag of the right size; all of the repeated fields
-  ///   in TestAllTypes didn't trigger the check.
+  /// Parsing repeated fixed size values used to fail. This message needs to be
+  /// used in order to get a tag of the right size; all of the repeated fields
+  /// in TestAllTypes didn't trigger the check.
   var repeatedFixed32: [UInt32] = []
 
-  ///   Check for a varint type, just for good measure.
+  /// Check for a varint type, just for good measure.
   var repeatedInt32: [Int32] = []
 
-  ///   These have two-byte tags.
+  /// These have two-byte tags.
   var repeatedFixed64: [UInt64] = []
 
   var repeatedInt64: [Int64] = []
 
-  ///   Three byte tags.
+  /// Three byte tags.
   var repeatedFloat: [Float] = []
 
   var repeatedUint64: [UInt64] = []
@@ -2397,7 +2397,7 @@ struct Proto3TestRepeatedScalarDifferentTagSizes: SwiftProtobuf.Message {
 struct Proto3TestCommentInjectionMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestCommentInjectionMessage"
 
-  ///   */ <- This should not close the generated doc comment
+  /// */ <- This should not close the generated doc comment
   var a: String = ""
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2421,7 +2421,7 @@ struct Proto3TestCommentInjectionMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test that RPC services work.
+/// Test that RPC services work.
 struct Proto3FooRequest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FooRequest"
 

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -92,8 +92,8 @@ enum Proto3ArenaUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNa
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -210,7 +210,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -339,7 +339,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
@@ -362,7 +362,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalLazyMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -610,7 +610,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
 
@@ -653,9 +653,9 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = Proto3ArenaUnittest_TestAllTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     var bb: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -997,7 +997,7 @@ struct Proto3ArenaUnittest_TestPackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   Explicitly set packed to false
+/// Explicitly set packed to false
 struct Proto3ArenaUnittest_TestUnpackedTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestUnpackedTypes"
 
@@ -1102,7 +1102,7 @@ struct Proto3ArenaUnittest_TestUnpackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   This proto includes a recusively nested message.
+/// This proto includes a recusively nested message.
 struct Proto3ArenaUnittest_NestedTestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedTestAllTypes"
 
@@ -1179,8 +1179,8 @@ struct Proto3ArenaUnittest_NestedTestAllTypes: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct Proto3ArenaUnittest_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 
@@ -1207,7 +1207,7 @@ struct Proto3ArenaUnittest_ForeignMessage: SwiftProtobuf.Message {
   }
 }
 
-///   TestEmptyMessage is used to test behavior of unknown fields.
+/// TestEmptyMessage is used to test behavior of unknown fields.
 struct Proto3ArenaUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessage"
 

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -92,8 +92,8 @@ enum Proto3ArenaLiteUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._Pro
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -210,7 +210,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -339,7 +339,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
@@ -362,7 +362,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalLazyMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -610,7 +610,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
 
@@ -653,9 +653,9 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = Proto3ArenaLiteUnittest_TestAllTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     var bb: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -997,7 +997,7 @@ struct Proto3ArenaLiteUnittest_TestPackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   Explicitly set packed to false
+/// Explicitly set packed to false
 struct Proto3ArenaLiteUnittest_TestUnpackedTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestUnpackedTypes"
 
@@ -1102,7 +1102,7 @@ struct Proto3ArenaLiteUnittest_TestUnpackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   This proto includes a recusively nested message.
+/// This proto includes a recusively nested message.
 struct Proto3ArenaLiteUnittest_NestedTestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedTestAllTypes"
 
@@ -1179,8 +1179,8 @@ struct Proto3ArenaLiteUnittest_NestedTestAllTypes: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct Proto3ArenaLiteUnittest_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 
@@ -1207,7 +1207,7 @@ struct Proto3ArenaLiteUnittest_ForeignMessage: SwiftProtobuf.Message {
   }
 }
 
-///   TestEmptyMessage is used to test behavior of unknown fields.
+/// TestEmptyMessage is used to test behavior of unknown fields.
 struct Proto3ArenaLiteUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessage"
 

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -92,8 +92,8 @@ enum Proto3LiteUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNam
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -210,7 +210,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -339,7 +339,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
@@ -362,7 +362,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalLazyMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -610,7 +610,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
 
@@ -653,9 +653,9 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = Proto3LiteUnittest_TestAllTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     var bb: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -997,7 +997,7 @@ struct Proto3LiteUnittest_TestPackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   Explicitly set packed to false
+/// Explicitly set packed to false
 struct Proto3LiteUnittest_TestUnpackedTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestUnpackedTypes"
 
@@ -1102,7 +1102,7 @@ struct Proto3LiteUnittest_TestUnpackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   This proto includes a recusively nested message.
+/// This proto includes a recusively nested message.
 struct Proto3LiteUnittest_NestedTestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedTestAllTypes"
 
@@ -1179,8 +1179,8 @@ struct Proto3LiteUnittest_NestedTestAllTypes: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct Proto3LiteUnittest_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 
@@ -1207,7 +1207,7 @@ struct Proto3LiteUnittest_ForeignMessage: SwiftProtobuf.Message {
   }
 }
 
-///   TestEmptyMessage is used to test behavior of unknown fields.
+/// TestEmptyMessage is used to test behavior of unknown fields.
 struct Proto3LiteUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessage"
 

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -21,9 +21,9 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-///   Test that we can include all well-known types.
-///   Each wrapper type is included separately, as languages
-///   map handle different wrappers in different ways.
+/// Test that we can include all well-known types.
+/// Each wrapper type is included separately, as languages
+/// map handle different wrappers in different ways.
 struct ProtobufUnittest_TestWellKnownTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestWellKnownTypes"
 
@@ -280,7 +280,7 @@ struct ProtobufUnittest_TestWellKnownTypes: SwiftProtobuf.Message {
     return _storage._bytesField = nil
   }
 
-  ///   Part of struct, but useful to be able to test separately
+  /// Part of struct, but useful to be able to test separately
   var valueField: Google_Protobuf_Value {
     get {return _storage._valueField ?? Google_Protobuf_Value()}
     set {_uniqueStorage()._valueField = newValue}
@@ -390,7 +390,7 @@ struct ProtobufUnittest_TestWellKnownTypes: SwiftProtobuf.Message {
   }
 }
 
-///   A repeated field for each well-known type.
+/// A repeated field for each well-known type.
 struct ProtobufUnittest_RepeatedWellKnownTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".RepeatedWellKnownTypes"
 
@@ -492,7 +492,7 @@ struct ProtobufUnittest_RepeatedWellKnownTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._typeField = newValue}
   }
 
-  ///   These don't actually make a lot of sense, but they're not prohibited...
+  /// These don't actually make a lot of sense, but they're not prohibited...
   var doubleField: [Google_Protobuf_DoubleValue] {
     get {return _storage._doubleField}
     set {_uniqueStorage()._doubleField = newValue}
@@ -1161,9 +1161,9 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message {
   }
 }
 
-///   A map field for each well-known type. We only
-///   need to worry about the value part of the map being the
-///   well-known types, as messages can't be map keys.
+/// A map field for each well-known type. We only
+/// need to worry about the value part of the map being the
+/// well-known types, as messages can't be map keys.
 struct ProtobufUnittest_MapWellKnownTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MapWellKnownTypes"
 

--- a/Reference/google/protobuf/wrappers.pb.swift
+++ b/Reference/google/protobuf/wrappers.pb.swift
@@ -6,40 +6,40 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Wrappers for primitive (non-message) types. These types are useful
-//  for embedding primitives in the `google.protobuf.Any` type and for places
-//  where we need to distinguish between the absence of a primitive
-//  typed field and its default value.
+// Wrappers for primitive (non-message) types. These types are useful
+// for embedding primitives in the `google.protobuf.Any` type and for places
+// where we need to distinguish between the absence of a primitive
+// typed field and its default value.
 
 import Foundation
 
@@ -55,13 +55,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   Wrapper message for `double`.
-///  
-///   The JSON representation for `DoubleValue` is JSON number.
+/// Wrapper message for `double`.
+///
+/// The JSON representation for `DoubleValue` is JSON number.
 struct Google_Protobuf_DoubleValue: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".DoubleValue"
 
-  ///   The double value.
+  /// The double value.
   var value: Double = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -85,13 +85,13 @@ struct Google_Protobuf_DoubleValue: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `float`.
-///  
-///   The JSON representation for `FloatValue` is JSON number.
+/// Wrapper message for `float`.
+///
+/// The JSON representation for `FloatValue` is JSON number.
 struct Google_Protobuf_FloatValue: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FloatValue"
 
-  ///   The float value.
+  /// The float value.
   var value: Float = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -115,13 +115,13 @@ struct Google_Protobuf_FloatValue: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `int64`.
-///  
-///   The JSON representation for `Int64Value` is JSON string.
+/// Wrapper message for `int64`.
+///
+/// The JSON representation for `Int64Value` is JSON string.
 struct Google_Protobuf_Int64Value: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Int64Value"
 
-  ///   The int64 value.
+  /// The int64 value.
   var value: Int64 = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -145,13 +145,13 @@ struct Google_Protobuf_Int64Value: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `uint64`.
-///  
-///   The JSON representation for `UInt64Value` is JSON string.
+/// Wrapper message for `uint64`.
+///
+/// The JSON representation for `UInt64Value` is JSON string.
 struct Google_Protobuf_UInt64Value: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".UInt64Value"
 
-  ///   The uint64 value.
+  /// The uint64 value.
   var value: UInt64 = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -175,13 +175,13 @@ struct Google_Protobuf_UInt64Value: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `int32`.
-///  
-///   The JSON representation for `Int32Value` is JSON number.
+/// Wrapper message for `int32`.
+///
+/// The JSON representation for `Int32Value` is JSON number.
 struct Google_Protobuf_Int32Value: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Int32Value"
 
-  ///   The int32 value.
+  /// The int32 value.
   var value: Int32 = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -205,13 +205,13 @@ struct Google_Protobuf_Int32Value: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `uint32`.
-///  
-///   The JSON representation for `UInt32Value` is JSON number.
+/// Wrapper message for `uint32`.
+///
+/// The JSON representation for `UInt32Value` is JSON number.
 struct Google_Protobuf_UInt32Value: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".UInt32Value"
 
-  ///   The uint32 value.
+  /// The uint32 value.
   var value: UInt32 = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -235,13 +235,13 @@ struct Google_Protobuf_UInt32Value: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `bool`.
-///  
-///   The JSON representation for `BoolValue` is JSON `true` and `false`.
+/// Wrapper message for `bool`.
+///
+/// The JSON representation for `BoolValue` is JSON `true` and `false`.
 struct Google_Protobuf_BoolValue: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".BoolValue"
 
-  ///   The bool value.
+  /// The bool value.
   var value: Bool = false
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -265,13 +265,13 @@ struct Google_Protobuf_BoolValue: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `string`.
-///  
-///   The JSON representation for `StringValue` is JSON string.
+/// Wrapper message for `string`.
+///
+/// The JSON representation for `StringValue` is JSON string.
 struct Google_Protobuf_StringValue: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".StringValue"
 
-  ///   The string value.
+  /// The string value.
   var value: String = ""
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -295,13 +295,13 @@ struct Google_Protobuf_StringValue: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `bytes`.
-///  
-///   The JSON representation for `BytesValue` is JSON string.
+/// Wrapper message for `bytes`.
+///
+/// The JSON representation for `BytesValue` is JSON string.
 struct Google_Protobuf_BytesValue: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".BytesValue"
 
-  ///   The bytes value.
+  /// The bytes value.
   var value: Data = Data()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-///   An addition to unittest.proto
+/// An addition to unittest.proto
 
 import Foundation
 import SwiftProtobuf
@@ -167,7 +167,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var requiredInt32: Int32 {
     get {return _storage._requiredInt32 ?? 0}
     set {_uniqueStorage()._requiredInt32 = newValue}
@@ -432,7 +432,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
     return _storage._requiredCord = nil
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var requiredPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._requiredPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._requiredPublicImportMessage = newValue}
@@ -455,7 +455,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
     return _storage._requiredLazyMessage = nil
   }
 
-  ///   Singular with defaults
+  /// Singular with defaults
   var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
@@ -813,7 +813,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -851,9 +851,9 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = ProtobufUnittest_TestAllRequiredTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     fileprivate var _bb: Int32? = nil
     var bb: Int32 {
       get {return _bb ?? 0}
@@ -1207,7 +1207,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
 struct ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestSomeRequiredTypes"
 
-  ///   Singular
+  /// Singular
   fileprivate var _requiredInt32: Int32? = nil
   var requiredInt32: Int32 {
     get {return _requiredInt32 ?? 0}

--- a/Reference/unittest_swift_cycle.pb.swift
+++ b/Reference/unittest_swift_cycle.pb.swift
@@ -6,34 +6,34 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2015 Google Inc.  All rights reserved.
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/unittest_swift_enum.pb.swift
+++ b/Reference/unittest_swift_enum.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2015 Apple, Inc.  All Rights Reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Apple, Inc.  All Rights Reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/unittest_swift_enum_optional_default.pb.swift
+++ b/Reference/unittest_swift_enum_optional_default.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_enum_optional_default.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test handling of enum fields with specified defaults
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_enum_optional_default.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test handling of enum fields with specified defaults
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf
@@ -66,8 +66,8 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: SwiftProtobuf.Message {
       return _storage
     }
 
-    ///   The circular reference here forces the generator to
-    ///   implement heap-backed storage.
+    /// The circular reference here forces the generator to
+    /// implement heap-backed storage.
     var message: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage {
       get {return _storage._message ?? ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage()}
       set {_uniqueStorage()._message = newValue}

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_extension.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test handling of extensions to deeply nested messages.
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_extension.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test handling of extensions to deeply nested messages.
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf
@@ -120,7 +120,7 @@ struct ProtobufUnittest_Extend_Foo: SwiftProtobuf.Message {
 struct ProtobufUnittest_Extend_C: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".C"
 
-  ///        extensions 10 to 20;
+  ///      extensions 10 to 20;
   fileprivate var _c: Int64? = nil
   var c: Int64 {
     get {return _c ?? 0}
@@ -291,7 +291,7 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
     return _storage._x = nil
   }
 
-  ///   Recursive class (i.e. - can build a graph), forces _StorageClass.
+  /// Recursive class (i.e. - can build a graph), forces _StorageClass.
   var y: ProtobufUnittest_Extend_MsgUsesStorage {
     get {return _storage._y ?? ProtobufUnittest_Extend_MsgUsesStorage()}
     set {_uniqueStorage()._y = newValue}

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -6,23 +6,23 @@
  *
  */
 
-//  Protos/unittest_swift_extension2.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test naming of extensions that differ only in proto package. This is a
-// / clone of unittest_swift_extension3.proto, but with a different proto package
-// / and different extension numbers.
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_extension2.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test naming of extensions that differ only in proto package. This is a
+/// clone of unittest_swift_extension3.proto, but with a different proto package
+/// and different extension numbers.
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -6,23 +6,23 @@
  *
  */
 
-//  Protos/unittest_swift_extension3.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test naming of extensions that differ only in proto package. This is a
-// / clone of unittest_swift_extension2.proto, but with a different proto package
-// / and different extension numbers.
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_extension3.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test naming of extensions that differ only in proto package. This is a
+/// clone of unittest_swift_extension2.proto, but with a different proto package
+/// and different extension numbers.
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -6,23 +6,23 @@
  *
  */
 
-//  Protos/unittest_swift_extension4.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test naming of extensions that differ only in proto package. This is a
-// / clone of unittest_swift_extension[23].proto, but with a different proto
-// / package, different extension numbers, and a Swift prefix option.
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_extension4.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test naming of extensions that differ only in proto package. This is a
+/// clone of unittest_swift_extension[23].proto, but with a different proto
+/// package, different extension numbers, and a Swift prefix option.
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_fieldorder.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Check that fields get properly ordered when serializing
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_fieldorder.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Check that fields get properly ordered when serializing
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2015 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -49,7 +49,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _1
 }
 
-///   Same field number appears inside and outside of the group.
+/// Same field number appears inside and outside of the group.
 struct SwiftTestGroupExtensions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = "SwiftTestGroupExtensions"
 

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -6,23 +6,23 @@
  *
  */
 
-//  Protos/unittest_swift_reserved.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test Swift reserved words used as enum or message names
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_reserved.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test Swift reserved words used as enum or message names
+///
+// -----------------------------------------------------------------------------
 
-///   proto2 syntax is used so the has*/clear* names also get generated.
+/// proto2 syntax is used so the has*/clear* names also get generated.
 
 import Foundation
 import SwiftProtobuf
@@ -898,13 +898,13 @@ enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum, SwiftProtobuf._Pro
   typealias RawValue = Int
   case aa // = 0
 
-  ///   protoc no longer allows enum naming that would differ only in underscores.
-  ///   Initial commit:
-  ///     https://github.com/google/protobuf/commit/cc8ca5b6a5478b40546d4206392eb1471454460d
-  ///   Change keep proto3 as error, but proto2 to just a warning:
-  ///     https://github.com/google/protobuf/pull/2204
-  ///   So this is in a second enum so it won't cause issues with the '_' one;
-  ///   but still ensure things generator correctly.
+  /// protoc no longer allows enum naming that would differ only in underscores.
+  /// Initial commit:
+  ///   https://github.com/google/protobuf/commit/cc8ca5b6a5478b40546d4206392eb1471454460d
+  /// Change keep proto3 as error, but proto2 to just a warning:
+  ///   https://github.com/google/protobuf/pull/2204
+  /// So this is in a second enum so it won't cause issues with the '_' one;
+  /// but still ensure things generator correctly.
   case ____ // = 1065
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Reference/unittest_swift_naming_no_prefix.pb.swift
+++ b/Reference/unittest_swift_naming_no_prefix.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_naming_no_prefix.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test Swift reserved words used as enum or message names
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_naming_no_prefix.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test Swift reserved words used as enum or message names
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf

--- a/Reference/unittest_swift_performance.pb.swift
+++ b/Reference/unittest_swift_performance.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -135,7 +135,7 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   One of every singular field type
+  /// One of every singular field type
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -216,7 +216,7 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedRecursiveMessage = newValue}
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -292,7 +292,7 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  ///   Map
+  /// Map
   var mapStringMessage: Dictionary<String,Swift_Performance_TestAllTypes> {
     get {return _storage._mapStringMessage}
     set {_uniqueStorage()._mapStringMessage = newValue}

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_reserved.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test Swift reserved words used as enum or message names
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_reserved.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test Swift reserved words used as enum or message names
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf
@@ -40,7 +40,7 @@ fileprivate let _protobuf_package = "protobuf_unittest"
 struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SwiftReservedTest"
 
-  ///   static r/o properties on Message, ensure they still work as fields.
+  /// static r/o properties on Message, ensure they still work as fields.
   fileprivate var _protoMessageName: Int32? = nil
   var protoMessageName: Int32 {
     get {return _protoMessageName ?? 0}
@@ -89,7 +89,7 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
     return _anyTypeURL = nil
   }
 
-  ///   r/o properties on Message, ensure it gets remapped.
+  /// r/o properties on Message, ensure it gets remapped.
   fileprivate var _isInitialized_p: String? = nil
   var isInitialized_p: String {
     get {return _isInitialized_p ?? ""}
@@ -325,17 +325,17 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
 
   struct Extensions {
 
-    ///   This will end up in the "struct Extensions" to scope it, but there
-    ///   the raw form is used ("hash_value", not the Swift one "hashValue"),
-    ///   so there is no conflict, and no renaming happens.
+    /// This will end up in the "struct Extensions" to scope it, but there
+    /// the raw form is used ("hash_value", not the Swift one "hashValue"),
+    /// so there is no conflict, and no renaming happens.
     static let hash_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
       _protobuf_fieldNumber: 1001,
       fieldName: "protobuf_unittest.SwiftReservedTestExt.hash_value",
       defaultValue: false
     )
 
-    ///   Reserved words, since these end up in the "struct Extensions", they
-    ///   can't just be get their names, and sanitation kicks.
+    /// Reserved words, since these end up in the "struct Extensions", they
+    /// can't just be get their names, and sanitation kicks.
     static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
       _protobuf_fieldNumber: 1022,
       fieldName: "protobuf_unittest.SwiftReservedTestExt.as",
@@ -379,15 +379,15 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
   }
 }
 
-///   Won't get _p added because it is fully qualified.
+/// Won't get _p added because it is fully qualified.
 let ProtobufUnittest_Extensions_debug_description = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
   _protobuf_fieldNumber: 1000,
   fieldName: "protobuf_unittest.debug_description",
   defaultValue: false
 )
 
-///   These are scoped to the file, so the package prefix (or a Swift prefix)
-///   will get added to them to they aren't going to get renamed.
+/// These are scoped to the file, so the package prefix (or a Swift prefix)
+/// will get added to them to they aren't going to get renamed.
 let ProtobufUnittest_Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
   _protobuf_fieldNumber: 1012,
   fieldName: "protobuf_unittest.as",
@@ -419,9 +419,9 @@ let ProtobufUnittest_Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExt
 )
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  ///   This will end up in the "struct Extensions" to scope it, but there
-  ///   the raw form is used ("hash_value", not the Swift one "hashValue"),
-  ///   so there is no conflict, and no renaming happens.
+  /// This will end up in the "struct Extensions" to scope it, but there
+  /// the raw form is used ("hash_value", not the Swift one "hashValue"),
+  /// so there is no conflict, and no renaming happens.
   var ProtobufUnittest_SwiftReservedTestExt_hashValue: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value, value: newValue)}
@@ -435,8 +435,8 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  ///   Reserved words, since these end up in the "struct Extensions", they
-  ///   can't just be get their names, and sanitation kicks.
+  /// Reserved words, since these end up in the "struct Extensions", they
+  /// can't just be get their names, and sanitation kicks.
   var ProtobufUnittest_SwiftReservedTestExt_as: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.as) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.as, value: newValue)}
@@ -502,7 +502,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  ///   Won't get _p added because it is fully qualified.
+  /// Won't get _p added because it is fully qualified.
   var ProtobufUnittest_debugDescription: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debug_description) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_debug_description, value: newValue)}
@@ -516,8 +516,8 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  ///   These are scoped to the file, so the package prefix (or a Swift prefix)
-  ///   will get added to them to they aren't going to get renamed.
+  /// These are scoped to the file, so the package prefix (or a Swift prefix)
+  /// will get added to them to they aren't going to get renamed.
   var ProtobufUnittest_as: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_as) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_as, value: newValue)}

--- a/Reference/unittest_swift_reserved_ext.pb.swift
+++ b/Reference/unittest_swift_reserved_ext.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_reserved_ext.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test Swift reserved words used as enum or message names
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_reserved_ext.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test Swift reserved words used as enum or message names
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf
@@ -48,8 +48,8 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
       defaultValue: false
     )
 
-    ///   Reserved words, since these end up in the "struct Extensions", they
-    ///   can't just be get their names, and sanitation kicks.
+    /// Reserved words, since these end up in the "struct Extensions", they
+    /// can't just be get their names, and sanitation kicks.
     static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
       _protobuf_fieldNumber: 1022,
       fieldName: "SwiftReservedTestExt2.as",
@@ -93,15 +93,15 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
   }
 }
 
-///   Will get _p added because it has no package/swift prefix to scope and
-///   would otherwise be a problem when added to the message.
+/// Will get _p added because it has no package/swift prefix to scope and
+/// would otherwise be a problem when added to the message.
 let Extensions_debugDescription = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
   _protobuf_fieldNumber: 1000,
   fieldName: "debugDescription",
   defaultValue: false
 )
 
-///   These will get _p added for the same reasoning.
+/// These will get _p added for the same reasoning.
 let Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
   _protobuf_fieldNumber: 1012,
   fieldName: "as",
@@ -146,8 +146,8 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  ///   Reserved words, since these end up in the "struct Extensions", they
-  ///   can't just be get their names, and sanitation kicks.
+  /// Reserved words, since these end up in the "struct Extensions", they
+  /// can't just be get their names, and sanitation kicks.
   var SwiftReservedTestExt2_as: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.as) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.as, value: newValue)}
@@ -213,8 +213,8 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  ///   Will get _p added because it has no package/swift prefix to scope and
-  ///   would otherwise be a problem when added to the message.
+  /// Will get _p added because it has no package/swift prefix to scope and
+  /// would otherwise be a problem when added to the message.
   var debugDescription_p: Bool {
     get {return getExtensionValue(ext: Extensions_debugDescription) ?? false}
     set {setExtensionValue(ext: Extensions_debugDescription, value: newValue)}
@@ -228,7 +228,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  ///   These will get _p added for the same reasoning.
+  /// These will get _p added for the same reasoning.
   var as_p: Bool {
     get {return getExtensionValue(ext: Extensions_as) ?? false}
     set {setExtensionValue(ext: Extensions_as, value: newValue)}

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -6,34 +6,34 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2015 Google Inc.  All rights reserved.
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -686,7 +686,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
     }
   }
 
-  ///   Some token map cases, too many combinations to list them all.
+  /// Some token map cases, too many combinations to list them all.
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
@@ -1495,7 +1495,7 @@ struct ProtobufUnittest_Msg2UsesStorage: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Recursive class (i.e. - can build a graph), forces _StorageClass.
+  /// Recursive class (i.e. - can build a graph), forces _StorageClass.
   var y: ProtobufUnittest_Msg2UsesStorage {
     get {return _storage._y ?? ProtobufUnittest_Msg2UsesStorage()}
     set {_uniqueStorage()._y = newValue}

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -6,34 +6,34 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2015 Google Inc.  All rights reserved.
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -253,7 +253,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  ///   No 'group' in proto3.
+  /// No 'group' in proto3.
   var optionalMessage: ProtobufUnittest_Message3 {
     get {return _storage._optionalMessage ?? ProtobufUnittest_Message3()}
     set {_uniqueStorage()._optionalMessage = newValue}
@@ -345,7 +345,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  ///   No 'group' in proto3.
+  /// No 'group' in proto3.
   var repeatedMessage: [ProtobufUnittest_Message3] {
     get {return _storage._repeatedMessage}
     set {_uniqueStorage()._repeatedMessage = newValue}
@@ -536,7 +536,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     }
   }
 
-  ///   No 'group' in proto3.
+  /// No 'group' in proto3.
   var oneofMessage: ProtobufUnittest_Message3 {
     get {
       if case .oneofMessage(let v)? = _storage._o {
@@ -561,7 +561,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     }
   }
 
-  ///   Some token map cases, too many combinations to list them all.
+  /// Some token map cases, too many combinations to list them all.
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
@@ -1195,7 +1195,7 @@ struct ProtobufUnittest_Msg3UsesStorage: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Recursive class (i.e. - can build a graph), forces _StorageClass.
+  /// Recursive class (i.e. - can build a graph), forces _StorageClass.
   var y: ProtobufUnittest_Msg3UsesStorage {
     get {return _storage._y ?? ProtobufUnittest_Msg3UsesStorage()}
     set {_uniqueStorage()._y = newValue}

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -105,7 +105,7 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
   }
 }
 
-///   Singular
+/// Singular
 let ProtobufObjcUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
   _protobuf_fieldNumber: 1,
   fieldName: "protobuf_objc_unittest.optional_int32_extension",
@@ -132,7 +132,7 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
 }
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
-  ///   Singular
+  /// Singular
   var ProtobufObjcUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension, value: newValue)}

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -88,11 +88,11 @@ enum Conformance_WireFormat: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProvidi
 
 }
 
-///   Represents a single test case's input.  The testee should:
-///  
-///     1. parse this proto (which should always succeed)
-///     2. parse the protobuf or JSON payload in "payload" (which may fail)
-///     3. if the parse succeeded, serialize the message in the requested format.
+/// Represents a single test case's input.  The testee should:
+///
+///   1. parse this proto (which should always succeed)
+///   2. parse the protobuf or JSON payload in "payload" (which may fail)
+///   3. if the parse succeeded, serialize the message in the requested format.
 struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ConformanceRequest"
 
@@ -122,7 +122,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
     }
   }
 
-  ///   Which format should the testee serialize its message to?
+  /// Which format should the testee serialize its message to?
   var requestedOutputFormat: Conformance_WireFormat = Conformance_WireFormat.unspecified
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -196,15 +196,15 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   }
 }
 
-///   Represents a single test case's output.
+/// Represents a single test case's output.
 struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ConformanceResponse"
 
-  ///   This string should be set to indicate parsing failed.  The string can
-  ///   provide more information about the parse error if it is available.
-  ///  
-  ///   Setting this string does not necessarily mean the testee failed the
-  ///   test.  Some of the test cases are intentionally invalid input.
+  /// This string should be set to indicate parsing failed.  The string can
+  /// provide more information about the parse error if it is available.
+  ///
+  /// Setting this string does not necessarily mean the testee failed the
+  /// test.  Some of the test cases are intentionally invalid input.
   var parseError: String {
     get {
       if case .parseError(let v)? = result {
@@ -219,9 +219,9 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
 
   var result: Conformance_ConformanceResponse.OneOf_Result? = nil
 
-  ///   If the input was successfully parsed but errors occurred when
-  ///   serializing it to the requested output format, set the error message in
-  ///   this field.
+  /// If the input was successfully parsed but errors occurred when
+  /// serializing it to the requested output format, set the error message in
+  /// this field.
   var serializeError: String {
     get {
       if case .serializeError(let v)? = result {
@@ -234,9 +234,9 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   This should be set if some other error occurred.  This will always
-  ///   indicate that the test failed.  The string can provide more information
-  ///   about the failure.
+  /// This should be set if some other error occurred.  This will always
+  /// indicate that the test failed.  The string can provide more information
+  /// about the failure.
   var runtimeError: String {
     get {
       if case .runtimeError(let v)? = result {
@@ -249,8 +249,8 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   If the input was successfully parsed and the requested output was
-  ///   protobuf, serialize it to protobuf and set it in this field.
+  /// If the input was successfully parsed and the requested output was
+  /// protobuf, serialize it to protobuf and set it in this field.
   var protobufPayload: Data {
     get {
       if case .protobufPayload(let v)? = result {
@@ -263,8 +263,8 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   If the input was successfully parsed and the requested output was JSON,
-  ///   serialize to JSON and set it in this field.
+  /// If the input was successfully parsed and the requested output was JSON,
+  /// serialize to JSON and set it in this field.
   var jsonPayload: String {
     get {
       if case .jsonPayload(let v)? = result {
@@ -277,8 +277,8 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   For when the testee skipped the test, likely because a certain feature
-  ///   wasn't supported, like JSON input/output.
+  /// For when the testee skipped the test, likely because a certain feature
+  /// wasn't supported, like JSON input/output.
   var skipped: String {
     get {
       if case .skipped(let v)? = result {

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-//  Test schema for proto3 messages.  This test schema is used by:
-// 
-//  - benchmarks
-//  - fuzz tests
-//  - conformance tests
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Test schema for proto3 messages.  This test schema is used by:
+//
+// - benchmarks
+// - fuzz tests
+// - conformance tests
 
 import Foundation
 import SwiftProtobuf
@@ -94,13 +94,13 @@ enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf.
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
-///  
-///   Also, crucially, all messages and enums in this file are eventually
-///   submessages of this message.  So for example, a fuzz test of TestAllTypes
-///   could trigger bugs that occur in any message type in this file.  We verify
-///   this stays true in a unit test.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
+///
+/// Also, crucially, all messages and enums in this file are eventually
+/// submessages of this message.  So for example, a fuzz test of TestAllTypes
+/// could trigger bugs that occur in any message type in this file.  We verify
+/// this stays true in a unit test.
 struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -343,7 +343,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -472,7 +472,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     return _storage._recursiveMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -578,7 +578,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  ///   Map
+  /// Map
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
@@ -782,7 +782,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  ///   Well-known types
+  /// Well-known types
   var optionalBoolWrapper: Google_Protobuf_BoolValue {
     get {return _storage._optionalBoolWrapper ?? Google_Protobuf_BoolValue()}
     set {_uniqueStorage()._optionalBoolWrapper = newValue}
@@ -1023,8 +1023,8 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedValue = newValue}
   }
 
-  ///   Test field-name-to-JSON-name convention.
-  ///   (protobuf says names can be any valid C/C++ identifier.)
+  /// Test field-name-to-JSON-name convention.
+  /// (protobuf says names can be any valid C/C++ identifier.)
   var fieldname1: Int32 {
     get {return _storage._fieldname1}
     set {_uniqueStorage()._fieldname1 = newValue}
@@ -1253,7 +1253,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 1
     case baz // = 2
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
 

--- a/Sources/PluginLibrary/descriptor.pb.swift
+++ b/Sources/PluginLibrary/descriptor.pb.swift
@@ -6,43 +6,43 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  The messages in this file describe the definitions found in .proto files.
-//  A valid .proto file can be translated directly to a FileDescriptorProto
-//  without any other information (e.g. without reading its imports).
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// The messages in this file describe the definitions found in .proto files.
+// A valid .proto file can be translated directly to a FileDescriptorProto
+// without any other information (e.g. without reading its imports).
 
 import Foundation
 import SwiftProtobuf
@@ -59,8 +59,8 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   The protocol compiler can output a FileDescriptorSet containing the .proto
-///   files it parses.
+/// The protocol compiler can output a FileDescriptorSet containing the .proto
+/// files it parses.
 public struct Google_Protobuf_FileDescriptorSet: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".FileDescriptorSet"
 
@@ -92,7 +92,7 @@ public struct Google_Protobuf_FileDescriptorSet: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a complete .proto file.
+/// Describes a complete .proto file.
 public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".FileDescriptorProto"
 
@@ -137,7 +137,7 @@ public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   file name, relative to root of source tree
+  /// file name, relative to root of source tree
   public var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
@@ -149,7 +149,7 @@ public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._name = nil
   }
 
-  ///   e.g. "foo", "foo.bar", etc.
+  /// e.g. "foo", "foo.bar", etc.
   public var package: String {
     get {return _storage._package ?? ""}
     set {_uniqueStorage()._package = newValue}
@@ -161,26 +161,26 @@ public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._package = nil
   }
 
-  ///   Names of files imported by this file.
+  /// Names of files imported by this file.
   public var dependency: [String] {
     get {return _storage._dependency}
     set {_uniqueStorage()._dependency = newValue}
   }
 
-  ///   Indexes of the public imported files in the dependency list above.
+  /// Indexes of the public imported files in the dependency list above.
   public var publicDependency: [Int32] {
     get {return _storage._publicDependency}
     set {_uniqueStorage()._publicDependency = newValue}
   }
 
-  ///   Indexes of the weak imported files in the dependency list.
-  ///   For Google-internal migration only. Do not use.
+  /// Indexes of the weak imported files in the dependency list.
+  /// For Google-internal migration only. Do not use.
   public var weakDependency: [Int32] {
     get {return _storage._weakDependency}
     set {_uniqueStorage()._weakDependency = newValue}
   }
 
-  ///   All top-level definitions in this file.
+  /// All top-level definitions in this file.
   public var messageType: [Google_Protobuf_DescriptorProto] {
     get {return _storage._messageType}
     set {_uniqueStorage()._messageType = newValue}
@@ -212,10 +212,10 @@ public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._options = nil
   }
 
-  ///   This field contains optional information about the original source code.
-  ///   You may safely remove this entire field without harming runtime
-  ///   functionality of the descriptors -- the information is needed only by
-  ///   development tools.
+  /// This field contains optional information about the original source code.
+  /// You may safely remove this entire field without harming runtime
+  /// functionality of the descriptors -- the information is needed only by
+  /// development tools.
   public var sourceCodeInfo: Google_Protobuf_SourceCodeInfo {
     get {return _storage._sourceCodeInfo ?? Google_Protobuf_SourceCodeInfo()}
     set {_uniqueStorage()._sourceCodeInfo = newValue}
@@ -227,8 +227,8 @@ public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._sourceCodeInfo = nil
   }
 
-  ///   The syntax of the proto file.
-  ///   The supported values are "proto2" and "proto3".
+  /// The syntax of the proto file.
+  /// The supported values are "proto2" and "proto3".
   public var syntax: String {
     get {return _storage._syntax ?? ""}
     set {_uniqueStorage()._syntax = newValue}
@@ -321,7 +321,7 @@ public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a message type.
+/// Describes a message type.
 public struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".DescriptorProto"
 
@@ -419,8 +419,8 @@ public struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
     set {_uniqueStorage()._reservedRange = newValue}
   }
 
-  ///   Reserved field names, which may not be used by fields in the same message.
-  ///   A given name may only be reserved once.
+  /// Reserved field names, which may not be used by fields in the same message.
+  /// A given name may only be reserved once.
   public var reservedName: [String] {
     get {return _storage._reservedName}
     set {_uniqueStorage()._reservedName = newValue}
@@ -480,13 +480,13 @@ public struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
     }
   }
 
-  ///   Range of reserved tag numbers. Reserved tag numbers may not be used by
-  ///   fields or extension ranges in the same message. Reserved ranges may
-  ///   not overlap.
+  /// Range of reserved tag numbers. Reserved tag numbers may not be used by
+  /// fields or extension ranges in the same message. Reserved ranges may
+  /// not overlap.
   public struct ReservedRange: SwiftProtobuf.Message {
     public static let protoMessageName: String = Google_Protobuf_DescriptorProto.protoMessageName + ".ReservedRange"
 
-    ///   Inclusive.
+    /// Inclusive.
     fileprivate var _start: Int32? = nil
     public var start: Int32 {
       get {return _start ?? 0}
@@ -499,7 +499,7 @@ public struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
       return _start = nil
     }
 
-    ///   Exclusive.
+    /// Exclusive.
     fileprivate var _end: Int32? = nil
     public var end: Int32 {
       get {return _end ?? 0}
@@ -609,7 +609,7 @@ public struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a field within a message.
+/// Describes a field within a message.
 public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".FieldDescriptorProto"
 
@@ -683,8 +683,8 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._label = nil
   }
 
-  ///   If type_name is set, this need not be set.  If both this and type_name
-  ///   are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
+  /// If type_name is set, this need not be set.  If both this and type_name
+  /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
   public var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
     get {return _storage._type ?? Google_Protobuf_FieldDescriptorProto.TypeEnum.double}
     set {_uniqueStorage()._type = newValue}
@@ -696,11 +696,11 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._type = nil
   }
 
-  ///   For message and enum types, this is the name of the type.  If the name
-  ///   starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-  ///   rules are used to find the type (i.e. first the nested types within this
-  ///   message are searched, then within the parent, on up to the root
-  ///   namespace).
+  /// For message and enum types, this is the name of the type.  If the name
+  /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+  /// rules are used to find the type (i.e. first the nested types within this
+  /// message are searched, then within the parent, on up to the root
+  /// namespace).
   public var typeName: String {
     get {return _storage._typeName ?? ""}
     set {_uniqueStorage()._typeName = newValue}
@@ -712,8 +712,8 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._typeName = nil
   }
 
-  ///   For extensions, this is the name of the type being extended.  It is
-  ///   resolved in the same manner as type_name.
+  /// For extensions, this is the name of the type being extended.  It is
+  /// resolved in the same manner as type_name.
   public var extendee: String {
     get {return _storage._extendee ?? ""}
     set {_uniqueStorage()._extendee = newValue}
@@ -725,11 +725,11 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._extendee = nil
   }
 
-  ///   For numeric types, contains the original text representation of the value.
-  ///   For booleans, "true" or "false".
-  ///   For strings, contains the default text contents (not escaped in any way).
-  ///   For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-  ///   TODO(kenton):  Base-64 encode?
+  /// For numeric types, contains the original text representation of the value.
+  /// For booleans, "true" or "false".
+  /// For strings, contains the default text contents (not escaped in any way).
+  /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+  /// TODO(kenton):  Base-64 encode?
   public var defaultValue: String {
     get {return _storage._defaultValue ?? ""}
     set {_uniqueStorage()._defaultValue = newValue}
@@ -741,8 +741,8 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._defaultValue = nil
   }
 
-  ///   If set, gives the index of a oneof in the containing type's oneof_decl
-  ///   list.  This field is a member of that oneof.
+  /// If set, gives the index of a oneof in the containing type's oneof_decl
+  /// list.  This field is a member of that oneof.
   public var oneofIndex: Int32 {
     get {return _storage._oneofIndex ?? 0}
     set {_uniqueStorage()._oneofIndex = newValue}
@@ -754,10 +754,10 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._oneofIndex = nil
   }
 
-  ///   JSON name of this field. The value is set by protocol compiler. If the
-  ///   user has set a "json_name" option on this field, that option's value
-  ///   will be used. Otherwise, it's deduced from the field's name by converting
-  ///   it to camelCase.
+  /// JSON name of this field. The value is set by protocol compiler. If the
+  /// user has set a "json_name" option on this field, that option's value
+  /// will be used. Otherwise, it's deduced from the field's name by converting
+  /// it to camelCase.
   public var jsonName: String {
     get {return _storage._jsonName ?? ""}
     set {_uniqueStorage()._jsonName = newValue}
@@ -785,44 +785,44 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   public enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     public typealias RawValue = Int
 
-    ///   0 is reserved for errors.
-    ///   Order is weird for historical reasons.
+    /// 0 is reserved for errors.
+    /// Order is weird for historical reasons.
     case double // = 1
     case float // = 2
 
-    ///   Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-    ///   negative values are likely.
+    /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+    /// negative values are likely.
     case int64 // = 3
     case uint64 // = 4
 
-    ///   Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-    ///   negative values are likely.
+    /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+    /// negative values are likely.
     case int32 // = 5
     case fixed64 // = 6
     case fixed32 // = 7
     case bool // = 8
     case string // = 9
 
-    ///   Tag-delimited aggregate.
-    ///   Group type is deprecated and not supported in proto3. However, Proto3
-    ///   implementations should still be able to parse the group wire format and
-    ///   treat group fields as unknown fields.
+    /// Tag-delimited aggregate.
+    /// Group type is deprecated and not supported in proto3. However, Proto3
+    /// implementations should still be able to parse the group wire format and
+    /// treat group fields as unknown fields.
     case group // = 10
 
-    ///   Length-delimited aggregate.
+    /// Length-delimited aggregate.
     case message // = 11
 
-    ///   New in version 2.
+    /// New in version 2.
     case bytes // = 12
     case uint32 // = 13
     case `enum` // = 14
     case sfixed32 // = 15
     case sfixed64 // = 16
 
-    ///   Uses ZigZag encoding.
+    /// Uses ZigZag encoding.
     case sint32 // = 17
 
-    ///   Uses ZigZag encoding.
+    /// Uses ZigZag encoding.
     case sint64 // = 18
 
     public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -902,7 +902,7 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   public enum Label: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     public typealias RawValue = Int
 
-    ///   0 is reserved for errors
+    /// 0 is reserved for errors
     case `optional` // = 1
     case `required` // = 2
     case repeated // = 3
@@ -1003,7 +1003,7 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a oneof.
+/// Describes a oneof.
 public struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".OneofDescriptorProto"
 
@@ -1087,7 +1087,7 @@ public struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes an enum type.
+/// Describes an enum type.
 public struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".EnumDescriptorProto"
 
@@ -1183,7 +1183,7 @@ public struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a value within an enum.
+/// Describes a value within an enum.
 public struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".EnumValueDescriptorProto"
 
@@ -1284,7 +1284,7 @@ public struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a service.
+/// Describes a service.
 public struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".ServiceDescriptorProto"
 
@@ -1380,7 +1380,7 @@ public struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a method of a service.
+/// Describes a method of a service.
 public struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".MethodDescriptorProto"
 
@@ -1424,8 +1424,8 @@ public struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
     return _storage._name = nil
   }
 
-  ///   Input and output type names.  These are resolved in the same way as
-  ///   FieldDescriptorProto.type_name, but must refer to a message type.
+  /// Input and output type names.  These are resolved in the same way as
+  /// FieldDescriptorProto.type_name, but must refer to a message type.
   public var inputType: String {
     get {return _storage._inputType ?? ""}
     set {_uniqueStorage()._inputType = newValue}
@@ -1459,7 +1459,7 @@ public struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
     return _storage._options = nil
   }
 
-  ///   Identifies if client streams multiple client messages
+  /// Identifies if client streams multiple client messages
   public var clientStreaming: Bool {
     get {return _storage._clientStreaming ?? false}
     set {_uniqueStorage()._clientStreaming = newValue}
@@ -1471,7 +1471,7 @@ public struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
     return _storage._clientStreaming = nil
   }
 
-  ///   Identifies if server streams multiple server messages
+  /// Identifies if server streams multiple server messages
   public var serverStreaming: Bool {
     get {return _storage._serverStreaming ?? false}
     set {_uniqueStorage()._serverStreaming = newValue}
@@ -1590,10 +1590,10 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage
   }
 
-  ///   Sets the Java package where classes generated from this .proto will be
-  ///   placed.  By default, the proto package is used, but this is often
-  ///   inappropriate because proto packages do not normally start with backwards
-  ///   domain names.
+  /// Sets the Java package where classes generated from this .proto will be
+  /// placed.  By default, the proto package is used, but this is often
+  /// inappropriate because proto packages do not normally start with backwards
+  /// domain names.
   public var javaPackage: String {
     get {return _storage._javaPackage ?? ""}
     set {_uniqueStorage()._javaPackage = newValue}
@@ -1605,11 +1605,11 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._javaPackage = nil
   }
 
-  ///   If set, all the classes from the .proto file are wrapped in a single
-  ///   outer class with the given name.  This applies to both Proto1
-  ///   (equivalent to the old "--one_java_file" option) and Proto2 (where
-  ///   a .proto always translates to a single class, but you may want to
-  ///   explicitly choose the class name).
+  /// If set, all the classes from the .proto file are wrapped in a single
+  /// outer class with the given name.  This applies to both Proto1
+  /// (equivalent to the old "--one_java_file" option) and Proto2 (where
+  /// a .proto always translates to a single class, but you may want to
+  /// explicitly choose the class name).
   public var javaOuterClassname: String {
     get {return _storage._javaOuterClassname ?? ""}
     set {_uniqueStorage()._javaOuterClassname = newValue}
@@ -1621,12 +1621,12 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._javaOuterClassname = nil
   }
 
-  ///   If set true, then the Java code generator will generate a separate .java
-  ///   file for each top-level message, enum, and service defined in the .proto
-  ///   file.  Thus, these types will *not* be nested inside the outer class
-  ///   named by java_outer_classname.  However, the outer class will still be
-  ///   generated to contain the file's getDescriptor() method as well as any
-  ///   top-level extensions defined in the file.
+  /// If set true, then the Java code generator will generate a separate .java
+  /// file for each top-level message, enum, and service defined in the .proto
+  /// file.  Thus, these types will *not* be nested inside the outer class
+  /// named by java_outer_classname.  However, the outer class will still be
+  /// generated to contain the file's getDescriptor() method as well as any
+  /// top-level extensions defined in the file.
   public var javaMultipleFiles: Bool {
     get {return _storage._javaMultipleFiles ?? false}
     set {_uniqueStorage()._javaMultipleFiles = newValue}
@@ -1638,7 +1638,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._javaMultipleFiles = nil
   }
 
-  ///   This option does nothing.
+  /// This option does nothing.
   public var javaGenerateEqualsAndHash: Bool {
     get {return _storage._javaGenerateEqualsAndHash ?? false}
     set {_uniqueStorage()._javaGenerateEqualsAndHash = newValue}
@@ -1650,12 +1650,12 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._javaGenerateEqualsAndHash = nil
   }
 
-  ///   If set true, then the Java2 code generator will generate code that
-  ///   throws an exception whenever an attempt is made to assign a non-UTF-8
-  ///   byte sequence to a string field.
-  ///   Message reflection will do the same.
-  ///   However, an extension field still accepts non-UTF-8 byte sequences.
-  ///   This option has no effect on when used with the lite runtime.
+  /// If set true, then the Java2 code generator will generate code that
+  /// throws an exception whenever an attempt is made to assign a non-UTF-8
+  /// byte sequence to a string field.
+  /// Message reflection will do the same.
+  /// However, an extension field still accepts non-UTF-8 byte sequences.
+  /// This option has no effect on when used with the lite runtime.
   public var javaStringCheckUtf8: Bool {
     get {return _storage._javaStringCheckUtf8 ?? false}
     set {_uniqueStorage()._javaStringCheckUtf8 = newValue}
@@ -1678,11 +1678,11 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._optimizeFor = nil
   }
 
-  ///   Sets the Go package where structs generated from this .proto will be
-  ///   placed. If omitted, the Go package will be derived from the following:
-  ///     - The basename of the package import path, if provided.
-  ///     - Otherwise, the package statement in the .proto file, if present.
-  ///     - Otherwise, the basename of the .proto file, without extension.
+  /// Sets the Go package where structs generated from this .proto will be
+  /// placed. If omitted, the Go package will be derived from the following:
+  ///   - The basename of the package import path, if provided.
+  ///   - Otherwise, the package statement in the .proto file, if present.
+  ///   - Otherwise, the basename of the .proto file, without extension.
   public var goPackage: String {
     get {return _storage._goPackage ?? ""}
     set {_uniqueStorage()._goPackage = newValue}
@@ -1694,16 +1694,16 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._goPackage = nil
   }
 
-  ///   Should generic services be generated in each language?  "Generic" services
-  ///   are not specific to any particular RPC system.  They are generated by the
-  ///   main code generators in each language (without additional plugins).
-  ///   Generic services were the only kind of service generation supported by
-  ///   early versions of google.protobuf.
-  ///  
-  ///   Generic services are now considered deprecated in favor of using plugins
-  ///   that generate code specific to your particular RPC system.  Therefore,
-  ///   these default to false.  Old code which depends on generic services should
-  ///   explicitly set them to true.
+  /// Should generic services be generated in each language?  "Generic" services
+  /// are not specific to any particular RPC system.  They are generated by the
+  /// main code generators in each language (without additional plugins).
+  /// Generic services were the only kind of service generation supported by
+  /// early versions of google.protobuf.
+  ///
+  /// Generic services are now considered deprecated in favor of using plugins
+  /// that generate code specific to your particular RPC system.  Therefore,
+  /// these default to false.  Old code which depends on generic services should
+  /// explicitly set them to true.
   public var ccGenericServices: Bool {
     get {return _storage._ccGenericServices ?? false}
     set {_uniqueStorage()._ccGenericServices = newValue}
@@ -1737,10 +1737,10 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._pyGenericServices = nil
   }
 
-  ///   Is this file deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for everything in the file, or it will be completely ignored; in the very
-  ///   least, this is a formalization for deprecating files.
+  /// Is this file deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for everything in the file, or it will be completely ignored; in the very
+  /// least, this is a formalization for deprecating files.
   public var deprecated: Bool {
     get {return _storage._deprecated ?? false}
     set {_uniqueStorage()._deprecated = newValue}
@@ -1752,8 +1752,8 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._deprecated = nil
   }
 
-  ///   Enables the use of arenas for the proto messages in this file. This applies
-  ///   only to generated classes for C++.
+  /// Enables the use of arenas for the proto messages in this file. This applies
+  /// only to generated classes for C++.
   public var ccEnableArenas: Bool {
     get {return _storage._ccEnableArenas ?? false}
     set {_uniqueStorage()._ccEnableArenas = newValue}
@@ -1765,8 +1765,8 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._ccEnableArenas = nil
   }
 
-  ///   Sets the objective c class prefix which is prepended to all objective c
-  ///   generated classes from this .proto. There is no default.
+  /// Sets the objective c class prefix which is prepended to all objective c
+  /// generated classes from this .proto. There is no default.
   public var objcClassPrefix: String {
     get {return _storage._objcClassPrefix ?? ""}
     set {_uniqueStorage()._objcClassPrefix = newValue}
@@ -1778,7 +1778,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._objcClassPrefix = nil
   }
 
-  ///   Namespace for generated classes; defaults to the package.
+  /// Namespace for generated classes; defaults to the package.
   public var csharpNamespace: String {
     get {return _storage._csharpNamespace ?? ""}
     set {_uniqueStorage()._csharpNamespace = newValue}
@@ -1790,10 +1790,10 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._csharpNamespace = nil
   }
 
-  ///   By default Swift generators will take the proto package and CamelCase it
-  ///   replacing '.' with underscore and use that to prefix the types/symbols
-  ///   defined. When this options is provided, they will use this value instead
-  ///   to prefix the types/symbols defined.
+  /// By default Swift generators will take the proto package and CamelCase it
+  /// replacing '.' with underscore and use that to prefix the types/symbols
+  /// defined. When this options is provided, they will use this value instead
+  /// to prefix the types/symbols defined.
   public var swiftPrefix: String {
     get {return _storage._swiftPrefix ?? ""}
     set {_uniqueStorage()._swiftPrefix = newValue}
@@ -1805,8 +1805,8 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._swiftPrefix = nil
   }
 
-  ///   Sets the php class prefix which is prepended to all php generated classes
-  ///   from this .proto. Default is empty.
+  /// Sets the php class prefix which is prepended to all php generated classes
+  /// from this .proto. Default is empty.
   public var phpClassPrefix: String {
     get {return _storage._phpClassPrefix ?? ""}
     set {_uniqueStorage()._phpClassPrefix = newValue}
@@ -1818,7 +1818,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _storage._phpClassPrefix = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] {
     get {return _storage._uninterpretedOption}
     set {_uniqueStorage()._uninterpretedOption = newValue}
@@ -1826,17 +1826,17 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   Generated classes can be optimized for speed or code size.
+  /// Generated classes can be optimized for speed or code size.
   public enum OptimizeMode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     public typealias RawValue = Int
 
-    ///   Generate complete code for parsing, serialization,
+    /// Generate complete code for parsing, serialization,
     case speed // = 1
 
-    ///   etc.
+    /// etc.
     case codeSize // = 2
 
-    ///   Generate code using MessageLite and the lite runtime.
+    /// Generate code using MessageLite and the lite runtime.
     case liteRuntime // = 3
 
     public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -1972,24 +1972,24 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
 public struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   public static let protoMessageName: String = _protobuf_package + ".MessageOptions"
 
-  ///   Set true to use the old proto1 MessageSet wire format for extensions.
-  ///   This is provided for backwards-compatibility with the MessageSet wire
-  ///   format.  You should not use this for any other reason:  It's less
-  ///   efficient, has fewer features, and is more complicated.
-  ///  
-  ///   The message must be defined exactly as follows:
-  ///     message Foo {
-  ///       option message_set_wire_format = true;
-  ///       extensions 4 to max;
-  ///     }
-  ///   Note that the message cannot have any defined fields; MessageSets only
-  ///   have extensions.
-  ///  
-  ///   All extensions of your type must be singular messages; e.g. they cannot
-  ///   be int32s, enums, or repeated messages.
-  ///  
-  ///   Because this is an option, the above two restrictions are not enforced by
-  ///   the protocol compiler.
+  /// Set true to use the old proto1 MessageSet wire format for extensions.
+  /// This is provided for backwards-compatibility with the MessageSet wire
+  /// format.  You should not use this for any other reason:  It's less
+  /// efficient, has fewer features, and is more complicated.
+  ///
+  /// The message must be defined exactly as follows:
+  ///   message Foo {
+  ///     option message_set_wire_format = true;
+  ///     extensions 4 to max;
+  ///   }
+  /// Note that the message cannot have any defined fields; MessageSets only
+  /// have extensions.
+  ///
+  /// All extensions of your type must be singular messages; e.g. they cannot
+  /// be int32s, enums, or repeated messages.
+  ///
+  /// Because this is an option, the above two restrictions are not enforced by
+  /// the protocol compiler.
   fileprivate var _messageSetWireFormat: Bool? = nil
   public var messageSetWireFormat: Bool {
     get {return _messageSetWireFormat ?? false}
@@ -2002,9 +2002,9 @@ public struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtob
     return _messageSetWireFormat = nil
   }
 
-  ///   Disables the generation of the standard "descriptor()" accessor, which can
-  ///   conflict with a field of the same name.  This is meant to make migration
-  ///   from proto1 easier; new code should avoid fields named "descriptor".
+  /// Disables the generation of the standard "descriptor()" accessor, which can
+  /// conflict with a field of the same name.  This is meant to make migration
+  /// from proto1 easier; new code should avoid fields named "descriptor".
   fileprivate var _noStandardDescriptorAccessor: Bool? = nil
   public var noStandardDescriptorAccessor: Bool {
     get {return _noStandardDescriptorAccessor ?? false}
@@ -2017,10 +2017,10 @@ public struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtob
     return _noStandardDescriptorAccessor = nil
   }
 
-  ///   Is this message deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the message, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating messages.
+  /// Is this message deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the message, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating messages.
   fileprivate var _deprecated: Bool? = nil
   public var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2033,27 +2033,27 @@ public struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtob
     return _deprecated = nil
   }
 
-  ///   Whether the message is an automatically generated map entry type for the
-  ///   maps field.
-  ///  
-  ///   For maps fields:
-  ///       map<KeyType, ValueType> map_field = 1;
-  ///   The parsed descriptor looks like:
-  ///       message MapFieldEntry {
-  ///           option map_entry = true;
-  ///           optional KeyType key = 1;
-  ///           optional ValueType value = 2;
-  ///       }
-  ///       repeated MapFieldEntry map_field = 1;
-  ///  
-  ///   Implementations may choose not to generate the map_entry=true message, but
-  ///   use a native map in the target language to hold the keys and values.
-  ///   The reflection APIs in such implementions still need to work as
-  ///   if the field is a repeated message field.
-  ///  
-  ///   NOTE: Do not set the option in .proto files. Always use the maps syntax
-  ///   instead. The option should only be implicitly set by the proto compiler
-  ///   parser.
+  /// Whether the message is an automatically generated map entry type for the
+  /// maps field.
+  ///
+  /// For maps fields:
+  ///     map<KeyType, ValueType> map_field = 1;
+  /// The parsed descriptor looks like:
+  ///     message MapFieldEntry {
+  ///         option map_entry = true;
+  ///         optional KeyType key = 1;
+  ///         optional ValueType value = 2;
+  ///     }
+  ///     repeated MapFieldEntry map_field = 1;
+  ///
+  /// Implementations may choose not to generate the map_entry=true message, but
+  /// use a native map in the target language to hold the keys and values.
+  /// The reflection APIs in such implementions still need to work as
+  /// if the field is a repeated message field.
+  ///
+  /// NOTE: Do not set the option in .proto files. Always use the maps syntax
+  /// instead. The option should only be implicitly set by the proto compiler
+  /// parser.
   fileprivate var _mapEntry: Bool? = nil
   public var mapEntry: Bool {
     get {return _mapEntry ?? false}
@@ -2066,7 +2066,7 @@ public struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtob
     return _mapEntry = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2120,10 +2120,10 @@ public struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtob
 public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   public static let protoMessageName: String = _protobuf_package + ".FieldOptions"
 
-  ///   The ctype option instructs the C++ code generator to use a different
-  ///   representation of the field than it normally would.  See the specific
-  ///   options below.  This option is not yet implemented in the open source
-  ///   release -- sorry, we'll try to include it in a future version!
+  /// The ctype option instructs the C++ code generator to use a different
+  /// representation of the field than it normally would.  See the specific
+  /// options below.  This option is not yet implemented in the open source
+  /// release -- sorry, we'll try to include it in a future version!
   fileprivate var _ctype: Google_Protobuf_FieldOptions.CType? = nil
   public var ctype: Google_Protobuf_FieldOptions.CType {
     get {return _ctype ?? Google_Protobuf_FieldOptions.CType.string}
@@ -2136,11 +2136,11 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
     return _ctype = nil
   }
 
-  ///   The packed option can be enabled for repeated primitive fields to enable
-  ///   a more efficient representation on the wire. Rather than repeatedly
-  ///   writing the tag and type for each element, the entire array is encoded as
-  ///   a single length-delimited blob. In proto3, only explicit setting it to
-  ///   false will avoid using packed encoding.
+  /// The packed option can be enabled for repeated primitive fields to enable
+  /// a more efficient representation on the wire. Rather than repeatedly
+  /// writing the tag and type for each element, the entire array is encoded as
+  /// a single length-delimited blob. In proto3, only explicit setting it to
+  /// false will avoid using packed encoding.
   fileprivate var _packed: Bool? = nil
   public var packed: Bool {
     get {return _packed ?? false}
@@ -2153,15 +2153,15 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
     return _packed = nil
   }
 
-  ///   The jstype option determines the JavaScript type used for values of the
-  ///   field.  The option is permitted only for 64 bit integral and fixed types
-  ///   (int64, uint64, sint64, fixed64, sfixed64).  By default these types are
-  ///   represented as JavaScript strings.  This avoids loss of precision that can
-  ///   happen when a large value is converted to a floating point JavaScript
-  ///   numbers.  Specifying JS_NUMBER for the jstype causes the generated
-  ///   JavaScript code to use the JavaScript "number" type instead of strings.
-  ///   This option is an enum to permit additional types to be added,
-  ///   e.g. goog.math.Integer.
+  /// The jstype option determines the JavaScript type used for values of the
+  /// field.  The option is permitted only for 64 bit integral and fixed types
+  /// (int64, uint64, sint64, fixed64, sfixed64).  By default these types are
+  /// represented as JavaScript strings.  This avoids loss of precision that can
+  /// happen when a large value is converted to a floating point JavaScript
+  /// numbers.  Specifying JS_NUMBER for the jstype causes the generated
+  /// JavaScript code to use the JavaScript "number" type instead of strings.
+  /// This option is an enum to permit additional types to be added,
+  /// e.g. goog.math.Integer.
   fileprivate var _jstype: Google_Protobuf_FieldOptions.JSType? = nil
   public var jstype: Google_Protobuf_FieldOptions.JSType {
     get {return _jstype ?? Google_Protobuf_FieldOptions.JSType.jsNormal}
@@ -2174,34 +2174,34 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
     return _jstype = nil
   }
 
-  ///   Should this field be parsed lazily?  Lazy applies only to message-type
-  ///   fields.  It means that when the outer message is initially parsed, the
-  ///   inner message's contents will not be parsed but instead stored in encoded
-  ///   form.  The inner message will actually be parsed when it is first accessed.
-  ///  
-  ///   This is only a hint.  Implementations are free to choose whether to use
-  ///   eager or lazy parsing regardless of the value of this option.  However,
-  ///   setting this option true suggests that the protocol author believes that
-  ///   using lazy parsing on this field is worth the additional bookkeeping
-  ///   overhead typically needed to implement it.
-  ///  
-  ///   This option does not affect the public interface of any generated code;
-  ///   all method signatures remain the same.  Furthermore, thread-safety of the
-  ///   interface is not affected by this option; const methods remain safe to
-  ///   call from multiple threads concurrently, while non-const methods continue
-  ///   to require exclusive access.
-  ///  
-  ///  
-  ///   Note that implementations may choose not to check required fields within
-  ///   a lazy sub-message.  That is, calling IsInitialized() on the outer message
-  ///   may return true even if the inner message has missing required fields.
-  ///   This is necessary because otherwise the inner message would have to be
-  ///   parsed in order to perform the check, defeating the purpose of lazy
-  ///   parsing.  An implementation which chooses not to check required fields
-  ///   must be consistent about it.  That is, for any particular sub-message, the
-  ///   implementation must either *always* check its required fields, or *never*
-  ///   check its required fields, regardless of whether or not the message has
-  ///   been parsed.
+  /// Should this field be parsed lazily?  Lazy applies only to message-type
+  /// fields.  It means that when the outer message is initially parsed, the
+  /// inner message's contents will not be parsed but instead stored in encoded
+  /// form.  The inner message will actually be parsed when it is first accessed.
+  ///
+  /// This is only a hint.  Implementations are free to choose whether to use
+  /// eager or lazy parsing regardless of the value of this option.  However,
+  /// setting this option true suggests that the protocol author believes that
+  /// using lazy parsing on this field is worth the additional bookkeeping
+  /// overhead typically needed to implement it.
+  ///
+  /// This option does not affect the public interface of any generated code;
+  /// all method signatures remain the same.  Furthermore, thread-safety of the
+  /// interface is not affected by this option; const methods remain safe to
+  /// call from multiple threads concurrently, while non-const methods continue
+  /// to require exclusive access.
+  ///
+  ///
+  /// Note that implementations may choose not to check required fields within
+  /// a lazy sub-message.  That is, calling IsInitialized() on the outer message
+  /// may return true even if the inner message has missing required fields.
+  /// This is necessary because otherwise the inner message would have to be
+  /// parsed in order to perform the check, defeating the purpose of lazy
+  /// parsing.  An implementation which chooses not to check required fields
+  /// must be consistent about it.  That is, for any particular sub-message, the
+  /// implementation must either *always* check its required fields, or *never*
+  /// check its required fields, regardless of whether or not the message has
+  /// been parsed.
   fileprivate var _lazy: Bool? = nil
   public var lazy: Bool {
     get {return _lazy ?? false}
@@ -2214,10 +2214,10 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
     return _lazy = nil
   }
 
-  ///   Is this field deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for accessors, or it will be completely ignored; in the very least, this
-  ///   is a formalization for deprecating fields.
+  /// Is this field deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for accessors, or it will be completely ignored; in the very least, this
+  /// is a formalization for deprecating fields.
   fileprivate var _deprecated: Bool? = nil
   public var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2230,7 +2230,7 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
     return _deprecated = nil
   }
 
-  ///   For Google-internal migration only. Do not use.
+  /// For Google-internal migration only. Do not use.
   fileprivate var _weak: Bool? = nil
   public var weak: Bool {
     get {return _weak ?? false}
@@ -2243,7 +2243,7 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
     return _weak = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2251,7 +2251,7 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
   public enum CType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     public typealias RawValue = Int
 
-    ///   Default mode.
+    /// Default mode.
     case string // = 0
     case cord // = 1
     case stringPiece // = 2
@@ -2288,13 +2288,13 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
   public enum JSType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     public typealias RawValue = Int
 
-    ///   Use the default type.
+    /// Use the default type.
     case jsNormal // = 0
 
-    ///   Use JavaScript strings.
+    /// Use JavaScript strings.
     case jsString // = 1
 
-    ///   Use JavaScript numbers.
+    /// Use JavaScript numbers.
     case jsNumber // = 2
 
     public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -2383,7 +2383,7 @@ public struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf
 public struct Google_Protobuf_OneofOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   public static let protoMessageName: String = _protobuf_package + ".OneofOptions"
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2421,8 +2421,8 @@ public struct Google_Protobuf_OneofOptions: SwiftProtobuf.Message, SwiftProtobuf
 public struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   public static let protoMessageName: String = _protobuf_package + ".EnumOptions"
 
-  ///   Set this option to true to allow mapping different tag names to the same
-  ///   value.
+  /// Set this option to true to allow mapping different tag names to the same
+  /// value.
   fileprivate var _allowAlias: Bool? = nil
   public var allowAlias: Bool {
     get {return _allowAlias ?? false}
@@ -2435,10 +2435,10 @@ public struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _allowAlias = nil
   }
 
-  ///   Is this enum deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the enum, or it will be completely ignored; in the very least, this
-  ///   is a formalization for deprecating enums.
+  /// Is this enum deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the enum, or it will be completely ignored; in the very least, this
+  /// is a formalization for deprecating enums.
   fileprivate var _deprecated: Bool? = nil
   public var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2451,7 +2451,7 @@ public struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.
     return _deprecated = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2497,10 +2497,10 @@ public struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.
 public struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   public static let protoMessageName: String = _protobuf_package + ".EnumValueOptions"
 
-  ///   Is this enum value deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the enum value, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating enum values.
+  /// Is this enum value deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the enum value, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating enum values.
   fileprivate var _deprecated: Bool? = nil
   public var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2513,7 +2513,7 @@ public struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Message, SwiftProt
     return _deprecated = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2555,10 +2555,10 @@ public struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Message, SwiftProt
 public struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   public static let protoMessageName: String = _protobuf_package + ".ServiceOptions"
 
-  ///   Is this service deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the service, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating services.
+  /// Is this service deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the service, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating services.
   fileprivate var _deprecated: Bool? = nil
   public var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2571,7 +2571,7 @@ public struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtob
     return _deprecated = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2613,10 +2613,10 @@ public struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtob
 public struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   public static let protoMessageName: String = _protobuf_package + ".MethodOptions"
 
-  ///   Is this method deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the method, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating methods.
+  /// Is this method deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the method, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating methods.
   fileprivate var _deprecated: Bool? = nil
   public var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2641,22 +2641,22 @@ public struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobu
     return _idempotencyLevel = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   public var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
-  ///   or neither? HTTP based RPC implementation may choose GET verb for safe
-  ///   methods, and PUT verb for idempotent methods instead of the default POST.
+  /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+  /// or neither? HTTP based RPC implementation may choose GET verb for safe
+  /// methods, and PUT verb for idempotent methods instead of the default POST.
   public enum IdempotencyLevel: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     public typealias RawValue = Int
     case idempotencyUnknown // = 0
 
-    ///   implies idempotent
+    /// implies idempotent
     case noSideEffects // = 1
 
-    ///   idempotent, but may have side effects
+    /// idempotent, but may have side effects
     case idempotent // = 2
 
     public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -2726,19 +2726,19 @@ public struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobu
   public var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   A message representing a option the parser does not recognize. This only
-///   appears in options protos created by the compiler::Parser class.
-///   DescriptorPool resolves these when building Descriptor objects. Therefore,
-///   options protos in descriptor objects (e.g. returned by Descriptor::options(),
-///   or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
-///   in them.
+/// A message representing a option the parser does not recognize. This only
+/// appears in options protos created by the compiler::Parser class.
+/// DescriptorPool resolves these when building Descriptor objects. Therefore,
+/// options protos in descriptor objects (e.g. returned by Descriptor::options(),
+/// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+/// in them.
 public struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".UninterpretedOption"
 
   public var name: [Google_Protobuf_UninterpretedOption.NamePart] = []
 
-  ///   The value of the uninterpreted option, in whatever type the tokenizer
-  ///   identified it as during parsing. Exactly one of these should be set.
+  /// The value of the uninterpreted option, in whatever type the tokenizer
+  /// identified it as during parsing. Exactly one of these should be set.
   fileprivate var _identifierValue: String? = nil
   public var identifierValue: String {
     get {return _identifierValue ?? ""}
@@ -2813,11 +2813,11 @@ public struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   The name of the uninterpreted option.  Each string represents a segment in
-  ///   a dot-separated name.  is_extension is true iff a segment represents an
-  ///   extension (denoted with parentheses in options specs in .proto files).
-  ///   E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
-  ///   "foo.(bar.baz).qux".
+  /// The name of the uninterpreted option.  Each string represents a segment in
+  /// a dot-separated name.  is_extension is true iff a segment represents an
+  /// extension (denoted with parentheses in options specs in .proto files).
+  /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+  /// "foo.(bar.baz).qux".
   public struct NamePart: SwiftProtobuf.Message {
     public static let protoMessageName: String = Google_Protobuf_UninterpretedOption.protoMessageName + ".NamePart"
 
@@ -2924,54 +2924,54 @@ public struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
   }
 }
 
-///   Encapsulates information about the original source file from which a
-///   FileDescriptorProto was generated.
+/// Encapsulates information about the original source file from which a
+/// FileDescriptorProto was generated.
 public struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".SourceCodeInfo"
 
-  ///   A Location identifies a piece of source code in a .proto file which
-  ///   corresponds to a particular definition.  This information is intended
-  ///   to be useful to IDEs, code indexers, documentation generators, and similar
-  ///   tools.
-  ///  
-  ///   For example, say we have a file like:
-  ///     message Foo {
-  ///       optional string foo = 1;
-  ///     }
-  ///   Let's look at just the field definition:
+  /// A Location identifies a piece of source code in a .proto file which
+  /// corresponds to a particular definition.  This information is intended
+  /// to be useful to IDEs, code indexers, documentation generators, and similar
+  /// tools.
+  ///
+  /// For example, say we have a file like:
+  ///   message Foo {
   ///     optional string foo = 1;
-  ///     ^       ^^     ^^  ^  ^^^
-  ///     a       bc     de  f  ghi
-  ///   We have the following locations:
-  ///     span   path               represents
-  ///     [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
-  ///     [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
-  ///     [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
-  ///     [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
-  ///     [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
-  ///  
-  ///   Notes:
-  ///   - A location may refer to a repeated field itself (i.e. not to any
-  ///     particular index within it).  This is used whenever a set of elements are
-  ///     logically enclosed in a single code segment.  For example, an entire
-  ///     extend block (possibly containing multiple extension definitions) will
-  ///     have an outer location whose path refers to the "extensions" repeated
-  ///     field without an index.
-  ///   - Multiple locations may have the same path.  This happens when a single
-  ///     logical declaration is spread out across multiple places.  The most
-  ///     obvious example is the "extend" block again -- there may be multiple
-  ///     extend blocks in the same scope, each of which will have the same path.
-  ///   - A location's span is not always a subset of its parent's span.  For
-  ///     example, the "extendee" of an extension declaration appears at the
-  ///     beginning of the "extend" block and is shared by all extensions within
-  ///     the block.
-  ///   - Just because a location's span is a subset of some other location's span
-  ///     does not mean that it is a descendent.  For example, a "group" defines
-  ///     both a type and a field in a single declaration.  Thus, the locations
-  ///     corresponding to the type and field and their components will overlap.
-  ///   - Code which tries to interpret locations should probably be designed to
-  ///     ignore those that it doesn't understand, as more types of locations could
-  ///     be recorded in the future.
+  ///   }
+  /// Let's look at just the field definition:
+  ///   optional string foo = 1;
+  ///   ^       ^^     ^^  ^  ^^^
+  ///   a       bc     de  f  ghi
+  /// We have the following locations:
+  ///   span   path               represents
+  ///   [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+  ///   [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+  ///   [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+  ///   [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+  ///   [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+  ///
+  /// Notes:
+  /// - A location may refer to a repeated field itself (i.e. not to any
+  ///   particular index within it).  This is used whenever a set of elements are
+  ///   logically enclosed in a single code segment.  For example, an entire
+  ///   extend block (possibly containing multiple extension definitions) will
+  ///   have an outer location whose path refers to the "extensions" repeated
+  ///   field without an index.
+  /// - Multiple locations may have the same path.  This happens when a single
+  ///   logical declaration is spread out across multiple places.  The most
+  ///   obvious example is the "extend" block again -- there may be multiple
+  ///   extend blocks in the same scope, each of which will have the same path.
+  /// - A location's span is not always a subset of its parent's span.  For
+  ///   example, the "extendee" of an extension declaration appears at the
+  ///   beginning of the "extend" block and is shared by all extensions within
+  ///   the block.
+  /// - Just because a location's span is a subset of some other location's span
+  ///   does not mean that it is a descendent.  For example, a "group" defines
+  ///   both a type and a field in a single declaration.  Thus, the locations
+  ///   corresponding to the type and field and their components will overlap.
+  /// - Code which tries to interpret locations should probably be designed to
+  ///   ignore those that it doesn't understand, as more types of locations could
+  ///   be recorded in the future.
   public var location: [Google_Protobuf_SourceCodeInfo.Location] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2979,85 +2979,85 @@ public struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
   public struct Location: SwiftProtobuf.Message {
     public static let protoMessageName: String = Google_Protobuf_SourceCodeInfo.protoMessageName + ".Location"
 
-    ///   Identifies which part of the FileDescriptorProto was defined at this
-    ///   location.
-    ///  
-    ///   Each element is a field number or an index.  They form a path from
-    ///   the root FileDescriptorProto to the place where the definition.  For
-    ///   example, this path:
-    ///     [ 4, 3, 2, 7, 1 ]
-    ///   refers to:
-    ///     file.message_type(3)  // 4, 3
-    ///         .field(7)         // 2, 7
-    ///         .name()           // 1
-    ///   This is because FileDescriptorProto.message_type has field number 4:
-    ///     repeated DescriptorProto message_type = 4;
-    ///   and DescriptorProto.field has field number 2:
-    ///     repeated FieldDescriptorProto field = 2;
-    ///   and FieldDescriptorProto.name has field number 1:
-    ///     optional string name = 1;
-    ///  
-    ///   Thus, the above path gives the location of a field name.  If we removed
-    ///   the last element:
-    ///     [ 4, 3, 2, 7 ]
-    ///   this path refers to the whole field declaration (from the beginning
-    ///   of the label to the terminating semicolon).
+    /// Identifies which part of the FileDescriptorProto was defined at this
+    /// location.
+    ///
+    /// Each element is a field number or an index.  They form a path from
+    /// the root FileDescriptorProto to the place where the definition.  For
+    /// example, this path:
+    ///   [ 4, 3, 2, 7, 1 ]
+    /// refers to:
+    ///   file.message_type(3)  // 4, 3
+    ///       .field(7)         // 2, 7
+    ///       .name()           // 1
+    /// This is because FileDescriptorProto.message_type has field number 4:
+    ///   repeated DescriptorProto message_type = 4;
+    /// and DescriptorProto.field has field number 2:
+    ///   repeated FieldDescriptorProto field = 2;
+    /// and FieldDescriptorProto.name has field number 1:
+    ///   optional string name = 1;
+    ///
+    /// Thus, the above path gives the location of a field name.  If we removed
+    /// the last element:
+    ///   [ 4, 3, 2, 7 ]
+    /// this path refers to the whole field declaration (from the beginning
+    /// of the label to the terminating semicolon).
     public var path: [Int32] = []
 
-    ///   Always has exactly three or four elements: start line, start column,
-    ///   end line (optional, otherwise assumed same as start line), end column.
-    ///   These are packed into a single field for efficiency.  Note that line
-    ///   and column numbers are zero-based -- typically you will want to add
-    ///   1 to each before displaying to a user.
+    /// Always has exactly three or four elements: start line, start column,
+    /// end line (optional, otherwise assumed same as start line), end column.
+    /// These are packed into a single field for efficiency.  Note that line
+    /// and column numbers are zero-based -- typically you will want to add
+    /// 1 to each before displaying to a user.
     public var span: [Int32] = []
 
-    ///   If this SourceCodeInfo represents a complete declaration, these are any
-    ///   comments appearing before and after the declaration which appear to be
-    ///   attached to the declaration.
-    ///  
-    ///   A series of line comments appearing on consecutive lines, with no other
-    ///   tokens appearing on those lines, will be treated as a single comment.
-    ///  
-    ///   leading_detached_comments will keep paragraphs of comments that appear
-    ///   before (but not connected to) the current element. Each paragraph,
-    ///   separated by empty lines, will be one comment element in the repeated
-    ///   field.
-    ///  
-    ///   Only the comment content is provided; comment markers (e.g. //) are
-    ///   stripped out.  For block comments, leading whitespace and an asterisk
-    ///   will be stripped from the beginning of each line other than the first.
-    ///   Newlines are included in the output.
-    ///  
-    ///   Examples:
-    ///  
-    ///     optional int32 foo = 1;  // Comment attached to foo.
-    ///     // Comment attached to bar.
-    ///     optional int32 bar = 2;
-    ///  
-    ///     optional string baz = 3;
-    ///     // Comment attached to baz.
-    ///     // Another line attached to baz.
-    ///  
-    ///     // Comment attached to qux.
-    ///     //
-    ///     // Another line attached to qux.
-    ///     optional double qux = 4;
-    ///  
-    ///     // Detached comment for corge. This is not leading or trailing comments
-    ///     // to qux or corge because there are blank lines separating it from
-    ///     // both.
-    ///  
-    ///     // Detached comment for corge paragraph 2.
-    ///  
-    ///     optional string corge = 5;
-    ///     /* Block comment attached
-    ///      * to corge.  Leading asterisks
-    ///      * will be removed. */
-    ///     /* Block comment attached to
-    ///      * grault. */
-    ///     optional int32 grault = 6;
-    ///  
-    ///     // ignored detached comments.
+    /// If this SourceCodeInfo represents a complete declaration, these are any
+    /// comments appearing before and after the declaration which appear to be
+    /// attached to the declaration.
+    ///
+    /// A series of line comments appearing on consecutive lines, with no other
+    /// tokens appearing on those lines, will be treated as a single comment.
+    ///
+    /// leading_detached_comments will keep paragraphs of comments that appear
+    /// before (but not connected to) the current element. Each paragraph,
+    /// separated by empty lines, will be one comment element in the repeated
+    /// field.
+    ///
+    /// Only the comment content is provided; comment markers (e.g. //) are
+    /// stripped out.  For block comments, leading whitespace and an asterisk
+    /// will be stripped from the beginning of each line other than the first.
+    /// Newlines are included in the output.
+    ///
+    /// Examples:
+    ///
+    ///   optional int32 foo = 1;  // Comment attached to foo.
+    ///   // Comment attached to bar.
+    ///   optional int32 bar = 2;
+    ///
+    ///   optional string baz = 3;
+    ///   // Comment attached to baz.
+    ///   // Another line attached to baz.
+    ///
+    ///   // Comment attached to qux.
+    ///   //
+    ///   // Another line attached to qux.
+    ///   optional double qux = 4;
+    ///
+    ///   // Detached comment for corge. This is not leading or trailing comments
+    ///   // to qux or corge because there are blank lines separating it from
+    ///   // both.
+    ///
+    ///   // Detached comment for corge paragraph 2.
+    ///
+    ///   optional string corge = 5;
+    ///   /* Block comment attached
+    ///    * to corge.  Leading asterisks
+    ///    * will be removed. */
+    ///   /* Block comment attached to
+    ///    * grault. */
+    ///   optional int32 grault = 6;
+    ///
+    ///   // ignored detached comments.
     fileprivate var _leadingComments: String? = nil
     public var leadingComments: String {
       get {return _leadingComments ?? ""}
@@ -3140,14 +3140,14 @@ public struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
   }
 }
 
-///   Describes the relationship between generated code and its original source
-///   file. A GeneratedCodeInfo message is associated with only one generated
-///   source file, but may contain references to different source .proto files.
+/// Describes the relationship between generated code and its original source
+/// file. A GeneratedCodeInfo message is associated with only one generated
+/// source file, but may contain references to different source .proto files.
 public struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".GeneratedCodeInfo"
 
-  ///   An Annotation connects some span of text in generated code to an element
-  ///   of its generating .proto file.
+  /// An Annotation connects some span of text in generated code to an element
+  /// of its generating .proto file.
   public var annotation: [Google_Protobuf_GeneratedCodeInfo.Annotation] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -3155,11 +3155,11 @@ public struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
   public struct Annotation: SwiftProtobuf.Message {
     public static let protoMessageName: String = Google_Protobuf_GeneratedCodeInfo.protoMessageName + ".Annotation"
 
-    ///   Identifies the element in the original source .proto file. This field
-    ///   is formatted the same as SourceCodeInfo.Location.path.
+    /// Identifies the element in the original source .proto file. This field
+    /// is formatted the same as SourceCodeInfo.Location.path.
     public var path: [Int32] = []
 
-    ///   Identifies the filesystem path to the original source .proto.
+    /// Identifies the filesystem path to the original source .proto.
     fileprivate var _sourceFile: String? = nil
     public var sourceFile: String {
       get {return _sourceFile ?? ""}
@@ -3172,8 +3172,8 @@ public struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
       return _sourceFile = nil
     }
 
-    ///   Identifies the starting offset in bytes in the generated code
-    ///   that relates to the identified object.
+    /// Identifies the starting offset in bytes in the generated code
+    /// that relates to the identified object.
     fileprivate var _begin: Int32? = nil
     public var begin: Int32 {
       get {return _begin ?? 0}
@@ -3186,9 +3186,9 @@ public struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
       return _begin = nil
     }
 
-    ///   Identifies the ending offset in bytes in the generated code that
-    ///   relates to the identified offset. The end offset should be one past
-    ///   the last relevant byte (so the length of the text = end - begin).
+    /// Identifies the ending offset in bytes in the generated code that
+    /// relates to the identified offset. The end offset should be one past
+    /// the last relevant byte (so the length of the text = end - begin).
     fileprivate var _end: Int32? = nil
     public var end: Int32 {
       get {return _end ?? 0}

--- a/Sources/PluginLibrary/plugin.pb.swift
+++ b/Sources/PluginLibrary/plugin.pb.swift
@@ -6,51 +6,51 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-// 
-//  WARNING:  The plugin interface is currently EXPERIMENTAL and is subject to
-//    change.
-// 
-//  protoc (aka the Protocol Compiler) can be extended via plugins.  A plugin is
-//  just a program that reads a CodeGeneratorRequest from stdin and writes a
-//  CodeGeneratorResponse to stdout.
-// 
-//  Plugins written using C++ can use google/protobuf/compiler/plugin.h instead
-//  of dealing with the raw protocol defined here.
-// 
-//  A plugin executable needs only to be placed somewhere in the path.  The
-//  plugin should be named "protoc-gen-$NAME", and will then be used when the
-//  flag "--${NAME}_out" is passed to protoc.
+// Author: kenton@google.com (Kenton Varda)
+//
+// WARNING:  The plugin interface is currently EXPERIMENTAL and is subject to
+//   change.
+//
+// protoc (aka the Protocol Compiler) can be extended via plugins.  A plugin is
+// just a program that reads a CodeGeneratorRequest from stdin and writes a
+// CodeGeneratorResponse to stdout.
+//
+// Plugins written using C++ can use google/protobuf/compiler/plugin.h instead
+// of dealing with the raw protocol defined here.
+//
+// A plugin executable needs only to be placed somewhere in the path.  The
+// plugin should be named "protoc-gen-$NAME", and will then be used when the
+// flag "--${NAME}_out" is passed to protoc.
 
 import Foundation
 import SwiftProtobuf
@@ -67,7 +67,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf.compiler"
 
-///   The version number of protocol compiler.
+/// The version number of protocol compiler.
 public struct Google_Protobuf_Compiler_Version: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Version"
 
@@ -107,8 +107,8 @@ public struct Google_Protobuf_Compiler_Version: SwiftProtobuf.Message {
     return _patch = nil
   }
 
-  ///   A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
-  ///   be empty for mainline stable releases.
+  /// A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+  /// be empty for mainline stable releases.
   fileprivate var _suffix: String? = nil
   public var suffix: String {
     get {return _suffix ?? ""}
@@ -154,7 +154,7 @@ public struct Google_Protobuf_Compiler_Version: SwiftProtobuf.Message {
   }
 }
 
-///   An encoded CodeGeneratorRequest is written to the plugin's stdin.
+/// An encoded CodeGeneratorRequest is written to the plugin's stdin.
 public struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".CodeGeneratorRequest"
 
@@ -183,15 +183,15 @@ public struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Messa
     return _storage
   }
 
-  ///   The .proto files that were explicitly listed on the command-line.  The
-  ///   code generator should generate code only for these files.  Each file's
-  ///   descriptor will be included in proto_file, below.
+  /// The .proto files that were explicitly listed on the command-line.  The
+  /// code generator should generate code only for these files.  Each file's
+  /// descriptor will be included in proto_file, below.
   public var fileToGenerate: [String] {
     get {return _storage._fileToGenerate}
     set {_uniqueStorage()._fileToGenerate = newValue}
   }
 
-  ///   The generator parameter passed on the command-line.
+  /// The generator parameter passed on the command-line.
   public var parameter: String {
     get {return _storage._parameter ?? ""}
     set {_uniqueStorage()._parameter = newValue}
@@ -203,23 +203,23 @@ public struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Messa
     return _storage._parameter = nil
   }
 
-  ///   FileDescriptorProtos for all files in files_to_generate and everything
-  ///   they import.  The files will appear in topological order, so each file
-  ///   appears before any file that imports it.
-  ///  
-  ///   protoc guarantees that all proto_files will be written after
-  ///   the fields above, even though this is not technically guaranteed by the
-  ///   protobuf wire format.  This theoretically could allow a plugin to stream
-  ///   in the FileDescriptorProtos and handle them one by one rather than read
-  ///   the entire set into memory at once.  However, as of this writing, this
-  ///   is not similarly optimized on protoc's end -- it will store all fields in
-  ///   memory at once before sending them to the plugin.
+  /// FileDescriptorProtos for all files in files_to_generate and everything
+  /// they import.  The files will appear in topological order, so each file
+  /// appears before any file that imports it.
+  ///
+  /// protoc guarantees that all proto_files will be written after
+  /// the fields above, even though this is not technically guaranteed by the
+  /// protobuf wire format.  This theoretically could allow a plugin to stream
+  /// in the FileDescriptorProtos and handle them one by one rather than read
+  /// the entire set into memory at once.  However, as of this writing, this
+  /// is not similarly optimized on protoc's end -- it will store all fields in
+  /// memory at once before sending them to the plugin.
   public var protoFile: [Google_Protobuf_FileDescriptorProto] {
     get {return _storage._protoFile}
     set {_uniqueStorage()._protoFile = newValue}
   }
 
-  ///   The version number of protocol compiler.
+  /// The version number of protocol compiler.
   public var compilerVersion: Google_Protobuf_Compiler_Version {
     get {return _storage._compilerVersion ?? Google_Protobuf_Compiler_Version()}
     set {_uniqueStorage()._compilerVersion = newValue}
@@ -276,18 +276,18 @@ public struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Messa
   }
 }
 
-///   The plugin writes an encoded CodeGeneratorResponse to stdout.
+/// The plugin writes an encoded CodeGeneratorResponse to stdout.
 public struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".CodeGeneratorResponse"
 
-  ///   Error message.  If non-empty, code generation failed.  The plugin process
-  ///   should exit with status code zero even if it reports an error in this way.
-  ///  
-  ///   This should be used to indicate errors in .proto files which prevent the
-  ///   code generator from generating correct code.  Errors which indicate a
-  ///   problem in protoc itself -- such as the input CodeGeneratorRequest being
-  ///   unparseable -- should be reported by writing a message to stderr and
-  ///   exiting with a non-zero status code.
+  /// Error message.  If non-empty, code generation failed.  The plugin process
+  /// should exit with status code zero even if it reports an error in this way.
+  ///
+  /// This should be used to indicate errors in .proto files which prevent the
+  /// code generator from generating correct code.  Errors which indicate a
+  /// problem in protoc itself -- such as the input CodeGeneratorRequest being
+  /// unparseable -- should be reported by writing a message to stderr and
+  /// exiting with a non-zero status code.
   fileprivate var _error: String? = nil
   public var error: String {
     get {return _error ?? ""}
@@ -304,21 +304,21 @@ public struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Mess
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   Represents a single generated file.
+  /// Represents a single generated file.
   public struct File: SwiftProtobuf.Message {
     public static let protoMessageName: String = Google_Protobuf_Compiler_CodeGeneratorResponse.protoMessageName + ".File"
 
-    ///   The file name, relative to the output directory.  The name must not
-    ///   contain "." or ".." components and must be relative, not be absolute (so,
-    ///   the file cannot lie outside the output directory).  "/" must be used as
-    ///   the path separator, not "\".
-    ///  
-    ///   If the name is omitted, the content will be appended to the previous
-    ///   file.  This allows the generator to break large files into small chunks,
-    ///   and allows the generated text to be streamed back to protoc so that large
-    ///   files need not reside completely in memory at one time.  Note that as of
-    ///   this writing protoc does not optimize for this -- it will read the entire
-    ///   CodeGeneratorResponse before writing files to disk.
+    /// The file name, relative to the output directory.  The name must not
+    /// contain "." or ".." components and must be relative, not be absolute (so,
+    /// the file cannot lie outside the output directory).  "/" must be used as
+    /// the path separator, not "\".
+    ///
+    /// If the name is omitted, the content will be appended to the previous
+    /// file.  This allows the generator to break large files into small chunks,
+    /// and allows the generated text to be streamed back to protoc so that large
+    /// files need not reside completely in memory at one time.  Note that as of
+    /// this writing protoc does not optimize for this -- it will read the entire
+    /// CodeGeneratorResponse before writing files to disk.
     fileprivate var _name: String? = nil
     public var name: String {
       get {return _name ?? ""}
@@ -331,43 +331,43 @@ public struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Mess
       return _name = nil
     }
 
-    ///   If non-empty, indicates that the named file should already exist, and the
-    ///   content here is to be inserted into that file at a defined insertion
-    ///   point.  This feature allows a code generator to extend the output
-    ///   produced by another code generator.  The original generator may provide
-    ///   insertion points by placing special annotations in the file that look
-    ///   like:
-    ///     @@protoc_insertion_point(NAME)
-    ///   The annotation can have arbitrary text before and after it on the line,
-    ///   which allows it to be placed in a comment.  NAME should be replaced with
-    ///   an identifier naming the point -- this is what other generators will use
-    ///   as the insertion_point.  Code inserted at this point will be placed
-    ///   immediately above the line containing the insertion point (thus multiple
-    ///   insertions to the same point will come out in the order they were added).
-    ///   The double-@ is intended to make it unlikely that the generated code
-    ///   could contain things that look like insertion points by accident.
-    ///  
-    ///   For example, the C++ code generator places the following line in the
-    ///   .pb.h files that it generates:
-    ///     // @@protoc_insertion_point(namespace_scope)
-    ///   This line appears within the scope of the file's package namespace, but
-    ///   outside of any particular class.  Another plugin can then specify the
-    ///   insertion_point "namespace_scope" to generate additional classes or
-    ///   other declarations that should be placed in this scope.
-    ///  
-    ///   Note that if the line containing the insertion point begins with
-    ///   whitespace, the same whitespace will be added to every line of the
-    ///   inserted text.  This is useful for languages like Python, where
-    ///   indentation matters.  In these languages, the insertion point comment
-    ///   should be indented the same amount as any inserted code will need to be
-    ///   in order to work correctly in that context.
-    ///  
-    ///   The code generator that generates the initial file and the one which
-    ///   inserts into it must both run as part of a single invocation of protoc.
-    ///   Code generators are executed in the order in which they appear on the
-    ///   command line.
-    ///  
-    ///   If |insertion_point| is present, |name| must also be present.
+    /// If non-empty, indicates that the named file should already exist, and the
+    /// content here is to be inserted into that file at a defined insertion
+    /// point.  This feature allows a code generator to extend the output
+    /// produced by another code generator.  The original generator may provide
+    /// insertion points by placing special annotations in the file that look
+    /// like:
+    ///   @@protoc_insertion_point(NAME)
+    /// The annotation can have arbitrary text before and after it on the line,
+    /// which allows it to be placed in a comment.  NAME should be replaced with
+    /// an identifier naming the point -- this is what other generators will use
+    /// as the insertion_point.  Code inserted at this point will be placed
+    /// immediately above the line containing the insertion point (thus multiple
+    /// insertions to the same point will come out in the order they were added).
+    /// The double-@ is intended to make it unlikely that the generated code
+    /// could contain things that look like insertion points by accident.
+    ///
+    /// For example, the C++ code generator places the following line in the
+    /// .pb.h files that it generates:
+    ///   // @@protoc_insertion_point(namespace_scope)
+    /// This line appears within the scope of the file's package namespace, but
+    /// outside of any particular class.  Another plugin can then specify the
+    /// insertion_point "namespace_scope" to generate additional classes or
+    /// other declarations that should be placed in this scope.
+    ///
+    /// Note that if the line containing the insertion point begins with
+    /// whitespace, the same whitespace will be added to every line of the
+    /// inserted text.  This is useful for languages like Python, where
+    /// indentation matters.  In these languages, the insertion point comment
+    /// should be indented the same amount as any inserted code will need to be
+    /// in order to work correctly in that context.
+    ///
+    /// The code generator that generates the initial file and the one which
+    /// inserts into it must both run as part of a single invocation of protoc.
+    /// Code generators are executed in the order in which they appear on the
+    /// command line.
+    ///
+    /// If |insertion_point| is present, |name| must also be present.
     fileprivate var _insertionPoint: String? = nil
     public var insertionPoint: String {
       get {return _insertionPoint ?? ""}
@@ -380,7 +380,7 @@ public struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Mess
       return _insertionPoint = nil
     }
 
-    ///   The file contents.
+    /// The file contents.
     fileprivate var _content: String? = nil
     public var content: String {
       get {return _content ?? ""}

--- a/Sources/SwiftProtobuf/any.pb.swift
+++ b/Sources/SwiftProtobuf/any.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,75 +50,75 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   `Any` contains an arbitrary serialized protocol buffer message along with a
-///   URL that describes the type of the serialized message.
-///  
-///   Protobuf library provides support to pack/unpack Any values in the form
-///   of utility functions or additional generated methods of the Any type.
-///  
-///   Example 1: Pack and unpack a message in C++.
-///  
-///       Foo foo = ...;
-///       Any any;
-///       any.PackFrom(foo);
+/// `Any` contains an arbitrary serialized protocol buffer message along with a
+/// URL that describes the type of the serialized message.
+///
+/// Protobuf library provides support to pack/unpack Any values in the form
+/// of utility functions or additional generated methods of the Any type.
+///
+/// Example 1: Pack and unpack a message in C++.
+///
+///     Foo foo = ...;
+///     Any any;
+///     any.PackFrom(foo);
+///     ...
+///     if (any.UnpackTo(&foo)) {
 ///       ...
-///       if (any.UnpackTo(&foo)) {
-///         ...
-///       }
-///  
-///   Example 2: Pack and unpack a message in Java.
-///  
-///       Foo foo = ...;
-///       Any any = Any.pack(foo);
+///     }
+///
+/// Example 2: Pack and unpack a message in Java.
+///
+///     Foo foo = ...;
+///     Any any = Any.pack(foo);
+///     ...
+///     if (any.is(Foo.class)) {
+///       foo = any.unpack(Foo.class);
+///     }
+///
+///  Example 3: Pack and unpack a message in Python.
+///
+///     foo = Foo(...)
+///     any = Any()
+///     any.Pack(foo)
+///     ...
+///     if any.Is(Foo.DESCRIPTOR):
+///       any.Unpack(foo)
 ///       ...
-///       if (any.is(Foo.class)) {
-///         foo = any.unpack(Foo.class);
-///       }
-///  
-///    Example 3: Pack and unpack a message in Python.
-///  
-///       foo = Foo(...)
-///       any = Any()
-///       any.Pack(foo)
-///       ...
-///       if any.Is(Foo.DESCRIPTOR):
-///         any.Unpack(foo)
-///         ...
-///  
-///   The pack methods provided by protobuf library will by default use
-///   'type.googleapis.com/full.type.name' as the type URL and the unpack
-///   methods only use the fully qualified type name after the last '/'
-///   in the type URL, for example "foo.bar.com/x/y.z" will yield type
-///   name "y.z".
-///  
-///  
-///   JSON
-///   ====
-///   The JSON representation of an `Any` value uses the regular
-///   representation of the deserialized, embedded message, with an
-///   additional field `@type` which contains the type URL. Example:
-///  
-///       package google.profile;
-///       message Person {
-///         string first_name = 1;
-///         string last_name = 2;
-///       }
-///  
-///       {
-///         "@type": "type.googleapis.com/google.profile.Person",
-///         "firstName": <string>,
-///         "lastName": <string>
-///       }
-///  
-///   If the embedded message type is well-known and has a custom JSON
-///   representation, that representation will be embedded adding a field
-///   `value` which holds the custom JSON in addition to the `@type`
-///   field. Example (for message [google.protobuf.Duration][]):
-///  
-///       {
-///         "@type": "type.googleapis.com/google.protobuf.Duration",
-///         "value": "1.212s"
-///       }
+///
+/// The pack methods provided by protobuf library will by default use
+/// 'type.googleapis.com/full.type.name' as the type URL and the unpack
+/// methods only use the fully qualified type name after the last '/'
+/// in the type URL, for example "foo.bar.com/x/y.z" will yield type
+/// name "y.z".
+///
+///
+/// JSON
+/// ====
+/// The JSON representation of an `Any` value uses the regular
+/// representation of the deserialized, embedded message, with an
+/// additional field `@type` which contains the type URL. Example:
+///
+///     package google.profile;
+///     message Person {
+///       string first_name = 1;
+///       string last_name = 2;
+///     }
+///
+///     {
+///       "@type": "type.googleapis.com/google.profile.Person",
+///       "firstName": <string>,
+///       "lastName": <string>
+///     }
+///
+/// If the embedded message type is well-known and has a custom JSON
+/// representation, that representation will be embedded adding a field
+/// `value` which holds the custom JSON in addition to the `@type`
+/// field. Example (for message [google.protobuf.Duration][]):
+///
+///     {
+///       "@type": "type.googleapis.com/google.protobuf.Duration",
+///       "value": "1.212s"
+///     }
 public struct Google_Protobuf_Any: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Any"
 
@@ -133,33 +133,33 @@ public struct Google_Protobuf_Any: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   A URL/resource name whose content describes the type of the
-  ///   serialized protocol buffer message.
-  ///  
-  ///   For URLs which use the scheme `http`, `https`, or no scheme, the
-  ///   following restrictions and interpretations apply:
-  ///  
-  ///   * If no scheme is provided, `https` is assumed.
-  ///   * The last segment of the URL's path must represent the fully
-  ///     qualified name of the type (as in `path/google.protobuf.Duration`).
-  ///     The name should be in a canonical form (e.g., leading "." is
-  ///     not accepted).
-  ///   * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-  ///     value in binary format, or produce an error.
-  ///   * Applications are allowed to cache lookup results based on the
-  ///     URL, or have them precompiled into a binary to avoid any
-  ///     lookup. Therefore, binary compatibility needs to be preserved
-  ///     on changes to types. (Use versioned type names to manage
-  ///     breaking changes.)
-  ///  
-  ///   Schemes other than `http`, `https` (or the empty scheme) might be
-  ///   used with implementation specific semantics.
+  /// A URL/resource name whose content describes the type of the
+  /// serialized protocol buffer message.
+  ///
+  /// For URLs which use the scheme `http`, `https`, or no scheme, the
+  /// following restrictions and interpretations apply:
+  ///
+  /// * If no scheme is provided, `https` is assumed.
+  /// * The last segment of the URL's path must represent the fully
+  ///   qualified name of the type (as in `path/google.protobuf.Duration`).
+  ///   The name should be in a canonical form (e.g., leading "." is
+  ///   not accepted).
+  /// * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+  ///   value in binary format, or produce an error.
+  /// * Applications are allowed to cache lookup results based on the
+  ///   URL, or have them precompiled into a binary to avoid any
+  ///   lookup. Therefore, binary compatibility needs to be preserved
+  ///   on changes to types. (Use versioned type names to manage
+  ///   breaking changes.)
+  ///
+  /// Schemes other than `http`, `https` (or the empty scheme) might be
+  /// used with implementation specific semantics.
   public var typeURL: String {
     get {return _storage._typeURL}
     set {_uniqueStorage()._typeURL = newValue}
   }
 
-  ///   Must be a valid serialized protocol buffer of the above specified type.
+  /// Must be a valid serialized protocol buffer of the above specified type.
   public var value: Data {
     get {return _storage._value}
     set {_uniqueStorage()._value = newValue}

--- a/Sources/SwiftProtobuf/api.pb.swift
+++ b/Sources/SwiftProtobuf/api.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,7 +50,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   Api is a light-weight descriptor for a protocol buffer service.
+/// Api is a light-weight descriptor for a protocol buffer service.
 public struct Google_Protobuf_Api: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Api"
 
@@ -85,52 +85,52 @@ public struct Google_Protobuf_Api: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   The fully qualified name of this api, including package name
-  ///   followed by the api's simple name.
+  /// The fully qualified name of this api, including package name
+  /// followed by the api's simple name.
   public var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
-  ///   The methods of this api, in unspecified order.
+  /// The methods of this api, in unspecified order.
   public var methods: [Google_Protobuf_Method] {
     get {return _storage._methods}
     set {_uniqueStorage()._methods = newValue}
   }
 
-  ///   Any metadata attached to the API.
+  /// Any metadata attached to the API.
   public var options: [Google_Protobuf_Option] {
     get {return _storage._options}
     set {_uniqueStorage()._options = newValue}
   }
 
-  ///   A version string for this api. If specified, must have the form
-  ///   `major-version.minor-version`, as in `1.10`. If the minor version
-  ///   is omitted, it defaults to zero. If the entire version field is
-  ///   empty, the major version is derived from the package name, as
-  ///   outlined below. If the field is not empty, the version in the
-  ///   package name will be verified to be consistent with what is
-  ///   provided here.
-  ///  
-  ///   The versioning schema uses [semantic
-  ///   versioning](http://semver.org) where the major version number
-  ///   indicates a breaking change and the minor version an additive,
-  ///   non-breaking change. Both version numbers are signals to users
-  ///   what to expect from different versions, and should be carefully
-  ///   chosen based on the product plan.
-  ///  
-  ///   The major version is also reflected in the package name of the
-  ///   API, which must end in `v<major-version>`, as in
-  ///   `google.feature.v1`. For major versions 0 and 1, the suffix can
-  ///   be omitted. Zero major versions must only be used for
-  ///   experimental, none-GA apis.
+  /// A version string for this api. If specified, must have the form
+  /// `major-version.minor-version`, as in `1.10`. If the minor version
+  /// is omitted, it defaults to zero. If the entire version field is
+  /// empty, the major version is derived from the package name, as
+  /// outlined below. If the field is not empty, the version in the
+  /// package name will be verified to be consistent with what is
+  /// provided here.
+  ///
+  /// The versioning schema uses [semantic
+  /// versioning](http://semver.org) where the major version number
+  /// indicates a breaking change and the minor version an additive,
+  /// non-breaking change. Both version numbers are signals to users
+  /// what to expect from different versions, and should be carefully
+  /// chosen based on the product plan.
+  ///
+  /// The major version is also reflected in the package name of the
+  /// API, which must end in `v<major-version>`, as in
+  /// `google.feature.v1`. For major versions 0 and 1, the suffix can
+  /// be omitted. Zero major versions must only be used for
+  /// experimental, none-GA apis.
   public var version: String {
     get {return _storage._version}
     set {_uniqueStorage()._version = newValue}
   }
 
-  ///   Source context for the protocol buffer service represented by this
-  ///   message.
+  /// Source context for the protocol buffer service represented by this
+  /// message.
   public var sourceContext: Google_Protobuf_SourceContext {
     get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContext = newValue}
@@ -142,13 +142,13 @@ public struct Google_Protobuf_Api: SwiftProtobuf.Message {
     return _storage._sourceContext = nil
   }
 
-  ///   Included APIs. See [Mixin][].
+  /// Included APIs. See [Mixin][].
   public var mixins: [Google_Protobuf_Mixin] {
     get {return _storage._mixins}
     set {_uniqueStorage()._mixins = newValue}
   }
 
-  ///   The source syntax of the service.
+  /// The source syntax of the service.
   public var syntax: Google_Protobuf_Syntax {
     get {return _storage._syntax}
     set {_uniqueStorage()._syntax = newValue}
@@ -204,29 +204,29 @@ public struct Google_Protobuf_Api: SwiftProtobuf.Message {
   }
 }
 
-///   Method represents a method of an api.
+/// Method represents a method of an api.
 public struct Google_Protobuf_Method: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Method"
 
-  ///   The simple name of this method.
+  /// The simple name of this method.
   public var name: String = ""
 
-  ///   A URL of the input message type.
+  /// A URL of the input message type.
   public var requestTypeURL: String = ""
 
-  ///   If true, the request is streamed.
+  /// If true, the request is streamed.
   public var requestStreaming: Bool = false
 
-  ///   The URL of the output message type.
+  /// The URL of the output message type.
   public var responseTypeURL: String = ""
 
-  ///   If true, the response is streamed.
+  /// If true, the response is streamed.
   public var responseStreaming: Bool = false
 
-  ///   Any metadata attached to the method.
+  /// Any metadata attached to the method.
   public var options: [Google_Protobuf_Option] = []
 
-  ///   The source syntax of this method.
+  /// The source syntax of this method.
   public var syntax: Google_Protobuf_Syntax = Google_Protobuf_Syntax.proto2
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -274,91 +274,91 @@ public struct Google_Protobuf_Method: SwiftProtobuf.Message {
   }
 }
 
-///   Declares an API to be included in this API. The including API must
-///   redeclare all the methods from the included API, but documentation
-///   and options are inherited as follows:
-///  
-///   - If after comment and whitespace stripping, the documentation
-///     string of the redeclared method is empty, it will be inherited
-///     from the original method.
-///  
-///   - Each annotation belonging to the service config (http,
-///     visibility) which is not set in the redeclared method will be
-///     inherited.
-///  
-///   - If an http annotation is inherited, the path pattern will be
-///     modified as follows. Any version prefix will be replaced by the
-///     version of the including API plus the [root][] path if specified.
-///  
-///   Example of a simple mixin:
-///  
-///       package google.acl.v1;
-///       service AccessControl {
-///         // Get the underlying ACL object.
-///         rpc GetAcl(GetAclRequest) returns (Acl) {
-///           option (google.api.http).get = "/v1/{resource=**}:getAcl";
-///         }
+/// Declares an API to be included in this API. The including API must
+/// redeclare all the methods from the included API, but documentation
+/// and options are inherited as follows:
+///
+/// - If after comment and whitespace stripping, the documentation
+///   string of the redeclared method is empty, it will be inherited
+///   from the original method.
+///
+/// - Each annotation belonging to the service config (http,
+///   visibility) which is not set in the redeclared method will be
+///   inherited.
+///
+/// - If an http annotation is inherited, the path pattern will be
+///   modified as follows. Any version prefix will be replaced by the
+///   version of the including API plus the [root][] path if specified.
+///
+/// Example of a simple mixin:
+///
+///     package google.acl.v1;
+///     service AccessControl {
+///       // Get the underlying ACL object.
+///       rpc GetAcl(GetAclRequest) returns (Acl) {
+///         option (google.api.http).get = "/v1/{resource=**}:getAcl";
 ///       }
-///  
-///       package google.storage.v2;
-///       service Storage {
-///         rpc GetAcl(GetAclRequest) returns (Acl);
-///  
-///         // Get a data record.
-///         rpc GetData(GetDataRequest) returns (Data) {
-///           option (google.api.http).get = "/v2/{resource=**}";
-///         }
+///     }
+///
+///     package google.storage.v2;
+///     service Storage {
+///       rpc GetAcl(GetAclRequest) returns (Acl);
+///
+///       // Get a data record.
+///       rpc GetData(GetDataRequest) returns (Data) {
+///         option (google.api.http).get = "/v2/{resource=**}";
 ///       }
-///  
-///   Example of a mixin configuration:
-///  
-///       apis:
-///       - name: google.storage.v2.Storage
-///         mixins:
-///         - name: google.acl.v1.AccessControl
-///  
-///   The mixin construct implies that all methods in `AccessControl` are
-///   also declared with same name and request/response types in
-///   `Storage`. A documentation generator or annotation processor will
-///   see the effective `Storage.GetAcl` method after inherting
-///   documentation and annotations as follows:
-///  
-///       service Storage {
-///         // Get the underlying ACL object.
-///         rpc GetAcl(GetAclRequest) returns (Acl) {
-///           option (google.api.http).get = "/v2/{resource=**}:getAcl";
-///         }
-///         ...
+///     }
+///
+/// Example of a mixin configuration:
+///
+///     apis:
+///     - name: google.storage.v2.Storage
+///       mixins:
+///       - name: google.acl.v1.AccessControl
+///
+/// The mixin construct implies that all methods in `AccessControl` are
+/// also declared with same name and request/response types in
+/// `Storage`. A documentation generator or annotation processor will
+/// see the effective `Storage.GetAcl` method after inherting
+/// documentation and annotations as follows:
+///
+///     service Storage {
+///       // Get the underlying ACL object.
+///       rpc GetAcl(GetAclRequest) returns (Acl) {
+///         option (google.api.http).get = "/v2/{resource=**}:getAcl";
 ///       }
-///  
-///   Note how the version in the path pattern changed from `v1` to `v2`.
-///  
-///   If the `root` field in the mixin is specified, it should be a
-///   relative path under which inherited HTTP paths are placed. Example:
-///  
-///       apis:
-///       - name: google.storage.v2.Storage
-///         mixins:
-///         - name: google.acl.v1.AccessControl
-///           root: acls
-///  
-///   This implies the following inherited HTTP annotation:
-///  
-///       service Storage {
-///         // Get the underlying ACL object.
-///         rpc GetAcl(GetAclRequest) returns (Acl) {
-///           option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";
-///         }
-///         ...
+///       ...
+///     }
+///
+/// Note how the version in the path pattern changed from `v1` to `v2`.
+///
+/// If the `root` field in the mixin is specified, it should be a
+/// relative path under which inherited HTTP paths are placed. Example:
+///
+///     apis:
+///     - name: google.storage.v2.Storage
+///       mixins:
+///       - name: google.acl.v1.AccessControl
+///         root: acls
+///
+/// This implies the following inherited HTTP annotation:
+///
+///     service Storage {
+///       // Get the underlying ACL object.
+///       rpc GetAcl(GetAclRequest) returns (Acl) {
+///         option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";
 ///       }
+///       ...
+///     }
 public struct Google_Protobuf_Mixin: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Mixin"
 
-  ///   The fully qualified name of the API which is included.
+  /// The fully qualified name of the API which is included.
   public var name: String = ""
 
-  ///   If non-empty specifies a path under which inherited HTTP paths
-  ///   are rooted.
+  /// If non-empty specifies a path under which inherited HTTP paths
+  /// are rooted.
   public var root: String = ""
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Sources/SwiftProtobuf/duration.pb.swift
+++ b/Sources/SwiftProtobuf/duration.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,65 +50,65 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   A Duration represents a signed, fixed-length span of time represented
-///   as a count of seconds and fractions of seconds at nanosecond
-///   resolution. It is independent of any calendar and concepts like "day"
-///   or "month". It is related to Timestamp in that the difference between
-///   two Timestamp values is a Duration and it can be added or subtracted
-///   from a Timestamp. Range is approximately +-10,000 years.
-///  
-///   Example 1: Compute Duration from two Timestamps in pseudo code.
-///  
-///       Timestamp start = ...;
-///       Timestamp end = ...;
-///       Duration duration = ...;
-///  
-///       duration.seconds = end.seconds - start.seconds;
-///       duration.nanos = end.nanos - start.nanos;
-///  
-///       if (duration.seconds < 0 && duration.nanos > 0) {
-///         duration.seconds += 1;
-///         duration.nanos -= 1000000000;
-///       } else if (durations.seconds > 0 && duration.nanos < 0) {
-///         duration.seconds -= 1;
-///         duration.nanos += 1000000000;
-///       }
-///  
-///   Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
-///  
-///       Timestamp start = ...;
-///       Duration duration = ...;
-///       Timestamp end = ...;
-///  
-///       end.seconds = start.seconds + duration.seconds;
-///       end.nanos = start.nanos + duration.nanos;
-///  
-///       if (end.nanos < 0) {
-///         end.seconds -= 1;
-///         end.nanos += 1000000000;
-///       } else if (end.nanos >= 1000000000) {
-///         end.seconds += 1;
-///         end.nanos -= 1000000000;
-///       }
-///  
-///   Example 3: Compute Duration from datetime.timedelta in Python.
-///  
-///       td = datetime.timedelta(days=3, minutes=10)
-///       duration = Duration()
-///       duration.FromTimedelta(td)
+/// A Duration represents a signed, fixed-length span of time represented
+/// as a count of seconds and fractions of seconds at nanosecond
+/// resolution. It is independent of any calendar and concepts like "day"
+/// or "month". It is related to Timestamp in that the difference between
+/// two Timestamp values is a Duration and it can be added or subtracted
+/// from a Timestamp. Range is approximately +-10,000 years.
+///
+/// Example 1: Compute Duration from two Timestamps in pseudo code.
+///
+///     Timestamp start = ...;
+///     Timestamp end = ...;
+///     Duration duration = ...;
+///
+///     duration.seconds = end.seconds - start.seconds;
+///     duration.nanos = end.nanos - start.nanos;
+///
+///     if (duration.seconds < 0 && duration.nanos > 0) {
+///       duration.seconds += 1;
+///       duration.nanos -= 1000000000;
+///     } else if (durations.seconds > 0 && duration.nanos < 0) {
+///       duration.seconds -= 1;
+///       duration.nanos += 1000000000;
+///     }
+///
+/// Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+///
+///     Timestamp start = ...;
+///     Duration duration = ...;
+///     Timestamp end = ...;
+///
+///     end.seconds = start.seconds + duration.seconds;
+///     end.nanos = start.nanos + duration.nanos;
+///
+///     if (end.nanos < 0) {
+///       end.seconds -= 1;
+///       end.nanos += 1000000000;
+///     } else if (end.nanos >= 1000000000) {
+///       end.seconds += 1;
+///       end.nanos -= 1000000000;
+///     }
+///
+/// Example 3: Compute Duration from datetime.timedelta in Python.
+///
+///     td = datetime.timedelta(days=3, minutes=10)
+///     duration = Duration()
+///     duration.FromTimedelta(td)
 public struct Google_Protobuf_Duration: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Duration"
 
-  ///   Signed seconds of the span of time. Must be from -315,576,000,000
-  ///   to +315,576,000,000 inclusive.
+  /// Signed seconds of the span of time. Must be from -315,576,000,000
+  /// to +315,576,000,000 inclusive.
   public var seconds: Int64 = 0
 
-  ///   Signed fractions of a second at nanosecond resolution of the span
-  ///   of time. Durations less than one second are represented with a 0
-  ///   `seconds` field and a positive or negative `nanos` field. For durations
-  ///   of one second or more, a non-zero value for the `nanos` field must be
-  ///   of the same sign as the `seconds` field. Must be from -999,999,999
-  ///   to +999,999,999 inclusive.
+  /// Signed fractions of a second at nanosecond resolution of the span
+  /// of time. Durations less than one second are represented with a 0
+  /// `seconds` field and a positive or negative `nanos` field. For durations
+  /// of one second or more, a non-zero value for the `nanos` field must be
+  /// of the same sign as the `seconds` field. Must be from -999,999,999
+  /// to +999,999,999 inclusive.
   public var nanos: Int32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Sources/SwiftProtobuf/empty.pb.swift
+++ b/Sources/SwiftProtobuf/empty.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,15 +50,15 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   A generic empty message that you can re-use to avoid defining duplicated
-///   empty messages in your APIs. A typical example is to use it as the request
-///   or the response type of an API method. For instance:
-///  
-///       service Foo {
-///         rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-///       }
-///  
-///   The JSON representation for `Empty` is empty JSON object `{}`.
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+///
+///     service Foo {
+///       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///     }
+///
+/// The JSON representation for `Empty` is empty JSON object `{}`.
 public struct Google_Protobuf_Empty: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Empty"
 

--- a/Sources/SwiftProtobuf/field_mask.pb.swift
+++ b/Sources/SwiftProtobuf/field_mask.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,211 +50,211 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   `FieldMask` represents a set of symbolic field paths, for example:
-///  
-///       paths: "f.a"
-///       paths: "f.b.d"
-///  
-///   Here `f` represents a field in some root message, `a` and `b`
-///   fields in the message found in `f`, and `d` a field found in the
-///   message in `f.b`.
-///  
-///   Field masks are used to specify a subset of fields that should be
-///   returned by a get operation or modified by an update operation.
-///   Field masks also have a custom JSON encoding (see below).
-///  
-///   # Field Masks in Projections
-///  
-///   When used in the context of a projection, a response message or
-///   sub-message is filtered by the API to only contain those fields as
-///   specified in the mask. For example, if the mask in the previous
-///   example is applied to a response message as follows:
-///  
-///       f {
-///         a : 22
-///         b {
-///           d : 1
-///           x : 2
-///         }
-///         y : 13
+/// `FieldMask` represents a set of symbolic field paths, for example:
+///
+///     paths: "f.a"
+///     paths: "f.b.d"
+///
+/// Here `f` represents a field in some root message, `a` and `b`
+/// fields in the message found in `f`, and `d` a field found in the
+/// message in `f.b`.
+///
+/// Field masks are used to specify a subset of fields that should be
+/// returned by a get operation or modified by an update operation.
+/// Field masks also have a custom JSON encoding (see below).
+///
+/// # Field Masks in Projections
+///
+/// When used in the context of a projection, a response message or
+/// sub-message is filtered by the API to only contain those fields as
+/// specified in the mask. For example, if the mask in the previous
+/// example is applied to a response message as follows:
+///
+///     f {
+///       a : 22
+///       b {
+///         d : 1
+///         x : 2
 ///       }
-///       z: 8
-///  
-///   The result will not contain specific values for fields x,y and z
-///   (their value will be set to the default, and omitted in proto text
-///   output):
-///  
-///  
-///       f {
-///         a : 22
-///         b {
-///           d : 1
-///         }
+///       y : 13
+///     }
+///     z: 8
+///
+/// The result will not contain specific values for fields x,y and z
+/// (their value will be set to the default, and omitted in proto text
+/// output):
+///
+///
+///     f {
+///       a : 22
+///       b {
+///         d : 1
 ///       }
-///  
-///   A repeated field is not allowed except at the last position of a
-///   paths string.
-///  
-///   If a FieldMask object is not present in a get operation, the
-///   operation applies to all fields (as if a FieldMask of all fields
-///   had been specified).
-///  
-///   Note that a field mask does not necessarily apply to the
-///   top-level response message. In case of a REST get operation, the
-///   field mask applies directly to the response, but in case of a REST
-///   list operation, the mask instead applies to each individual message
-///   in the returned resource list. In case of a REST custom method,
-///   other definitions may be used. Where the mask applies will be
-///   clearly documented together with its declaration in the API.  In
-///   any case, the effect on the returned resource/resources is required
-///   behavior for APIs.
-///  
-///   # Field Masks in Update Operations
-///  
-///   A field mask in update operations specifies which fields of the
-///   targeted resource are going to be updated. The API is required
-///   to only change the values of the fields as specified in the mask
-///   and leave the others untouched. If a resource is passed in to
-///   describe the updated values, the API ignores the values of all
-///   fields not covered by the mask.
-///  
-///   If a repeated field is specified for an update operation, the existing
-///   repeated values in the target resource will be overwritten by the new values.
-///   Note that a repeated field is only allowed in the last position of a `paths`
-///   string.
-///  
-///   If a sub-message is specified in the last position of the field mask for an
-///   update operation, then the existing sub-message in the target resource is
-///   overwritten. Given the target message:
-///  
-///       f {
-///         b {
-///           d : 1
-///           x : 2
-///         }
-///         c : 1
+///     }
+///
+/// A repeated field is not allowed except at the last position of a
+/// paths string.
+///
+/// If a FieldMask object is not present in a get operation, the
+/// operation applies to all fields (as if a FieldMask of all fields
+/// had been specified).
+///
+/// Note that a field mask does not necessarily apply to the
+/// top-level response message. In case of a REST get operation, the
+/// field mask applies directly to the response, but in case of a REST
+/// list operation, the mask instead applies to each individual message
+/// in the returned resource list. In case of a REST custom method,
+/// other definitions may be used. Where the mask applies will be
+/// clearly documented together with its declaration in the API.  In
+/// any case, the effect on the returned resource/resources is required
+/// behavior for APIs.
+///
+/// # Field Masks in Update Operations
+///
+/// A field mask in update operations specifies which fields of the
+/// targeted resource are going to be updated. The API is required
+/// to only change the values of the fields as specified in the mask
+/// and leave the others untouched. If a resource is passed in to
+/// describe the updated values, the API ignores the values of all
+/// fields not covered by the mask.
+///
+/// If a repeated field is specified for an update operation, the existing
+/// repeated values in the target resource will be overwritten by the new values.
+/// Note that a repeated field is only allowed in the last position of a `paths`
+/// string.
+///
+/// If a sub-message is specified in the last position of the field mask for an
+/// update operation, then the existing sub-message in the target resource is
+/// overwritten. Given the target message:
+///
+///     f {
+///       b {
+///         d : 1
+///         x : 2
 ///       }
-///  
-///   And an update message:
-///  
-///       f {
-///         b {
-///           d : 10
-///         }
+///       c : 1
+///     }
+///
+/// And an update message:
+///
+///     f {
+///       b {
+///         d : 10
 ///       }
-///  
-///   then if the field mask is:
-///  
-///    paths: "f.b"
-///  
-///   then the result will be:
-///  
-///       f {
-///         b {
-///           d : 10
-///         }
-///         c : 1
+///     }
+///
+/// then if the field mask is:
+///
+///  paths: "f.b"
+///
+/// then the result will be:
+///
+///     f {
+///       b {
+///         d : 10
 ///       }
-///  
-///   However, if the update mask was:
-///  
-///    paths: "f.b.d"
-///  
-///   then the result would be:
-///  
-///       f {
-///         b {
-///           d : 10
-///           x : 2
-///         }
-///         c : 1
+///       c : 1
+///     }
+///
+/// However, if the update mask was:
+///
+///  paths: "f.b.d"
+///
+/// then the result would be:
+///
+///     f {
+///       b {
+///         d : 10
+///         x : 2
 ///       }
-///  
-///   In order to reset a field's value to the default, the field must
-///   be in the mask and set to the default value in the provided resource.
-///   Hence, in order to reset all fields of a resource, provide a default
-///   instance of the resource and set all fields in the mask, or do
-///   not provide a mask as described below.
-///  
-///   If a field mask is not present on update, the operation applies to
-///   all fields (as if a field mask of all fields has been specified).
-///   Note that in the presence of schema evolution, this may mean that
-///   fields the client does not know and has therefore not filled into
-///   the request will be reset to their default. If this is unwanted
-///   behavior, a specific service may require a client to always specify
-///   a field mask, producing an error if not.
-///  
-///   As with get operations, the location of the resource which
-///   describes the updated values in the request message depends on the
-///   operation kind. In any case, the effect of the field mask is
-///   required to be honored by the API.
-///  
-///   ## Considerations for HTTP REST
-///  
-///   The HTTP kind of an update operation which uses a field mask must
-///   be set to PATCH instead of PUT in order to satisfy HTTP semantics
-///   (PUT must only be used for full updates).
-///  
-///   # JSON Encoding of Field Masks
-///  
-///   In JSON, a field mask is encoded as a single string where paths are
-///   separated by a comma. Fields name in each path are converted
-///   to/from lower-camel naming conventions.
-///  
-///   As an example, consider the following message declarations:
-///  
-///       message Profile {
-///         User user = 1;
-///         Photo photo = 2;
+///       c : 1
+///     }
+///
+/// In order to reset a field's value to the default, the field must
+/// be in the mask and set to the default value in the provided resource.
+/// Hence, in order to reset all fields of a resource, provide a default
+/// instance of the resource and set all fields in the mask, or do
+/// not provide a mask as described below.
+///
+/// If a field mask is not present on update, the operation applies to
+/// all fields (as if a field mask of all fields has been specified).
+/// Note that in the presence of schema evolution, this may mean that
+/// fields the client does not know and has therefore not filled into
+/// the request will be reset to their default. If this is unwanted
+/// behavior, a specific service may require a client to always specify
+/// a field mask, producing an error if not.
+///
+/// As with get operations, the location of the resource which
+/// describes the updated values in the request message depends on the
+/// operation kind. In any case, the effect of the field mask is
+/// required to be honored by the API.
+///
+/// ## Considerations for HTTP REST
+///
+/// The HTTP kind of an update operation which uses a field mask must
+/// be set to PATCH instead of PUT in order to satisfy HTTP semantics
+/// (PUT must only be used for full updates).
+///
+/// # JSON Encoding of Field Masks
+///
+/// In JSON, a field mask is encoded as a single string where paths are
+/// separated by a comma. Fields name in each path are converted
+/// to/from lower-camel naming conventions.
+///
+/// As an example, consider the following message declarations:
+///
+///     message Profile {
+///       User user = 1;
+///       Photo photo = 2;
+///     }
+///     message User {
+///       string display_name = 1;
+///       string address = 2;
+///     }
+///
+/// In proto a field mask for `Profile` may look as such:
+///
+///     mask {
+///       paths: "user.display_name"
+///       paths: "photo"
+///     }
+///
+/// In JSON, the same mask is represented as below:
+///
+///     {
+///       mask: "user.displayName,photo"
+///     }
+///
+/// # Field Masks and Oneof Fields
+///
+/// Field masks treat fields in oneofs just as regular fields. Consider the
+/// following message:
+///
+///     message SampleMessage {
+///       oneof test_oneof {
+///         string name = 4;
+///         SubMessage sub_message = 9;
 ///       }
-///       message User {
-///         string display_name = 1;
-///         string address = 2;
-///       }
-///  
-///   In proto a field mask for `Profile` may look as such:
-///  
-///       mask {
-///         paths: "user.display_name"
-///         paths: "photo"
-///       }
-///  
-///   In JSON, the same mask is represented as below:
-///  
-///       {
-///         mask: "user.displayName,photo"
-///       }
-///  
-///   # Field Masks and Oneof Fields
-///  
-///   Field masks treat fields in oneofs just as regular fields. Consider the
-///   following message:
-///  
-///       message SampleMessage {
-///         oneof test_oneof {
-///           string name = 4;
-///           SubMessage sub_message = 9;
-///         }
-///       }
-///  
-///   The field mask can be:
-///  
-///       mask {
-///         paths: "name"
-///       }
-///  
-///   Or:
-///  
-///       mask {
-///         paths: "sub_message"
-///       }
-///  
-///   Note that oneof type names ("test_oneof" in this case) cannot be used in
-///   paths.
+///     }
+///
+/// The field mask can be:
+///
+///     mask {
+///       paths: "name"
+///     }
+///
+/// Or:
+///
+///     mask {
+///       paths: "sub_message"
+///     }
+///
+/// Note that oneof type names ("test_oneof" in this case) cannot be used in
+/// paths.
 public struct Google_Protobuf_FieldMask: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".FieldMask"
 
-  ///   The set of field mask paths.
+  /// The set of field mask paths.
   public var paths: [String] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Sources/SwiftProtobuf/source_context.pb.swift
+++ b/Sources/SwiftProtobuf/source_context.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,13 +50,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   `SourceContext` represents information about the source of a
-///   protobuf element, like the file in which it is defined.
+/// `SourceContext` represents information about the source of a
+/// protobuf element, like the file in which it is defined.
 public struct Google_Protobuf_SourceContext: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".SourceContext"
 
-  ///   The path-qualified name of the .proto file that contained the associated
-  ///   protobuf element.  For example: `"google/protobuf/source_context.proto"`.
+  /// The path-qualified name of the .proto file that contained the associated
+  /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
   public var fileName: String = ""
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,14 +50,14 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   `NullValue` is a singleton enumeration to represent the null value for the
-///   `Value` type union.
-///  
-///    The JSON representation for `NullValue` is JSON `null`.
+/// `NullValue` is a singleton enumeration to represent the null value for the
+/// `Value` type union.
+///
+///  The JSON representation for `NullValue` is JSON `null`.
 public enum Google_Protobuf_NullValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   public typealias RawValue = Int
 
-  ///   Null value.
+  /// Null value.
   case nullValue // = 0
   case UNRECOGNIZED(Int)
 
@@ -85,18 +85,18 @@ public enum Google_Protobuf_NullValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoN
 
 }
 
-///   `Struct` represents a structured data value, consisting of fields
-///   which map to dynamically typed values. In some languages, `Struct`
-///   might be supported by a native representation. For example, in
-///   scripting languages like JS a struct is represented as an
-///   object. The details of that representation are described together
-///   with the proto support for the language.
-///  
-///   The JSON representation for `Struct` is JSON object.
+/// `Struct` represents a structured data value, consisting of fields
+/// which map to dynamically typed values. In some languages, `Struct`
+/// might be supported by a native representation. For example, in
+/// scripting languages like JS a struct is represented as an
+/// object. The details of that representation are described together
+/// with the proto support for the language.
+///
+/// The JSON representation for `Struct` is JSON object.
 public struct Google_Protobuf_Struct: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Struct"
 
-  ///   Unordered map of dynamically typed values.
+  /// Unordered map of dynamically typed values.
   public var fields: Dictionary<String,Google_Protobuf_Value> = [:]
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -120,12 +120,12 @@ public struct Google_Protobuf_Struct: SwiftProtobuf.Message {
   }
 }
 
-///   `Value` represents a dynamically typed value which can be either
-///   null, a number, a string, a boolean, a recursive struct value, or a
-///   list of values. A producer of value is expected to set one of that
-///   variants, absence of any variant indicates an error.
-///  
-///   The JSON representation for `Value` is JSON value.
+/// `Value` represents a dynamically typed value which can be either
+/// null, a number, a string, a boolean, a recursive struct value, or a
+/// list of values. A producer of value is expected to set one of that
+/// variants, absence of any variant indicates an error.
+///
+/// The JSON representation for `Value` is JSON value.
 public struct Google_Protobuf_Value: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Value"
 
@@ -148,7 +148,7 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Represents a null value.
+  /// Represents a null value.
   public var nullValue: Google_Protobuf_NullValue {
     get {
       if case .nullValue(let v)? = _storage._kind {
@@ -161,7 +161,7 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
     }
   }
 
-  ///   Represents a double value.
+  /// Represents a double value.
   public var numberValue: Double {
     get {
       if case .numberValue(let v)? = _storage._kind {
@@ -174,7 +174,7 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
     }
   }
 
-  ///   Represents a string value.
+  /// Represents a string value.
   public var stringValue: String {
     get {
       if case .stringValue(let v)? = _storage._kind {
@@ -187,7 +187,7 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
     }
   }
 
-  ///   Represents a boolean value.
+  /// Represents a boolean value.
   public var boolValue: Bool {
     get {
       if case .boolValue(let v)? = _storage._kind {
@@ -200,7 +200,7 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
     }
   }
 
-  ///   Represents a structured value.
+  /// Represents a structured value.
   public var structValue: Google_Protobuf_Struct {
     get {
       if case .structValue(let v)? = _storage._kind {
@@ -213,7 +213,7 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
     }
   }
 
-  ///   Represents a repeated `Value`.
+  /// Represents a repeated `Value`.
   public var listValue: Google_Protobuf_ListValue {
     get {
       if case .listValue(let v)? = _storage._kind {
@@ -353,13 +353,13 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
   }
 }
 
-///   `ListValue` is a wrapper around a repeated field of values.
-///  
-///   The JSON representation for `ListValue` is JSON array.
+/// `ListValue` is a wrapper around a repeated field of values.
+///
+/// The JSON representation for `ListValue` is JSON array.
 public struct Google_Protobuf_ListValue: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".ListValue"
 
-  ///   Repeated field of dynamically typed values.
+  /// Repeated field of dynamically typed values.
   public var values: [Google_Protobuf_Value] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Sources/SwiftProtobuf/timestamp.pb.swift
+++ b/Sources/SwiftProtobuf/timestamp.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,69 +50,69 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   A Timestamp represents a point in time independent of any time zone
-///   or calendar, represented as seconds and fractions of seconds at
-///   nanosecond resolution in UTC Epoch time. It is encoded using the
-///   Proleptic Gregorian Calendar which extends the Gregorian calendar
-///   backwards to year one. It is encoded assuming all minutes are 60
-///   seconds long, i.e. leap seconds are "smeared" so that no leap second
-///   table is needed for interpretation. Range is from
-///   0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
-///   By restricting to that range, we ensure that we can convert to
-///   and from  RFC 3339 date strings.
-///   See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
-///  
-///   Example 1: Compute Timestamp from POSIX `time()`.
-///  
-///       Timestamp timestamp;
-///       timestamp.set_seconds(time(NULL));
-///       timestamp.set_nanos(0);
-///  
-///   Example 2: Compute Timestamp from POSIX `gettimeofday()`.
-///  
-///       struct timeval tv;
-///       gettimeofday(&tv, NULL);
-///  
-///       Timestamp timestamp;
-///       timestamp.set_seconds(tv.tv_sec);
-///       timestamp.set_nanos(tv.tv_usec * 1000);
-///  
-///   Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
-///  
-///       FILETIME ft;
-///       GetSystemTimeAsFileTime(&ft);
-///       UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
-///  
-///       // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
-///       // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
-///       Timestamp timestamp;
-///       timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
-///       timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
-///  
-///   Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
-///  
-///       long millis = System.currentTimeMillis();
-///  
-///       Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
-///           .setNanos((int) ((millis % 1000) * 1000000)).build();
-///  
-///  
-///   Example 5: Compute Timestamp from current time in Python.
-///  
-///       timestamp = Timestamp()
-///       timestamp.GetCurrentTime()
+/// A Timestamp represents a point in time independent of any time zone
+/// or calendar, represented as seconds and fractions of seconds at
+/// nanosecond resolution in UTC Epoch time. It is encoded using the
+/// Proleptic Gregorian Calendar which extends the Gregorian calendar
+/// backwards to year one. It is encoded assuming all minutes are 60
+/// seconds long, i.e. leap seconds are "smeared" so that no leap second
+/// table is needed for interpretation. Range is from
+/// 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
+/// By restricting to that range, we ensure that we can convert to
+/// and from  RFC 3339 date strings.
+/// See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+///
+/// Example 1: Compute Timestamp from POSIX `time()`.
+///
+///     Timestamp timestamp;
+///     timestamp.set_seconds(time(NULL));
+///     timestamp.set_nanos(0);
+///
+/// Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+///
+///     struct timeval tv;
+///     gettimeofday(&tv, NULL);
+///
+///     Timestamp timestamp;
+///     timestamp.set_seconds(tv.tv_sec);
+///     timestamp.set_nanos(tv.tv_usec * 1000);
+///
+/// Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+///
+///     FILETIME ft;
+///     GetSystemTimeAsFileTime(&ft);
+///     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+///
+///     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+///     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+///     Timestamp timestamp;
+///     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+///     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+///
+/// Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+///
+///     long millis = System.currentTimeMillis();
+///
+///     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+///         .setNanos((int) ((millis % 1000) * 1000000)).build();
+///
+///
+/// Example 5: Compute Timestamp from current time in Python.
+///
+///     timestamp = Timestamp()
+///     timestamp.GetCurrentTime()
 public struct Google_Protobuf_Timestamp: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Timestamp"
 
-  ///   Represents seconds of UTC time since Unix epoch
-  ///   1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
-  ///   9999-12-31T23:59:59Z inclusive.
+  /// Represents seconds of UTC time since Unix epoch
+  /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+  /// 9999-12-31T23:59:59Z inclusive.
   public var seconds: Int64 = 0
 
-  ///   Non-negative fractions of a second at nanosecond resolution. Negative
-  ///   second values with fractions must still have non-negative nanos values
-  ///   that count forward in time. Must be from 0 to 999,999,999
-  ///   inclusive.
+  /// Non-negative fractions of a second at nanosecond resolution. Negative
+  /// second values with fractions must still have non-negative nanos values
+  /// that count forward in time. Must be from 0 to 999,999,999
+  /// inclusive.
   public var nanos: Int32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Sources/SwiftProtobuf/type.pb.swift
+++ b/Sources/SwiftProtobuf/type.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
@@ -50,14 +50,14 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   The syntax in which a protocol buffer element is defined.
+/// The syntax in which a protocol buffer element is defined.
 public enum Google_Protobuf_Syntax: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   public typealias RawValue = Int
 
-  ///   Syntax `proto2`.
+  /// Syntax `proto2`.
   case proto2 // = 0
 
-  ///   Syntax `proto3`.
+  /// Syntax `proto3`.
   case proto3 // = 1
   case UNRECOGNIZED(Int)
 
@@ -88,7 +88,7 @@ public enum Google_Protobuf_Syntax: SwiftProtobuf.Enum, SwiftProtobuf._ProtoName
 
 }
 
-///   A protocol buffer message type.
+/// A protocol buffer message type.
 public struct Google_Protobuf_Type: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Type"
 
@@ -121,31 +121,31 @@ public struct Google_Protobuf_Type: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   The fully qualified message name.
+  /// The fully qualified message name.
   public var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
-  ///   The list of fields.
+  /// The list of fields.
   public var fields: [Google_Protobuf_Field] {
     get {return _storage._fields}
     set {_uniqueStorage()._fields = newValue}
   }
 
-  ///   The list of types appearing in `oneof` definitions in this type.
+  /// The list of types appearing in `oneof` definitions in this type.
   public var oneofs: [String] {
     get {return _storage._oneofs}
     set {_uniqueStorage()._oneofs = newValue}
   }
 
-  ///   The protocol buffer options.
+  /// The protocol buffer options.
   public var options: [Google_Protobuf_Option] {
     get {return _storage._options}
     set {_uniqueStorage()._options = newValue}
   }
 
-  ///   The source context.
+  /// The source context.
   public var sourceContext: Google_Protobuf_SourceContext {
     get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContext = newValue}
@@ -157,7 +157,7 @@ public struct Google_Protobuf_Type: SwiftProtobuf.Message {
     return _storage._sourceContext = nil
   }
 
-  ///   The source syntax.
+  /// The source syntax.
   public var syntax: Google_Protobuf_Syntax {
     get {return _storage._syntax}
     set {_uniqueStorage()._syntax = newValue}
@@ -209,103 +209,103 @@ public struct Google_Protobuf_Type: SwiftProtobuf.Message {
   }
 }
 
-///   A single field of a message type.
+/// A single field of a message type.
 public struct Google_Protobuf_Field: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Field"
 
-  ///   The field type.
+  /// The field type.
   public var kind: Google_Protobuf_Field.Kind = Google_Protobuf_Field.Kind.typeUnknown
 
-  ///   The field cardinality.
+  /// The field cardinality.
   public var cardinality: Google_Protobuf_Field.Cardinality = Google_Protobuf_Field.Cardinality.unknown
 
-  ///   The field number.
+  /// The field number.
   public var number: Int32 = 0
 
-  ///   The field name.
+  /// The field name.
   public var name: String = ""
 
-  ///   The field type URL, without the scheme, for message or enumeration
-  ///   types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
+  /// The field type URL, without the scheme, for message or enumeration
+  /// types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
   public var typeURL: String = ""
 
-  ///   The index of the field type in `Type.oneofs`, for message or enumeration
-  ///   types. The first type has index 1; zero means the type is not in the list.
+  /// The index of the field type in `Type.oneofs`, for message or enumeration
+  /// types. The first type has index 1; zero means the type is not in the list.
   public var oneofIndex: Int32 = 0
 
-  ///   Whether to use alternative packed wire representation.
+  /// Whether to use alternative packed wire representation.
   public var packed: Bool = false
 
-  ///   The protocol buffer options.
+  /// The protocol buffer options.
   public var options: [Google_Protobuf_Option] = []
 
-  ///   The field JSON name.
+  /// The field JSON name.
   public var jsonName: String = ""
 
-  ///   The string value of the default value of this field. Proto2 syntax only.
+  /// The string value of the default value of this field. Proto2 syntax only.
   public var defaultValue: String = ""
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   Basic field types.
+  /// Basic field types.
   public enum Kind: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     public typealias RawValue = Int
 
-    ///   Field type unknown.
+    /// Field type unknown.
     case typeUnknown // = 0
 
-    ///   Field type double.
+    /// Field type double.
     case typeDouble // = 1
 
-    ///   Field type float.
+    /// Field type float.
     case typeFloat // = 2
 
-    ///   Field type int64.
+    /// Field type int64.
     case typeInt64 // = 3
 
-    ///   Field type uint64.
+    /// Field type uint64.
     case typeUint64 // = 4
 
-    ///   Field type int32.
+    /// Field type int32.
     case typeInt32 // = 5
 
-    ///   Field type fixed64.
+    /// Field type fixed64.
     case typeFixed64 // = 6
 
-    ///   Field type fixed32.
+    /// Field type fixed32.
     case typeFixed32 // = 7
 
-    ///   Field type bool.
+    /// Field type bool.
     case typeBool // = 8
 
-    ///   Field type string.
+    /// Field type string.
     case typeString // = 9
 
-    ///   Field type group. Proto2 syntax only, and deprecated.
+    /// Field type group. Proto2 syntax only, and deprecated.
     case typeGroup // = 10
 
-    ///   Field type message.
+    /// Field type message.
     case typeMessage // = 11
 
-    ///   Field type bytes.
+    /// Field type bytes.
     case typeBytes // = 12
 
-    ///   Field type uint32.
+    /// Field type uint32.
     case typeUint32 // = 13
 
-    ///   Field type enum.
+    /// Field type enum.
     case typeEnum // = 14
 
-    ///   Field type sfixed32.
+    /// Field type sfixed32.
     case typeSfixed32 // = 15
 
-    ///   Field type sfixed64.
+    /// Field type sfixed64.
     case typeSfixed64 // = 16
 
-    ///   Field type sint32.
+    /// Field type sint32.
     case typeSint32 // = 17
 
-    ///   Field type sint64.
+    /// Field type sint64.
     case typeSint64 // = 18
     case UNRECOGNIZED(Int)
 
@@ -387,20 +387,20 @@ public struct Google_Protobuf_Field: SwiftProtobuf.Message {
 
   }
 
-  ///   Whether a field is optional, required, or repeated.
+  /// Whether a field is optional, required, or repeated.
   public enum Cardinality: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     public typealias RawValue = Int
 
-    ///   For fields with unknown cardinality.
+    /// For fields with unknown cardinality.
     case unknown // = 0
 
-    ///   For optional fields.
+    /// For optional fields.
     case `optional` // = 1
 
-    ///   For required fields. Proto2 syntax only.
+    /// For required fields. Proto2 syntax only.
     case `required` // = 2
 
-    ///   For repeated fields.
+    /// For repeated fields.
     case repeated // = 3
     case UNRECOGNIZED(Int)
 
@@ -492,7 +492,7 @@ public struct Google_Protobuf_Field: SwiftProtobuf.Message {
   }
 }
 
-///   Enum type definition.
+/// Enum type definition.
 public struct Google_Protobuf_Enum: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Enum"
 
@@ -523,25 +523,25 @@ public struct Google_Protobuf_Enum: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Enum type name.
+  /// Enum type name.
   public var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
-  ///   Enum value definitions.
+  /// Enum value definitions.
   public var enumvalue: [Google_Protobuf_EnumValue] {
     get {return _storage._enumvalue}
     set {_uniqueStorage()._enumvalue = newValue}
   }
 
-  ///   Protocol buffer options.
+  /// Protocol buffer options.
   public var options: [Google_Protobuf_Option] {
     get {return _storage._options}
     set {_uniqueStorage()._options = newValue}
   }
 
-  ///   The source context.
+  /// The source context.
   public var sourceContext: Google_Protobuf_SourceContext {
     get {return _storage._sourceContext ?? Google_Protobuf_SourceContext()}
     set {_uniqueStorage()._sourceContext = newValue}
@@ -553,7 +553,7 @@ public struct Google_Protobuf_Enum: SwiftProtobuf.Message {
     return _storage._sourceContext = nil
   }
 
-  ///   The source syntax.
+  /// The source syntax.
   public var syntax: Google_Protobuf_Syntax {
     get {return _storage._syntax}
     set {_uniqueStorage()._syntax = newValue}
@@ -601,17 +601,17 @@ public struct Google_Protobuf_Enum: SwiftProtobuf.Message {
   }
 }
 
-///   Enum value definition.
+/// Enum value definition.
 public struct Google_Protobuf_EnumValue: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".EnumValue"
 
-  ///   Enum value name.
+  /// Enum value name.
   public var name: String = ""
 
-  ///   Enum value number.
+  /// Enum value number.
   public var number: Int32 = 0
 
-  ///   Protocol buffer options.
+  /// Protocol buffer options.
   public var options: [Google_Protobuf_Option] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -643,8 +643,8 @@ public struct Google_Protobuf_EnumValue: SwiftProtobuf.Message {
   }
 }
 
-///   A protocol buffer option, which can be attached to a message, field,
-///   enumeration, etc.
+/// A protocol buffer option, which can be attached to a message, field,
+/// enumeration, etc.
 public struct Google_Protobuf_Option: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Option"
 
@@ -669,19 +669,19 @@ public struct Google_Protobuf_Option: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   The option's name. For protobuf built-in options (options defined in
-  ///   descriptor.proto), this is the short name. For example, `"map_entry"`.
-  ///   For custom options, it should be the fully-qualified name. For example,
-  ///   `"google.api.http"`.
+  /// The option's name. For protobuf built-in options (options defined in
+  /// descriptor.proto), this is the short name. For example, `"map_entry"`.
+  /// For custom options, it should be the fully-qualified name. For example,
+  /// `"google.api.http"`.
   public var name: String {
     get {return _storage._name}
     set {_uniqueStorage()._name = newValue}
   }
 
-  ///   The option's value packed in an Any message. If the value is a primitive,
-  ///   the corresponding wrapper type defined in google/protobuf/wrappers.proto
-  ///   should be used. If the value is an enum, it should be stored as an int32
-  ///   value using the google.protobuf.Int32Value type.
+  /// The option's value packed in an Any message. If the value is a primitive,
+  /// the corresponding wrapper type defined in google/protobuf/wrappers.proto
+  /// should be used. If the value is an enum, it should be stored as an int32
+  /// value using the google.protobuf.Int32Value type.
   public var value: Google_Protobuf_Any {
     get {return _storage._value ?? Google_Protobuf_Any()}
     set {_uniqueStorage()._value = newValue}

--- a/Sources/SwiftProtobuf/wrappers.pb.swift
+++ b/Sources/SwiftProtobuf/wrappers.pb.swift
@@ -6,40 +6,40 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Wrappers for primitive (non-message) types. These types are useful
-//  for embedding primitives in the `google.protobuf.Any` type and for places
-//  where we need to distinguish between the absence of a primitive
-//  typed field and its default value.
+// Wrappers for primitive (non-message) types. These types are useful
+// for embedding primitives in the `google.protobuf.Any` type and for places
+// where we need to distinguish between the absence of a primitive
+// typed field and its default value.
 
 import Foundation
 
@@ -55,13 +55,13 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   Wrapper message for `double`.
-///  
-///   The JSON representation for `DoubleValue` is JSON number.
+/// Wrapper message for `double`.
+///
+/// The JSON representation for `DoubleValue` is JSON number.
 public struct Google_Protobuf_DoubleValue: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".DoubleValue"
 
-  ///   The double value.
+  /// The double value.
   public var value: Double = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -85,13 +85,13 @@ public struct Google_Protobuf_DoubleValue: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `float`.
-///  
-///   The JSON representation for `FloatValue` is JSON number.
+/// Wrapper message for `float`.
+///
+/// The JSON representation for `FloatValue` is JSON number.
 public struct Google_Protobuf_FloatValue: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".FloatValue"
 
-  ///   The float value.
+  /// The float value.
   public var value: Float = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -115,13 +115,13 @@ public struct Google_Protobuf_FloatValue: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `int64`.
-///  
-///   The JSON representation for `Int64Value` is JSON string.
+/// Wrapper message for `int64`.
+///
+/// The JSON representation for `Int64Value` is JSON string.
 public struct Google_Protobuf_Int64Value: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Int64Value"
 
-  ///   The int64 value.
+  /// The int64 value.
   public var value: Int64 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -145,13 +145,13 @@ public struct Google_Protobuf_Int64Value: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `uint64`.
-///  
-///   The JSON representation for `UInt64Value` is JSON string.
+/// Wrapper message for `uint64`.
+///
+/// The JSON representation for `UInt64Value` is JSON string.
 public struct Google_Protobuf_UInt64Value: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".UInt64Value"
 
-  ///   The uint64 value.
+  /// The uint64 value.
   public var value: UInt64 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -175,13 +175,13 @@ public struct Google_Protobuf_UInt64Value: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `int32`.
-///  
-///   The JSON representation for `Int32Value` is JSON number.
+/// Wrapper message for `int32`.
+///
+/// The JSON representation for `Int32Value` is JSON number.
 public struct Google_Protobuf_Int32Value: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Int32Value"
 
-  ///   The int32 value.
+  /// The int32 value.
   public var value: Int32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -205,13 +205,13 @@ public struct Google_Protobuf_Int32Value: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `uint32`.
-///  
-///   The JSON representation for `UInt32Value` is JSON number.
+/// Wrapper message for `uint32`.
+///
+/// The JSON representation for `UInt32Value` is JSON number.
 public struct Google_Protobuf_UInt32Value: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".UInt32Value"
 
-  ///   The uint32 value.
+  /// The uint32 value.
   public var value: UInt32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -235,13 +235,13 @@ public struct Google_Protobuf_UInt32Value: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `bool`.
-///  
-///   The JSON representation for `BoolValue` is JSON `true` and `false`.
+/// Wrapper message for `bool`.
+///
+/// The JSON representation for `BoolValue` is JSON `true` and `false`.
 public struct Google_Protobuf_BoolValue: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".BoolValue"
 
-  ///   The bool value.
+  /// The bool value.
   public var value: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -265,13 +265,13 @@ public struct Google_Protobuf_BoolValue: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `string`.
-///  
-///   The JSON representation for `StringValue` is JSON string.
+/// Wrapper message for `string`.
+///
+/// The JSON representation for `StringValue` is JSON string.
 public struct Google_Protobuf_StringValue: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".StringValue"
 
-  ///   The string value.
+  /// The string value.
   public var value: String = ""
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -295,13 +295,13 @@ public struct Google_Protobuf_StringValue: SwiftProtobuf.Message {
   }
 }
 
-///   Wrapper message for `bytes`.
-///  
-///   The JSON representation for `BytesValue` is JSON string.
+/// Wrapper message for `bytes`.
+///
+/// The JSON representation for `BytesValue` is JSON string.
 public struct Google_Protobuf_BytesValue: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".BytesValue"
 
-  ///   The bytes value.
+  /// The bytes value.
   public var value: Data = Data()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -250,7 +250,7 @@ class FileGenerator {
 
             if includeLeadingDetached {
                 for detached in location.leadingDetachedComments {
-                    let comment = prefixLines(text: detached, prefix: "// ")
+                    let comment = prefixLines(text: detached, prefix: "//")
                     if !comment.isEmpty {
                         result += comment
                         // Detached comments have blank lines between then (and
@@ -261,7 +261,7 @@ class FileGenerator {
             }
 
             let comments = location.hasLeadingComments ? location.leadingComments : location.trailingComments
-            result += prefixLines(text: escapeMarkup(comments), prefix: "///  ")
+            result += prefixLines(text: escapeMarkup(comments), prefix: "///")
             return result
         }
         return ""

--- a/Tests/SwiftProtobufTests/any_test.pb.swift
+++ b/Tests/SwiftProtobufTests/any_test.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -88,11 +88,11 @@ enum Conformance_WireFormat: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProvidi
 
 }
 
-///   Represents a single test case's input.  The testee should:
-///  
-///     1. parse this proto (which should always succeed)
-///     2. parse the protobuf or JSON payload in "payload" (which may fail)
-///     3. if the parse succeeded, serialize the message in the requested format.
+/// Represents a single test case's input.  The testee should:
+///
+///   1. parse this proto (which should always succeed)
+///   2. parse the protobuf or JSON payload in "payload" (which may fail)
+///   3. if the parse succeeded, serialize the message in the requested format.
 struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ConformanceRequest"
 
@@ -122,7 +122,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
     }
   }
 
-  ///   Which format should the testee serialize its message to?
+  /// Which format should the testee serialize its message to?
   var requestedOutputFormat: Conformance_WireFormat = Conformance_WireFormat.unspecified
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -196,15 +196,15 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   }
 }
 
-///   Represents a single test case's output.
+/// Represents a single test case's output.
 struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ConformanceResponse"
 
-  ///   This string should be set to indicate parsing failed.  The string can
-  ///   provide more information about the parse error if it is available.
-  ///  
-  ///   Setting this string does not necessarily mean the testee failed the
-  ///   test.  Some of the test cases are intentionally invalid input.
+  /// This string should be set to indicate parsing failed.  The string can
+  /// provide more information about the parse error if it is available.
+  ///
+  /// Setting this string does not necessarily mean the testee failed the
+  /// test.  Some of the test cases are intentionally invalid input.
   var parseError: String {
     get {
       if case .parseError(let v)? = result {
@@ -219,9 +219,9 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
 
   var result: Conformance_ConformanceResponse.OneOf_Result? = nil
 
-  ///   If the input was successfully parsed but errors occurred when
-  ///   serializing it to the requested output format, set the error message in
-  ///   this field.
+  /// If the input was successfully parsed but errors occurred when
+  /// serializing it to the requested output format, set the error message in
+  /// this field.
   var serializeError: String {
     get {
       if case .serializeError(let v)? = result {
@@ -234,9 +234,9 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   This should be set if some other error occurred.  This will always
-  ///   indicate that the test failed.  The string can provide more information
-  ///   about the failure.
+  /// This should be set if some other error occurred.  This will always
+  /// indicate that the test failed.  The string can provide more information
+  /// about the failure.
   var runtimeError: String {
     get {
       if case .runtimeError(let v)? = result {
@@ -249,8 +249,8 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   If the input was successfully parsed and the requested output was
-  ///   protobuf, serialize it to protobuf and set it in this field.
+  /// If the input was successfully parsed and the requested output was
+  /// protobuf, serialize it to protobuf and set it in this field.
   var protobufPayload: Data {
     get {
       if case .protobufPayload(let v)? = result {
@@ -263,8 +263,8 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   If the input was successfully parsed and the requested output was JSON,
-  ///   serialize to JSON and set it in this field.
+  /// If the input was successfully parsed and the requested output was JSON,
+  /// serialize to JSON and set it in this field.
   var jsonPayload: String {
     get {
       if case .jsonPayload(let v)? = result {
@@ -277,8 +277,8 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
     }
   }
 
-  ///   For when the testee skipped the test, likely because a certain feature
-  ///   wasn't supported, like JSON input/output.
+  /// For when the testee skipped the test, likely because a certain feature
+  /// wasn't supported, like JSON input/output.
   var skipped: String {
     get {
       if case .skipped(let v)? = result {

--- a/Tests/SwiftProtobufTests/descriptor.pb.swift
+++ b/Tests/SwiftProtobufTests/descriptor.pb.swift
@@ -6,43 +6,43 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  The messages in this file describe the definitions found in .proto files.
-//  A valid .proto file can be translated directly to a FileDescriptorProto
-//  without any other information (e.g. without reading its imports).
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// The messages in this file describe the definitions found in .proto files.
+// A valid .proto file can be translated directly to a FileDescriptorProto
+// without any other information (e.g. without reading its imports).
 
 import Foundation
 import SwiftProtobuf
@@ -59,8 +59,8 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "google.protobuf"
 
-///   The protocol compiler can output a FileDescriptorSet containing the .proto
-///   files it parses.
+/// The protocol compiler can output a FileDescriptorSet containing the .proto
+/// files it parses.
 struct Google_Protobuf_FileDescriptorSet: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FileDescriptorSet"
 
@@ -92,7 +92,7 @@ struct Google_Protobuf_FileDescriptorSet: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a complete .proto file.
+/// Describes a complete .proto file.
 struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FileDescriptorProto"
 
@@ -137,7 +137,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   file name, relative to root of source tree
+  /// file name, relative to root of source tree
   var name: String {
     get {return _storage._name ?? ""}
     set {_uniqueStorage()._name = newValue}
@@ -149,7 +149,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._name = nil
   }
 
-  ///   e.g. "foo", "foo.bar", etc.
+  /// e.g. "foo", "foo.bar", etc.
   var package: String {
     get {return _storage._package ?? ""}
     set {_uniqueStorage()._package = newValue}
@@ -161,26 +161,26 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._package = nil
   }
 
-  ///   Names of files imported by this file.
+  /// Names of files imported by this file.
   var dependency: [String] {
     get {return _storage._dependency}
     set {_uniqueStorage()._dependency = newValue}
   }
 
-  ///   Indexes of the public imported files in the dependency list above.
+  /// Indexes of the public imported files in the dependency list above.
   var publicDependency: [Int32] {
     get {return _storage._publicDependency}
     set {_uniqueStorage()._publicDependency = newValue}
   }
 
-  ///   Indexes of the weak imported files in the dependency list.
-  ///   For Google-internal migration only. Do not use.
+  /// Indexes of the weak imported files in the dependency list.
+  /// For Google-internal migration only. Do not use.
   var weakDependency: [Int32] {
     get {return _storage._weakDependency}
     set {_uniqueStorage()._weakDependency = newValue}
   }
 
-  ///   All top-level definitions in this file.
+  /// All top-level definitions in this file.
   var messageType: [Google_Protobuf_DescriptorProto] {
     get {return _storage._messageType}
     set {_uniqueStorage()._messageType = newValue}
@@ -212,10 +212,10 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._options = nil
   }
 
-  ///   This field contains optional information about the original source code.
-  ///   You may safely remove this entire field without harming runtime
-  ///   functionality of the descriptors -- the information is needed only by
-  ///   development tools.
+  /// This field contains optional information about the original source code.
+  /// You may safely remove this entire field without harming runtime
+  /// functionality of the descriptors -- the information is needed only by
+  /// development tools.
   var sourceCodeInfo: Google_Protobuf_SourceCodeInfo {
     get {return _storage._sourceCodeInfo ?? Google_Protobuf_SourceCodeInfo()}
     set {_uniqueStorage()._sourceCodeInfo = newValue}
@@ -227,8 +227,8 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
     return _storage._sourceCodeInfo = nil
   }
 
-  ///   The syntax of the proto file.
-  ///   The supported values are "proto2" and "proto3".
+  /// The syntax of the proto file.
+  /// The supported values are "proto2" and "proto3".
   var syntax: String {
     get {return _storage._syntax ?? ""}
     set {_uniqueStorage()._syntax = newValue}
@@ -321,7 +321,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a message type.
+/// Describes a message type.
 struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".DescriptorProto"
 
@@ -419,8 +419,8 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
     set {_uniqueStorage()._reservedRange = newValue}
   }
 
-  ///   Reserved field names, which may not be used by fields in the same message.
-  ///   A given name may only be reserved once.
+  /// Reserved field names, which may not be used by fields in the same message.
+  /// A given name may only be reserved once.
   var reservedName: [String] {
     get {return _storage._reservedName}
     set {_uniqueStorage()._reservedName = newValue}
@@ -480,13 +480,13 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
     }
   }
 
-  ///   Range of reserved tag numbers. Reserved tag numbers may not be used by
-  ///   fields or extension ranges in the same message. Reserved ranges may
-  ///   not overlap.
+  /// Range of reserved tag numbers. Reserved tag numbers may not be used by
+  /// fields or extension ranges in the same message. Reserved ranges may
+  /// not overlap.
   struct ReservedRange: SwiftProtobuf.Message {
     static let protoMessageName: String = Google_Protobuf_DescriptorProto.protoMessageName + ".ReservedRange"
 
-    ///   Inclusive.
+    /// Inclusive.
     fileprivate var _start: Int32? = nil
     var start: Int32 {
       get {return _start ?? 0}
@@ -499,7 +499,7 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
       return _start = nil
     }
 
-    ///   Exclusive.
+    /// Exclusive.
     fileprivate var _end: Int32? = nil
     var end: Int32 {
       get {return _end ?? 0}
@@ -609,7 +609,7 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a field within a message.
+/// Describes a field within a message.
 struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FieldDescriptorProto"
 
@@ -683,8 +683,8 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._label = nil
   }
 
-  ///   If type_name is set, this need not be set.  If both this and type_name
-  ///   are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
+  /// If type_name is set, this need not be set.  If both this and type_name
+  /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
   var type: Google_Protobuf_FieldDescriptorProto.TypeEnum {
     get {return _storage._type ?? Google_Protobuf_FieldDescriptorProto.TypeEnum.double}
     set {_uniqueStorage()._type = newValue}
@@ -696,11 +696,11 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._type = nil
   }
 
-  ///   For message and enum types, this is the name of the type.  If the name
-  ///   starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
-  ///   rules are used to find the type (i.e. first the nested types within this
-  ///   message are searched, then within the parent, on up to the root
-  ///   namespace).
+  /// For message and enum types, this is the name of the type.  If the name
+  /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+  /// rules are used to find the type (i.e. first the nested types within this
+  /// message are searched, then within the parent, on up to the root
+  /// namespace).
   var typeName: String {
     get {return _storage._typeName ?? ""}
     set {_uniqueStorage()._typeName = newValue}
@@ -712,8 +712,8 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._typeName = nil
   }
 
-  ///   For extensions, this is the name of the type being extended.  It is
-  ///   resolved in the same manner as type_name.
+  /// For extensions, this is the name of the type being extended.  It is
+  /// resolved in the same manner as type_name.
   var extendee: String {
     get {return _storage._extendee ?? ""}
     set {_uniqueStorage()._extendee = newValue}
@@ -725,11 +725,11 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._extendee = nil
   }
 
-  ///   For numeric types, contains the original text representation of the value.
-  ///   For booleans, "true" or "false".
-  ///   For strings, contains the default text contents (not escaped in any way).
-  ///   For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
-  ///   TODO(kenton):  Base-64 encode?
+  /// For numeric types, contains the original text representation of the value.
+  /// For booleans, "true" or "false".
+  /// For strings, contains the default text contents (not escaped in any way).
+  /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+  /// TODO(kenton):  Base-64 encode?
   var defaultValue: String {
     get {return _storage._defaultValue ?? ""}
     set {_uniqueStorage()._defaultValue = newValue}
@@ -741,8 +741,8 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._defaultValue = nil
   }
 
-  ///   If set, gives the index of a oneof in the containing type's oneof_decl
-  ///   list.  This field is a member of that oneof.
+  /// If set, gives the index of a oneof in the containing type's oneof_decl
+  /// list.  This field is a member of that oneof.
   var oneofIndex: Int32 {
     get {return _storage._oneofIndex ?? 0}
     set {_uniqueStorage()._oneofIndex = newValue}
@@ -754,10 +754,10 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
     return _storage._oneofIndex = nil
   }
 
-  ///   JSON name of this field. The value is set by protocol compiler. If the
-  ///   user has set a "json_name" option on this field, that option's value
-  ///   will be used. Otherwise, it's deduced from the field's name by converting
-  ///   it to camelCase.
+  /// JSON name of this field. The value is set by protocol compiler. If the
+  /// user has set a "json_name" option on this field, that option's value
+  /// will be used. Otherwise, it's deduced from the field's name by converting
+  /// it to camelCase.
   var jsonName: String {
     get {return _storage._jsonName ?? ""}
     set {_uniqueStorage()._jsonName = newValue}
@@ -785,44 +785,44 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   enum TypeEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   0 is reserved for errors.
-    ///   Order is weird for historical reasons.
+    /// 0 is reserved for errors.
+    /// Order is weird for historical reasons.
     case double // = 1
     case float // = 2
 
-    ///   Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
-    ///   negative values are likely.
+    /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+    /// negative values are likely.
     case int64 // = 3
     case uint64 // = 4
 
-    ///   Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
-    ///   negative values are likely.
+    /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+    /// negative values are likely.
     case int32 // = 5
     case fixed64 // = 6
     case fixed32 // = 7
     case bool // = 8
     case string // = 9
 
-    ///   Tag-delimited aggregate.
-    ///   Group type is deprecated and not supported in proto3. However, Proto3
-    ///   implementations should still be able to parse the group wire format and
-    ///   treat group fields as unknown fields.
+    /// Tag-delimited aggregate.
+    /// Group type is deprecated and not supported in proto3. However, Proto3
+    /// implementations should still be able to parse the group wire format and
+    /// treat group fields as unknown fields.
     case group // = 10
 
-    ///   Length-delimited aggregate.
+    /// Length-delimited aggregate.
     case message // = 11
 
-    ///   New in version 2.
+    /// New in version 2.
     case bytes // = 12
     case uint32 // = 13
     case `enum` // = 14
     case sfixed32 // = 15
     case sfixed64 // = 16
 
-    ///   Uses ZigZag encoding.
+    /// Uses ZigZag encoding.
     case sint32 // = 17
 
-    ///   Uses ZigZag encoding.
+    /// Uses ZigZag encoding.
     case sint64 // = 18
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -902,7 +902,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   enum Label: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   0 is reserved for errors
+    /// 0 is reserved for errors
     case `optional` // = 1
     case `required` // = 2
     case repeated // = 3
@@ -1003,7 +1003,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a oneof.
+/// Describes a oneof.
 struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OneofDescriptorProto"
 
@@ -1087,7 +1087,7 @@ struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes an enum type.
+/// Describes an enum type.
 struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".EnumDescriptorProto"
 
@@ -1183,7 +1183,7 @@ struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a value within an enum.
+/// Describes a value within an enum.
 struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".EnumValueDescriptorProto"
 
@@ -1284,7 +1284,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a service.
+/// Describes a service.
 struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ServiceDescriptorProto"
 
@@ -1380,7 +1380,7 @@ struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message {
   }
 }
 
-///   Describes a method of a service.
+/// Describes a method of a service.
 struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MethodDescriptorProto"
 
@@ -1424,8 +1424,8 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
     return _storage._name = nil
   }
 
-  ///   Input and output type names.  These are resolved in the same way as
-  ///   FieldDescriptorProto.type_name, but must refer to a message type.
+  /// Input and output type names.  These are resolved in the same way as
+  /// FieldDescriptorProto.type_name, but must refer to a message type.
   var inputType: String {
     get {return _storage._inputType ?? ""}
     set {_uniqueStorage()._inputType = newValue}
@@ -1459,7 +1459,7 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
     return _storage._options = nil
   }
 
-  ///   Identifies if client streams multiple client messages
+  /// Identifies if client streams multiple client messages
   var clientStreaming: Bool {
     get {return _storage._clientStreaming ?? false}
     set {_uniqueStorage()._clientStreaming = newValue}
@@ -1471,7 +1471,7 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
     return _storage._clientStreaming = nil
   }
 
-  ///   Identifies if server streams multiple server messages
+  /// Identifies if server streams multiple server messages
   var serverStreaming: Bool {
     get {return _storage._serverStreaming ?? false}
     set {_uniqueStorage()._serverStreaming = newValue}
@@ -1590,10 +1590,10 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage
   }
 
-  ///   Sets the Java package where classes generated from this .proto will be
-  ///   placed.  By default, the proto package is used, but this is often
-  ///   inappropriate because proto packages do not normally start with backwards
-  ///   domain names.
+  /// Sets the Java package where classes generated from this .proto will be
+  /// placed.  By default, the proto package is used, but this is often
+  /// inappropriate because proto packages do not normally start with backwards
+  /// domain names.
   var javaPackage: String {
     get {return _storage._javaPackage ?? ""}
     set {_uniqueStorage()._javaPackage = newValue}
@@ -1605,11 +1605,11 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._javaPackage = nil
   }
 
-  ///   If set, all the classes from the .proto file are wrapped in a single
-  ///   outer class with the given name.  This applies to both Proto1
-  ///   (equivalent to the old "--one_java_file" option) and Proto2 (where
-  ///   a .proto always translates to a single class, but you may want to
-  ///   explicitly choose the class name).
+  /// If set, all the classes from the .proto file are wrapped in a single
+  /// outer class with the given name.  This applies to both Proto1
+  /// (equivalent to the old "--one_java_file" option) and Proto2 (where
+  /// a .proto always translates to a single class, but you may want to
+  /// explicitly choose the class name).
   var javaOuterClassname: String {
     get {return _storage._javaOuterClassname ?? ""}
     set {_uniqueStorage()._javaOuterClassname = newValue}
@@ -1621,12 +1621,12 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._javaOuterClassname = nil
   }
 
-  ///   If set true, then the Java code generator will generate a separate .java
-  ///   file for each top-level message, enum, and service defined in the .proto
-  ///   file.  Thus, these types will *not* be nested inside the outer class
-  ///   named by java_outer_classname.  However, the outer class will still be
-  ///   generated to contain the file's getDescriptor() method as well as any
-  ///   top-level extensions defined in the file.
+  /// If set true, then the Java code generator will generate a separate .java
+  /// file for each top-level message, enum, and service defined in the .proto
+  /// file.  Thus, these types will *not* be nested inside the outer class
+  /// named by java_outer_classname.  However, the outer class will still be
+  /// generated to contain the file's getDescriptor() method as well as any
+  /// top-level extensions defined in the file.
   var javaMultipleFiles: Bool {
     get {return _storage._javaMultipleFiles ?? false}
     set {_uniqueStorage()._javaMultipleFiles = newValue}
@@ -1638,7 +1638,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._javaMultipleFiles = nil
   }
 
-  ///   This option does nothing.
+  /// This option does nothing.
   var javaGenerateEqualsAndHash: Bool {
     get {return _storage._javaGenerateEqualsAndHash ?? false}
     set {_uniqueStorage()._javaGenerateEqualsAndHash = newValue}
@@ -1650,12 +1650,12 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._javaGenerateEqualsAndHash = nil
   }
 
-  ///   If set true, then the Java2 code generator will generate code that
-  ///   throws an exception whenever an attempt is made to assign a non-UTF-8
-  ///   byte sequence to a string field.
-  ///   Message reflection will do the same.
-  ///   However, an extension field still accepts non-UTF-8 byte sequences.
-  ///   This option has no effect on when used with the lite runtime.
+  /// If set true, then the Java2 code generator will generate code that
+  /// throws an exception whenever an attempt is made to assign a non-UTF-8
+  /// byte sequence to a string field.
+  /// Message reflection will do the same.
+  /// However, an extension field still accepts non-UTF-8 byte sequences.
+  /// This option has no effect on when used with the lite runtime.
   var javaStringCheckUtf8: Bool {
     get {return _storage._javaStringCheckUtf8 ?? false}
     set {_uniqueStorage()._javaStringCheckUtf8 = newValue}
@@ -1678,11 +1678,11 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._optimizeFor = nil
   }
 
-  ///   Sets the Go package where structs generated from this .proto will be
-  ///   placed. If omitted, the Go package will be derived from the following:
-  ///     - The basename of the package import path, if provided.
-  ///     - Otherwise, the package statement in the .proto file, if present.
-  ///     - Otherwise, the basename of the .proto file, without extension.
+  /// Sets the Go package where structs generated from this .proto will be
+  /// placed. If omitted, the Go package will be derived from the following:
+  ///   - The basename of the package import path, if provided.
+  ///   - Otherwise, the package statement in the .proto file, if present.
+  ///   - Otherwise, the basename of the .proto file, without extension.
   var goPackage: String {
     get {return _storage._goPackage ?? ""}
     set {_uniqueStorage()._goPackage = newValue}
@@ -1694,16 +1694,16 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._goPackage = nil
   }
 
-  ///   Should generic services be generated in each language?  "Generic" services
-  ///   are not specific to any particular RPC system.  They are generated by the
-  ///   main code generators in each language (without additional plugins).
-  ///   Generic services were the only kind of service generation supported by
-  ///   early versions of google.protobuf.
-  ///  
-  ///   Generic services are now considered deprecated in favor of using plugins
-  ///   that generate code specific to your particular RPC system.  Therefore,
-  ///   these default to false.  Old code which depends on generic services should
-  ///   explicitly set them to true.
+  /// Should generic services be generated in each language?  "Generic" services
+  /// are not specific to any particular RPC system.  They are generated by the
+  /// main code generators in each language (without additional plugins).
+  /// Generic services were the only kind of service generation supported by
+  /// early versions of google.protobuf.
+  ///
+  /// Generic services are now considered deprecated in favor of using plugins
+  /// that generate code specific to your particular RPC system.  Therefore,
+  /// these default to false.  Old code which depends on generic services should
+  /// explicitly set them to true.
   var ccGenericServices: Bool {
     get {return _storage._ccGenericServices ?? false}
     set {_uniqueStorage()._ccGenericServices = newValue}
@@ -1737,10 +1737,10 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._pyGenericServices = nil
   }
 
-  ///   Is this file deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for everything in the file, or it will be completely ignored; in the very
-  ///   least, this is a formalization for deprecating files.
+  /// Is this file deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for everything in the file, or it will be completely ignored; in the very
+  /// least, this is a formalization for deprecating files.
   var deprecated: Bool {
     get {return _storage._deprecated ?? false}
     set {_uniqueStorage()._deprecated = newValue}
@@ -1752,8 +1752,8 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._deprecated = nil
   }
 
-  ///   Enables the use of arenas for the proto messages in this file. This applies
-  ///   only to generated classes for C++.
+  /// Enables the use of arenas for the proto messages in this file. This applies
+  /// only to generated classes for C++.
   var ccEnableArenas: Bool {
     get {return _storage._ccEnableArenas ?? false}
     set {_uniqueStorage()._ccEnableArenas = newValue}
@@ -1765,8 +1765,8 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._ccEnableArenas = nil
   }
 
-  ///   Sets the objective c class prefix which is prepended to all objective c
-  ///   generated classes from this .proto. There is no default.
+  /// Sets the objective c class prefix which is prepended to all objective c
+  /// generated classes from this .proto. There is no default.
   var objcClassPrefix: String {
     get {return _storage._objcClassPrefix ?? ""}
     set {_uniqueStorage()._objcClassPrefix = newValue}
@@ -1778,7 +1778,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._objcClassPrefix = nil
   }
 
-  ///   Namespace for generated classes; defaults to the package.
+  /// Namespace for generated classes; defaults to the package.
   var csharpNamespace: String {
     get {return _storage._csharpNamespace ?? ""}
     set {_uniqueStorage()._csharpNamespace = newValue}
@@ -1790,10 +1790,10 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._csharpNamespace = nil
   }
 
-  ///   By default Swift generators will take the proto package and CamelCase it
-  ///   replacing '.' with underscore and use that to prefix the types/symbols
-  ///   defined. When this options is provided, they will use this value instead
-  ///   to prefix the types/symbols defined.
+  /// By default Swift generators will take the proto package and CamelCase it
+  /// replacing '.' with underscore and use that to prefix the types/symbols
+  /// defined. When this options is provided, they will use this value instead
+  /// to prefix the types/symbols defined.
   var swiftPrefix: String {
     get {return _storage._swiftPrefix ?? ""}
     set {_uniqueStorage()._swiftPrefix = newValue}
@@ -1805,8 +1805,8 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._swiftPrefix = nil
   }
 
-  ///   Sets the php class prefix which is prepended to all php generated classes
-  ///   from this .proto. Default is empty.
+  /// Sets the php class prefix which is prepended to all php generated classes
+  /// from this .proto. Default is empty.
   var phpClassPrefix: String {
     get {return _storage._phpClassPrefix ?? ""}
     set {_uniqueStorage()._phpClassPrefix = newValue}
@@ -1818,7 +1818,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _storage._phpClassPrefix = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] {
     get {return _storage._uninterpretedOption}
     set {_uniqueStorage()._uninterpretedOption = newValue}
@@ -1826,17 +1826,17 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   Generated classes can be optimized for speed or code size.
+  /// Generated classes can be optimized for speed or code size.
   enum OptimizeMode: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   Generate complete code for parsing, serialization,
+    /// Generate complete code for parsing, serialization,
     case speed // = 1
 
-    ///   etc.
+    /// etc.
     case codeSize // = 2
 
-    ///   Generate code using MessageLite and the lite runtime.
+    /// Generate code using MessageLite and the lite runtime.
     case liteRuntime // = 3
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -1972,24 +1972,24 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
 struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".MessageOptions"
 
-  ///   Set true to use the old proto1 MessageSet wire format for extensions.
-  ///   This is provided for backwards-compatibility with the MessageSet wire
-  ///   format.  You should not use this for any other reason:  It's less
-  ///   efficient, has fewer features, and is more complicated.
-  ///  
-  ///   The message must be defined exactly as follows:
-  ///     message Foo {
-  ///       option message_set_wire_format = true;
-  ///       extensions 4 to max;
-  ///     }
-  ///   Note that the message cannot have any defined fields; MessageSets only
-  ///   have extensions.
-  ///  
-  ///   All extensions of your type must be singular messages; e.g. they cannot
-  ///   be int32s, enums, or repeated messages.
-  ///  
-  ///   Because this is an option, the above two restrictions are not enforced by
-  ///   the protocol compiler.
+  /// Set true to use the old proto1 MessageSet wire format for extensions.
+  /// This is provided for backwards-compatibility with the MessageSet wire
+  /// format.  You should not use this for any other reason:  It's less
+  /// efficient, has fewer features, and is more complicated.
+  ///
+  /// The message must be defined exactly as follows:
+  ///   message Foo {
+  ///     option message_set_wire_format = true;
+  ///     extensions 4 to max;
+  ///   }
+  /// Note that the message cannot have any defined fields; MessageSets only
+  /// have extensions.
+  ///
+  /// All extensions of your type must be singular messages; e.g. they cannot
+  /// be int32s, enums, or repeated messages.
+  ///
+  /// Because this is an option, the above two restrictions are not enforced by
+  /// the protocol compiler.
   fileprivate var _messageSetWireFormat: Bool? = nil
   var messageSetWireFormat: Bool {
     get {return _messageSetWireFormat ?? false}
@@ -2002,9 +2002,9 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     return _messageSetWireFormat = nil
   }
 
-  ///   Disables the generation of the standard "descriptor()" accessor, which can
-  ///   conflict with a field of the same name.  This is meant to make migration
-  ///   from proto1 easier; new code should avoid fields named "descriptor".
+  /// Disables the generation of the standard "descriptor()" accessor, which can
+  /// conflict with a field of the same name.  This is meant to make migration
+  /// from proto1 easier; new code should avoid fields named "descriptor".
   fileprivate var _noStandardDescriptorAccessor: Bool? = nil
   var noStandardDescriptorAccessor: Bool {
     get {return _noStandardDescriptorAccessor ?? false}
@@ -2017,10 +2017,10 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     return _noStandardDescriptorAccessor = nil
   }
 
-  ///   Is this message deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the message, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating messages.
+  /// Is this message deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the message, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating messages.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2033,27 +2033,27 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     return _deprecated = nil
   }
 
-  ///   Whether the message is an automatically generated map entry type for the
-  ///   maps field.
-  ///  
-  ///   For maps fields:
-  ///       map<KeyType, ValueType> map_field = 1;
-  ///   The parsed descriptor looks like:
-  ///       message MapFieldEntry {
-  ///           option map_entry = true;
-  ///           optional KeyType key = 1;
-  ///           optional ValueType value = 2;
-  ///       }
-  ///       repeated MapFieldEntry map_field = 1;
-  ///  
-  ///   Implementations may choose not to generate the map_entry=true message, but
-  ///   use a native map in the target language to hold the keys and values.
-  ///   The reflection APIs in such implementions still need to work as
-  ///   if the field is a repeated message field.
-  ///  
-  ///   NOTE: Do not set the option in .proto files. Always use the maps syntax
-  ///   instead. The option should only be implicitly set by the proto compiler
-  ///   parser.
+  /// Whether the message is an automatically generated map entry type for the
+  /// maps field.
+  ///
+  /// For maps fields:
+  ///     map<KeyType, ValueType> map_field = 1;
+  /// The parsed descriptor looks like:
+  ///     message MapFieldEntry {
+  ///         option map_entry = true;
+  ///         optional KeyType key = 1;
+  ///         optional ValueType value = 2;
+  ///     }
+  ///     repeated MapFieldEntry map_field = 1;
+  ///
+  /// Implementations may choose not to generate the map_entry=true message, but
+  /// use a native map in the target language to hold the keys and values.
+  /// The reflection APIs in such implementions still need to work as
+  /// if the field is a repeated message field.
+  ///
+  /// NOTE: Do not set the option in .proto files. Always use the maps syntax
+  /// instead. The option should only be implicitly set by the proto compiler
+  /// parser.
   fileprivate var _mapEntry: Bool? = nil
   var mapEntry: Bool {
     get {return _mapEntry ?? false}
@@ -2066,7 +2066,7 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     return _mapEntry = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2120,10 +2120,10 @@ struct Google_Protobuf_MessageOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
 struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".FieldOptions"
 
-  ///   The ctype option instructs the C++ code generator to use a different
-  ///   representation of the field than it normally would.  See the specific
-  ///   options below.  This option is not yet implemented in the open source
-  ///   release -- sorry, we'll try to include it in a future version!
+  /// The ctype option instructs the C++ code generator to use a different
+  /// representation of the field than it normally would.  See the specific
+  /// options below.  This option is not yet implemented in the open source
+  /// release -- sorry, we'll try to include it in a future version!
   fileprivate var _ctype: Google_Protobuf_FieldOptions.CType? = nil
   var ctype: Google_Protobuf_FieldOptions.CType {
     get {return _ctype ?? Google_Protobuf_FieldOptions.CType.string}
@@ -2136,11 +2136,11 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _ctype = nil
   }
 
-  ///   The packed option can be enabled for repeated primitive fields to enable
-  ///   a more efficient representation on the wire. Rather than repeatedly
-  ///   writing the tag and type for each element, the entire array is encoded as
-  ///   a single length-delimited blob. In proto3, only explicit setting it to
-  ///   false will avoid using packed encoding.
+  /// The packed option can be enabled for repeated primitive fields to enable
+  /// a more efficient representation on the wire. Rather than repeatedly
+  /// writing the tag and type for each element, the entire array is encoded as
+  /// a single length-delimited blob. In proto3, only explicit setting it to
+  /// false will avoid using packed encoding.
   fileprivate var _packed: Bool? = nil
   var packed: Bool {
     get {return _packed ?? false}
@@ -2153,15 +2153,15 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _packed = nil
   }
 
-  ///   The jstype option determines the JavaScript type used for values of the
-  ///   field.  The option is permitted only for 64 bit integral and fixed types
-  ///   (int64, uint64, sint64, fixed64, sfixed64).  By default these types are
-  ///   represented as JavaScript strings.  This avoids loss of precision that can
-  ///   happen when a large value is converted to a floating point JavaScript
-  ///   numbers.  Specifying JS_NUMBER for the jstype causes the generated
-  ///   JavaScript code to use the JavaScript "number" type instead of strings.
-  ///   This option is an enum to permit additional types to be added,
-  ///   e.g. goog.math.Integer.
+  /// The jstype option determines the JavaScript type used for values of the
+  /// field.  The option is permitted only for 64 bit integral and fixed types
+  /// (int64, uint64, sint64, fixed64, sfixed64).  By default these types are
+  /// represented as JavaScript strings.  This avoids loss of precision that can
+  /// happen when a large value is converted to a floating point JavaScript
+  /// numbers.  Specifying JS_NUMBER for the jstype causes the generated
+  /// JavaScript code to use the JavaScript "number" type instead of strings.
+  /// This option is an enum to permit additional types to be added,
+  /// e.g. goog.math.Integer.
   fileprivate var _jstype: Google_Protobuf_FieldOptions.JSType? = nil
   var jstype: Google_Protobuf_FieldOptions.JSType {
     get {return _jstype ?? Google_Protobuf_FieldOptions.JSType.jsNormal}
@@ -2174,34 +2174,34 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _jstype = nil
   }
 
-  ///   Should this field be parsed lazily?  Lazy applies only to message-type
-  ///   fields.  It means that when the outer message is initially parsed, the
-  ///   inner message's contents will not be parsed but instead stored in encoded
-  ///   form.  The inner message will actually be parsed when it is first accessed.
-  ///  
-  ///   This is only a hint.  Implementations are free to choose whether to use
-  ///   eager or lazy parsing regardless of the value of this option.  However,
-  ///   setting this option true suggests that the protocol author believes that
-  ///   using lazy parsing on this field is worth the additional bookkeeping
-  ///   overhead typically needed to implement it.
-  ///  
-  ///   This option does not affect the public interface of any generated code;
-  ///   all method signatures remain the same.  Furthermore, thread-safety of the
-  ///   interface is not affected by this option; const methods remain safe to
-  ///   call from multiple threads concurrently, while non-const methods continue
-  ///   to require exclusive access.
-  ///  
-  ///  
-  ///   Note that implementations may choose not to check required fields within
-  ///   a lazy sub-message.  That is, calling IsInitialized() on the outer message
-  ///   may return true even if the inner message has missing required fields.
-  ///   This is necessary because otherwise the inner message would have to be
-  ///   parsed in order to perform the check, defeating the purpose of lazy
-  ///   parsing.  An implementation which chooses not to check required fields
-  ///   must be consistent about it.  That is, for any particular sub-message, the
-  ///   implementation must either *always* check its required fields, or *never*
-  ///   check its required fields, regardless of whether or not the message has
-  ///   been parsed.
+  /// Should this field be parsed lazily?  Lazy applies only to message-type
+  /// fields.  It means that when the outer message is initially parsed, the
+  /// inner message's contents will not be parsed but instead stored in encoded
+  /// form.  The inner message will actually be parsed when it is first accessed.
+  ///
+  /// This is only a hint.  Implementations are free to choose whether to use
+  /// eager or lazy parsing regardless of the value of this option.  However,
+  /// setting this option true suggests that the protocol author believes that
+  /// using lazy parsing on this field is worth the additional bookkeeping
+  /// overhead typically needed to implement it.
+  ///
+  /// This option does not affect the public interface of any generated code;
+  /// all method signatures remain the same.  Furthermore, thread-safety of the
+  /// interface is not affected by this option; const methods remain safe to
+  /// call from multiple threads concurrently, while non-const methods continue
+  /// to require exclusive access.
+  ///
+  ///
+  /// Note that implementations may choose not to check required fields within
+  /// a lazy sub-message.  That is, calling IsInitialized() on the outer message
+  /// may return true even if the inner message has missing required fields.
+  /// This is necessary because otherwise the inner message would have to be
+  /// parsed in order to perform the check, defeating the purpose of lazy
+  /// parsing.  An implementation which chooses not to check required fields
+  /// must be consistent about it.  That is, for any particular sub-message, the
+  /// implementation must either *always* check its required fields, or *never*
+  /// check its required fields, regardless of whether or not the message has
+  /// been parsed.
   fileprivate var _lazy: Bool? = nil
   var lazy: Bool {
     get {return _lazy ?? false}
@@ -2214,10 +2214,10 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _lazy = nil
   }
 
-  ///   Is this field deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for accessors, or it will be completely ignored; in the very least, this
-  ///   is a formalization for deprecating fields.
+  /// Is this field deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for accessors, or it will be completely ignored; in the very least, this
+  /// is a formalization for deprecating fields.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2230,7 +2230,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _deprecated = nil
   }
 
-  ///   For Google-internal migration only. Do not use.
+  /// For Google-internal migration only. Do not use.
   fileprivate var _weak: Bool? = nil
   var weak: Bool {
     get {return _weak ?? false}
@@ -2243,7 +2243,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
     return _weak = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2251,7 +2251,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
   enum CType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   Default mode.
+    /// Default mode.
     case string // = 0
     case cord // = 1
     case stringPiece // = 2
@@ -2288,13 +2288,13 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
   enum JSType: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
 
-    ///   Use the default type.
+    /// Use the default type.
     case jsNormal // = 0
 
-    ///   Use JavaScript strings.
+    /// Use JavaScript strings.
     case jsString // = 1
 
-    ///   Use JavaScript numbers.
+    /// Use JavaScript numbers.
     case jsNumber // = 2
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -2383,7 +2383,7 @@ struct Google_Protobuf_FieldOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
 struct Google_Protobuf_OneofOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".OneofOptions"
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2421,8 +2421,8 @@ struct Google_Protobuf_OneofOptions: SwiftProtobuf.Message, SwiftProtobuf.Extens
 struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".EnumOptions"
 
-  ///   Set this option to true to allow mapping different tag names to the same
-  ///   value.
+  /// Set this option to true to allow mapping different tag names to the same
+  /// value.
   fileprivate var _allowAlias: Bool? = nil
   var allowAlias: Bool {
     get {return _allowAlias ?? false}
@@ -2435,10 +2435,10 @@ struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _allowAlias = nil
   }
 
-  ///   Is this enum deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the enum, or it will be completely ignored; in the very least, this
-  ///   is a formalization for deprecating enums.
+  /// Is this enum deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the enum, or it will be completely ignored; in the very least, this
+  /// is a formalization for deprecating enums.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2451,7 +2451,7 @@ struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
     return _deprecated = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2497,10 +2497,10 @@ struct Google_Protobuf_EnumOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
 struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".EnumValueOptions"
 
-  ///   Is this enum value deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the enum value, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating enum values.
+  /// Is this enum value deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the enum value, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating enum values.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2513,7 +2513,7 @@ struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Message, SwiftProtobuf.Ex
     return _deprecated = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2555,10 +2555,10 @@ struct Google_Protobuf_EnumValueOptions: SwiftProtobuf.Message, SwiftProtobuf.Ex
 struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".ServiceOptions"
 
-  ///   Is this service deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the service, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating services.
+  /// Is this service deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the service, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating services.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2571,7 +2571,7 @@ struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
     return _deprecated = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2613,10 +2613,10 @@ struct Google_Protobuf_ServiceOptions: SwiftProtobuf.Message, SwiftProtobuf.Exte
 struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".MethodOptions"
 
-  ///   Is this method deprecated?
-  ///   Depending on the target platform, this can emit Deprecated annotations
-  ///   for the method, or it will be completely ignored; in the very least,
-  ///   this is a formalization for deprecating methods.
+  /// Is this method deprecated?
+  /// Depending on the target platform, this can emit Deprecated annotations
+  /// for the method, or it will be completely ignored; in the very least,
+  /// this is a formalization for deprecating methods.
   fileprivate var _deprecated: Bool? = nil
   var deprecated: Bool {
     get {return _deprecated ?? false}
@@ -2641,22 +2641,22 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.Exten
     return _idempotencyLevel = nil
   }
 
-  ///   The parser stores options it doesn't recognize here. See above.
+  /// The parser stores options it doesn't recognize here. See above.
   var uninterpretedOption: [Google_Protobuf_UninterpretedOption] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
-  ///   or neither? HTTP based RPC implementation may choose GET verb for safe
-  ///   methods, and PUT verb for idempotent methods instead of the default POST.
+  /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+  /// or neither? HTTP based RPC implementation may choose GET verb for safe
+  /// methods, and PUT verb for idempotent methods instead of the default POST.
   enum IdempotencyLevel: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
     typealias RawValue = Int
     case idempotencyUnknown // = 0
 
-    ///   implies idempotent
+    /// implies idempotent
     case noSideEffects // = 1
 
-    ///   idempotent, but may have side effects
+    /// idempotent, but may have side effects
     case idempotent // = 2
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -2726,19 +2726,19 @@ struct Google_Protobuf_MethodOptions: SwiftProtobuf.Message, SwiftProtobuf.Exten
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   A message representing a option the parser does not recognize. This only
-///   appears in options protos created by the compiler::Parser class.
-///   DescriptorPool resolves these when building Descriptor objects. Therefore,
-///   options protos in descriptor objects (e.g. returned by Descriptor::options(),
-///   or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
-///   in them.
+/// A message representing a option the parser does not recognize. This only
+/// appears in options protos created by the compiler::Parser class.
+/// DescriptorPool resolves these when building Descriptor objects. Therefore,
+/// options protos in descriptor objects (e.g. returned by Descriptor::options(),
+/// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+/// in them.
 struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".UninterpretedOption"
 
   var name: [Google_Protobuf_UninterpretedOption.NamePart] = []
 
-  ///   The value of the uninterpreted option, in whatever type the tokenizer
-  ///   identified it as during parsing. Exactly one of these should be set.
+  /// The value of the uninterpreted option, in whatever type the tokenizer
+  /// identified it as during parsing. Exactly one of these should be set.
   fileprivate var _identifierValue: String? = nil
   var identifierValue: String {
     get {return _identifierValue ?? ""}
@@ -2813,11 +2813,11 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   The name of the uninterpreted option.  Each string represents a segment in
-  ///   a dot-separated name.  is_extension is true iff a segment represents an
-  ///   extension (denoted with parentheses in options specs in .proto files).
-  ///   E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
-  ///   "foo.(bar.baz).qux".
+  /// The name of the uninterpreted option.  Each string represents a segment in
+  /// a dot-separated name.  is_extension is true iff a segment represents an
+  /// extension (denoted with parentheses in options specs in .proto files).
+  /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+  /// "foo.(bar.baz).qux".
   struct NamePart: SwiftProtobuf.Message {
     static let protoMessageName: String = Google_Protobuf_UninterpretedOption.protoMessageName + ".NamePart"
 
@@ -2924,54 +2924,54 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
   }
 }
 
-///   Encapsulates information about the original source file from which a
-///   FileDescriptorProto was generated.
+/// Encapsulates information about the original source file from which a
+/// FileDescriptorProto was generated.
 struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SourceCodeInfo"
 
-  ///   A Location identifies a piece of source code in a .proto file which
-  ///   corresponds to a particular definition.  This information is intended
-  ///   to be useful to IDEs, code indexers, documentation generators, and similar
-  ///   tools.
-  ///  
-  ///   For example, say we have a file like:
-  ///     message Foo {
-  ///       optional string foo = 1;
-  ///     }
-  ///   Let's look at just the field definition:
+  /// A Location identifies a piece of source code in a .proto file which
+  /// corresponds to a particular definition.  This information is intended
+  /// to be useful to IDEs, code indexers, documentation generators, and similar
+  /// tools.
+  ///
+  /// For example, say we have a file like:
+  ///   message Foo {
   ///     optional string foo = 1;
-  ///     ^       ^^     ^^  ^  ^^^
-  ///     a       bc     de  f  ghi
-  ///   We have the following locations:
-  ///     span   path               represents
-  ///     [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
-  ///     [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
-  ///     [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
-  ///     [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
-  ///     [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
-  ///  
-  ///   Notes:
-  ///   - A location may refer to a repeated field itself (i.e. not to any
-  ///     particular index within it).  This is used whenever a set of elements are
-  ///     logically enclosed in a single code segment.  For example, an entire
-  ///     extend block (possibly containing multiple extension definitions) will
-  ///     have an outer location whose path refers to the "extensions" repeated
-  ///     field without an index.
-  ///   - Multiple locations may have the same path.  This happens when a single
-  ///     logical declaration is spread out across multiple places.  The most
-  ///     obvious example is the "extend" block again -- there may be multiple
-  ///     extend blocks in the same scope, each of which will have the same path.
-  ///   - A location's span is not always a subset of its parent's span.  For
-  ///     example, the "extendee" of an extension declaration appears at the
-  ///     beginning of the "extend" block and is shared by all extensions within
-  ///     the block.
-  ///   - Just because a location's span is a subset of some other location's span
-  ///     does not mean that it is a descendent.  For example, a "group" defines
-  ///     both a type and a field in a single declaration.  Thus, the locations
-  ///     corresponding to the type and field and their components will overlap.
-  ///   - Code which tries to interpret locations should probably be designed to
-  ///     ignore those that it doesn't understand, as more types of locations could
-  ///     be recorded in the future.
+  ///   }
+  /// Let's look at just the field definition:
+  ///   optional string foo = 1;
+  ///   ^       ^^     ^^  ^  ^^^
+  ///   a       bc     de  f  ghi
+  /// We have the following locations:
+  ///   span   path               represents
+  ///   [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+  ///   [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+  ///   [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+  ///   [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+  ///   [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+  ///
+  /// Notes:
+  /// - A location may refer to a repeated field itself (i.e. not to any
+  ///   particular index within it).  This is used whenever a set of elements are
+  ///   logically enclosed in a single code segment.  For example, an entire
+  ///   extend block (possibly containing multiple extension definitions) will
+  ///   have an outer location whose path refers to the "extensions" repeated
+  ///   field without an index.
+  /// - Multiple locations may have the same path.  This happens when a single
+  ///   logical declaration is spread out across multiple places.  The most
+  ///   obvious example is the "extend" block again -- there may be multiple
+  ///   extend blocks in the same scope, each of which will have the same path.
+  /// - A location's span is not always a subset of its parent's span.  For
+  ///   example, the "extendee" of an extension declaration appears at the
+  ///   beginning of the "extend" block and is shared by all extensions within
+  ///   the block.
+  /// - Just because a location's span is a subset of some other location's span
+  ///   does not mean that it is a descendent.  For example, a "group" defines
+  ///   both a type and a field in a single declaration.  Thus, the locations
+  ///   corresponding to the type and field and their components will overlap.
+  /// - Code which tries to interpret locations should probably be designed to
+  ///   ignore those that it doesn't understand, as more types of locations could
+  ///   be recorded in the future.
   var location: [Google_Protobuf_SourceCodeInfo.Location] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2979,85 +2979,85 @@ struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
   struct Location: SwiftProtobuf.Message {
     static let protoMessageName: String = Google_Protobuf_SourceCodeInfo.protoMessageName + ".Location"
 
-    ///   Identifies which part of the FileDescriptorProto was defined at this
-    ///   location.
-    ///  
-    ///   Each element is a field number or an index.  They form a path from
-    ///   the root FileDescriptorProto to the place where the definition.  For
-    ///   example, this path:
-    ///     [ 4, 3, 2, 7, 1 ]
-    ///   refers to:
-    ///     file.message_type(3)  // 4, 3
-    ///         .field(7)         // 2, 7
-    ///         .name()           // 1
-    ///   This is because FileDescriptorProto.message_type has field number 4:
-    ///     repeated DescriptorProto message_type = 4;
-    ///   and DescriptorProto.field has field number 2:
-    ///     repeated FieldDescriptorProto field = 2;
-    ///   and FieldDescriptorProto.name has field number 1:
-    ///     optional string name = 1;
-    ///  
-    ///   Thus, the above path gives the location of a field name.  If we removed
-    ///   the last element:
-    ///     [ 4, 3, 2, 7 ]
-    ///   this path refers to the whole field declaration (from the beginning
-    ///   of the label to the terminating semicolon).
+    /// Identifies which part of the FileDescriptorProto was defined at this
+    /// location.
+    ///
+    /// Each element is a field number or an index.  They form a path from
+    /// the root FileDescriptorProto to the place where the definition.  For
+    /// example, this path:
+    ///   [ 4, 3, 2, 7, 1 ]
+    /// refers to:
+    ///   file.message_type(3)  // 4, 3
+    ///       .field(7)         // 2, 7
+    ///       .name()           // 1
+    /// This is because FileDescriptorProto.message_type has field number 4:
+    ///   repeated DescriptorProto message_type = 4;
+    /// and DescriptorProto.field has field number 2:
+    ///   repeated FieldDescriptorProto field = 2;
+    /// and FieldDescriptorProto.name has field number 1:
+    ///   optional string name = 1;
+    ///
+    /// Thus, the above path gives the location of a field name.  If we removed
+    /// the last element:
+    ///   [ 4, 3, 2, 7 ]
+    /// this path refers to the whole field declaration (from the beginning
+    /// of the label to the terminating semicolon).
     var path: [Int32] = []
 
-    ///   Always has exactly three or four elements: start line, start column,
-    ///   end line (optional, otherwise assumed same as start line), end column.
-    ///   These are packed into a single field for efficiency.  Note that line
-    ///   and column numbers are zero-based -- typically you will want to add
-    ///   1 to each before displaying to a user.
+    /// Always has exactly three or four elements: start line, start column,
+    /// end line (optional, otherwise assumed same as start line), end column.
+    /// These are packed into a single field for efficiency.  Note that line
+    /// and column numbers are zero-based -- typically you will want to add
+    /// 1 to each before displaying to a user.
     var span: [Int32] = []
 
-    ///   If this SourceCodeInfo represents a complete declaration, these are any
-    ///   comments appearing before and after the declaration which appear to be
-    ///   attached to the declaration.
-    ///  
-    ///   A series of line comments appearing on consecutive lines, with no other
-    ///   tokens appearing on those lines, will be treated as a single comment.
-    ///  
-    ///   leading_detached_comments will keep paragraphs of comments that appear
-    ///   before (but not connected to) the current element. Each paragraph,
-    ///   separated by empty lines, will be one comment element in the repeated
-    ///   field.
-    ///  
-    ///   Only the comment content is provided; comment markers (e.g. //) are
-    ///   stripped out.  For block comments, leading whitespace and an asterisk
-    ///   will be stripped from the beginning of each line other than the first.
-    ///   Newlines are included in the output.
-    ///  
-    ///   Examples:
-    ///  
-    ///     optional int32 foo = 1;  // Comment attached to foo.
-    ///     // Comment attached to bar.
-    ///     optional int32 bar = 2;
-    ///  
-    ///     optional string baz = 3;
-    ///     // Comment attached to baz.
-    ///     // Another line attached to baz.
-    ///  
-    ///     // Comment attached to qux.
-    ///     //
-    ///     // Another line attached to qux.
-    ///     optional double qux = 4;
-    ///  
-    ///     // Detached comment for corge. This is not leading or trailing comments
-    ///     // to qux or corge because there are blank lines separating it from
-    ///     // both.
-    ///  
-    ///     // Detached comment for corge paragraph 2.
-    ///  
-    ///     optional string corge = 5;
-    ///     /* Block comment attached
-    ///      * to corge.  Leading asterisks
-    ///      * will be removed. */
-    ///     /* Block comment attached to
-    ///      * grault. */
-    ///     optional int32 grault = 6;
-    ///  
-    ///     // ignored detached comments.
+    /// If this SourceCodeInfo represents a complete declaration, these are any
+    /// comments appearing before and after the declaration which appear to be
+    /// attached to the declaration.
+    ///
+    /// A series of line comments appearing on consecutive lines, with no other
+    /// tokens appearing on those lines, will be treated as a single comment.
+    ///
+    /// leading_detached_comments will keep paragraphs of comments that appear
+    /// before (but not connected to) the current element. Each paragraph,
+    /// separated by empty lines, will be one comment element in the repeated
+    /// field.
+    ///
+    /// Only the comment content is provided; comment markers (e.g. //) are
+    /// stripped out.  For block comments, leading whitespace and an asterisk
+    /// will be stripped from the beginning of each line other than the first.
+    /// Newlines are included in the output.
+    ///
+    /// Examples:
+    ///
+    ///   optional int32 foo = 1;  // Comment attached to foo.
+    ///   // Comment attached to bar.
+    ///   optional int32 bar = 2;
+    ///
+    ///   optional string baz = 3;
+    ///   // Comment attached to baz.
+    ///   // Another line attached to baz.
+    ///
+    ///   // Comment attached to qux.
+    ///   //
+    ///   // Another line attached to qux.
+    ///   optional double qux = 4;
+    ///
+    ///   // Detached comment for corge. This is not leading or trailing comments
+    ///   // to qux or corge because there are blank lines separating it from
+    ///   // both.
+    ///
+    ///   // Detached comment for corge paragraph 2.
+    ///
+    ///   optional string corge = 5;
+    ///   /* Block comment attached
+    ///    * to corge.  Leading asterisks
+    ///    * will be removed. */
+    ///   /* Block comment attached to
+    ///    * grault. */
+    ///   optional int32 grault = 6;
+    ///
+    ///   // ignored detached comments.
     fileprivate var _leadingComments: String? = nil
     var leadingComments: String {
       get {return _leadingComments ?? ""}
@@ -3140,14 +3140,14 @@ struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
   }
 }
 
-///   Describes the relationship between generated code and its original source
-///   file. A GeneratedCodeInfo message is associated with only one generated
-///   source file, but may contain references to different source .proto files.
+/// Describes the relationship between generated code and its original source
+/// file. A GeneratedCodeInfo message is associated with only one generated
+/// source file, but may contain references to different source .proto files.
 struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".GeneratedCodeInfo"
 
-  ///   An Annotation connects some span of text in generated code to an element
-  ///   of its generating .proto file.
+  /// An Annotation connects some span of text in generated code to an element
+  /// of its generating .proto file.
   var annotation: [Google_Protobuf_GeneratedCodeInfo.Annotation] = []
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -3155,11 +3155,11 @@ struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
   struct Annotation: SwiftProtobuf.Message {
     static let protoMessageName: String = Google_Protobuf_GeneratedCodeInfo.protoMessageName + ".Annotation"
 
-    ///   Identifies the element in the original source .proto file. This field
-    ///   is formatted the same as SourceCodeInfo.Location.path.
+    /// Identifies the element in the original source .proto file. This field
+    /// is formatted the same as SourceCodeInfo.Location.path.
     var path: [Int32] = []
 
-    ///   Identifies the filesystem path to the original source .proto.
+    /// Identifies the filesystem path to the original source .proto.
     fileprivate var _sourceFile: String? = nil
     var sourceFile: String {
       get {return _sourceFile ?? ""}
@@ -3172,8 +3172,8 @@ struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
       return _sourceFile = nil
     }
 
-    ///   Identifies the starting offset in bytes in the generated code
-    ///   that relates to the identified object.
+    /// Identifies the starting offset in bytes in the generated code
+    /// that relates to the identified object.
     fileprivate var _begin: Int32? = nil
     var begin: Int32 {
       get {return _begin ?? 0}
@@ -3186,9 +3186,9 @@ struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
       return _begin = nil
     }
 
-    ///   Identifies the ending offset in bytes in the generated code that
-    ///   relates to the identified offset. The end offset should be one past
-    ///   the last relevant byte (so the length of the text = end - begin).
+    /// Identifies the ending offset in bytes in the generated code that
+    /// relates to the identified offset. The end offset should be one past
+    /// the last relevant byte (so the length of the text = end - begin).
     fileprivate var _end: Int32? = nil
     var end: Int32 {
       get {return _end ?? 0}

--- a/Tests/SwiftProtobufTests/map_proto2_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_proto2_unittest.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -241,7 +241,7 @@ struct ProtobufUnittest_TestIntIntMap: SwiftProtobuf.Message {
   }
 }
 
-///   Test all key types: string, plus the non-floating-point scalars.
+/// Test all key types: string, plus the non-floating-point scalars.
 struct ProtobufUnittest_TestMaps: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMaps"
 

--- a/Tests/SwiftProtobufTests/map_unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/map_unittest.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -88,7 +88,7 @@ enum ProtobufUnittest_MapEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProvi
 
 }
 
-///   Tests maps.
+/// Tests maps.
 struct ProtobufUnittest_TestMap: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMap"
 
@@ -414,7 +414,7 @@ struct ProtobufUnittest_TestMessageMap: SwiftProtobuf.Message {
   }
 }
 
-///   Two map fields share the same entry default instance.
+/// Two map fields share the same entry default instance.
 struct ProtobufUnittest_TestSameTypeMap: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestSameTypeMap"
 
@@ -447,7 +447,7 @@ struct ProtobufUnittest_TestSameTypeMap: SwiftProtobuf.Message {
   }
 }
 
-///   Test embedded message with required fields
+/// Test embedded message with required fields
 struct ProtobufUnittest_TestRequiredMessageMap: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRequiredMessageMap"
 
@@ -719,8 +719,8 @@ struct ProtobufUnittest_TestArenaMap: SwiftProtobuf.Message {
   }
 }
 
-///   Previously, message containing enum called Type cannot be used as value of
-///   map field.
+/// Previously, message containing enum called Type cannot be used as value of
+/// map field.
 struct ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MessageContainingEnumCalledType"
 
@@ -776,7 +776,7 @@ struct ProtobufUnittest_MessageContainingEnumCalledType: SwiftProtobuf.Message {
   }
 }
 
-///   Previously, message cannot contain map field called "entry".
+/// Previously, message cannot contain map field called "entry".
 struct ProtobufUnittest_MessageContainingMapCalledEntry: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MessageContainingMapCalledEntry"
 

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-//  Test schema for proto3 messages.  This test schema is used by:
-// 
-//  - benchmarks
-//  - fuzz tests
-//  - conformance tests
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Test schema for proto3 messages.  This test schema is used by:
+//
+// - benchmarks
+// - fuzz tests
+// - conformance tests
 
 import Foundation
 import SwiftProtobuf
@@ -94,13 +94,13 @@ enum ProtobufTestMessages_Proto3_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf.
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
-///  
-///   Also, crucially, all messages and enums in this file are eventually
-///   submessages of this message.  So for example, a fuzz test of TestAllTypes
-///   could trigger bugs that occur in any message type in this file.  We verify
-///   this stays true in a unit test.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
+///
+/// Also, crucially, all messages and enums in this file are eventually
+/// submessages of this message.  So for example, a fuzz test of TestAllTypes
+/// could trigger bugs that occur in any message type in this file.  We verify
+/// this stays true in a unit test.
 struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -343,7 +343,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -472,7 +472,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     return _storage._recursiveMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -578,7 +578,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedCord = newValue}
   }
 
-  ///   Map
+  /// Map
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
@@ -782,7 +782,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     }
   }
 
-  ///   Well-known types
+  /// Well-known types
   var optionalBoolWrapper: Google_Protobuf_BoolValue {
     get {return _storage._optionalBoolWrapper ?? Google_Protobuf_BoolValue()}
     set {_uniqueStorage()._optionalBoolWrapper = newValue}
@@ -1023,8 +1023,8 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedValue = newValue}
   }
 
-  ///   Test field-name-to-JSON-name convention.
-  ///   (protobuf says names can be any valid C/C++ identifier.)
+  /// Test field-name-to-JSON-name convention.
+  /// (protobuf says names can be any valid C/C++ identifier.)
   var fieldname1: Int32 {
     get {return _storage._fieldname1}
     set {_uniqueStorage()._fieldname1 = newValue}
@@ -1253,7 +1253,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 1
     case baz // = 2
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
 

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file we will use for unit testing.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file we will use for unit testing.
 
 import Foundation
 import SwiftProtobuf
@@ -92,7 +92,7 @@ enum ProtobufUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameP
 
 }
 
-///   Test an enum that has multiple values with the same number.
+/// Test an enum that has multiple values with the same number.
 enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case foo1 // = 1
@@ -130,7 +130,7 @@ enum ProtobufUnittest_TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._P
 
 }
 
-///   Test an enum with large, unordered values.
+/// Test an enum with large, unordered values.
 enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case sparseA // = 123
@@ -182,8 +182,8 @@ enum ProtobufUnittest_TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNa
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -348,7 +348,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -613,7 +613,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalCord = nil
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
@@ -636,7 +636,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalLazyMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -762,7 +762,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  ///   Singular with defaults
+  /// Singular with defaults
   var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
@@ -1120,7 +1120,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -1158,9 +1158,9 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = ProtobufUnittest_TestAllTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     fileprivate var _bb: Int32? = nil
     var bb: Int32 {
       get {return _bb ?? 0}
@@ -1576,7 +1576,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   }
 }
 
-///   This proto includes a recusively nested message.
+/// This proto includes a recusively nested message.
 struct ProtobufUnittest_NestedTestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedTestAllTypes"
 
@@ -1717,8 +1717,8 @@ struct ProtobufUnittest_TestDeprecatedMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct ProtobufUnittest_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 
@@ -1895,16 +1895,16 @@ struct ProtobufUnittest_TestNestedExtension: SwiftProtobuf.Message {
 
   struct Extensions {
 
-    ///   Check for bug where string extensions declared in tested scope did not
-    ///   compile.
+    /// Check for bug where string extensions declared in tested scope did not
+    /// compile.
     static let test = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
       _protobuf_fieldNumber: 1002,
       fieldName: "protobuf_unittest.TestNestedExtension.test",
       defaultValue: "test"
     )
 
-    ///   Used to test if generated extension name is correct when there are
-    ///   underscores.
+    /// Used to test if generated extension name is correct when there are
+    /// underscores.
     static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
       _protobuf_fieldNumber: 1003,
       fieldName: "protobuf_unittest.TestNestedExtension.nested_string_extension",
@@ -1924,11 +1924,11 @@ struct ProtobufUnittest_TestNestedExtension: SwiftProtobuf.Message {
   }
 }
 
-///   We have separate messages for testing required fields because it's
-///   annoying to have to fill in required fields in TestProto in order to
-///   do anything with it.  Note that we don't need to test every type of
-///   required filed because the code output is basically identical to
-///   optional fields for all types.
+/// We have separate messages for testing required fields because it's
+/// annoying to have to fill in required fields in TestProto in order to
+/// do anything with it.  Note that we don't need to test every type of
+/// required filed because the code output is basically identical to
+/// optional fields for all types.
 struct ProtobufUnittest_TestRequired: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRequired"
 
@@ -2048,8 +2048,8 @@ struct ProtobufUnittest_TestRequired: SwiftProtobuf.Message {
     return _storage._b = nil
   }
 
-  ///   Pad the field count to 32 so that we can test that IsInitialized()
-  ///   properly checks multiple elements of has_bits_.
+  /// Pad the field count to 32 so that we can test that IsInitialized()
+  /// properly checks multiple elements of has_bits_.
   var dummy4: Int32 {
     get {return _storage._dummy4 ?? 0}
     set {_uniqueStorage()._dummy4 = newValue}
@@ -2653,7 +2653,7 @@ struct ProtobufUnittest_TestRequiredForeign: SwiftProtobuf.Message {
   }
 }
 
-///   Test that we can use NestedMessage from outside TestAllTypes.
+/// Test that we can use NestedMessage from outside TestAllTypes.
 struct ProtobufUnittest_TestForeignNested: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestForeignNested"
 
@@ -2713,7 +2713,7 @@ struct ProtobufUnittest_TestForeignNested: SwiftProtobuf.Message {
   }
 }
 
-///   TestEmptyMessage is used to test unknown field support.
+/// TestEmptyMessage is used to test unknown field support.
 struct ProtobufUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessage"
 
@@ -2731,8 +2731,8 @@ struct ProtobufUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Like above, but declare all field numbers as potential extensions.  No
-///   actual extensions should ever be defined for this type.
+/// Like above, but declare all field numbers as potential extensions.  No
+/// actual extensions should ever be defined for this type.
 struct ProtobufUnittest_TestEmptyMessageWithExtensions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessageWithExtensions"
 
@@ -2791,12 +2791,12 @@ struct ProtobufUnittest_TestMultipleExtensionRanges: SwiftProtobuf.Message, Swif
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   Test that really large tag numbers don't break anything.
+/// Test that really large tag numbers don't break anything.
 struct ProtobufUnittest_TestReallyLargeTagNumber: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestReallyLargeTagNumber"
 
-  ///   The largest possible tag number is 2^28 - 1, since the wire format uses
-  ///   three bits to communicate wire type.
+  /// The largest possible tag number is 2^28 - 1, since the wire format uses
+  /// three bits to communicate wire type.
   fileprivate var _a: Int32? = nil
   var a: Int32 {
     get {return _a ?? 0}
@@ -2922,7 +2922,7 @@ struct ProtobufUnittest_TestRecursiveMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test that mutual recursion works.
+/// Test that mutual recursion works.
 struct ProtobufUnittest_TestMutualRecursionA: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMutualRecursionA"
 
@@ -3058,10 +3058,10 @@ struct ProtobufUnittest_TestMutualRecursionB: SwiftProtobuf.Message {
   }
 }
 
-///   Test that groups have disjoint field numbers from their siblings and
-///   parents.  This is NOT possible in proto1; only google.protobuf.  When attempting
-///   to compile with proto1, this will emit an error; so we only include it
-///   in protobuf_unittest_proto.
+/// Test that groups have disjoint field numbers from their siblings and
+/// parents.  This is NOT possible in proto1; only google.protobuf.  When attempting
+/// to compile with proto1, this will emit an error; so we only include it
+/// in protobuf_unittest_proto.
 struct ProtobufUnittest_TestDupFieldNumber: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestDupFieldNumber"
 
@@ -3088,7 +3088,7 @@ struct ProtobufUnittest_TestDupFieldNumber: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   NO_PROTO1
+  /// NO_PROTO1
   var a: Int32 {
     get {return _storage._a ?? 0}
     set {_uniqueStorage()._a = newValue}
@@ -3228,7 +3228,7 @@ struct ProtobufUnittest_TestDupFieldNumber: SwiftProtobuf.Message {
   }
 }
 
-///   Additional messages for testing lazy fields.
+/// Additional messages for testing lazy fields.
 struct ProtobufUnittest_TestEagerMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEagerMessage"
 
@@ -3347,7 +3347,7 @@ struct ProtobufUnittest_TestLazyMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Needed for a Python test.
+/// Needed for a Python test.
 struct ProtobufUnittest_TestNestedMessageHasBits: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestNestedMessageHasBits"
 
@@ -3439,8 +3439,8 @@ struct ProtobufUnittest_TestNestedMessageHasBits: SwiftProtobuf.Message {
   }
 }
 
-///   Test message with CamelCase field names.  This violates Protocol Buffer
-///   standard style.
+/// Test message with CamelCase field names.  This violates Protocol Buffer
+/// standard style.
 struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestCamelCaseFieldNames"
 
@@ -3651,8 +3651,8 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message {
   }
 }
 
-///   We list fields out of order, to ensure that we're using field number and not
-///   field index to determine serialization order.
+/// We list fields out of order, to ensure that we're using field number and not
+/// field index to determine serialization order.
 struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestFieldOrderings"
 
@@ -3742,9 +3742,9 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf
       return _oo = nil
     }
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     fileprivate var _bb: Int32? = nil
     var bb: Int32 {
       get {return _bb ?? 0}
@@ -3980,9 +3980,9 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._reallySmallInt64 = nil
   }
 
-  ///   The default value here is UTF-8 for "\u1234".  (We could also just type
-  ///   the UTF-8 text directly into this text file rather than escape it, but
-  ///   lots of people use editors that would be confused by this.)
+  /// The default value here is UTF-8 for "\u1234".  (We could also just type
+  /// the UTF-8 text directly into this text file rather than escape it, but
+  /// lots of people use editors that would be confused by this.)
   var utf8String: String {
     get {return _storage._utf8String ?? "ሴ"}
     set {_uniqueStorage()._utf8String = newValue}
@@ -3994,7 +3994,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._utf8String = nil
   }
 
-  ///   Tests for single-precision floating-point values.
+  /// Tests for single-precision floating-point values.
   var zeroFloat: Float {
     get {return _storage._zeroFloat ?? 0}
     set {_uniqueStorage()._zeroFloat = newValue}
@@ -4050,7 +4050,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._negativeFloat = nil
   }
 
-  ///   Using exponents
+  /// Using exponents
   var largeFloat: Float {
     get {return _storage._largeFloat ?? 2e+08}
     set {_uniqueStorage()._largeFloat = newValue}
@@ -4073,7 +4073,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._smallNegativeFloat = nil
   }
 
-  ///   Text for nonfinite floating-point values.
+  /// Text for nonfinite floating-point values.
   var infDouble: Double {
     get {return _storage._infDouble ?? Double.infinity}
     set {_uniqueStorage()._infDouble = newValue}
@@ -4140,11 +4140,11 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._nanFloat = nil
   }
 
-  ///   Tests for C++ trigraphs.
-  ///   Trigraphs should be escaped in C++ generated files, but they should not be
-  ///   escaped for other languages.
-  ///   Note that in .proto file, "\?" is a valid way to escape ? in string
-  ///   literals.
+  /// Tests for C++ trigraphs.
+  /// Trigraphs should be escaped in C++ generated files, but they should not be
+  /// escaped for other languages.
+  /// Note that in .proto file, "\?" is a valid way to escape ? in string
+  /// literals.
   var cppTrigraph: String {
     get {return _storage._cppTrigraph ?? "? ? ?? ?? ??? ??/ ??-"}
     set {_uniqueStorage()._cppTrigraph = newValue}
@@ -4156,7 +4156,7 @@ struct ProtobufUnittest_TestExtremeDefaultValues: SwiftProtobuf.Message {
     return _storage._cppTrigraph = nil
   }
 
-  ///   String defaults containing the character '\000'
+  /// String defaults containing the character '\000'
   var stringWithZero: String {
     get {return _storage._stringWithZero ?? "hel\0lo"}
     set {_uniqueStorage()._stringWithZero = newValue}
@@ -4378,7 +4378,7 @@ struct ProtobufUnittest_SparseEnumMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test String and Bytes: string is for valid UTF-8 strings
+/// Test String and Bytes: string is for valid UTF-8 strings
 struct ProtobufUnittest_OneString: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OneString"
 
@@ -4503,7 +4503,7 @@ struct ProtobufUnittest_MoreBytes: SwiftProtobuf.Message {
   }
 }
 
-///   Test int32, uint32, int64, uint64, and bool are all compatible
+/// Test int32, uint32, int64, uint64, and bool are all compatible
 struct ProtobufUnittest_Int32Message: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Int32Message"
 
@@ -4684,7 +4684,7 @@ struct ProtobufUnittest_BoolMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test oneofs.
+/// Test oneofs.
 struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestOneof"
 
@@ -6043,8 +6043,8 @@ struct ProtobufUnittest_TestPackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   A message with the same fields as TestPackedTypes, but without packing. Used
-///   to test packed <-> unpacked wire compatibility.
+/// A message with the same fields as TestPackedTypes, but without packing. Used
+/// to test packed <-> unpacked wire compatibility.
 struct ProtobufUnittest_TestUnpackedTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestUnpackedTypes"
 
@@ -6205,9 +6205,9 @@ struct ProtobufUnittest_TestUnpackedExtensions: SwiftProtobuf.Message, SwiftProt
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   Used by ExtensionSetTest/DynamicExtensions.  The test actually builds
-///   a set of extensions to TestAllExtensions dynamically, based on the fields
-///   of this message type.
+/// Used by ExtensionSetTest/DynamicExtensions.  The test actually builds
+/// a set of extensions to TestAllExtensions dynamically, based on the fields
+/// of this message type.
 struct ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestDynamicExtensions"
 
@@ -6431,20 +6431,20 @@ struct ProtobufUnittest_TestDynamicExtensions: SwiftProtobuf.Message {
 struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRepeatedScalarDifferentTagSizes"
 
-  ///   Parsing repeated fixed size values used to fail. This message needs to be
-  ///   used in order to get a tag of the right size; all of the repeated fields
-  ///   in TestAllTypes didn't trigger the check.
+  /// Parsing repeated fixed size values used to fail. This message needs to be
+  /// used in order to get a tag of the right size; all of the repeated fields
+  /// in TestAllTypes didn't trigger the check.
   var repeatedFixed32: [UInt32] = []
 
-  ///   Check for a varint type, just for good measure.
+  /// Check for a varint type, just for good measure.
   var repeatedInt32: [Int32] = []
 
-  ///   These have two-byte tags.
+  /// These have two-byte tags.
   var repeatedFixed64: [UInt64] = []
 
   var repeatedInt64: [Int64] = []
 
-  ///   Three byte tags.
+  /// Three byte tags.
   var repeatedFloat: [Float] = []
 
   var repeatedUint64: [UInt64] = []
@@ -6490,8 +6490,8 @@ struct ProtobufUnittest_TestRepeatedScalarDifferentTagSizes: SwiftProtobuf.Messa
   }
 }
 
-///   Test that if an optional or required message/group field appears multiple
-///   times in the input, they need to be merged.
+/// Test that if an optional or required message/group field appears multiple
+/// times in the input, they need to be merged.
 struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestParsingMerge"
 
@@ -6567,11 +6567,11 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.E
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  ///   RepeatedFieldsGenerator defines matching field types as TestParsingMerge,
-  ///   except that all fields are repeated. In the tests, we will serialize the
-  ///   RepeatedFieldsGenerator to bytes, and parse the bytes to TestParsingMerge.
-  ///   Repeated fields in RepeatedFieldsGenerator are expected to be merged into
-  ///   the corresponding required/optional fields in TestParsingMerge.
+  /// RepeatedFieldsGenerator defines matching field types as TestParsingMerge,
+  /// except that all fields are repeated. In the tests, we will serialize the
+  /// RepeatedFieldsGenerator to bytes, and parse the bytes to TestParsingMerge.
+  /// Repeated fields in RepeatedFieldsGenerator are expected to be merged into
+  /// the corresponding required/optional fields in TestParsingMerge.
   struct RepeatedFieldsGenerator: SwiftProtobuf.Message {
     static let protoMessageName: String = ProtobufUnittest_TestParsingMerge.protoMessageName + ".RepeatedFieldsGenerator"
 
@@ -6941,7 +6941,7 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.E
 struct ProtobufUnittest_TestCommentInjectionMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestCommentInjectionMessage"
 
-  ///   */ <- This should not close the generated doc comment
+  /// */ <- This should not close the generated doc comment
   fileprivate var _a: String? = nil
   var a: String {
     get {return _a ?? "*/ <- Neither should this."}
@@ -6975,7 +6975,7 @@ struct ProtobufUnittest_TestCommentInjectionMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test that RPC services work.
+/// Test that RPC services work.
 struct ProtobufUnittest_FooRequest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FooRequest"
 
@@ -7571,7 +7571,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   Singular
+/// Singular
 let ProtobufUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 1,
   fieldName: "protobuf_unittest.optional_int32_extension",
@@ -7728,7 +7728,7 @@ let ProtobufUnittest_Extensions_optional_lazy_message_extension = SwiftProtobuf.
   defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
 )
 
-///   Repeated
+/// Repeated
 let ProtobufUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 31,
   fieldName: "protobuf_unittest.repeated_int32_extension",
@@ -7879,7 +7879,7 @@ let ProtobufUnittest_Extensions_repeated_lazy_message_extension = SwiftProtobuf.
   defaultValue: []
 )
 
-///   Singular with defaults
+/// Singular with defaults
 let ProtobufUnittest_Extensions_default_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 61,
   fieldName: "protobuf_unittest.default_int32_extension",
@@ -8000,7 +8000,7 @@ let ProtobufUnittest_Extensions_default_cord_extension = SwiftProtobuf.MessageEx
   defaultValue: "123"
 )
 
-///   For oneof test
+/// For oneof test
 let ProtobufUnittest_Extensions_oneof_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 111,
   fieldName: "protobuf_unittest.oneof_uint32_extension",
@@ -8212,8 +8212,8 @@ let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<
 )
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   Check for bug where string extensions declared in tested scope did not
-  ///   compile.
+  /// Check for bug where string extensions declared in tested scope did not
+  /// compile.
   var ProtobufUnittest_TestNestedExtension_test: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test) ?? "test"}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test, value: newValue)}
@@ -8227,8 +8227,8 @@ extension ProtobufUnittest_TestAllExtensions {
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   Used to test if generated extension name is correct when there are
-  ///   underscores.
+  /// Used to test if generated extension name is correct when there are
+  /// underscores.
   var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? ""}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension, value: newValue)}
@@ -8294,7 +8294,7 @@ extension ProtobufUnittest_TestParsingMerge {
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   Singular
+  /// Singular
   var ProtobufUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension, value: newValue)}
@@ -8633,7 +8633,7 @@ extension ProtobufUnittest_TestAllExtensions {
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   Repeated
+  /// Repeated
   var ProtobufUnittest_repeatedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension)}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension, value: newValue)}
@@ -8959,7 +8959,7 @@ extension ProtobufUnittest_TestAllExtensions {
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   Singular with defaults
+  /// Singular with defaults
   var ProtobufUnittest_defaultInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension) ?? 41}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension, value: newValue)}
@@ -9220,7 +9220,7 @@ extension ProtobufUnittest_TestAllExtensions {
 }
 
 extension ProtobufUnittest_TestAllExtensions {
-  ///   For oneof test
+  /// For oneof test
   var ProtobufUnittest_oneofUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension, value: newValue)}

--- a/Tests/SwiftProtobufTests/unittest_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_arena.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: benjy@google.com (Benjy Weinberger)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file used to test the "custom options" feature of google.protobuf.
+// Author: benjy@google.com (Benjy Weinberger)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file used to test the "custom options" feature of google.protobuf.
 
 import Foundation
 import SwiftProtobuf
@@ -115,8 +115,8 @@ enum ProtobufUnittest_AggregateEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNam
 
 }
 
-///   A test message with custom options at all possible locations (and also some
-///   regular options, to make sure they interact nicely).
+/// A test message with custom options at all possible locations (and also some
+/// regular options, to make sure they interact nicely).
 struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMessageWithCustomOptions"
 
@@ -238,8 +238,8 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
   }
 }
 
-///   A test RPC service with custom options at all possible locations (and also
-///   some regular options, to make sure they interact nicely).
+/// A test RPC service with custom options at all possible locations (and also
+/// some regular options, to make sure they interact nicely).
 struct ProtobufUnittest_CustomOptionFooRequest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".CustomOptionFooRequest"
 
@@ -852,7 +852,7 @@ struct ProtobufUnittest_ComplexOpt6: SwiftProtobuf.Message {
   }
 }
 
-///   Note that we try various different ways of naming the same extension.
+/// Note that we try various different ways of naming the same extension.
 struct ProtobufUnittest_VariousComplexOptions: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".VariousComplexOptions"
 
@@ -943,7 +943,7 @@ struct ProtobufUnittest_AggregateMessageSetElement: SwiftProtobuf.Message {
   }
 }
 
-///   A helper type used to test aggregate option parsing
+/// A helper type used to test aggregate option parsing
 struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Aggregate"
 
@@ -996,7 +996,7 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
     return _storage._s = nil
   }
 
-  ///   A nested object
+  /// A nested object
   var sub: ProtobufUnittest_Aggregate {
     get {return _storage._sub ?? ProtobufUnittest_Aggregate()}
     set {_uniqueStorage()._sub = newValue}
@@ -1008,7 +1008,7 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
     return _storage._sub = nil
   }
 
-  ///   To test the parsing of extensions inside aggregate values
+  /// To test the parsing of extensions inside aggregate values
   var file: Google_Protobuf_FileOptions {
     get {return _storage._file ?? Google_Protobuf_FileOptions()}
     set {_uniqueStorage()._file = newValue}
@@ -1020,7 +1020,7 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
     return _storage._file = nil
   }
 
-  ///   An embedded message set
+  /// An embedded message set
   var mset: ProtobufUnittest_AggregateMessageSet {
     get {return _storage._mset ?? ProtobufUnittest_AggregateMessageSet()}
     set {_uniqueStorage()._mset = newValue}
@@ -1128,7 +1128,7 @@ struct ProtobufUnittest_AggregateMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test custom options for nested type.
+/// Test custom options for nested type.
 struct ProtobufUnittest_NestedOptionType: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedOptionType"
 
@@ -1218,8 +1218,8 @@ struct ProtobufUnittest_NestedOptionType: SwiftProtobuf.Message {
   }
 }
 
-///   Custom message option that has a required enum field.
-///   WARNING: this is strongly discouraged!
+/// Custom message option that has a required enum field.
+/// WARNING: this is strongly discouraged!
 struct ProtobufUnittest_OldOptionType: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OldOptionType"
 
@@ -1288,7 +1288,7 @@ struct ProtobufUnittest_OldOptionType: SwiftProtobuf.Message {
   }
 }
 
-///   Updated version of the custom option above.
+/// Updated version of the custom option above.
 struct ProtobufUnittest_NewOptionType: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NewOptionType"
 
@@ -1361,7 +1361,7 @@ struct ProtobufUnittest_NewOptionType: SwiftProtobuf.Message {
   }
 }
 
-///   Test message using the "required_enum_opt" option defined above.
+/// Test message using the "required_enum_opt" option defined above.
 struct ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMessageWithRequiredEnumOption"
 
@@ -1397,8 +1397,8 @@ let ProtobufUnittest_Extensions_field_opt1 = SwiftProtobuf.MessageExtension<Opti
   defaultValue: 0
 )
 
-///   This is useful for testing that we correctly register default values for
-///   extension options.
+/// This is useful for testing that we correctly register default values for
+/// extension options.
 let ProtobufUnittest_Extensions_field_opt2 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FieldOptions>(
   _protobuf_fieldNumber: 7753913,
   fieldName: "protobuf_unittest.field_opt2",
@@ -1725,8 +1725,8 @@ extension Google_Protobuf_FieldOptions {
 }
 
 extension Google_Protobuf_FieldOptions {
-  ///   This is useful for testing that we correctly register default values for
-  ///   extension options.
+  /// This is useful for testing that we correctly register default values for
+  /// extension options.
   var ProtobufUnittest_fieldOpt2: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2) ?? 42}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2, value: newValue)}

--- a/Tests/SwiftProtobufTests/unittest_drop_unknown_fields.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_drop_unknown_fields.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_embed_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_embed_optimize_for.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file which imports a proto file that uses optimize_for = CODE_SIZE.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file which imports a proto file that uses optimize_for = CODE_SIZE.
 
 import Foundation
 import SwiftProtobuf
@@ -81,8 +81,8 @@ struct ProtobufUnittest_TestEmbedOptimizedForSize: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Test that embedding a message which has optimize_for = CODE_SIZE into
-  ///   one optimized for speed works.
+  /// Test that embedding a message which has optimize_for = CODE_SIZE into
+  /// one optimized for speed works.
   var optionalMessage: ProtobufUnittest_TestOptimizedForSize {
     get {return _storage._optionalMessage ?? ProtobufUnittest_TestOptimizedForSize()}
     set {_uniqueStorage()._optionalMessage = newValue}

--- a/Tests/SwiftProtobufTests/unittest_empty.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_empty.pb.swift
@@ -6,42 +6,42 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  This file intentionally left blank.  (At one point this wouldn't compile
-//  correctly.)
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// This file intentionally left blank.  (At one point this wouldn't compile
+// correctly.)
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_import.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file which is imported by unittest.proto to test importing.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file which is imported by unittest.proto to test importing.
 
 import Foundation
 import SwiftProtobuf
@@ -92,7 +92,7 @@ enum ProtobufUnittestImport_ImportEnum: SwiftProtobuf.Enum, SwiftProtobuf._Proto
 
 }
 
-///   To use an enum in a map, it must has the first value as 0.
+/// To use an enum in a map, it must has the first value as 0.
 enum ProtobufUnittestImport_ImportEnumForMap: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case unknown // = 0

--- a/Tests/SwiftProtobufTests/unittest_import_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_lite.pb.swift
@@ -6,39 +6,39 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-// 
-//  This is like unittest_import.proto but with optimize_for = LITE_RUNTIME.
+// Author: kenton@google.com (Kenton Varda)
+//
+// This is like unittest_import.proto but with optimize_for = LITE_RUNTIME.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_import_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_proto3.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file which is imported by unittest_proto3.proto to test importing.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file which is imported by unittest_proto3.proto to test importing.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_import_public.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_public.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: liujisi@google.com (Pherl Liu)
+// Author: liujisi@google.com (Pherl Liu)
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_import_public_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_public_lite.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: liujisi@google.com (Pherl Liu)
+// Author: liujisi@google.com (Pherl Liu)
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_import_public_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_public_proto3.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: liujisi@google.com (Pherl Liu)
+// Author: liujisi@google.com (Pherl Liu)
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -6,39 +6,39 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-// 
-//  This is like unittest.proto but with optimize_for = LITE_RUNTIME.
+// Author: kenton@google.com (Kenton Varda)
+//
+// This is like unittest.proto but with optimize_for = LITE_RUNTIME.
 
 import Foundation
 import SwiftProtobuf
@@ -148,7 +148,7 @@ enum ProtobufUnittest_V2EnumLite: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePr
 
 }
 
-///   Same as TestAllTypes but with the lite runtime.
+/// Same as TestAllTypes but with the lite runtime.
 struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypesLite"
 
@@ -315,7 +315,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -580,7 +580,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     return _storage._optionalCord = nil
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessageLite {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessageLite()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
@@ -603,7 +603,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     return _storage._optionalLazyMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -729,7 +729,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  ///   Singular with defaults
+  /// Singular with defaults
   var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
@@ -1010,7 +1010,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
     }
   }
 
-  ///   Tests toString for non-repeated fields with a list suffix
+  /// Tests toString for non-repeated fields with a list suffix
   var deceptivelyNamedList: Int32 {
     get {return _storage._deceptivelyNamedList ?? 0}
     set {_uniqueStorage()._deceptivelyNamedList = newValue}
@@ -1885,8 +1885,8 @@ struct ProtobufUnittest_TestNestedExtensionLite: SwiftProtobuf.Message {
   }
 }
 
-///   Test that deprecated fields work.  We only verify that they compile (at one
-///   point this failed).
+/// Test that deprecated fields work.  We only verify that they compile (at one
+/// point this failed).
 struct ProtobufUnittest_TestDeprecatedLite: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestDeprecatedLite"
 
@@ -1923,7 +1923,7 @@ struct ProtobufUnittest_TestDeprecatedLite: SwiftProtobuf.Message {
   }
 }
 
-///   See the comments of the same type in unittest.proto.
+/// See the comments of the same type in unittest.proto.
 struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestParsingMergeLite"
 
@@ -2365,7 +2365,7 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   TestEmptyMessageLite is used to test unknown fields support in lite mode.
+/// TestEmptyMessageLite is used to test unknown fields support in lite mode.
 struct ProtobufUnittest_TestEmptyMessageLite: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessageLite"
 
@@ -2383,8 +2383,8 @@ struct ProtobufUnittest_TestEmptyMessageLite: SwiftProtobuf.Message {
   }
 }
 
-///   Like above, but declare all field numbers as potential extensions.  No
-///   actual extensions should ever be defined for this type.
+/// Like above, but declare all field numbers as potential extensions.  No
+/// actual extensions should ever be defined for this type.
 struct ProtobufUnittest_TestEmptyMessageWithExtensionsLite: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessageWithExtensionsLite"
 
@@ -2904,7 +2904,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-///   Singular
+/// Singular
 let ProtobufUnittest_Extensions_optional_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 1,
   fieldName: "protobuf_unittest.optional_int32_extension_lite",
@@ -3061,7 +3061,7 @@ let ProtobufUnittest_Extensions_optional_lazy_message_extension_lite = SwiftProt
   defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
 )
 
-///   Repeated
+/// Repeated
 let ProtobufUnittest_Extensions_repeated_int32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 31,
   fieldName: "protobuf_unittest.repeated_int32_extension_lite",
@@ -3212,7 +3212,7 @@ let ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite = SwiftProt
   defaultValue: []
 )
 
-///   Singular with defaults
+/// Singular with defaults
 let ProtobufUnittest_Extensions_default_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 61,
   fieldName: "protobuf_unittest.default_int32_extension_lite",
@@ -3333,7 +3333,7 @@ let ProtobufUnittest_Extensions_default_cord_extension_lite = SwiftProtobuf.Mess
   defaultValue: "123"
 )
 
-///   For oneof test
+/// For oneof test
 let ProtobufUnittest_Extensions_oneof_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 111,
   fieldName: "protobuf_unittest.oneof_uint32_extension_lite",
@@ -3488,7 +3488,7 @@ extension ProtobufUnittest_TestParsingMergeLite {
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  ///   Singular
+  /// Singular
   var ProtobufUnittest_optionalInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite, value: newValue)}
@@ -3827,7 +3827,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  ///   Repeated
+  /// Repeated
   var ProtobufUnittest_repeatedInt32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite)}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite, value: newValue)}
@@ -4153,7 +4153,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  ///   Singular with defaults
+  /// Singular with defaults
   var ProtobufUnittest_defaultInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite) ?? 41}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite, value: newValue)}
@@ -4414,7 +4414,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 }
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  ///   For oneof test
+  /// For oneof test
   var ProtobufUnittest_oneofUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite, value: newValue)}

--- a/Tests/SwiftProtobufTests/unittest_lite_imports_nonlite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite_imports_nonlite.pb.swift
@@ -6,39 +6,39 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-// 
-//  Tests that a "lite" message can import a regular message.
+// Author: kenton@google.com (Kenton Varda)
+//
+// Tests that a "lite" message can import a regular message.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -6,42 +6,42 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  This file is similar to unittest_mset_wire_format.proto, but does not
-//  have a TestMessageSet, so it can be downgraded to proto1.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// This file is similar to unittest_mset_wire_format.proto, but does not
+// have a TestMessageSet, so it can be downgraded to proto1.
 
 import Foundation
 import SwiftProtobuf
@@ -214,7 +214,7 @@ struct ProtobufUnittest_TestMessageSetExtension2: SwiftProtobuf.Message {
   }
 }
 
-///   MessageSet wire format is equivalent to this.
+/// MessageSet wire format is equivalent to this.
 struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".RawMessageSet"
 

--- a/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset_wire_format.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  This file contains messages for testing message_set_wire_format.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// This file contains messages for testing message_set_wire_format.
 
 import Foundation
 import SwiftProtobuf
@@ -57,7 +57,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "proto2_wireformat_unittest"
 
-///   A message with message_set_wire_format.
+/// A message with message_set_wire_format.
 struct Proto2WireformatUnittest_TestMessageSet: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = _protobuf_package + ".TestMessageSet"
 

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -6,43 +6,43 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  This proto file contains copies of TestAllTypes and friends, but with arena
-//  support disabled in code generation. It allows us to test the performance
-//  impact against baseline (non-arena) google.protobuf.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// This proto file contains copies of TestAllTypes and friends, but with arena
+// support disabled in code generation. It allows us to test the performance
+// impact against baseline (non-arena) google.protobuf.
 
 import Foundation
 import SwiftProtobuf
@@ -94,8 +94,8 @@ enum ProtobufUnittestNoArena_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._Pro
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -260,7 +260,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32 ?? 0}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -525,7 +525,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalCord = nil
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
@@ -548,7 +548,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -674,7 +674,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedLazyMessage = newValue}
   }
 
-  ///   Singular with defaults
+  /// Singular with defaults
   var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
@@ -1057,7 +1057,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -1095,9 +1095,9 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = ProtobufUnittestNoArena_TestAllTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     fileprivate var _bb: Int32? = nil
     var bb: Int32 {
       get {return _bb ?? 0}
@@ -1513,8 +1513,8 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct ProtobufUnittestNoArena_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 

--- a/Tests/SwiftProtobufTests/unittest_no_arena_import.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena_import.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_no_arena_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena_lite.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  A proto file used to test a message type with no explicit field presence.
+// A proto file used to test a message type with no explicit field presence.
 
 import Foundation
 import SwiftProtobuf
@@ -90,8 +90,8 @@ enum Proto2NofieldpresenceUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobu
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -206,9 +206,9 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
-  ///   TODO: remove 'optional' labels as soon as CL 69188077 is LGTM'd to make
-  ///   'optional' optional.
+  /// Singular
+  /// TODO: remove 'optional' labels as soon as CL 69188077 is LGTM'd to make
+  /// 'optional' optional.
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -322,9 +322,9 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._optionalNestedEnum = newValue}
   }
 
-  ///   N.B.: proto2-enum-type fields not allowed, because their default values
-  ///   might not be zero.
-  ///  optional protobuf_unittest.ForeignEnum          optional_proto2_enum     = 23;
+  /// N.B.: proto2-enum-type fields not allowed, because their default values
+  /// might not be zero.
+  ///optional protobuf_unittest.ForeignEnum          optional_proto2_enum     = 23;
   var optionalForeignEnum: Proto2NofieldpresenceUnittest_ForeignEnum {
     get {return _storage._optionalForeignEnum}
     set {_uniqueStorage()._optionalForeignEnum = newValue}
@@ -351,7 +351,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalLazyMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -931,8 +931,8 @@ struct Proto2NofieldpresenceUnittest_TestProto2Required: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct Proto2NofieldpresenceUnittest_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
+// Author: kenton@google.com (Kenton Varda)
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file which uses optimize_for = CODE_SIZE.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file which uses optimize_for = CODE_SIZE.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -138,7 +138,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
 
   var repeatedPackedE: [Proto3PreserveUnknownEnumUnittest_MyEnum] = []
 
-  ///   not packed
+  /// not packed
   var repeatedPackedUnexpectedE: [Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra] = []
 
   var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnum {

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -105,7 +105,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
 
   var repeatedPackedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
 
-  ///   not packed
+  /// not packed
   var repeatedPackedUnexpectedE: [Proto2PreserveUnknownEnumUnittest_MyEnum] = []
 
   var oneofE1: Proto2PreserveUnknownEnumUnittest_MyEnum {

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -6,41 +6,41 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//  Author: kenton@google.com (Kenton Varda)
-//   Based on original Protocol Buffers design by
-//   Sanjay Ghemawat, Jeff Dean, and others.
-// 
-//  A proto file we will use for unit testing.
+// Author: kenton@google.com (Kenton Varda)
+//  Based on original Protocol Buffers design by
+//  Sanjay Ghemawat, Jeff Dean, and others.
+//
+// A proto file we will use for unit testing.
 
 import Foundation
 import SwiftProtobuf
@@ -98,7 +98,7 @@ enum Proto3ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
 
 }
 
-///   Test an enum that has multiple values with the same number.
+/// Test an enum that has multiple values with the same number.
 enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case testEnumWithDupValueUnspecified // = 0
@@ -142,7 +142,7 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNamePro
 
 }
 
-///   Test an enum with large, unordered values.
+/// Test an enum with large, unordered values.
 enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding {
   typealias RawValue = Int
   case testSparseEnumUnspecified // = 0
@@ -152,8 +152,8 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding
   case sparseD // = -15
   case sparseE // = -53452
 
-  ///   In proto3, value 0 must be the first one specified
-  ///   SPARSE_F = 0;
+  /// In proto3, value 0 must be the first one specified
+  /// SPARSE_F = 0;
   case sparseG // = 2
   case UNRECOGNIZED(Int)
 
@@ -199,8 +199,8 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNameProviding
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct Proto3TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -311,7 +311,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var singleInt32: Int32 {
     get {return _storage._singleInt32}
     set {_uniqueStorage()._singleInt32 = newValue}
@@ -435,7 +435,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._singleImportEnum = newValue}
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var singlePublicImportMessage: Proto3PublicImportMessage {
     get {return _storage._singlePublicImportMessage ?? Proto3PublicImportMessage()}
     set {_uniqueStorage()._singlePublicImportMessage = newValue}
@@ -447,7 +447,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     return _storage._singlePublicImportMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -553,7 +553,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedImportEnum = newValue}
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var repeatedPublicImportMessage: [Proto3PublicImportMessage] {
     get {return _storage._repeatedPublicImportMessage}
     set {_uniqueStorage()._repeatedPublicImportMessage = newValue}
@@ -691,7 +691,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
 
@@ -734,9 +734,9 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = Proto3TestAllTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     var bb: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -962,7 +962,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
   }
 }
 
-///   This proto includes a recusively nested message.
+/// This proto includes a recusively nested message.
 struct Proto3NestedTestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedTestAllTypes"
 
@@ -1076,8 +1076,8 @@ struct Proto3TestDeprecatedFields: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct Proto3ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 
@@ -1121,7 +1121,7 @@ struct Proto3TestReservedFields: SwiftProtobuf.Message {
   }
 }
 
-///   Test that we can use NestedMessage from outside TestAllTypes.
+/// Test that we can use NestedMessage from outside TestAllTypes.
 struct Proto3TestForeignNested: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestForeignNested"
 
@@ -1181,12 +1181,12 @@ struct Proto3TestForeignNested: SwiftProtobuf.Message {
   }
 }
 
-///   Test that really large tag numbers don't break anything.
+/// Test that really large tag numbers don't break anything.
 struct Proto3TestReallyLargeTagNumber: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestReallyLargeTagNumber"
 
-  ///   The largest possible tag number is 2^28 - 1, since the wire format uses
-  ///   three bits to communicate wire type.
+  /// The largest possible tag number is 2^28 - 1, since the wire format uses
+  /// three bits to communicate wire type.
   var a: Int32 = 0
 
   var bb: Int32 = 0
@@ -1286,7 +1286,7 @@ struct Proto3TestRecursiveMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test that mutual recursion works.
+/// Test that mutual recursion works.
 struct Proto3TestMutualRecursionA: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestMutualRecursionA"
 
@@ -1442,8 +1442,8 @@ struct Proto3TestEnumAllowAlias: SwiftProtobuf.Message {
   }
 }
 
-///   Test message with CamelCase field names.  This violates Protocol Buffer
-///   standard style.
+/// Test message with CamelCase field names.  This violates Protocol Buffer
+/// standard style.
 struct Proto3TestCamelCaseFieldNames: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestCamelCaseFieldNames"
 
@@ -1580,8 +1580,8 @@ struct Proto3TestCamelCaseFieldNames: SwiftProtobuf.Message {
   }
 }
 
-///   We list fields out of order, to ensure that we're using field number and not
-///   field index to determine serialization order.
+/// We list fields out of order, to ensure that we're using field number and not
+/// field index to determine serialization order.
 struct Proto3TestFieldOrderings: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestFieldOrderings"
 
@@ -1643,9 +1643,9 @@ struct Proto3TestFieldOrderings: SwiftProtobuf.Message {
 
     var oo: Int64 = 0
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     var bb: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -1735,7 +1735,7 @@ struct Proto3SparseEnumMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test String and Bytes: string is for valid UTF-8 strings
+/// Test String and Bytes: string is for valid UTF-8 strings
 struct Proto3OneString: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OneString"
 
@@ -1840,7 +1840,7 @@ struct Proto3MoreBytes: SwiftProtobuf.Message {
   }
 }
 
-///   Test int32, uint32, int64, uint64, and bool are all compatible
+/// Test int32, uint32, int64, uint64, and bool are all compatible
 struct Proto3Int32Message: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Int32Message"
 
@@ -1971,7 +1971,7 @@ struct Proto3BoolMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test oneofs.
+/// Test oneofs.
 struct Proto3TestOneof: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestOneof"
 
@@ -2226,8 +2226,8 @@ struct Proto3TestPackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   A message with the same fields as TestPackedTypes, but without packing. Used
-///   to test packed <-> unpacked wire compatibility.
+/// A message with the same fields as TestPackedTypes, but without packing. Used
+/// to test packed <-> unpacked wire compatibility.
 struct Proto3TestUnpackedTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestUnpackedTypes"
 
@@ -2335,20 +2335,20 @@ struct Proto3TestUnpackedTypes: SwiftProtobuf.Message {
 struct Proto3TestRepeatedScalarDifferentTagSizes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestRepeatedScalarDifferentTagSizes"
 
-  ///   Parsing repeated fixed size values used to fail. This message needs to be
-  ///   used in order to get a tag of the right size; all of the repeated fields
-  ///   in TestAllTypes didn't trigger the check.
+  /// Parsing repeated fixed size values used to fail. This message needs to be
+  /// used in order to get a tag of the right size; all of the repeated fields
+  /// in TestAllTypes didn't trigger the check.
   var repeatedFixed32: [UInt32] = []
 
-  ///   Check for a varint type, just for good measure.
+  /// Check for a varint type, just for good measure.
   var repeatedInt32: [Int32] = []
 
-  ///   These have two-byte tags.
+  /// These have two-byte tags.
   var repeatedFixed64: [UInt64] = []
 
   var repeatedInt64: [Int64] = []
 
-  ///   Three byte tags.
+  /// Three byte tags.
   var repeatedFloat: [Float] = []
 
   var repeatedUint64: [UInt64] = []
@@ -2397,7 +2397,7 @@ struct Proto3TestRepeatedScalarDifferentTagSizes: SwiftProtobuf.Message {
 struct Proto3TestCommentInjectionMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestCommentInjectionMessage"
 
-  ///   */ <- This should not close the generated doc comment
+  /// */ <- This should not close the generated doc comment
   var a: String = ""
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -2421,7 +2421,7 @@ struct Proto3TestCommentInjectionMessage: SwiftProtobuf.Message {
   }
 }
 
-///   Test that RPC services work.
+/// Test that RPC services work.
 struct Proto3FooRequest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".FooRequest"
 

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -92,8 +92,8 @@ enum Proto3ArenaUnittest_ForeignEnum: SwiftProtobuf.Enum, SwiftProtobuf._ProtoNa
 
 }
 
-///   This proto includes every type of field in both singular and repeated
-///   forms.
+/// This proto includes every type of field in both singular and repeated
+/// forms.
 struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestAllTypes"
 
@@ -210,7 +210,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -339,7 +339,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._optionalCord = newValue}
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._optionalPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._optionalPublicImportMessage = newValue}
@@ -362,7 +362,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     return _storage._optionalLazyMessage = nil
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -610,7 +610,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
     case UNRECOGNIZED(Int)
 
@@ -653,9 +653,9 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = Proto3ArenaUnittest_TestAllTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     var bb: Int32 = 0
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -997,7 +997,7 @@ struct Proto3ArenaUnittest_TestPackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   Explicitly set packed to false
+/// Explicitly set packed to false
 struct Proto3ArenaUnittest_TestUnpackedTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestUnpackedTypes"
 
@@ -1102,7 +1102,7 @@ struct Proto3ArenaUnittest_TestUnpackedTypes: SwiftProtobuf.Message {
   }
 }
 
-///   This proto includes a recusively nested message.
+/// This proto includes a recusively nested message.
 struct Proto3ArenaUnittest_NestedTestAllTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".NestedTestAllTypes"
 
@@ -1179,8 +1179,8 @@ struct Proto3ArenaUnittest_NestedTestAllTypes: SwiftProtobuf.Message {
   }
 }
 
-///   Define these after TestAllTypes to make sure the compiler can handle
-///   that.
+/// Define these after TestAllTypes to make sure the compiler can handle
+/// that.
 struct Proto3ArenaUnittest_ForeignMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".ForeignMessage"
 
@@ -1207,7 +1207,7 @@ struct Proto3ArenaUnittest_ForeignMessage: SwiftProtobuf.Message {
   }
 }
 
-///   TestEmptyMessage is used to test behavior of unknown fields.
+/// TestEmptyMessage is used to test behavior of unknown fields.
 struct Proto3ArenaUnittest_TestEmptyMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEmptyMessage"
 

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -6,37 +6,37 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-///   An addition to unittest.proto
+/// An addition to unittest.proto
 
 import Foundation
 import SwiftProtobuf
@@ -167,7 +167,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Singular
+  /// Singular
   var requiredInt32: Int32 {
     get {return _storage._requiredInt32 ?? 0}
     set {_uniqueStorage()._requiredInt32 = newValue}
@@ -432,7 +432,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
     return _storage._requiredCord = nil
   }
 
-  ///   Defined in unittest_import_public.proto
+  /// Defined in unittest_import_public.proto
   var requiredPublicImportMessage: ProtobufUnittestImport_PublicImportMessage {
     get {return _storage._requiredPublicImportMessage ?? ProtobufUnittestImport_PublicImportMessage()}
     set {_uniqueStorage()._requiredPublicImportMessage = newValue}
@@ -455,7 +455,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
     return _storage._requiredLazyMessage = nil
   }
 
-  ///   Singular with defaults
+  /// Singular with defaults
   var defaultInt32: Int32 {
     get {return _storage._defaultInt32 ?? 41}
     set {_uniqueStorage()._defaultInt32 = newValue}
@@ -813,7 +813,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
     case bar // = 2
     case baz // = 3
 
-    ///   Intentionally negative.
+    /// Intentionally negative.
     case neg // = -1
 
     static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
@@ -851,9 +851,9 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
   struct NestedMessage: SwiftProtobuf.Message {
     static let protoMessageName: String = ProtobufUnittest_TestAllRequiredTypes.protoMessageName + ".NestedMessage"
 
-    ///   The field name "b" fails to compile in proto1 because it conflicts with
-    ///   a local variable named "b" in one of the generated methods.  Doh.
-    ///   This file needs to compile in proto1 to test backwards-compatibility.
+    /// The field name "b" fails to compile in proto1 because it conflicts with
+    /// a local variable named "b" in one of the generated methods.  Doh.
+    /// This file needs to compile in proto1 to test backwards-compatibility.
     fileprivate var _bb: Int32? = nil
     var bb: Int32 {
       get {return _bb ?? 0}
@@ -1207,7 +1207,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
 struct ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestSomeRequiredTypes"
 
-  ///   Singular
+  /// Singular
   fileprivate var _requiredInt32: Int32? = nil
   var requiredInt32: Int32 {
     get {return _requiredInt32 ?? 0}

--- a/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_cycle.pb.swift
@@ -6,34 +6,34 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2015 Google Inc.  All rights reserved.
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2015 Apple, Inc.  All Rights Reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Apple, Inc.  All Rights Reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum_optional_default.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_enum_optional_default.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test handling of enum fields with specified defaults
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_enum_optional_default.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test handling of enum fields with specified defaults
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf
@@ -66,8 +66,8 @@ struct ProtobufUnittest_Extend_EnumOptionalDefault: SwiftProtobuf.Message {
       return _storage
     }
 
-    ///   The circular reference here forces the generator to
-    ///   implement heap-backed storage.
+    /// The circular reference here forces the generator to
+    /// implement heap-backed storage.
     var message: ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage {
       get {return _storage._message ?? ProtobufUnittest_Extend_EnumOptionalDefault.NestedMessage()}
       set {_uniqueStorage()._message = newValue}

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_extension.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test handling of extensions to deeply nested messages.
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_extension.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test handling of extensions to deeply nested messages.
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf
@@ -120,7 +120,7 @@ struct ProtobufUnittest_Extend_Foo: SwiftProtobuf.Message {
 struct ProtobufUnittest_Extend_C: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".C"
 
-  ///        extensions 10 to 20;
+  ///      extensions 10 to 20;
   fileprivate var _c: Int64? = nil
   var c: Int64 {
     get {return _c ?? 0}
@@ -291,7 +291,7 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
     return _storage._x = nil
   }
 
-  ///   Recursive class (i.e. - can build a graph), forces _StorageClass.
+  /// Recursive class (i.e. - can build a graph), forces _StorageClass.
   var y: ProtobufUnittest_Extend_MsgUsesStorage {
     get {return _storage._y ?? ProtobufUnittest_Extend_MsgUsesStorage()}
     set {_uniqueStorage()._y = newValue}

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -6,23 +6,23 @@
  *
  */
 
-//  Protos/unittest_swift_extension2.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test naming of extensions that differ only in proto package. This is a
-// / clone of unittest_swift_extension3.proto, but with a different proto package
-// / and different extension numbers.
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_extension2.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test naming of extensions that differ only in proto package. This is a
+/// clone of unittest_swift_extension3.proto, but with a different proto package
+/// and different extension numbers.
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -6,23 +6,23 @@
  *
  */
 
-//  Protos/unittest_swift_extension3.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test naming of extensions that differ only in proto package. This is a
-// / clone of unittest_swift_extension2.proto, but with a different proto package
-// / and different extension numbers.
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_extension3.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test naming of extensions that differ only in proto package. This is a
+/// clone of unittest_swift_extension2.proto, but with a different proto package
+/// and different extension numbers.
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -6,23 +6,23 @@
  *
  */
 
-//  Protos/unittest_swift_extension4.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test naming of extensions that differ only in proto package. This is a
-// / clone of unittest_swift_extension[23].proto, but with a different proto
-// / package, different extension numbers, and a Swift prefix option.
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_extension4.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test naming of extensions that differ only in proto package. This is a
+/// clone of unittest_swift_extension[23].proto, but with a different proto
+/// package, different extension numbers, and a Swift prefix option.
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_fieldorder.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Check that fields get properly ordered when serializing
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_fieldorder.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Check that fields get properly ordered when serializing
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2015 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -49,7 +49,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _1
 }
 
-///   Same field number appears inside and outside of the group.
+/// Same field number appears inside and outside of the group.
 struct SwiftTestGroupExtensions: SwiftProtobuf.Message, SwiftProtobuf.ExtensibleMessage {
   static let protoMessageName: String = "SwiftTestGroupExtensions"
 

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -6,23 +6,23 @@
  *
  */
 
-//  Protos/unittest_swift_reserved.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test Swift reserved words used as enum or message names
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_reserved.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test Swift reserved words used as enum or message names
+///
+// -----------------------------------------------------------------------------
 
-///   proto2 syntax is used so the has*/clear* names also get generated.
+/// proto2 syntax is used so the has*/clear* names also get generated.
 
 import Foundation
 import SwiftProtobuf
@@ -898,13 +898,13 @@ enum SwiftUnittest_Names_EnumFieldNames2: SwiftProtobuf.Enum, SwiftProtobuf._Pro
   typealias RawValue = Int
   case aa // = 0
 
-  ///   protoc no longer allows enum naming that would differ only in underscores.
-  ///   Initial commit:
-  ///     https://github.com/google/protobuf/commit/cc8ca5b6a5478b40546d4206392eb1471454460d
-  ///   Change keep proto3 as error, but proto2 to just a warning:
-  ///     https://github.com/google/protobuf/pull/2204
-  ///   So this is in a second enum so it won't cause issues with the '_' one;
-  ///   but still ensure things generator correctly.
+  /// protoc no longer allows enum naming that would differ only in underscores.
+  /// Initial commit:
+  ///   https://github.com/google/protobuf/commit/cc8ca5b6a5478b40546d4206392eb1471454460d
+  /// Change keep proto3 as error, but proto2 to just a warning:
+  ///   https://github.com/google/protobuf/pull/2204
+  /// So this is in a second enum so it won't cause issues with the '_' one;
+  /// but still ensure things generator correctly.
   case ____ // = 1065
 
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [

--- a/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_naming_no_prefix.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test Swift reserved words used as enum or message names
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_naming_no_prefix.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test Swift reserved words used as enum or message names
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf

--- a/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -135,7 +135,7 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   One of every singular field type
+  /// One of every singular field type
   var optionalInt32: Int32 {
     get {return _storage._optionalInt32}
     set {_uniqueStorage()._optionalInt32 = newValue}
@@ -216,7 +216,7 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedRecursiveMessage = newValue}
   }
 
-  ///   Repeated
+  /// Repeated
   var repeatedInt32: [Int32] {
     get {return _storage._repeatedInt32}
     set {_uniqueStorage()._repeatedInt32 = newValue}
@@ -292,7 +292,7 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  ///   Map
+  /// Map
   var mapStringMessage: Dictionary<String,Swift_Performance_TestAllTypes> {
     get {return _storage._mapStringMessage}
     set {_uniqueStorage()._mapStringMessage = newValue}

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_reserved.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test Swift reserved words used as enum or message names
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_reserved.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test Swift reserved words used as enum or message names
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf
@@ -40,7 +40,7 @@ fileprivate let _protobuf_package = "protobuf_unittest"
 struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SwiftReservedTest"
 
-  ///   static r/o properties on Message, ensure they still work as fields.
+  /// static r/o properties on Message, ensure they still work as fields.
   fileprivate var _protoMessageName: Int32? = nil
   var protoMessageName: Int32 {
     get {return _protoMessageName ?? 0}
@@ -89,7 +89,7 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
     return _anyTypeURL = nil
   }
 
-  ///   r/o properties on Message, ensure it gets remapped.
+  /// r/o properties on Message, ensure it gets remapped.
   fileprivate var _isInitialized_p: String? = nil
   var isInitialized_p: String {
     get {return _isInitialized_p ?? ""}
@@ -325,17 +325,17 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
 
   struct Extensions {
 
-    ///   This will end up in the "struct Extensions" to scope it, but there
-    ///   the raw form is used ("hash_value", not the Swift one "hashValue"),
-    ///   so there is no conflict, and no renaming happens.
+    /// This will end up in the "struct Extensions" to scope it, but there
+    /// the raw form is used ("hash_value", not the Swift one "hashValue"),
+    /// so there is no conflict, and no renaming happens.
     static let hash_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
       _protobuf_fieldNumber: 1001,
       fieldName: "protobuf_unittest.SwiftReservedTestExt.hash_value",
       defaultValue: false
     )
 
-    ///   Reserved words, since these end up in the "struct Extensions", they
-    ///   can't just be get their names, and sanitation kicks.
+    /// Reserved words, since these end up in the "struct Extensions", they
+    /// can't just be get their names, and sanitation kicks.
     static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
       _protobuf_fieldNumber: 1022,
       fieldName: "protobuf_unittest.SwiftReservedTestExt.as",
@@ -379,15 +379,15 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
   }
 }
 
-///   Won't get _p added because it is fully qualified.
+/// Won't get _p added because it is fully qualified.
 let ProtobufUnittest_Extensions_debug_description = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
   _protobuf_fieldNumber: 1000,
   fieldName: "protobuf_unittest.debug_description",
   defaultValue: false
 )
 
-///   These are scoped to the file, so the package prefix (or a Swift prefix)
-///   will get added to them to they aren't going to get renamed.
+/// These are scoped to the file, so the package prefix (or a Swift prefix)
+/// will get added to them to they aren't going to get renamed.
 let ProtobufUnittest_Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
   _protobuf_fieldNumber: 1012,
   fieldName: "protobuf_unittest.as",
@@ -419,9 +419,9 @@ let ProtobufUnittest_Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExt
 )
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  ///   This will end up in the "struct Extensions" to scope it, but there
-  ///   the raw form is used ("hash_value", not the Swift one "hashValue"),
-  ///   so there is no conflict, and no renaming happens.
+  /// This will end up in the "struct Extensions" to scope it, but there
+  /// the raw form is used ("hash_value", not the Swift one "hashValue"),
+  /// so there is no conflict, and no renaming happens.
   var ProtobufUnittest_SwiftReservedTestExt_hashValue: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value, value: newValue)}
@@ -435,8 +435,8 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  ///   Reserved words, since these end up in the "struct Extensions", they
-  ///   can't just be get their names, and sanitation kicks.
+  /// Reserved words, since these end up in the "struct Extensions", they
+  /// can't just be get their names, and sanitation kicks.
   var ProtobufUnittest_SwiftReservedTestExt_as: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.as) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.as, value: newValue)}
@@ -502,7 +502,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  ///   Won't get _p added because it is fully qualified.
+  /// Won't get _p added because it is fully qualified.
   var ProtobufUnittest_debugDescription: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debug_description) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_debug_description, value: newValue)}
@@ -516,8 +516,8 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  ///   These are scoped to the file, so the package prefix (or a Swift prefix)
-  ///   will get added to them to they aren't going to get renamed.
+  /// These are scoped to the file, so the package prefix (or a Swift prefix)
+  /// will get added to them to they aren't going to get renamed.
   var ProtobufUnittest_as: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_as) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_as, value: newValue)}

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
@@ -6,21 +6,21 @@
  *
  */
 
-//  Protos/unittest_swift_reserved_ext.proto - test proto
-// 
-//  This source file is part of the Swift.org open source project
-// 
-//  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
-//  Licensed under Apache License v2.0 with Runtime Library Exception
-// 
-//  See http://swift.org/LICENSE.txt for license information
-//  See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-// 
-//  -----------------------------------------------------------------------------
-// /
-// / Test Swift reserved words used as enum or message names
-// /
-//  -----------------------------------------------------------------------------
+// Protos/unittest_swift_reserved_ext.proto - test proto
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+// -----------------------------------------------------------------------------
+///
+/// Test Swift reserved words used as enum or message names
+///
+// -----------------------------------------------------------------------------
 
 import Foundation
 import SwiftProtobuf
@@ -48,8 +48,8 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
       defaultValue: false
     )
 
-    ///   Reserved words, since these end up in the "struct Extensions", they
-    ///   can't just be get their names, and sanitation kicks.
+    /// Reserved words, since these end up in the "struct Extensions", they
+    /// can't just be get their names, and sanitation kicks.
     static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
       _protobuf_fieldNumber: 1022,
       fieldName: "SwiftReservedTestExt2.as",
@@ -93,15 +93,15 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
   }
 }
 
-///   Will get _p added because it has no package/swift prefix to scope and
-///   would otherwise be a problem when added to the message.
+/// Will get _p added because it has no package/swift prefix to scope and
+/// would otherwise be a problem when added to the message.
 let Extensions_debugDescription = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
   _protobuf_fieldNumber: 1000,
   fieldName: "debugDescription",
   defaultValue: false
 )
 
-///   These will get _p added for the same reasoning.
+/// These will get _p added for the same reasoning.
 let Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
   _protobuf_fieldNumber: 1012,
   fieldName: "as",
@@ -146,8 +146,8 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  ///   Reserved words, since these end up in the "struct Extensions", they
-  ///   can't just be get their names, and sanitation kicks.
+  /// Reserved words, since these end up in the "struct Extensions", they
+  /// can't just be get their names, and sanitation kicks.
   var SwiftReservedTestExt2_as: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.as) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.as, value: newValue)}
@@ -213,8 +213,8 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  ///   Will get _p added because it has no package/swift prefix to scope and
-  ///   would otherwise be a problem when added to the message.
+  /// Will get _p added because it has no package/swift prefix to scope and
+  /// would otherwise be a problem when added to the message.
   var debugDescription_p: Bool {
     get {return getExtensionValue(ext: Extensions_debugDescription) ?? false}
     set {setExtensionValue(ext: Extensions_debugDescription, value: newValue)}
@@ -228,7 +228,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  ///   These will get _p added for the same reasoning.
+  /// These will get _p added for the same reasoning.
   var as_p: Bool {
     get {return getExtensionValue(ext: Extensions_as) ?? false}
     set {setExtensionValue(ext: Extensions_as, value: newValue)}

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -6,34 +6,34 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2015 Google Inc.  All rights reserved.
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -686,7 +686,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
     }
   }
 
-  ///   Some token map cases, too many combinations to list them all.
+  /// Some token map cases, too many combinations to list them all.
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
@@ -1495,7 +1495,7 @@ struct ProtobufUnittest_Msg2UsesStorage: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Recursive class (i.e. - can build a graph), forces _StorageClass.
+  /// Recursive class (i.e. - can build a graph), forces _StorageClass.
   var y: ProtobufUnittest_Msg2UsesStorage {
     get {return _storage._y ?? ProtobufUnittest_Msg2UsesStorage()}
     set {_uniqueStorage()._y = newValue}

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -6,34 +6,34 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2015 Google Inc.  All rights reserved.
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2015 Google Inc.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -253,7 +253,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     set {_uniqueStorage()._optionalBytes = newValue}
   }
 
-  ///   No 'group' in proto3.
+  /// No 'group' in proto3.
   var optionalMessage: ProtobufUnittest_Message3 {
     get {return _storage._optionalMessage ?? ProtobufUnittest_Message3()}
     set {_uniqueStorage()._optionalMessage = newValue}
@@ -345,7 +345,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     set {_uniqueStorage()._repeatedBytes = newValue}
   }
 
-  ///   No 'group' in proto3.
+  /// No 'group' in proto3.
   var repeatedMessage: [ProtobufUnittest_Message3] {
     get {return _storage._repeatedMessage}
     set {_uniqueStorage()._repeatedMessage = newValue}
@@ -536,7 +536,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     }
   }
 
-  ///   No 'group' in proto3.
+  /// No 'group' in proto3.
   var oneofMessage: ProtobufUnittest_Message3 {
     get {
       if case .oneofMessage(let v)? = _storage._o {
@@ -561,7 +561,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     }
   }
 
-  ///   Some token map cases, too many combinations to list them all.
+  /// Some token map cases, too many combinations to list them all.
   var mapInt32Int32: Dictionary<Int32,Int32> {
     get {return _storage._mapInt32Int32}
     set {_uniqueStorage()._mapInt32Int32 = newValue}
@@ -1195,7 +1195,7 @@ struct ProtobufUnittest_Msg3UsesStorage: SwiftProtobuf.Message {
     return _storage
   }
 
-  ///   Recursive class (i.e. - can build a graph), forces _StorageClass.
+  /// Recursive class (i.e. - can build a graph), forces _StorageClass.
   var y: ProtobufUnittest_Msg3UsesStorage {
     get {return _storage._y ?? ProtobufUnittest_Msg3UsesStorage()}
     set {_uniqueStorage()._y = newValue}

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -6,35 +6,35 @@
  *
  */
 
-//  Protocol Buffers - Google's data interchange format
-//  Copyright 2008 Google Inc.  All rights reserved.
-//  https://developers.google.com/protocol-buffers/
-// 
-//  Redistribution and use in source and binary forms, with or without
-//  modification, are permitted provided that the following conditions are
-//  met:
-// 
-//      * Redistributions of source code must retain the above copyright
-//  notice, this list of conditions and the following disclaimer.
-//      * Redistributions in binary form must reproduce the above
-//  copyright notice, this list of conditions and the following disclaimer
-//  in the documentation and/or other materials provided with the
-//  distribution.
-//      * Neither the name of Google Inc. nor the names of its
-//  contributors may be used to endorse or promote products derived from
-//  this software without specific prior written permission.
-// 
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 import SwiftProtobuf
@@ -105,7 +105,7 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
   }
 }
 
-///   Singular
+/// Singular
 let ProtobufObjcUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
   _protobuf_fieldNumber: 1,
   fieldName: "protobuf_objc_unittest.optional_int32_extension",
@@ -132,7 +132,7 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
 }
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
-  ///   Singular
+  /// Singular
   var ProtobufObjcUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension, value: newValue)}

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -21,9 +21,9 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 fileprivate let _protobuf_package = "protobuf_unittest"
 
-///   Test that we can include all well-known types.
-///   Each wrapper type is included separately, as languages
-///   map handle different wrappers in different ways.
+/// Test that we can include all well-known types.
+/// Each wrapper type is included separately, as languages
+/// map handle different wrappers in different ways.
 struct ProtobufUnittest_TestWellKnownTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestWellKnownTypes"
 
@@ -280,7 +280,7 @@ struct ProtobufUnittest_TestWellKnownTypes: SwiftProtobuf.Message {
     return _storage._bytesField = nil
   }
 
-  ///   Part of struct, but useful to be able to test separately
+  /// Part of struct, but useful to be able to test separately
   var valueField: Google_Protobuf_Value {
     get {return _storage._valueField ?? Google_Protobuf_Value()}
     set {_uniqueStorage()._valueField = newValue}
@@ -390,7 +390,7 @@ struct ProtobufUnittest_TestWellKnownTypes: SwiftProtobuf.Message {
   }
 }
 
-///   A repeated field for each well-known type.
+/// A repeated field for each well-known type.
 struct ProtobufUnittest_RepeatedWellKnownTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".RepeatedWellKnownTypes"
 
@@ -492,7 +492,7 @@ struct ProtobufUnittest_RepeatedWellKnownTypes: SwiftProtobuf.Message {
     set {_uniqueStorage()._typeField = newValue}
   }
 
-  ///   These don't actually make a lot of sense, but they're not prohibited...
+  /// These don't actually make a lot of sense, but they're not prohibited...
   var doubleField: [Google_Protobuf_DoubleValue] {
     get {return _storage._doubleField}
     set {_uniqueStorage()._doubleField = newValue}
@@ -1161,9 +1161,9 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message {
   }
 }
 
-///   A map field for each well-known type. We only
-///   need to worry about the value part of the map being the
-///   well-known types, as messages can't be map keys.
+/// A map field for each well-known type. We only
+/// need to worry about the value part of the map being the
+/// well-known types, as messages can't be map keys.
 struct ProtobufUnittest_MapWellKnownTypes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MapWellKnownTypes"
 


### PR DESCRIPTION
protoc captures the leading spaces on the proto file comments; so
never add spaces between the "//" or "///" the generator puts
on the front and instead rely on the spacing from the proto file.

When looking at the generated source, it seemed overly the content
after the comment marker was overly indented; this seems (to me)
to be a little more natural.