### PR TITLE
Split the oneof Enum generation.

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -124,37 +124,6 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .protobufPayload(value)
-        return
-      case 2:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .jsonPayload(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .protobufPayload(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
-        }
-      case .jsonPayload(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      }
-    }
   }
 
   init() {}
@@ -274,73 +243,6 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .parseError(value)
-        return
-      case 2:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .runtimeError(value)
-        return
-      case 3:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .protobufPayload(value)
-        return
-      case 4:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .jsonPayload(value)
-        return
-      case 5:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .skipped(value)
-        return
-      case 6:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .serializeError(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .parseError(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-        }
-      case .runtimeError(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .protobufPayload(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
-        }
-      case .jsonPayload(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-        }
-      case .skipped(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-        }
-      case .serializeError(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   init() {}
@@ -387,6 +289,39 @@ extension Conformance_ConformanceRequest: SwiftProtobuf._MessageImplementationBa
   }
 }
 
+extension Conformance_ConformanceRequest.OneOf_Payload {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .protobufPayload(value)
+      return
+    case 2:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .jsonPayload(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .protobufPayload(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
+      }
+    case .jsonPayload(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    }
+  }
+}
+
 extension Conformance_ConformanceResponse: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "parse_error"),
@@ -401,5 +336,74 @@ extension Conformance_ConformanceResponse: SwiftProtobuf._MessageImplementationB
     if result != other.result {return false}
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Conformance_ConformanceResponse.OneOf_Result {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .parseError(value)
+      return
+    case 2:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .runtimeError(value)
+      return
+    case 3:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .protobufPayload(value)
+      return
+    case 4:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .jsonPayload(value)
+      return
+    case 5:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .skipped(value)
+      return
+    case 6:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .serializeError(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .parseError(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+      }
+    case .runtimeError(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .protobufPayload(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
+      }
+    case .jsonPayload(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+      }
+    case .skipped(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+      }
+    case .serializeError(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+      }
+    }
   }
 }

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -250,77 +250,6 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value = Google_Protobuf_NullValue()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .nullValue(value)
-        return
-      case 2:
-        var value = Double()
-        try decoder.decodeSingularDoubleField(value: &value)
-        self = .numberValue(value)
-        return
-      case 3:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .stringValue(value)
-        return
-      case 4:
-        var value = Bool()
-        try decoder.decodeSingularBoolField(value: &value)
-        self = .boolValue(value)
-        return
-      case 5:
-        var value: Google_Protobuf_Struct?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .structValue(value)
-          return
-        }
-      case 6:
-        var value: Google_Protobuf_ListValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .listValue(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .nullValue(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
-        }
-      case .numberValue(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
-        }
-      case .stringValue(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-        }
-      case .boolValue(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
-        }
-      case .structValue(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-        }
-      case .listValue(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   init() {}
@@ -417,6 +346,79 @@ extension Google_Protobuf_Value: SwiftProtobuf._MessageImplementationBase, Swift
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Google_Protobuf_Value.OneOf_Kind {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value = Google_Protobuf_NullValue()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .nullValue(value)
+      return
+    case 2:
+      var value = Double()
+      try decoder.decodeSingularDoubleField(value: &value)
+      self = .numberValue(value)
+      return
+    case 3:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .stringValue(value)
+      return
+    case 4:
+      var value = Bool()
+      try decoder.decodeSingularBoolField(value: &value)
+      self = .boolValue(value)
+      return
+    case 5:
+      var value: Google_Protobuf_Struct?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .structValue(value)
+        return
+      }
+    case 6:
+      var value: Google_Protobuf_ListValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .listValue(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .nullValue(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
+      }
+    case .numberValue(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
+      }
+    case .stringValue(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      }
+    case .boolValue(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
+      }
+    case .structValue(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      }
+    case .listValue(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -1143,102 +1143,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      case 115:
-        var value = Bool()
-        try decoder.decodeSingularBoolField(value: &value)
-        self = .oneofBool(value)
-        return
-      case 116:
-        var value = UInt64()
-        try decoder.decodeSingularUInt64Field(value: &value)
-        self = .oneofUint64(value)
-        return
-      case 117:
-        var value = Float()
-        try decoder.decodeSingularFloatField(value: &value)
-        self = .oneofFloat(value)
-        return
-      case 118:
-        var value = Double()
-        try decoder.decodeSingularDoubleField(value: &value)
-        self = .oneofDouble(value)
-        return
-      case 119:
-        var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofEnum(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      case .oneofBool(let v):
-        if start <= 115 && 115 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
-        }
-      case .oneofUint64(let v):
-        if start <= 116 && 116 < end {
-          try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
-        }
-      case .oneofFloat(let v):
-        if start <= 117 && 117 < end {
-          try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
-        }
-      case .oneofDouble(let v):
-        if start <= 118 && 118 < end {
-          try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
-        }
-      case .oneofEnum(let v):
-        if start <= 119 && 119 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -2090,6 +1994,104 @@ extension ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf._MessageImplem
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    case 115:
+      var value = Bool()
+      try decoder.decodeSingularBoolField(value: &value)
+      self = .oneofBool(value)
+      return
+    case 116:
+      var value = UInt64()
+      try decoder.decodeSingularUInt64Field(value: &value)
+      self = .oneofUint64(value)
+      return
+    case 117:
+      var value = Float()
+      try decoder.decodeSingularFloatField(value: &value)
+      self = .oneofFloat(value)
+      return
+    case 118:
+      var value = Double()
+      try decoder.decodeSingularDoubleField(value: &value)
+      self = .oneofDouble(value)
+      return
+    case 119:
+      var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofEnum(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    case .oneofBool(let v):
+      if start <= 115 && 115 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
+      }
+    case .oneofUint64(let v):
+      if start <= 116 && 116 < end {
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
+      }
+    case .oneofFloat(let v):
+      if start <= 117 && 117 < end {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
+      }
+    case .oneofDouble(let v):
+      if start <= 118 && 118 < end {
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
+      }
+    case .oneofEnum(let v):
+      if start <= 119 && 119 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -1033,63 +1033,6 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 112:
-        var value: ProtobufUnittest_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 114:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -4750,63 +4693,6 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .fooInt(value)
-          return
-        }
-      case 2:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .fooString(value)
-          return
-        }
-      case 3:
-        var value: ProtobufUnittest_TestAllTypes?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fooMessage(value)
-          return
-        }
-      case 4:
-        var value: ProtobufUnittest_TestOneof.FooGroup?
-        try decoder.decodeSingularGroupField(value: &value)
-        if let value = value {
-          self = .fooGroup(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .fooInt(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-        }
-      case .fooString(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .fooMessage(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-        }
-      case .fooGroup(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
-        }
-      }
-    }
   }
 
   struct FooGroup: SwiftProtobuf.Message {
@@ -5320,118 +5206,6 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .fooInt(value)
-          return
-        }
-      case 2:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .fooString(value)
-          return
-        }
-      case 3:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .fooCord(value)
-          return
-        }
-      case 4:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .fooStringPiece(value)
-          return
-        }
-      case 5:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .fooBytes(value)
-          return
-        }
-      case 6:
-        var value: ProtobufUnittest_TestOneof2.NestedEnum?
-        try decoder.decodeSingularEnumField(value: &value)
-        if let value = value {
-          self = .fooEnum(value)
-          return
-        }
-      case 7:
-        var value: ProtobufUnittest_TestOneof2.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fooMessage(value)
-          return
-        }
-      case 8:
-        var value: ProtobufUnittest_TestOneof2.FooGroup?
-        try decoder.decodeSingularGroupField(value: &value)
-        if let value = value {
-          self = .fooGroup(value)
-          return
-        }
-      case 11:
-        var value: ProtobufUnittest_TestOneof2.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fooLazyMessage(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .fooInt(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-        }
-      case .fooString(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .fooCord(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-        }
-      case .fooStringPiece(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-        }
-      case .fooBytes(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
-        }
-      case .fooEnum(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-        }
-      case .fooMessage(let v):
-        if start <= 7 && 7 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-        }
-      case .fooGroup(let v):
-        if start <= 8 && 8 < end {
-          try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
-        }
-      case .fooLazyMessage(let v):
-        if start <= 11 && 11 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-        }
-      }
-    }
   }
 
   enum OneOf_Bar: Equatable {
@@ -5451,85 +5225,6 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       case (.barBytes(let l), .barBytes(let r)): return l == r
       case (.barEnum(let l), .barEnum(let r)): return l == r
       default: return false
-      }
-    }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 12:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .barInt(value)
-          return
-        }
-      case 13:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .barString(value)
-          return
-        }
-      case 14:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .barCord(value)
-          return
-        }
-      case 15:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .barStringPiece(value)
-          return
-        }
-      case 16:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .barBytes(value)
-          return
-        }
-      case 17:
-        var value: ProtobufUnittest_TestOneof2.NestedEnum?
-        try decoder.decodeSingularEnumField(value: &value)
-        if let value = value {
-          self = .barEnum(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .barInt(let v):
-        if start <= 12 && 12 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
-        }
-      case .barString(let v):
-        if start <= 13 && 13 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 13)
-        }
-      case .barCord(let v):
-        if start <= 14 && 14 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 14)
-        }
-      case .barStringPiece(let v):
-        if start <= 15 && 15 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 15)
-        }
-      case .barBytes(let v):
-        if start <= 16 && 16 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
-        }
-      case .barEnum(let v):
-        if start <= 17 && 17 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
-        }
       }
     }
   }
@@ -5775,52 +5470,6 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message {
       case (.fooString(let l), .fooString(let r)): return l == r
       case (.fooMessage(let l), .fooMessage(let r)): return l == r
       default: return false
-      }
-    }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .fooInt(value)
-          return
-        }
-      case 2:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .fooString(value)
-          return
-        }
-      case 3:
-        var value: ProtobufUnittest_TestRequiredOneof.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fooMessage(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .fooInt(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-        }
-      case .fooString(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .fooMessage(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-        }
       }
     }
   }
@@ -7357,63 +7006,6 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
       default: return false
-      }
-    }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 536870011:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 536870012:
-        var value: ProtobufUnittest_TestAllTypes?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofTestAllTypes(value)
-          return
-        }
-      case 536870013:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 536870014:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 536870011 && 536870011 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-        }
-      case .oneofTestAllTypes(let v):
-        if start <= 536870012 && 536870012 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-        }
-      case .oneofString(let v):
-        if start <= 536870013 && 536870013 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-        }
-      case .oneofBytes(let v):
-        if start <= 536870014 && 536870014 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-        }
       }
     }
   }
@@ -9940,6 +9532,65 @@ extension ProtobufUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBas
   }
 }
 
+extension ProtobufUnittest_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 112:
+      var value: ProtobufUnittest_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 114:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    }
+  }
+}
+
 extension ProtobufUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     -1: .same(proto: "NEG"),
@@ -10721,6 +10372,65 @@ extension ProtobufUnittest_TestOneof: SwiftProtobuf._MessageImplementationBase, 
   }
 }
 
+extension ProtobufUnittest_TestOneof.OneOf_Foo {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .fooInt(value)
+        return
+      }
+    case 2:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .fooString(value)
+        return
+      }
+    case 3:
+      var value: ProtobufUnittest_TestAllTypes?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fooMessage(value)
+        return
+      }
+    case 4:
+      var value: ProtobufUnittest_TestOneof.FooGroup?
+      try decoder.decodeSingularGroupField(value: &value)
+      if let value = value {
+        self = .fooGroup(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .fooInt(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      }
+    case .fooString(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .fooMessage(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+    case .fooGroup(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
+      }
+    }
+  }
+}
+
 extension ProtobufUnittest_TestOneof.FooGroup: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     5: .same(proto: "a"),
@@ -10810,6 +10520,201 @@ extension ProtobufUnittest_TestOneof2: SwiftProtobuf._MessageImplementationBase,
   }
 }
 
+extension ProtobufUnittest_TestOneof2.OneOf_Foo {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .fooInt(value)
+        return
+      }
+    case 2:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .fooString(value)
+        return
+      }
+    case 3:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .fooCord(value)
+        return
+      }
+    case 4:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .fooStringPiece(value)
+        return
+      }
+    case 5:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .fooBytes(value)
+        return
+      }
+    case 6:
+      var value: ProtobufUnittest_TestOneof2.NestedEnum?
+      try decoder.decodeSingularEnumField(value: &value)
+      if let value = value {
+        self = .fooEnum(value)
+        return
+      }
+    case 7:
+      var value: ProtobufUnittest_TestOneof2.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fooMessage(value)
+        return
+      }
+    case 8:
+      var value: ProtobufUnittest_TestOneof2.FooGroup?
+      try decoder.decodeSingularGroupField(value: &value)
+      if let value = value {
+        self = .fooGroup(value)
+        return
+      }
+    case 11:
+      var value: ProtobufUnittest_TestOneof2.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fooLazyMessage(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .fooInt(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      }
+    case .fooString(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .fooCord(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      }
+    case .fooStringPiece(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+      }
+    case .fooBytes(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
+      }
+    case .fooEnum(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+      }
+    case .fooMessage(let v):
+      if start <= 7 && 7 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      }
+    case .fooGroup(let v):
+      if start <= 8 && 8 < end {
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
+      }
+    case .fooLazyMessage(let v):
+      if start <= 11 && 11 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      }
+    }
+  }
+}
+
+extension ProtobufUnittest_TestOneof2.OneOf_Bar {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 12:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .barInt(value)
+        return
+      }
+    case 13:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .barString(value)
+        return
+      }
+    case 14:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .barCord(value)
+        return
+      }
+    case 15:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .barStringPiece(value)
+        return
+      }
+    case 16:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .barBytes(value)
+        return
+      }
+    case 17:
+      var value: ProtobufUnittest_TestOneof2.NestedEnum?
+      try decoder.decodeSingularEnumField(value: &value)
+      if let value = value {
+        self = .barEnum(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .barInt(let v):
+      if start <= 12 && 12 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
+      }
+    case .barString(let v):
+      if start <= 13 && 13 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 13)
+      }
+    case .barCord(let v):
+      if start <= 14 && 14 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 14)
+      }
+    case .barStringPiece(let v):
+      if start <= 15 && 15 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 15)
+      }
+    case .barBytes(let v):
+      if start <= 16 && 16 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
+      }
+    case .barEnum(let v):
+      if start <= 17 && 17 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
+      }
+    }
+  }
+}
+
 extension ProtobufUnittest_TestOneof2.NestedEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "FOO"),
@@ -10863,6 +10768,54 @@ extension ProtobufUnittest_TestRequiredOneof: SwiftProtobuf._MessageImplementati
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestRequiredOneof.OneOf_Foo {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .fooInt(value)
+        return
+      }
+    case 2:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .fooString(value)
+        return
+      }
+    case 3:
+      var value: ProtobufUnittest_TestRequiredOneof.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fooMessage(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .fooInt(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      }
+    case .fooString(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .fooMessage(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+    }
   }
 }
 
@@ -11296,6 +11249,65 @@ extension ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf._MessageImplement
     if unknownFields != other.unknownFields {return false}
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 536870011:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 536870012:
+      var value: ProtobufUnittest_TestAllTypes?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofTestAllTypes(value)
+        return
+      }
+    case 536870013:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 536870014:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 536870011 && 536870011 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+      }
+    case .oneofTestAllTypes(let v):
+      if start <= 536870012 && 536870012 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+      }
+    case .oneofString(let v):
+      if start <= 536870013 && 536870013 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+      }
+    case .oneofBytes(let v):
+      if start <= 536870014 && 536870014 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -143,30 +143,6 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
       case (.oneofField(let l), .oneofField(let r)): return l == r
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 2:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .oneofField(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofField(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-        }
-      }
-    }
   }
 
   enum AnEnum: SwiftProtobuf.Enum {
@@ -2270,6 +2246,32 @@ extension ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf._MessageI
     if anOneof != other.anOneof {return false}
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 2:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .oneofField(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofField(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -1033,74 +1033,6 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 112:
-        var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 114:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      case 115:
-        var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofLazyNestedMessage(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      case .oneofLazyNestedMessage(let v):
-        if start <= 115 && 115 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -2710,63 +2642,6 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
       default: return false
-      }
-    }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 536870011:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 536870012:
-        var value: ProtobufUnittest_TestAllTypesLite?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofTestAllTypes(value)
-          return
-        }
-      case 536870013:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 536870014:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 536870011 && 536870011 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-        }
-      case .oneofTestAllTypes(let v):
-        if start <= 536870012 && 536870012 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-        }
-      case .oneofString(let v):
-        if start <= 536870013 && 536870013 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-        }
-      case .oneofBytes(let v):
-        if start <= 536870014 && 536870014 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-        }
       }
     }
   }
@@ -4923,6 +4798,76 @@ extension ProtobufUnittest_TestAllTypesLite: SwiftProtobuf._MessageImplementatio
   }
 }
 
+extension ProtobufUnittest_TestAllTypesLite.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 112:
+      var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 114:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    case 115:
+      var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofLazyNestedMessage(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    case .oneofLazyNestedMessage(let v):
+      if start <= 115 && 115 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
+      }
+    }
+  }
+}
+
 extension ProtobufUnittest_TestAllTypesLite.NestedEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "FOO"),
@@ -5293,6 +5238,65 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf._MessageImple
     if unknownFields != other.unknownFields {return false}
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 536870011:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 536870012:
+      var value: ProtobufUnittest_TestAllTypesLite?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofTestAllTypes(value)
+        return
+      }
+    case 536870013:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 536870014:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 536870011 && 536870011 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+      }
+    case .oneofTestAllTypes(let v):
+      if start <= 536870012 && 536870012 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+      }
+    case .oneofString(let v):
+      if start <= 536870013 && 536870013 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+      }
+    case .oneofBytes(let v):
+      if start <= 536870014 && 536870014 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -975,74 +975,6 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 112:
-        var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 114:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      case 115:
-        var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .lazyOneofNestedMessage(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      case .lazyOneofNestedMessage(let v):
-        if start <= 115 && 115 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1766,6 +1698,76 @@ extension ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf._MessageImplementa
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 112:
+      var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 114:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    case 115:
+      var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .lazyOneofNestedMessage(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    case .lazyOneofNestedMessage(let v):
+      if start <= 115 && 115 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -533,57 +533,6 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofEnum(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofEnum(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1065,6 +1014,59 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf._MessageImpl
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofEnum(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofEnum(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -149,41 +149,6 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 2:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .integerField(value)
-          return
-        }
-      case 3:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .stringField(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .integerField(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-        }
-      case .stringField(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-        }
-      }
-    }
   }
 
   struct Extensions {
@@ -404,6 +369,43 @@ extension ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf._MessageImplement
     if unknownFields != other.unknownFields {return false}
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestOptimizedForSize.OneOf_Foo {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 2:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .integerField(value)
+        return
+      }
+    case 3:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .stringField(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .integerField(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+      }
+    case .stringField(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -159,37 +159,6 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 5:
-        var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofE1(value)
-        return
-      case 6:
-        var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofE2(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofE1(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-        }
-      case .oneofE2(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   init() {}
@@ -271,37 +240,6 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 5:
-        var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofE1(value)
-        return
-      case 6:
-        var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofE2(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofE1(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-        }
-      case .oneofE2(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   init() {}
@@ -379,6 +317,39 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf._MessageImp
   }
 }
 
+extension Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 5:
+      var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofE1(value)
+      return
+    case 6:
+      var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofE2(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofE1(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+      }
+    case .oneofE2(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+      }
+    }
+  }
+}
+
 extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "e"),
@@ -397,5 +368,38 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf._M
     if o != other.o {return false}
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 5:
+      var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofE1(value)
+      return
+    case 6:
+      var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofE2(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofE1(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+      }
+    case .oneofE2(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+      }
+    }
   }
 }

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -133,41 +133,6 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 5:
-        var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
-        try decoder.decodeSingularEnumField(value: &value)
-        if let value = value {
-          self = .oneofE1(value)
-          return
-        }
-      case 6:
-        var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
-        try decoder.decodeSingularEnumField(value: &value)
-        if let value = value {
-          self = .oneofE2(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofE1(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-        }
-      case .oneofE2(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   init() {}
@@ -233,5 +198,42 @@ extension Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf._MessageImp
     if o != other.o {return false}
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 5:
+      var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
+      try decoder.decodeSingularEnumField(value: &value)
+      if let value = value {
+        self = .oneofE1(value)
+        return
+      }
+    case 6:
+      var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
+      try decoder.decodeSingularEnumField(value: &value)
+      if let value = value {
+        self = .oneofE2(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofE1(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+      }
+    case .oneofE2(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+      }
+    }
   }
 }

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -607,57 +607,6 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: Proto3TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -2020,48 +1969,6 @@ struct Proto3TestOneof: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value = Int32()
-        try decoder.decodeSingularInt32Field(value: &value)
-        self = .fooInt(value)
-        return
-      case 2:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .fooString(value)
-        return
-      case 3:
-        var value: Proto3TestAllTypes?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fooMessage(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .fooInt(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-        }
-      case .fooString(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .fooMessage(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-        }
-      }
-    }
   }
 
   init() {}
@@ -2631,6 +2538,59 @@ extension Proto3TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftPro
   }
 }
 
+extension Proto3TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: Proto3TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    }
+  }
+}
+
 extension Proto3TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     -1: .same(proto: "NEG"),
@@ -3017,6 +2977,50 @@ extension Proto3TestOneof: SwiftProtobuf._MessageImplementationBase, SwiftProtob
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto3TestOneof.OneOf_Foo {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value = Int32()
+      try decoder.decodeSingularInt32Field(value: &value)
+      self = .fooInt(value)
+      return
+    case 2:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .fooString(value)
+      return
+    case 3:
+      var value: Proto3TestAllTypes?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fooMessage(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .fooInt(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      }
+    case .fooString(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .fooMessage(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -543,57 +543,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: Proto3ArenaUnittest_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1331,6 +1280,59 @@ extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf._MessageImplementation
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: Proto3ArenaUnittest_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -543,57 +543,6 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1331,6 +1280,59 @@ extension Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf._MessageImplementa
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -543,57 +543,6 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: Proto3LiteUnittest_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1331,6 +1280,59 @@ extension Proto3LiteUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationB
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto3LiteUnittest_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: Proto3LiteUnittest_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -922,217 +922,6 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value: Google_Protobuf_Any?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .anyField(value)
-          return
-        }
-      case 2:
-        var value: Google_Protobuf_Api?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .apiField(value)
-          return
-        }
-      case 3:
-        var value: Google_Protobuf_Duration?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .durationField(value)
-          return
-        }
-      case 4:
-        var value: Google_Protobuf_Empty?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .emptyField(value)
-          return
-        }
-      case 5:
-        var value: Google_Protobuf_FieldMask?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fieldMaskField(value)
-          return
-        }
-      case 6:
-        var value: Google_Protobuf_SourceContext?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .sourceContextField(value)
-          return
-        }
-      case 7:
-        var value: Google_Protobuf_Struct?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .structField(value)
-          return
-        }
-      case 8:
-        var value: Google_Protobuf_Timestamp?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .timestampField(value)
-          return
-        }
-      case 9:
-        var value: Google_Protobuf_Type?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .typeField(value)
-          return
-        }
-      case 10:
-        var value: Google_Protobuf_DoubleValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .doubleField(value)
-          return
-        }
-      case 11:
-        var value: Google_Protobuf_FloatValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .floatField(value)
-          return
-        }
-      case 12:
-        var value: Google_Protobuf_Int64Value?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .int64Field(value)
-          return
-        }
-      case 13:
-        var value: Google_Protobuf_UInt64Value?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .uint64Field(value)
-          return
-        }
-      case 14:
-        var value: Google_Protobuf_Int32Value?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .int32Field(value)
-          return
-        }
-      case 15:
-        var value: Google_Protobuf_UInt32Value?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .uint32Field(value)
-          return
-        }
-      case 16:
-        var value: Google_Protobuf_BoolValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .boolField(value)
-          return
-        }
-      case 17:
-        var value: Google_Protobuf_StringValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .stringField(value)
-          return
-        }
-      case 18:
-        var value: Google_Protobuf_BytesValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .bytesField(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .anyField(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-        }
-      case .apiField(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-        }
-      case .durationField(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-        }
-      case .emptyField(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-        }
-      case .fieldMaskField(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-        }
-      case .sourceContextField(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-        }
-      case .structField(let v):
-        if start <= 7 && 7 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-        }
-      case .timestampField(let v):
-        if start <= 8 && 8 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-        }
-      case .typeField(let v):
-        if start <= 9 && 9 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-        }
-      case .doubleField(let v):
-        if start <= 10 && 10 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-        }
-      case .floatField(let v):
-        if start <= 11 && 11 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-        }
-      case .int64Field(let v):
-        if start <= 12 && 12 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-        }
-      case .uint64Field(let v):
-        if start <= 13 && 13 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-        }
-      case .int32Field(let v):
-        if start <= 14 && 14 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
-        }
-      case .uint32Field(let v):
-        if start <= 15 && 15 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
-        }
-      case .boolField(let v):
-        if start <= 16 && 16 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
-        }
-      case .stringField(let v):
-        if start <= 17 && 17 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
-        }
-      case .bytesField(let v):
-        if start <= 18 && 18 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
-        }
-      }
-    }
   }
 
   init() {}
@@ -1542,6 +1331,219 @@ extension ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf._MessageImplementa
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value: Google_Protobuf_Any?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .anyField(value)
+        return
+      }
+    case 2:
+      var value: Google_Protobuf_Api?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .apiField(value)
+        return
+      }
+    case 3:
+      var value: Google_Protobuf_Duration?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .durationField(value)
+        return
+      }
+    case 4:
+      var value: Google_Protobuf_Empty?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .emptyField(value)
+        return
+      }
+    case 5:
+      var value: Google_Protobuf_FieldMask?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fieldMaskField(value)
+        return
+      }
+    case 6:
+      var value: Google_Protobuf_SourceContext?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .sourceContextField(value)
+        return
+      }
+    case 7:
+      var value: Google_Protobuf_Struct?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .structField(value)
+        return
+      }
+    case 8:
+      var value: Google_Protobuf_Timestamp?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .timestampField(value)
+        return
+      }
+    case 9:
+      var value: Google_Protobuf_Type?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .typeField(value)
+        return
+      }
+    case 10:
+      var value: Google_Protobuf_DoubleValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .doubleField(value)
+        return
+      }
+    case 11:
+      var value: Google_Protobuf_FloatValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .floatField(value)
+        return
+      }
+    case 12:
+      var value: Google_Protobuf_Int64Value?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .int64Field(value)
+        return
+      }
+    case 13:
+      var value: Google_Protobuf_UInt64Value?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .uint64Field(value)
+        return
+      }
+    case 14:
+      var value: Google_Protobuf_Int32Value?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .int32Field(value)
+        return
+      }
+    case 15:
+      var value: Google_Protobuf_UInt32Value?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .uint32Field(value)
+        return
+      }
+    case 16:
+      var value: Google_Protobuf_BoolValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .boolField(value)
+        return
+      }
+    case 17:
+      var value: Google_Protobuf_StringValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .stringField(value)
+        return
+      }
+    case 18:
+      var value: Google_Protobuf_BytesValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .bytesField(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .anyField(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+    case .apiField(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+    case .durationField(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+    case .emptyField(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      }
+    case .fieldMaskField(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      }
+    case .sourceContextField(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      }
+    case .structField(let v):
+      if start <= 7 && 7 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      }
+    case .timestampField(let v):
+      if start <= 8 && 8 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+      }
+    case .typeField(let v):
+      if start <= 9 && 9 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+      }
+    case .doubleField(let v):
+      if start <= 10 && 10 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+      }
+    case .floatField(let v):
+      if start <= 11 && 11 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      }
+    case .int64Field(let v):
+      if start <= 12 && 12 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+      }
+    case .uint64Field(let v):
+      if start <= 13 && 13 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+      }
+    case .int32Field(let v):
+      if start <= 14 && 14 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
+      }
+    case .uint32Field(let v):
+      if start <= 15 && 15 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+      }
+    case .boolField(let v):
+      if start <= 16 && 16 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
+      }
+    case .stringField(let v):
+      if start <= 17 && 17 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
+      }
+    case .bytesField(let v):
+      if start <= 18 && 18 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
+      }
+    }
   }
 }
 

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -748,63 +748,6 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 112:
-        var value: ProtobufUnittest_TestAllRequiredTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 114:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1457,6 +1400,65 @@ extension ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf._MessageImplement
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 112:
+      var value: ProtobufUnittest_TestAllRequiredTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 114:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    }
   }
 }
 

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -183,63 +183,6 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 9:
-        var value: Bool?
-        try decoder.decodeSingularBoolField(value: &value)
-        if let value = value {
-          self = .oneofBool(value)
-          return
-        }
-      case 10:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .oneofInt32(value)
-          return
-        }
-      case 60:
-        var value: Int64?
-        try decoder.decodeSingularInt64Field(value: &value)
-        if let value = value {
-          self = .oneofInt64(value)
-          return
-        }
-      case 150:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofBool(let v):
-        if start <= 9 && 9 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
-        }
-      case .oneofInt32(let v):
-        if start <= 10 && 10 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
-        }
-      case .oneofInt64(let v):
-        if start <= 60 && 60 < end {
-          try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
-        }
-      case .oneofString(let v):
-        if start <= 150 && 150 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 150)
-        }
-      }
-    }
   }
 
   struct NestedMessage: SwiftProtobuf.Message {
@@ -419,6 +362,65 @@ extension Swift_Protobuf_TestFieldOrderings: SwiftProtobuf._MessageImplementatio
     if unknownFields != other.unknownFields {return false}
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
+  }
+}
+
+extension Swift_Protobuf_TestFieldOrderings.OneOf_Options {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 9:
+      var value: Bool?
+      try decoder.decodeSingularBoolField(value: &value)
+      if let value = value {
+        self = .oneofBool(value)
+        return
+      }
+    case 10:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .oneofInt32(value)
+        return
+      }
+    case 60:
+      var value: Int64?
+      try decoder.decodeSingularInt64Field(value: &value)
+      if let value = value {
+        self = .oneofInt64(value)
+        return
+      }
+    case 150:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofBool(let v):
+      if start <= 9 && 9 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
+      }
+    case .oneofInt32(let v):
+      if start <= 10 && 10 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
+      }
+    case .oneofInt64(let v):
+      if start <= 60 && 60 < end {
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
+      }
+    case .oneofString(let v):
+      if start <= 150 && 150 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 150)
+      }
+    }
   }
 }
 

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -834,217 +834,6 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 51:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .oneofInt32(value)
-          return
-        }
-      case 52:
-        var value: Int64?
-        try decoder.decodeSingularInt64Field(value: &value)
-        if let value = value {
-          self = .oneofInt64(value)
-          return
-        }
-      case 53:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 54:
-        var value: UInt64?
-        try decoder.decodeSingularUInt64Field(value: &value)
-        if let value = value {
-          self = .oneofUint64(value)
-          return
-        }
-      case 55:
-        var value: Int32?
-        try decoder.decodeSingularSInt32Field(value: &value)
-        if let value = value {
-          self = .oneofSint32(value)
-          return
-        }
-      case 56:
-        var value: Int64?
-        try decoder.decodeSingularSInt64Field(value: &value)
-        if let value = value {
-          self = .oneofSint64(value)
-          return
-        }
-      case 57:
-        var value: UInt32?
-        try decoder.decodeSingularFixed32Field(value: &value)
-        if let value = value {
-          self = .oneofFixed32(value)
-          return
-        }
-      case 58:
-        var value: UInt64?
-        try decoder.decodeSingularFixed64Field(value: &value)
-        if let value = value {
-          self = .oneofFixed64(value)
-          return
-        }
-      case 59:
-        var value: Int32?
-        try decoder.decodeSingularSFixed32Field(value: &value)
-        if let value = value {
-          self = .oneofSfixed32(value)
-          return
-        }
-      case 60:
-        var value: Int64?
-        try decoder.decodeSingularSFixed64Field(value: &value)
-        if let value = value {
-          self = .oneofSfixed64(value)
-          return
-        }
-      case 61:
-        var value: Float?
-        try decoder.decodeSingularFloatField(value: &value)
-        if let value = value {
-          self = .oneofFloat(value)
-          return
-        }
-      case 62:
-        var value: Double?
-        try decoder.decodeSingularDoubleField(value: &value)
-        if let value = value {
-          self = .oneofDouble(value)
-          return
-        }
-      case 63:
-        var value: Bool?
-        try decoder.decodeSingularBoolField(value: &value)
-        if let value = value {
-          self = .oneofBool(value)
-          return
-        }
-      case 64:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 65:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      case 66:
-        var value: ProtobufUnittest_Message2.OneofGroup?
-        try decoder.decodeSingularGroupField(value: &value)
-        if let value = value {
-          self = .oneofGroup(value)
-          return
-        }
-      case 68:
-        var value: ProtobufUnittest_Message2?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofMessage(value)
-          return
-        }
-      case 69:
-        var value: ProtobufUnittest_Message2.Enum?
-        try decoder.decodeSingularEnumField(value: &value)
-        if let value = value {
-          self = .oneofEnum(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofInt32(let v):
-        if start <= 51 && 51 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
-        }
-      case .oneofInt64(let v):
-        if start <= 52 && 52 < end {
-          try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
-        }
-      case .oneofUint32(let v):
-        if start <= 53 && 53 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
-        }
-      case .oneofUint64(let v):
-        if start <= 54 && 54 < end {
-          try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
-        }
-      case .oneofSint32(let v):
-        if start <= 55 && 55 < end {
-          try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
-        }
-      case .oneofSint64(let v):
-        if start <= 56 && 56 < end {
-          try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
-        }
-      case .oneofFixed32(let v):
-        if start <= 57 && 57 < end {
-          try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
-        }
-      case .oneofFixed64(let v):
-        if start <= 58 && 58 < end {
-          try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
-        }
-      case .oneofSfixed32(let v):
-        if start <= 59 && 59 < end {
-          try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
-        }
-      case .oneofSfixed64(let v):
-        if start <= 60 && 60 < end {
-          try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
-        }
-      case .oneofFloat(let v):
-        if start <= 61 && 61 < end {
-          try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
-        }
-      case .oneofDouble(let v):
-        if start <= 62 && 62 < end {
-          try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
-        }
-      case .oneofBool(let v):
-        if start <= 63 && 63 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
-        }
-      case .oneofString(let v):
-        if start <= 64 && 64 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 64)
-        }
-      case .oneofBytes(let v):
-        if start <= 65 && 65 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
-        }
-      case .oneofGroup(let v):
-        if start <= 66 && 66 < end {
-          try visitor.visitSingularGroupField(value: v, fieldNumber: 66)
-        }
-      case .oneofMessage(let v):
-        if start <= 68 && 68 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
-        }
-      case .oneofEnum(let v):
-        if start <= 69 && 69 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-        }
-      }
-    }
   }
 
   enum Enum: SwiftProtobuf.Enum {
@@ -1668,6 +1457,219 @@ extension ProtobufUnittest_Message2: SwiftProtobuf._MessageImplementationBase, S
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_Message2.OneOf_O {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 51:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .oneofInt32(value)
+        return
+      }
+    case 52:
+      var value: Int64?
+      try decoder.decodeSingularInt64Field(value: &value)
+      if let value = value {
+        self = .oneofInt64(value)
+        return
+      }
+    case 53:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 54:
+      var value: UInt64?
+      try decoder.decodeSingularUInt64Field(value: &value)
+      if let value = value {
+        self = .oneofUint64(value)
+        return
+      }
+    case 55:
+      var value: Int32?
+      try decoder.decodeSingularSInt32Field(value: &value)
+      if let value = value {
+        self = .oneofSint32(value)
+        return
+      }
+    case 56:
+      var value: Int64?
+      try decoder.decodeSingularSInt64Field(value: &value)
+      if let value = value {
+        self = .oneofSint64(value)
+        return
+      }
+    case 57:
+      var value: UInt32?
+      try decoder.decodeSingularFixed32Field(value: &value)
+      if let value = value {
+        self = .oneofFixed32(value)
+        return
+      }
+    case 58:
+      var value: UInt64?
+      try decoder.decodeSingularFixed64Field(value: &value)
+      if let value = value {
+        self = .oneofFixed64(value)
+        return
+      }
+    case 59:
+      var value: Int32?
+      try decoder.decodeSingularSFixed32Field(value: &value)
+      if let value = value {
+        self = .oneofSfixed32(value)
+        return
+      }
+    case 60:
+      var value: Int64?
+      try decoder.decodeSingularSFixed64Field(value: &value)
+      if let value = value {
+        self = .oneofSfixed64(value)
+        return
+      }
+    case 61:
+      var value: Float?
+      try decoder.decodeSingularFloatField(value: &value)
+      if let value = value {
+        self = .oneofFloat(value)
+        return
+      }
+    case 62:
+      var value: Double?
+      try decoder.decodeSingularDoubleField(value: &value)
+      if let value = value {
+        self = .oneofDouble(value)
+        return
+      }
+    case 63:
+      var value: Bool?
+      try decoder.decodeSingularBoolField(value: &value)
+      if let value = value {
+        self = .oneofBool(value)
+        return
+      }
+    case 64:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 65:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    case 66:
+      var value: ProtobufUnittest_Message2.OneofGroup?
+      try decoder.decodeSingularGroupField(value: &value)
+      if let value = value {
+        self = .oneofGroup(value)
+        return
+      }
+    case 68:
+      var value: ProtobufUnittest_Message2?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofMessage(value)
+        return
+      }
+    case 69:
+      var value: ProtobufUnittest_Message2.Enum?
+      try decoder.decodeSingularEnumField(value: &value)
+      if let value = value {
+        self = .oneofEnum(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofInt32(let v):
+      if start <= 51 && 51 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
+      }
+    case .oneofInt64(let v):
+      if start <= 52 && 52 < end {
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
+      }
+    case .oneofUint32(let v):
+      if start <= 53 && 53 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
+      }
+    case .oneofUint64(let v):
+      if start <= 54 && 54 < end {
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
+      }
+    case .oneofSint32(let v):
+      if start <= 55 && 55 < end {
+        try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
+      }
+    case .oneofSint64(let v):
+      if start <= 56 && 56 < end {
+        try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
+      }
+    case .oneofFixed32(let v):
+      if start <= 57 && 57 < end {
+        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
+      }
+    case .oneofFixed64(let v):
+      if start <= 58 && 58 < end {
+        try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
+      }
+    case .oneofSfixed32(let v):
+      if start <= 59 && 59 < end {
+        try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
+      }
+    case .oneofSfixed64(let v):
+      if start <= 60 && 60 < end {
+        try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
+      }
+    case .oneofFloat(let v):
+      if start <= 61 && 61 < end {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
+      }
+    case .oneofDouble(let v):
+      if start <= 62 && 62 < end {
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
+      }
+    case .oneofBool(let v):
+      if start <= 63 && 63 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
+      }
+    case .oneofString(let v):
+      if start <= 64 && 64 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 64)
+      }
+    case .oneofBytes(let v):
+      if start <= 65 && 65 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
+      }
+    case .oneofGroup(let v):
+      if start <= 66 && 66 < end {
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 66)
+      }
+    case .oneofMessage(let v):
+      if start <= 68 && 68 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
+      }
+    case .oneofEnum(let v):
+      if start <= 69 && 69 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
+      }
+    }
   }
 }
 

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -707,174 +707,6 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 51:
-        var value = Int32()
-        try decoder.decodeSingularInt32Field(value: &value)
-        self = .oneofInt32(value)
-        return
-      case 52:
-        var value = Int64()
-        try decoder.decodeSingularInt64Field(value: &value)
-        self = .oneofInt64(value)
-        return
-      case 53:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 54:
-        var value = UInt64()
-        try decoder.decodeSingularUInt64Field(value: &value)
-        self = .oneofUint64(value)
-        return
-      case 55:
-        var value = Int32()
-        try decoder.decodeSingularSInt32Field(value: &value)
-        self = .oneofSint32(value)
-        return
-      case 56:
-        var value = Int64()
-        try decoder.decodeSingularSInt64Field(value: &value)
-        self = .oneofSint64(value)
-        return
-      case 57:
-        var value = UInt32()
-        try decoder.decodeSingularFixed32Field(value: &value)
-        self = .oneofFixed32(value)
-        return
-      case 58:
-        var value = UInt64()
-        try decoder.decodeSingularFixed64Field(value: &value)
-        self = .oneofFixed64(value)
-        return
-      case 59:
-        var value = Int32()
-        try decoder.decodeSingularSFixed32Field(value: &value)
-        self = .oneofSfixed32(value)
-        return
-      case 60:
-        var value = Int64()
-        try decoder.decodeSingularSFixed64Field(value: &value)
-        self = .oneofSfixed64(value)
-        return
-      case 61:
-        var value = Float()
-        try decoder.decodeSingularFloatField(value: &value)
-        self = .oneofFloat(value)
-        return
-      case 62:
-        var value = Double()
-        try decoder.decodeSingularDoubleField(value: &value)
-        self = .oneofDouble(value)
-        return
-      case 63:
-        var value = Bool()
-        try decoder.decodeSingularBoolField(value: &value)
-        self = .oneofBool(value)
-        return
-      case 64:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 65:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      case 68:
-        var value: ProtobufUnittest_Message3?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofMessage(value)
-          return
-        }
-      case 69:
-        var value = ProtobufUnittest_Message3.Enum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofEnum(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofInt32(let v):
-        if start <= 51 && 51 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
-        }
-      case .oneofInt64(let v):
-        if start <= 52 && 52 < end {
-          try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
-        }
-      case .oneofUint32(let v):
-        if start <= 53 && 53 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
-        }
-      case .oneofUint64(let v):
-        if start <= 54 && 54 < end {
-          try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
-        }
-      case .oneofSint32(let v):
-        if start <= 55 && 55 < end {
-          try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
-        }
-      case .oneofSint64(let v):
-        if start <= 56 && 56 < end {
-          try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
-        }
-      case .oneofFixed32(let v):
-        if start <= 57 && 57 < end {
-          try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
-        }
-      case .oneofFixed64(let v):
-        if start <= 58 && 58 < end {
-          try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
-        }
-      case .oneofSfixed32(let v):
-        if start <= 59 && 59 < end {
-          try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
-        }
-      case .oneofSfixed64(let v):
-        if start <= 60 && 60 < end {
-          try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
-        }
-      case .oneofFloat(let v):
-        if start <= 61 && 61 < end {
-          try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
-        }
-      case .oneofDouble(let v):
-        if start <= 62 && 62 < end {
-          try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
-        }
-      case .oneofBool(let v):
-        if start <= 63 && 63 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
-        }
-      case .oneofString(let v):
-        if start <= 64 && 64 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 64)
-        }
-      case .oneofBytes(let v):
-        if start <= 65 && 65 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
-        }
-      case .oneofMessage(let v):
-        if start <= 68 && 68 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
-        }
-      case .oneofEnum(let v):
-        if start <= 69 && 69 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-        }
-      }
-    }
   }
 
   enum Enum: SwiftProtobuf.Enum {
@@ -1363,6 +1195,176 @@ extension ProtobufUnittest_Message3: SwiftProtobuf._MessageImplementationBase, S
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_Message3.OneOf_O {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 51:
+      var value = Int32()
+      try decoder.decodeSingularInt32Field(value: &value)
+      self = .oneofInt32(value)
+      return
+    case 52:
+      var value = Int64()
+      try decoder.decodeSingularInt64Field(value: &value)
+      self = .oneofInt64(value)
+      return
+    case 53:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 54:
+      var value = UInt64()
+      try decoder.decodeSingularUInt64Field(value: &value)
+      self = .oneofUint64(value)
+      return
+    case 55:
+      var value = Int32()
+      try decoder.decodeSingularSInt32Field(value: &value)
+      self = .oneofSint32(value)
+      return
+    case 56:
+      var value = Int64()
+      try decoder.decodeSingularSInt64Field(value: &value)
+      self = .oneofSint64(value)
+      return
+    case 57:
+      var value = UInt32()
+      try decoder.decodeSingularFixed32Field(value: &value)
+      self = .oneofFixed32(value)
+      return
+    case 58:
+      var value = UInt64()
+      try decoder.decodeSingularFixed64Field(value: &value)
+      self = .oneofFixed64(value)
+      return
+    case 59:
+      var value = Int32()
+      try decoder.decodeSingularSFixed32Field(value: &value)
+      self = .oneofSfixed32(value)
+      return
+    case 60:
+      var value = Int64()
+      try decoder.decodeSingularSFixed64Field(value: &value)
+      self = .oneofSfixed64(value)
+      return
+    case 61:
+      var value = Float()
+      try decoder.decodeSingularFloatField(value: &value)
+      self = .oneofFloat(value)
+      return
+    case 62:
+      var value = Double()
+      try decoder.decodeSingularDoubleField(value: &value)
+      self = .oneofDouble(value)
+      return
+    case 63:
+      var value = Bool()
+      try decoder.decodeSingularBoolField(value: &value)
+      self = .oneofBool(value)
+      return
+    case 64:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 65:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    case 68:
+      var value: ProtobufUnittest_Message3?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofMessage(value)
+        return
+      }
+    case 69:
+      var value = ProtobufUnittest_Message3.Enum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofEnum(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofInt32(let v):
+      if start <= 51 && 51 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
+      }
+    case .oneofInt64(let v):
+      if start <= 52 && 52 < end {
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
+      }
+    case .oneofUint32(let v):
+      if start <= 53 && 53 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
+      }
+    case .oneofUint64(let v):
+      if start <= 54 && 54 < end {
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
+      }
+    case .oneofSint32(let v):
+      if start <= 55 && 55 < end {
+        try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
+      }
+    case .oneofSint64(let v):
+      if start <= 56 && 56 < end {
+        try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
+      }
+    case .oneofFixed32(let v):
+      if start <= 57 && 57 < end {
+        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
+      }
+    case .oneofFixed64(let v):
+      if start <= 58 && 58 < end {
+        try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
+      }
+    case .oneofSfixed32(let v):
+      if start <= 59 && 59 < end {
+        try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
+      }
+    case .oneofSfixed64(let v):
+      if start <= 60 && 60 < end {
+        try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
+      }
+    case .oneofFloat(let v):
+      if start <= 61 && 61 < end {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
+      }
+    case .oneofDouble(let v):
+      if start <= 62 && 62 < end {
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
+      }
+    case .oneofBool(let v):
+      if start <= 63 && 63 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
+      }
+    case .oneofString(let v):
+      if start <= 64 && 64 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 64)
+      }
+    case .oneofBytes(let v):
+      if start <= 65 && 65 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
+      }
+    case .oneofMessage(let v):
+      if start <= 68 && 68 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
+      }
+    case .oneofEnum(let v):
+      if start <= 69 && 69 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
+      }
+    }
   }
 }
 

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -124,37 +124,6 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .protobufPayload(value)
-        return
-      case 2:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .jsonPayload(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .protobufPayload(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
-        }
-      case .jsonPayload(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      }
-    }
   }
 
   init() {}
@@ -274,73 +243,6 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .parseError(value)
-        return
-      case 2:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .runtimeError(value)
-        return
-      case 3:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .protobufPayload(value)
-        return
-      case 4:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .jsonPayload(value)
-        return
-      case 5:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .skipped(value)
-        return
-      case 6:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .serializeError(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .parseError(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-        }
-      case .runtimeError(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .protobufPayload(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
-        }
-      case .jsonPayload(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-        }
-      case .skipped(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-        }
-      case .serializeError(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   init() {}
@@ -387,6 +289,39 @@ extension Conformance_ConformanceRequest: SwiftProtobuf._MessageImplementationBa
   }
 }
 
+extension Conformance_ConformanceRequest.OneOf_Payload {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .protobufPayload(value)
+      return
+    case 2:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .jsonPayload(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .protobufPayload(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
+      }
+    case .jsonPayload(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    }
+  }
+}
+
 extension Conformance_ConformanceResponse: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "parse_error"),
@@ -401,5 +336,74 @@ extension Conformance_ConformanceResponse: SwiftProtobuf._MessageImplementationB
     if result != other.result {return false}
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Conformance_ConformanceResponse.OneOf_Result {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .parseError(value)
+      return
+    case 2:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .runtimeError(value)
+      return
+    case 3:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .protobufPayload(value)
+      return
+    case 4:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .jsonPayload(value)
+      return
+    case 5:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .skipped(value)
+      return
+    case 6:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .serializeError(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .parseError(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+      }
+    case .runtimeError(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .protobufPayload(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
+      }
+    case .jsonPayload(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+      }
+    case .skipped(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+      }
+    case .serializeError(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+      }
+    }
   }
 }

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -1143,102 +1143,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      case 115:
-        var value = Bool()
-        try decoder.decodeSingularBoolField(value: &value)
-        self = .oneofBool(value)
-        return
-      case 116:
-        var value = UInt64()
-        try decoder.decodeSingularUInt64Field(value: &value)
-        self = .oneofUint64(value)
-        return
-      case 117:
-        var value = Float()
-        try decoder.decodeSingularFloatField(value: &value)
-        self = .oneofFloat(value)
-        return
-      case 118:
-        var value = Double()
-        try decoder.decodeSingularDoubleField(value: &value)
-        self = .oneofDouble(value)
-        return
-      case 119:
-        var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofEnum(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      case .oneofBool(let v):
-        if start <= 115 && 115 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
-        }
-      case .oneofUint64(let v):
-        if start <= 116 && 116 < end {
-          try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
-        }
-      case .oneofFloat(let v):
-        if start <= 117 && 117 < end {
-          try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
-        }
-      case .oneofDouble(let v):
-        if start <= 118 && 118 < end {
-          try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
-        }
-      case .oneofEnum(let v):
-        if start <= 119 && 119 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -2090,6 +1994,104 @@ extension ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf._MessageImplem
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    case 115:
+      var value = Bool()
+      try decoder.decodeSingularBoolField(value: &value)
+      self = .oneofBool(value)
+      return
+    case 116:
+      var value = UInt64()
+      try decoder.decodeSingularUInt64Field(value: &value)
+      self = .oneofUint64(value)
+      return
+    case 117:
+      var value = Float()
+      try decoder.decodeSingularFloatField(value: &value)
+      self = .oneofFloat(value)
+      return
+    case 118:
+      var value = Double()
+      try decoder.decodeSingularDoubleField(value: &value)
+      self = .oneofDouble(value)
+      return
+    case 119:
+      var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofEnum(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    case .oneofBool(let v):
+      if start <= 115 && 115 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
+      }
+    case .oneofUint64(let v):
+      if start <= 116 && 116 < end {
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
+      }
+    case .oneofFloat(let v):
+      if start <= 117 && 117 < end {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
+      }
+    case .oneofDouble(let v):
+      if start <= 118 && 118 < end {
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
+      }
+    case .oneofEnum(let v):
+      if start <= 119 && 119 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
+      }
+    }
   }
 }
 

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -250,77 +250,6 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value = Google_Protobuf_NullValue()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .nullValue(value)
-        return
-      case 2:
-        var value = Double()
-        try decoder.decodeSingularDoubleField(value: &value)
-        self = .numberValue(value)
-        return
-      case 3:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .stringValue(value)
-        return
-      case 4:
-        var value = Bool()
-        try decoder.decodeSingularBoolField(value: &value)
-        self = .boolValue(value)
-        return
-      case 5:
-        var value: Google_Protobuf_Struct?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .structValue(value)
-          return
-        }
-      case 6:
-        var value: Google_Protobuf_ListValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .listValue(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .nullValue(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
-        }
-      case .numberValue(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
-        }
-      case .stringValue(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-        }
-      case .boolValue(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
-        }
-      case .structValue(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-        }
-      case .listValue(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   public init() {}
@@ -417,6 +346,79 @@ extension Google_Protobuf_Value: SwiftProtobuf._MessageImplementationBase, Swift
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Google_Protobuf_Value.OneOf_Kind {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value = Google_Protobuf_NullValue()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .nullValue(value)
+      return
+    case 2:
+      var value = Double()
+      try decoder.decodeSingularDoubleField(value: &value)
+      self = .numberValue(value)
+      return
+    case 3:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .stringValue(value)
+      return
+    case 4:
+      var value = Bool()
+      try decoder.decodeSingularBoolField(value: &value)
+      self = .boolValue(value)
+      return
+    case 5:
+      var value: Google_Protobuf_Struct?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .structValue(value)
+        return
+      }
+    case 6:
+      var value: Google_Protobuf_ListValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .listValue(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .nullValue(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
+      }
+    case .numberValue(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
+      }
+    case .stringValue(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      }
+    case .boolValue(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
+      }
+    case .structValue(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      }
+    case .listValue(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      }
+    }
   }
 }
 

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -224,7 +224,7 @@ class MessageGenerator {
     p.print("\(visibility)var unknownFields = SwiftProtobuf.UnknownStorage()\n")
 
     for o in oneofs {
-      o.generateNested(printer: &p)
+      o.generateMainEnum(printer: &p)
     }
 
     // Nested enums
@@ -304,6 +304,10 @@ class MessageGenerator {
     generateMessageImplementationBase(printer: &p)
     p.outdent()
     p.print("}\n")
+
+    for o in oneofs {
+      o.generateRuntimeSupport(printer: &p)
+    }
 
     // Nested enums and messages
     for e in enums {

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -47,7 +47,7 @@ class OneofGenerator {
         self.swiftFullName = swiftMessageFullName + "." + swiftRelativeName
     }
 
-    func generateNested(printer p: inout CodePrinter) {
+    func generateMainEnum(printer p: inout CodePrinter) {
         p.print("\n")
         p.print("\(generatorOptions.visibilitySourceSnippet)enum \(swiftRelativeName): Equatable {\n")
         p.indent()
@@ -78,8 +78,16 @@ class OneofGenerator {
         p.outdent()
         p.print("}\n")
 
-        // Decode one of our members
+        p.outdent()
+        p.print("}\n")
+    }
+
+    func generateRuntimeSupport(printer p: inout CodePrinter) {
         p.print("\n")
+        p.print("extension \(swiftFullName) {\n")
+        p.indent()
+
+        // Decode one of our members
         p.print("fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {\n")
         p.indent()
         p.print("switch fieldNumber {\n")

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -124,37 +124,6 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .protobufPayload(value)
-        return
-      case 2:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .jsonPayload(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .protobufPayload(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
-        }
-      case .jsonPayload(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      }
-    }
   }
 
   init() {}
@@ -274,73 +243,6 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .parseError(value)
-        return
-      case 2:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .runtimeError(value)
-        return
-      case 3:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .protobufPayload(value)
-        return
-      case 4:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .jsonPayload(value)
-        return
-      case 5:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .skipped(value)
-        return
-      case 6:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .serializeError(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .parseError(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-        }
-      case .runtimeError(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .protobufPayload(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
-        }
-      case .jsonPayload(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-        }
-      case .skipped(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-        }
-      case .serializeError(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   init() {}
@@ -387,6 +289,39 @@ extension Conformance_ConformanceRequest: SwiftProtobuf._MessageImplementationBa
   }
 }
 
+extension Conformance_ConformanceRequest.OneOf_Payload {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .protobufPayload(value)
+      return
+    case 2:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .jsonPayload(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .protobufPayload(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
+      }
+    case .jsonPayload(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    }
+  }
+}
+
 extension Conformance_ConformanceResponse: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "parse_error"),
@@ -401,5 +336,74 @@ extension Conformance_ConformanceResponse: SwiftProtobuf._MessageImplementationB
     if result != other.result {return false}
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Conformance_ConformanceResponse.OneOf_Result {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .parseError(value)
+      return
+    case 2:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .runtimeError(value)
+      return
+    case 3:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .protobufPayload(value)
+      return
+    case 4:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .jsonPayload(value)
+      return
+    case 5:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .skipped(value)
+      return
+    case 6:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .serializeError(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .parseError(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+      }
+    case .runtimeError(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .protobufPayload(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
+      }
+    case .jsonPayload(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+      }
+    case .skipped(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+      }
+    case .serializeError(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+      }
+    }
   }
 }

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -1143,102 +1143,6 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      case 115:
-        var value = Bool()
-        try decoder.decodeSingularBoolField(value: &value)
-        self = .oneofBool(value)
-        return
-      case 116:
-        var value = UInt64()
-        try decoder.decodeSingularUInt64Field(value: &value)
-        self = .oneofUint64(value)
-        return
-      case 117:
-        var value = Float()
-        try decoder.decodeSingularFloatField(value: &value)
-        self = .oneofFloat(value)
-        return
-      case 118:
-        var value = Double()
-        try decoder.decodeSingularDoubleField(value: &value)
-        self = .oneofDouble(value)
-        return
-      case 119:
-        var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofEnum(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      case .oneofBool(let v):
-        if start <= 115 && 115 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
-        }
-      case .oneofUint64(let v):
-        if start <= 116 && 116 < end {
-          try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
-        }
-      case .oneofFloat(let v):
-        if start <= 117 && 117 < end {
-          try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
-        }
-      case .oneofDouble(let v):
-        if start <= 118 && 118 < end {
-          try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
-        }
-      case .oneofEnum(let v):
-        if start <= 119 && 119 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -2090,6 +1994,104 @@ extension ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf._MessageImplem
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    case 115:
+      var value = Bool()
+      try decoder.decodeSingularBoolField(value: &value)
+      self = .oneofBool(value)
+      return
+    case 116:
+      var value = UInt64()
+      try decoder.decodeSingularUInt64Field(value: &value)
+      self = .oneofUint64(value)
+      return
+    case 117:
+      var value = Float()
+      try decoder.decodeSingularFloatField(value: &value)
+      self = .oneofFloat(value)
+      return
+    case 118:
+      var value = Double()
+      try decoder.decodeSingularDoubleField(value: &value)
+      self = .oneofDouble(value)
+      return
+    case 119:
+      var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofEnum(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    case .oneofBool(let v):
+      if start <= 115 && 115 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
+      }
+    case .oneofUint64(let v):
+      if start <= 116 && 116 < end {
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
+      }
+    case .oneofFloat(let v):
+      if start <= 117 && 117 < end {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
+      }
+    case .oneofDouble(let v):
+      if start <= 118 && 118 < end {
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
+      }
+    case .oneofEnum(let v):
+      if start <= 119 && 119 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -1033,63 +1033,6 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 112:
-        var value: ProtobufUnittest_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 114:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -4750,63 +4693,6 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .fooInt(value)
-          return
-        }
-      case 2:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .fooString(value)
-          return
-        }
-      case 3:
-        var value: ProtobufUnittest_TestAllTypes?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fooMessage(value)
-          return
-        }
-      case 4:
-        var value: ProtobufUnittest_TestOneof.FooGroup?
-        try decoder.decodeSingularGroupField(value: &value)
-        if let value = value {
-          self = .fooGroup(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .fooInt(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-        }
-      case .fooString(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .fooMessage(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-        }
-      case .fooGroup(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
-        }
-      }
-    }
   }
 
   struct FooGroup: SwiftProtobuf.Message {
@@ -5320,118 +5206,6 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .fooInt(value)
-          return
-        }
-      case 2:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .fooString(value)
-          return
-        }
-      case 3:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .fooCord(value)
-          return
-        }
-      case 4:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .fooStringPiece(value)
-          return
-        }
-      case 5:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .fooBytes(value)
-          return
-        }
-      case 6:
-        var value: ProtobufUnittest_TestOneof2.NestedEnum?
-        try decoder.decodeSingularEnumField(value: &value)
-        if let value = value {
-          self = .fooEnum(value)
-          return
-        }
-      case 7:
-        var value: ProtobufUnittest_TestOneof2.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fooMessage(value)
-          return
-        }
-      case 8:
-        var value: ProtobufUnittest_TestOneof2.FooGroup?
-        try decoder.decodeSingularGroupField(value: &value)
-        if let value = value {
-          self = .fooGroup(value)
-          return
-        }
-      case 11:
-        var value: ProtobufUnittest_TestOneof2.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fooLazyMessage(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .fooInt(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-        }
-      case .fooString(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .fooCord(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-        }
-      case .fooStringPiece(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-        }
-      case .fooBytes(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
-        }
-      case .fooEnum(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-        }
-      case .fooMessage(let v):
-        if start <= 7 && 7 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-        }
-      case .fooGroup(let v):
-        if start <= 8 && 8 < end {
-          try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
-        }
-      case .fooLazyMessage(let v):
-        if start <= 11 && 11 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-        }
-      }
-    }
   }
 
   enum OneOf_Bar: Equatable {
@@ -5451,85 +5225,6 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       case (.barBytes(let l), .barBytes(let r)): return l == r
       case (.barEnum(let l), .barEnum(let r)): return l == r
       default: return false
-      }
-    }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 12:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .barInt(value)
-          return
-        }
-      case 13:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .barString(value)
-          return
-        }
-      case 14:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .barCord(value)
-          return
-        }
-      case 15:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .barStringPiece(value)
-          return
-        }
-      case 16:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .barBytes(value)
-          return
-        }
-      case 17:
-        var value: ProtobufUnittest_TestOneof2.NestedEnum?
-        try decoder.decodeSingularEnumField(value: &value)
-        if let value = value {
-          self = .barEnum(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .barInt(let v):
-        if start <= 12 && 12 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
-        }
-      case .barString(let v):
-        if start <= 13 && 13 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 13)
-        }
-      case .barCord(let v):
-        if start <= 14 && 14 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 14)
-        }
-      case .barStringPiece(let v):
-        if start <= 15 && 15 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 15)
-        }
-      case .barBytes(let v):
-        if start <= 16 && 16 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
-        }
-      case .barEnum(let v):
-        if start <= 17 && 17 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
-        }
       }
     }
   }
@@ -5775,52 +5470,6 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message {
       case (.fooString(let l), .fooString(let r)): return l == r
       case (.fooMessage(let l), .fooMessage(let r)): return l == r
       default: return false
-      }
-    }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .fooInt(value)
-          return
-        }
-      case 2:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .fooString(value)
-          return
-        }
-      case 3:
-        var value: ProtobufUnittest_TestRequiredOneof.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fooMessage(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .fooInt(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-        }
-      case .fooString(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .fooMessage(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-        }
       }
     }
   }
@@ -7357,63 +7006,6 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
       default: return false
-      }
-    }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 536870011:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 536870012:
-        var value: ProtobufUnittest_TestAllTypes?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofTestAllTypes(value)
-          return
-        }
-      case 536870013:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 536870014:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 536870011 && 536870011 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-        }
-      case .oneofTestAllTypes(let v):
-        if start <= 536870012 && 536870012 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-        }
-      case .oneofString(let v):
-        if start <= 536870013 && 536870013 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-        }
-      case .oneofBytes(let v):
-        if start <= 536870014 && 536870014 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-        }
       }
     }
   }
@@ -9940,6 +9532,65 @@ extension ProtobufUnittest_TestAllTypes: SwiftProtobuf._MessageImplementationBas
   }
 }
 
+extension ProtobufUnittest_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 112:
+      var value: ProtobufUnittest_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 114:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    }
+  }
+}
+
 extension ProtobufUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     -1: .same(proto: "NEG"),
@@ -10721,6 +10372,65 @@ extension ProtobufUnittest_TestOneof: SwiftProtobuf._MessageImplementationBase, 
   }
 }
 
+extension ProtobufUnittest_TestOneof.OneOf_Foo {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .fooInt(value)
+        return
+      }
+    case 2:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .fooString(value)
+        return
+      }
+    case 3:
+      var value: ProtobufUnittest_TestAllTypes?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fooMessage(value)
+        return
+      }
+    case 4:
+      var value: ProtobufUnittest_TestOneof.FooGroup?
+      try decoder.decodeSingularGroupField(value: &value)
+      if let value = value {
+        self = .fooGroup(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .fooInt(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      }
+    case .fooString(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .fooMessage(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+    case .fooGroup(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
+      }
+    }
+  }
+}
+
 extension ProtobufUnittest_TestOneof.FooGroup: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     5: .same(proto: "a"),
@@ -10810,6 +10520,201 @@ extension ProtobufUnittest_TestOneof2: SwiftProtobuf._MessageImplementationBase,
   }
 }
 
+extension ProtobufUnittest_TestOneof2.OneOf_Foo {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .fooInt(value)
+        return
+      }
+    case 2:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .fooString(value)
+        return
+      }
+    case 3:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .fooCord(value)
+        return
+      }
+    case 4:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .fooStringPiece(value)
+        return
+      }
+    case 5:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .fooBytes(value)
+        return
+      }
+    case 6:
+      var value: ProtobufUnittest_TestOneof2.NestedEnum?
+      try decoder.decodeSingularEnumField(value: &value)
+      if let value = value {
+        self = .fooEnum(value)
+        return
+      }
+    case 7:
+      var value: ProtobufUnittest_TestOneof2.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fooMessage(value)
+        return
+      }
+    case 8:
+      var value: ProtobufUnittest_TestOneof2.FooGroup?
+      try decoder.decodeSingularGroupField(value: &value)
+      if let value = value {
+        self = .fooGroup(value)
+        return
+      }
+    case 11:
+      var value: ProtobufUnittest_TestOneof2.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fooLazyMessage(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .fooInt(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      }
+    case .fooString(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .fooCord(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      }
+    case .fooStringPiece(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+      }
+    case .fooBytes(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
+      }
+    case .fooEnum(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+      }
+    case .fooMessage(let v):
+      if start <= 7 && 7 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      }
+    case .fooGroup(let v):
+      if start <= 8 && 8 < end {
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
+      }
+    case .fooLazyMessage(let v):
+      if start <= 11 && 11 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      }
+    }
+  }
+}
+
+extension ProtobufUnittest_TestOneof2.OneOf_Bar {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 12:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .barInt(value)
+        return
+      }
+    case 13:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .barString(value)
+        return
+      }
+    case 14:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .barCord(value)
+        return
+      }
+    case 15:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .barStringPiece(value)
+        return
+      }
+    case 16:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .barBytes(value)
+        return
+      }
+    case 17:
+      var value: ProtobufUnittest_TestOneof2.NestedEnum?
+      try decoder.decodeSingularEnumField(value: &value)
+      if let value = value {
+        self = .barEnum(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .barInt(let v):
+      if start <= 12 && 12 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
+      }
+    case .barString(let v):
+      if start <= 13 && 13 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 13)
+      }
+    case .barCord(let v):
+      if start <= 14 && 14 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 14)
+      }
+    case .barStringPiece(let v):
+      if start <= 15 && 15 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 15)
+      }
+    case .barBytes(let v):
+      if start <= 16 && 16 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
+      }
+    case .barEnum(let v):
+      if start <= 17 && 17 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
+      }
+    }
+  }
+}
+
 extension ProtobufUnittest_TestOneof2.NestedEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "FOO"),
@@ -10863,6 +10768,54 @@ extension ProtobufUnittest_TestRequiredOneof: SwiftProtobuf._MessageImplementati
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestRequiredOneof.OneOf_Foo {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .fooInt(value)
+        return
+      }
+    case 2:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .fooString(value)
+        return
+      }
+    case 3:
+      var value: ProtobufUnittest_TestRequiredOneof.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fooMessage(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .fooInt(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      }
+    case .fooString(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .fooMessage(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+    }
   }
 }
 
@@ -11296,6 +11249,65 @@ extension ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf._MessageImplement
     if unknownFields != other.unknownFields {return false}
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 536870011:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 536870012:
+      var value: ProtobufUnittest_TestAllTypes?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofTestAllTypes(value)
+        return
+      }
+    case 536870013:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 536870014:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 536870011 && 536870011 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+      }
+    case .oneofTestAllTypes(let v):
+      if start <= 536870012 && 536870012 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+      }
+    case .oneofString(let v):
+      if start <= 536870013 && 536870013 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+      }
+    case .oneofBytes(let v):
+      if start <= 536870014 && 536870014 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -143,30 +143,6 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
       case (.oneofField(let l), .oneofField(let r)): return l == r
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 2:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .oneofField(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofField(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-        }
-      }
-    }
   }
 
   enum AnEnum: SwiftProtobuf.Enum {
@@ -2270,6 +2246,32 @@ extension ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf._MessageI
     if anOneof != other.anOneof {return false}
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 2:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .oneofField(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofField(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -1033,74 +1033,6 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 112:
-        var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 114:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      case 115:
-        var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofLazyNestedMessage(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      case .oneofLazyNestedMessage(let v):
-        if start <= 115 && 115 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -2710,63 +2642,6 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       case (.oneofString(let l), .oneofString(let r)): return l == r
       case (.oneofBytes(let l), .oneofBytes(let r)): return l == r
       default: return false
-      }
-    }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 536870011:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 536870012:
-        var value: ProtobufUnittest_TestAllTypesLite?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofTestAllTypes(value)
-          return
-        }
-      case 536870013:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 536870014:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 536870011 && 536870011 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-        }
-      case .oneofTestAllTypes(let v):
-        if start <= 536870012 && 536870012 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-        }
-      case .oneofString(let v):
-        if start <= 536870013 && 536870013 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-        }
-      case .oneofBytes(let v):
-        if start <= 536870014 && 536870014 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-        }
       }
     }
   }
@@ -4923,6 +4798,76 @@ extension ProtobufUnittest_TestAllTypesLite: SwiftProtobuf._MessageImplementatio
   }
 }
 
+extension ProtobufUnittest_TestAllTypesLite.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 112:
+      var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 114:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    case 115:
+      var value: ProtobufUnittest_TestAllTypesLite.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofLazyNestedMessage(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    case .oneofLazyNestedMessage(let v):
+      if start <= 115 && 115 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
+      }
+    }
+  }
+}
+
 extension ProtobufUnittest_TestAllTypesLite.NestedEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "FOO"),
@@ -5293,6 +5238,65 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf._MessageImple
     if unknownFields != other.unknownFields {return false}
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 536870011:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 536870012:
+      var value: ProtobufUnittest_TestAllTypesLite?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofTestAllTypes(value)
+        return
+      }
+    case 536870013:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 536870014:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 536870011 && 536870011 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+      }
+    case .oneofTestAllTypes(let v):
+      if start <= 536870012 && 536870012 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+      }
+    case .oneofString(let v):
+      if start <= 536870013 && 536870013 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+      }
+    case .oneofBytes(let v):
+      if start <= 536870014 && 536870014 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -975,74 +975,6 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 112:
-        var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 114:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      case 115:
-        var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .lazyOneofNestedMessage(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      case .lazyOneofNestedMessage(let v):
-        if start <= 115 && 115 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1766,6 +1698,76 @@ extension ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf._MessageImplementa
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 112:
+      var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 114:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    case 115:
+      var value: ProtobufUnittestNoArena_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .lazyOneofNestedMessage(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    case .lazyOneofNestedMessage(let v):
+      if start <= 115 && 115 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -533,57 +533,6 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofEnum(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofEnum(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1065,6 +1014,59 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf._MessageImpl
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofEnum(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofEnum(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -149,41 +149,6 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 2:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .integerField(value)
-          return
-        }
-      case 3:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .stringField(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .integerField(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-        }
-      case .stringField(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-        }
-      }
-    }
   }
 
   struct Extensions {
@@ -404,6 +369,43 @@ extension ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf._MessageImplement
     if unknownFields != other.unknownFields {return false}
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestOptimizedForSize.OneOf_Foo {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 2:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .integerField(value)
+        return
+      }
+    case 3:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .stringField(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .integerField(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+      }
+    case .stringField(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -159,37 +159,6 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 5:
-        var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofE1(value)
-        return
-      case 6:
-        var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofE2(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofE1(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-        }
-      case .oneofE2(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   init() {}
@@ -271,37 +240,6 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 5:
-        var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofE1(value)
-        return
-      case 6:
-        var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofE2(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofE1(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-        }
-      case .oneofE2(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   init() {}
@@ -379,6 +317,39 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf._MessageImp
   }
 }
 
+extension Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 5:
+      var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofE1(value)
+      return
+    case 6:
+      var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofE2(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofE1(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+      }
+    case .oneofE2(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+      }
+    }
+  }
+}
+
 extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "e"),
@@ -397,5 +368,38 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf._M
     if o != other.o {return false}
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 5:
+      var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofE1(value)
+      return
+    case 6:
+      var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofE2(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofE1(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+      }
+    case .oneofE2(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+      }
+    }
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -133,41 +133,6 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 5:
-        var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
-        try decoder.decodeSingularEnumField(value: &value)
-        if let value = value {
-          self = .oneofE1(value)
-          return
-        }
-      case 6:
-        var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
-        try decoder.decodeSingularEnumField(value: &value)
-        if let value = value {
-          self = .oneofE2(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofE1(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-        }
-      case .oneofE2(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-        }
-      }
-    }
   }
 
   init() {}
@@ -233,5 +198,42 @@ extension Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf._MessageImp
     if o != other.o {return false}
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 5:
+      var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
+      try decoder.decodeSingularEnumField(value: &value)
+      if let value = value {
+        self = .oneofE1(value)
+        return
+      }
+    case 6:
+      var value: Proto2PreserveUnknownEnumUnittest_MyEnum?
+      try decoder.decodeSingularEnumField(value: &value)
+      if let value = value {
+        self = .oneofE2(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofE1(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+      }
+    case .oneofE2(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+      }
+    }
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -607,57 +607,6 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: Proto3TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -2020,48 +1969,6 @@ struct Proto3TestOneof: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value = Int32()
-        try decoder.decodeSingularInt32Field(value: &value)
-        self = .fooInt(value)
-        return
-      case 2:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .fooString(value)
-        return
-      case 3:
-        var value: Proto3TestAllTypes?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fooMessage(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .fooInt(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-        }
-      case .fooString(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-        }
-      case .fooMessage(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-        }
-      }
-    }
   }
 
   init() {}
@@ -2631,6 +2538,59 @@ extension Proto3TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftPro
   }
 }
 
+extension Proto3TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: Proto3TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    }
+  }
+}
+
 extension Proto3TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     -1: .same(proto: "NEG"),
@@ -3017,6 +2977,50 @@ extension Proto3TestOneof: SwiftProtobuf._MessageImplementationBase, SwiftProtob
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto3TestOneof.OneOf_Foo {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value = Int32()
+      try decoder.decodeSingularInt32Field(value: &value)
+      self = .fooInt(value)
+      return
+    case 2:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .fooString(value)
+      return
+    case 3:
+      var value: Proto3TestAllTypes?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fooMessage(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .fooInt(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      }
+    case .fooString(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      }
+    case .fooMessage(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -543,57 +543,6 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 112:
-        var value: Proto3ArenaUnittest_TestAllTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 114:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1331,6 +1280,59 @@ extension Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf._MessageImplementation
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 112:
+      var value: Proto3ArenaUnittest_TestAllTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 114:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -748,63 +748,6 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 111:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 112:
-        var value: ProtobufUnittest_TestAllRequiredTypes.NestedMessage?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofNestedMessage(value)
-          return
-        }
-      case 113:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 114:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofUint32(let v):
-        if start <= 111 && 111 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-        }
-      case .oneofNestedMessage(let v):
-        if start <= 112 && 112 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-        }
-      case .oneofString(let v):
-        if start <= 113 && 113 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-        }
-      case .oneofBytes(let v):
-        if start <= 114 && 114 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-        }
-      }
-    }
   }
 
   enum NestedEnum: SwiftProtobuf.Enum {
@@ -1457,6 +1400,65 @@ extension ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf._MessageImplement
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 111:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 112:
+      var value: ProtobufUnittest_TestAllRequiredTypes.NestedMessage?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofNestedMessage(value)
+        return
+      }
+    case 113:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 114:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofUint32(let v):
+      if start <= 111 && 111 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      }
+    case .oneofNestedMessage(let v):
+      if start <= 112 && 112 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      }
+    case .oneofString(let v):
+      if start <= 113 && 113 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      }
+    case .oneofBytes(let v):
+      if start <= 114 && 114 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -183,63 +183,6 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 9:
-        var value: Bool?
-        try decoder.decodeSingularBoolField(value: &value)
-        if let value = value {
-          self = .oneofBool(value)
-          return
-        }
-      case 10:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .oneofInt32(value)
-          return
-        }
-      case 60:
-        var value: Int64?
-        try decoder.decodeSingularInt64Field(value: &value)
-        if let value = value {
-          self = .oneofInt64(value)
-          return
-        }
-      case 150:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofBool(let v):
-        if start <= 9 && 9 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
-        }
-      case .oneofInt32(let v):
-        if start <= 10 && 10 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
-        }
-      case .oneofInt64(let v):
-        if start <= 60 && 60 < end {
-          try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
-        }
-      case .oneofString(let v):
-        if start <= 150 && 150 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 150)
-        }
-      }
-    }
   }
 
   struct NestedMessage: SwiftProtobuf.Message {
@@ -419,6 +362,65 @@ extension Swift_Protobuf_TestFieldOrderings: SwiftProtobuf._MessageImplementatio
     if unknownFields != other.unknownFields {return false}
     if _protobuf_extensionFieldValues != other._protobuf_extensionFieldValues {return false}
     return true
+  }
+}
+
+extension Swift_Protobuf_TestFieldOrderings.OneOf_Options {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 9:
+      var value: Bool?
+      try decoder.decodeSingularBoolField(value: &value)
+      if let value = value {
+        self = .oneofBool(value)
+        return
+      }
+    case 10:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .oneofInt32(value)
+        return
+      }
+    case 60:
+      var value: Int64?
+      try decoder.decodeSingularInt64Field(value: &value)
+      if let value = value {
+        self = .oneofInt64(value)
+        return
+      }
+    case 150:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofBool(let v):
+      if start <= 9 && 9 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
+      }
+    case .oneofInt32(let v):
+      if start <= 10 && 10 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
+      }
+    case .oneofInt64(let v):
+      if start <= 60 && 60 < end {
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
+      }
+    case .oneofString(let v):
+      if start <= 150 && 150 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 150)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -834,217 +834,6 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 51:
-        var value: Int32?
-        try decoder.decodeSingularInt32Field(value: &value)
-        if let value = value {
-          self = .oneofInt32(value)
-          return
-        }
-      case 52:
-        var value: Int64?
-        try decoder.decodeSingularInt64Field(value: &value)
-        if let value = value {
-          self = .oneofInt64(value)
-          return
-        }
-      case 53:
-        var value: UInt32?
-        try decoder.decodeSingularUInt32Field(value: &value)
-        if let value = value {
-          self = .oneofUint32(value)
-          return
-        }
-      case 54:
-        var value: UInt64?
-        try decoder.decodeSingularUInt64Field(value: &value)
-        if let value = value {
-          self = .oneofUint64(value)
-          return
-        }
-      case 55:
-        var value: Int32?
-        try decoder.decodeSingularSInt32Field(value: &value)
-        if let value = value {
-          self = .oneofSint32(value)
-          return
-        }
-      case 56:
-        var value: Int64?
-        try decoder.decodeSingularSInt64Field(value: &value)
-        if let value = value {
-          self = .oneofSint64(value)
-          return
-        }
-      case 57:
-        var value: UInt32?
-        try decoder.decodeSingularFixed32Field(value: &value)
-        if let value = value {
-          self = .oneofFixed32(value)
-          return
-        }
-      case 58:
-        var value: UInt64?
-        try decoder.decodeSingularFixed64Field(value: &value)
-        if let value = value {
-          self = .oneofFixed64(value)
-          return
-        }
-      case 59:
-        var value: Int32?
-        try decoder.decodeSingularSFixed32Field(value: &value)
-        if let value = value {
-          self = .oneofSfixed32(value)
-          return
-        }
-      case 60:
-        var value: Int64?
-        try decoder.decodeSingularSFixed64Field(value: &value)
-        if let value = value {
-          self = .oneofSfixed64(value)
-          return
-        }
-      case 61:
-        var value: Float?
-        try decoder.decodeSingularFloatField(value: &value)
-        if let value = value {
-          self = .oneofFloat(value)
-          return
-        }
-      case 62:
-        var value: Double?
-        try decoder.decodeSingularDoubleField(value: &value)
-        if let value = value {
-          self = .oneofDouble(value)
-          return
-        }
-      case 63:
-        var value: Bool?
-        try decoder.decodeSingularBoolField(value: &value)
-        if let value = value {
-          self = .oneofBool(value)
-          return
-        }
-      case 64:
-        var value: String?
-        try decoder.decodeSingularStringField(value: &value)
-        if let value = value {
-          self = .oneofString(value)
-          return
-        }
-      case 65:
-        var value: Data?
-        try decoder.decodeSingularBytesField(value: &value)
-        if let value = value {
-          self = .oneofBytes(value)
-          return
-        }
-      case 66:
-        var value: ProtobufUnittest_Message2.OneofGroup?
-        try decoder.decodeSingularGroupField(value: &value)
-        if let value = value {
-          self = .oneofGroup(value)
-          return
-        }
-      case 68:
-        var value: ProtobufUnittest_Message2?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofMessage(value)
-          return
-        }
-      case 69:
-        var value: ProtobufUnittest_Message2.Enum?
-        try decoder.decodeSingularEnumField(value: &value)
-        if let value = value {
-          self = .oneofEnum(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofInt32(let v):
-        if start <= 51 && 51 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
-        }
-      case .oneofInt64(let v):
-        if start <= 52 && 52 < end {
-          try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
-        }
-      case .oneofUint32(let v):
-        if start <= 53 && 53 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
-        }
-      case .oneofUint64(let v):
-        if start <= 54 && 54 < end {
-          try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
-        }
-      case .oneofSint32(let v):
-        if start <= 55 && 55 < end {
-          try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
-        }
-      case .oneofSint64(let v):
-        if start <= 56 && 56 < end {
-          try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
-        }
-      case .oneofFixed32(let v):
-        if start <= 57 && 57 < end {
-          try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
-        }
-      case .oneofFixed64(let v):
-        if start <= 58 && 58 < end {
-          try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
-        }
-      case .oneofSfixed32(let v):
-        if start <= 59 && 59 < end {
-          try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
-        }
-      case .oneofSfixed64(let v):
-        if start <= 60 && 60 < end {
-          try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
-        }
-      case .oneofFloat(let v):
-        if start <= 61 && 61 < end {
-          try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
-        }
-      case .oneofDouble(let v):
-        if start <= 62 && 62 < end {
-          try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
-        }
-      case .oneofBool(let v):
-        if start <= 63 && 63 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
-        }
-      case .oneofString(let v):
-        if start <= 64 && 64 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 64)
-        }
-      case .oneofBytes(let v):
-        if start <= 65 && 65 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
-        }
-      case .oneofGroup(let v):
-        if start <= 66 && 66 < end {
-          try visitor.visitSingularGroupField(value: v, fieldNumber: 66)
-        }
-      case .oneofMessage(let v):
-        if start <= 68 && 68 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
-        }
-      case .oneofEnum(let v):
-        if start <= 69 && 69 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-        }
-      }
-    }
   }
 
   enum Enum: SwiftProtobuf.Enum {
@@ -1668,6 +1457,219 @@ extension ProtobufUnittest_Message2: SwiftProtobuf._MessageImplementationBase, S
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_Message2.OneOf_O {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 51:
+      var value: Int32?
+      try decoder.decodeSingularInt32Field(value: &value)
+      if let value = value {
+        self = .oneofInt32(value)
+        return
+      }
+    case 52:
+      var value: Int64?
+      try decoder.decodeSingularInt64Field(value: &value)
+      if let value = value {
+        self = .oneofInt64(value)
+        return
+      }
+    case 53:
+      var value: UInt32?
+      try decoder.decodeSingularUInt32Field(value: &value)
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
+    case 54:
+      var value: UInt64?
+      try decoder.decodeSingularUInt64Field(value: &value)
+      if let value = value {
+        self = .oneofUint64(value)
+        return
+      }
+    case 55:
+      var value: Int32?
+      try decoder.decodeSingularSInt32Field(value: &value)
+      if let value = value {
+        self = .oneofSint32(value)
+        return
+      }
+    case 56:
+      var value: Int64?
+      try decoder.decodeSingularSInt64Field(value: &value)
+      if let value = value {
+        self = .oneofSint64(value)
+        return
+      }
+    case 57:
+      var value: UInt32?
+      try decoder.decodeSingularFixed32Field(value: &value)
+      if let value = value {
+        self = .oneofFixed32(value)
+        return
+      }
+    case 58:
+      var value: UInt64?
+      try decoder.decodeSingularFixed64Field(value: &value)
+      if let value = value {
+        self = .oneofFixed64(value)
+        return
+      }
+    case 59:
+      var value: Int32?
+      try decoder.decodeSingularSFixed32Field(value: &value)
+      if let value = value {
+        self = .oneofSfixed32(value)
+        return
+      }
+    case 60:
+      var value: Int64?
+      try decoder.decodeSingularSFixed64Field(value: &value)
+      if let value = value {
+        self = .oneofSfixed64(value)
+        return
+      }
+    case 61:
+      var value: Float?
+      try decoder.decodeSingularFloatField(value: &value)
+      if let value = value {
+        self = .oneofFloat(value)
+        return
+      }
+    case 62:
+      var value: Double?
+      try decoder.decodeSingularDoubleField(value: &value)
+      if let value = value {
+        self = .oneofDouble(value)
+        return
+      }
+    case 63:
+      var value: Bool?
+      try decoder.decodeSingularBoolField(value: &value)
+      if let value = value {
+        self = .oneofBool(value)
+        return
+      }
+    case 64:
+      var value: String?
+      try decoder.decodeSingularStringField(value: &value)
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
+    case 65:
+      var value: Data?
+      try decoder.decodeSingularBytesField(value: &value)
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
+    case 66:
+      var value: ProtobufUnittest_Message2.OneofGroup?
+      try decoder.decodeSingularGroupField(value: &value)
+      if let value = value {
+        self = .oneofGroup(value)
+        return
+      }
+    case 68:
+      var value: ProtobufUnittest_Message2?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofMessage(value)
+        return
+      }
+    case 69:
+      var value: ProtobufUnittest_Message2.Enum?
+      try decoder.decodeSingularEnumField(value: &value)
+      if let value = value {
+        self = .oneofEnum(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofInt32(let v):
+      if start <= 51 && 51 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
+      }
+    case .oneofInt64(let v):
+      if start <= 52 && 52 < end {
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
+      }
+    case .oneofUint32(let v):
+      if start <= 53 && 53 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
+      }
+    case .oneofUint64(let v):
+      if start <= 54 && 54 < end {
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
+      }
+    case .oneofSint32(let v):
+      if start <= 55 && 55 < end {
+        try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
+      }
+    case .oneofSint64(let v):
+      if start <= 56 && 56 < end {
+        try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
+      }
+    case .oneofFixed32(let v):
+      if start <= 57 && 57 < end {
+        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
+      }
+    case .oneofFixed64(let v):
+      if start <= 58 && 58 < end {
+        try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
+      }
+    case .oneofSfixed32(let v):
+      if start <= 59 && 59 < end {
+        try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
+      }
+    case .oneofSfixed64(let v):
+      if start <= 60 && 60 < end {
+        try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
+      }
+    case .oneofFloat(let v):
+      if start <= 61 && 61 < end {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
+      }
+    case .oneofDouble(let v):
+      if start <= 62 && 62 < end {
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
+      }
+    case .oneofBool(let v):
+      if start <= 63 && 63 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
+      }
+    case .oneofString(let v):
+      if start <= 64 && 64 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 64)
+      }
+    case .oneofBytes(let v):
+      if start <= 65 && 65 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
+      }
+    case .oneofGroup(let v):
+      if start <= 66 && 66 < end {
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 66)
+      }
+    case .oneofMessage(let v):
+      if start <= 68 && 68 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
+      }
+    case .oneofEnum(let v):
+      if start <= 69 && 69 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -707,174 +707,6 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 51:
-        var value = Int32()
-        try decoder.decodeSingularInt32Field(value: &value)
-        self = .oneofInt32(value)
-        return
-      case 52:
-        var value = Int64()
-        try decoder.decodeSingularInt64Field(value: &value)
-        self = .oneofInt64(value)
-        return
-      case 53:
-        var value = UInt32()
-        try decoder.decodeSingularUInt32Field(value: &value)
-        self = .oneofUint32(value)
-        return
-      case 54:
-        var value = UInt64()
-        try decoder.decodeSingularUInt64Field(value: &value)
-        self = .oneofUint64(value)
-        return
-      case 55:
-        var value = Int32()
-        try decoder.decodeSingularSInt32Field(value: &value)
-        self = .oneofSint32(value)
-        return
-      case 56:
-        var value = Int64()
-        try decoder.decodeSingularSInt64Field(value: &value)
-        self = .oneofSint64(value)
-        return
-      case 57:
-        var value = UInt32()
-        try decoder.decodeSingularFixed32Field(value: &value)
-        self = .oneofFixed32(value)
-        return
-      case 58:
-        var value = UInt64()
-        try decoder.decodeSingularFixed64Field(value: &value)
-        self = .oneofFixed64(value)
-        return
-      case 59:
-        var value = Int32()
-        try decoder.decodeSingularSFixed32Field(value: &value)
-        self = .oneofSfixed32(value)
-        return
-      case 60:
-        var value = Int64()
-        try decoder.decodeSingularSFixed64Field(value: &value)
-        self = .oneofSfixed64(value)
-        return
-      case 61:
-        var value = Float()
-        try decoder.decodeSingularFloatField(value: &value)
-        self = .oneofFloat(value)
-        return
-      case 62:
-        var value = Double()
-        try decoder.decodeSingularDoubleField(value: &value)
-        self = .oneofDouble(value)
-        return
-      case 63:
-        var value = Bool()
-        try decoder.decodeSingularBoolField(value: &value)
-        self = .oneofBool(value)
-        return
-      case 64:
-        var value = String()
-        try decoder.decodeSingularStringField(value: &value)
-        self = .oneofString(value)
-        return
-      case 65:
-        var value = Data()
-        try decoder.decodeSingularBytesField(value: &value)
-        self = .oneofBytes(value)
-        return
-      case 68:
-        var value: ProtobufUnittest_Message3?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .oneofMessage(value)
-          return
-        }
-      case 69:
-        var value = ProtobufUnittest_Message3.Enum()
-        try decoder.decodeSingularEnumField(value: &value)
-        self = .oneofEnum(value)
-        return
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .oneofInt32(let v):
-        if start <= 51 && 51 < end {
-          try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
-        }
-      case .oneofInt64(let v):
-        if start <= 52 && 52 < end {
-          try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
-        }
-      case .oneofUint32(let v):
-        if start <= 53 && 53 < end {
-          try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
-        }
-      case .oneofUint64(let v):
-        if start <= 54 && 54 < end {
-          try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
-        }
-      case .oneofSint32(let v):
-        if start <= 55 && 55 < end {
-          try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
-        }
-      case .oneofSint64(let v):
-        if start <= 56 && 56 < end {
-          try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
-        }
-      case .oneofFixed32(let v):
-        if start <= 57 && 57 < end {
-          try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
-        }
-      case .oneofFixed64(let v):
-        if start <= 58 && 58 < end {
-          try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
-        }
-      case .oneofSfixed32(let v):
-        if start <= 59 && 59 < end {
-          try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
-        }
-      case .oneofSfixed64(let v):
-        if start <= 60 && 60 < end {
-          try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
-        }
-      case .oneofFloat(let v):
-        if start <= 61 && 61 < end {
-          try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
-        }
-      case .oneofDouble(let v):
-        if start <= 62 && 62 < end {
-          try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
-        }
-      case .oneofBool(let v):
-        if start <= 63 && 63 < end {
-          try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
-        }
-      case .oneofString(let v):
-        if start <= 64 && 64 < end {
-          try visitor.visitSingularStringField(value: v, fieldNumber: 64)
-        }
-      case .oneofBytes(let v):
-        if start <= 65 && 65 < end {
-          try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
-        }
-      case .oneofMessage(let v):
-        if start <= 68 && 68 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
-        }
-      case .oneofEnum(let v):
-        if start <= 69 && 69 < end {
-          try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-        }
-      }
-    }
   }
 
   enum Enum: SwiftProtobuf.Enum {
@@ -1363,6 +1195,176 @@ extension ProtobufUnittest_Message3: SwiftProtobuf._MessageImplementationBase, S
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_Message3.OneOf_O {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 51:
+      var value = Int32()
+      try decoder.decodeSingularInt32Field(value: &value)
+      self = .oneofInt32(value)
+      return
+    case 52:
+      var value = Int64()
+      try decoder.decodeSingularInt64Field(value: &value)
+      self = .oneofInt64(value)
+      return
+    case 53:
+      var value = UInt32()
+      try decoder.decodeSingularUInt32Field(value: &value)
+      self = .oneofUint32(value)
+      return
+    case 54:
+      var value = UInt64()
+      try decoder.decodeSingularUInt64Field(value: &value)
+      self = .oneofUint64(value)
+      return
+    case 55:
+      var value = Int32()
+      try decoder.decodeSingularSInt32Field(value: &value)
+      self = .oneofSint32(value)
+      return
+    case 56:
+      var value = Int64()
+      try decoder.decodeSingularSInt64Field(value: &value)
+      self = .oneofSint64(value)
+      return
+    case 57:
+      var value = UInt32()
+      try decoder.decodeSingularFixed32Field(value: &value)
+      self = .oneofFixed32(value)
+      return
+    case 58:
+      var value = UInt64()
+      try decoder.decodeSingularFixed64Field(value: &value)
+      self = .oneofFixed64(value)
+      return
+    case 59:
+      var value = Int32()
+      try decoder.decodeSingularSFixed32Field(value: &value)
+      self = .oneofSfixed32(value)
+      return
+    case 60:
+      var value = Int64()
+      try decoder.decodeSingularSFixed64Field(value: &value)
+      self = .oneofSfixed64(value)
+      return
+    case 61:
+      var value = Float()
+      try decoder.decodeSingularFloatField(value: &value)
+      self = .oneofFloat(value)
+      return
+    case 62:
+      var value = Double()
+      try decoder.decodeSingularDoubleField(value: &value)
+      self = .oneofDouble(value)
+      return
+    case 63:
+      var value = Bool()
+      try decoder.decodeSingularBoolField(value: &value)
+      self = .oneofBool(value)
+      return
+    case 64:
+      var value = String()
+      try decoder.decodeSingularStringField(value: &value)
+      self = .oneofString(value)
+      return
+    case 65:
+      var value = Data()
+      try decoder.decodeSingularBytesField(value: &value)
+      self = .oneofBytes(value)
+      return
+    case 68:
+      var value: ProtobufUnittest_Message3?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .oneofMessage(value)
+        return
+      }
+    case 69:
+      var value = ProtobufUnittest_Message3.Enum()
+      try decoder.decodeSingularEnumField(value: &value)
+      self = .oneofEnum(value)
+      return
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .oneofInt32(let v):
+      if start <= 51 && 51 < end {
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
+      }
+    case .oneofInt64(let v):
+      if start <= 52 && 52 < end {
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
+      }
+    case .oneofUint32(let v):
+      if start <= 53 && 53 < end {
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
+      }
+    case .oneofUint64(let v):
+      if start <= 54 && 54 < end {
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
+      }
+    case .oneofSint32(let v):
+      if start <= 55 && 55 < end {
+        try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
+      }
+    case .oneofSint64(let v):
+      if start <= 56 && 56 < end {
+        try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
+      }
+    case .oneofFixed32(let v):
+      if start <= 57 && 57 < end {
+        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
+      }
+    case .oneofFixed64(let v):
+      if start <= 58 && 58 < end {
+        try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
+      }
+    case .oneofSfixed32(let v):
+      if start <= 59 && 59 < end {
+        try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
+      }
+    case .oneofSfixed64(let v):
+      if start <= 60 && 60 < end {
+        try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
+      }
+    case .oneofFloat(let v):
+      if start <= 61 && 61 < end {
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
+      }
+    case .oneofDouble(let v):
+      if start <= 62 && 62 < end {
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
+      }
+    case .oneofBool(let v):
+      if start <= 63 && 63 < end {
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
+      }
+    case .oneofString(let v):
+      if start <= 64 && 64 < end {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 64)
+      }
+    case .oneofBytes(let v):
+      if start <= 65 && 65 < end {
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
+      }
+    case .oneofMessage(let v):
+      if start <= 68 && 68 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
+      }
+    case .oneofEnum(let v):
+      if start <= 69 && 69 < end {
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
+      }
+    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -922,217 +922,6 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message {
       default: return false
       }
     }
-
-    fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
-      switch fieldNumber {
-      case 1:
-        var value: Google_Protobuf_Any?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .anyField(value)
-          return
-        }
-      case 2:
-        var value: Google_Protobuf_Api?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .apiField(value)
-          return
-        }
-      case 3:
-        var value: Google_Protobuf_Duration?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .durationField(value)
-          return
-        }
-      case 4:
-        var value: Google_Protobuf_Empty?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .emptyField(value)
-          return
-        }
-      case 5:
-        var value: Google_Protobuf_FieldMask?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .fieldMaskField(value)
-          return
-        }
-      case 6:
-        var value: Google_Protobuf_SourceContext?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .sourceContextField(value)
-          return
-        }
-      case 7:
-        var value: Google_Protobuf_Struct?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .structField(value)
-          return
-        }
-      case 8:
-        var value: Google_Protobuf_Timestamp?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .timestampField(value)
-          return
-        }
-      case 9:
-        var value: Google_Protobuf_Type?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .typeField(value)
-          return
-        }
-      case 10:
-        var value: Google_Protobuf_DoubleValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .doubleField(value)
-          return
-        }
-      case 11:
-        var value: Google_Protobuf_FloatValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .floatField(value)
-          return
-        }
-      case 12:
-        var value: Google_Protobuf_Int64Value?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .int64Field(value)
-          return
-        }
-      case 13:
-        var value: Google_Protobuf_UInt64Value?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .uint64Field(value)
-          return
-        }
-      case 14:
-        var value: Google_Protobuf_Int32Value?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .int32Field(value)
-          return
-        }
-      case 15:
-        var value: Google_Protobuf_UInt32Value?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .uint32Field(value)
-          return
-        }
-      case 16:
-        var value: Google_Protobuf_BoolValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .boolField(value)
-          return
-        }
-      case 17:
-        var value: Google_Protobuf_StringValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .stringField(value)
-          return
-        }
-      case 18:
-        var value: Google_Protobuf_BytesValue?
-        try decoder.decodeSingularMessageField(value: &value)
-        if let value = value {
-          self = .bytesField(value)
-          return
-        }
-      default:
-        break
-      }
-      return nil
-    }
-
-    fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
-      switch self {
-      case .anyField(let v):
-        if start <= 1 && 1 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-        }
-      case .apiField(let v):
-        if start <= 2 && 2 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-        }
-      case .durationField(let v):
-        if start <= 3 && 3 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-        }
-      case .emptyField(let v):
-        if start <= 4 && 4 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-        }
-      case .fieldMaskField(let v):
-        if start <= 5 && 5 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-        }
-      case .sourceContextField(let v):
-        if start <= 6 && 6 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-        }
-      case .structField(let v):
-        if start <= 7 && 7 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-        }
-      case .timestampField(let v):
-        if start <= 8 && 8 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-        }
-      case .typeField(let v):
-        if start <= 9 && 9 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-        }
-      case .doubleField(let v):
-        if start <= 10 && 10 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-        }
-      case .floatField(let v):
-        if start <= 11 && 11 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-        }
-      case .int64Field(let v):
-        if start <= 12 && 12 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-        }
-      case .uint64Field(let v):
-        if start <= 13 && 13 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-        }
-      case .int32Field(let v):
-        if start <= 14 && 14 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
-        }
-      case .uint32Field(let v):
-        if start <= 15 && 15 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
-        }
-      case .boolField(let v):
-        if start <= 16 && 16 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
-        }
-      case .stringField(let v):
-        if start <= 17 && 17 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
-        }
-      case .bytesField(let v):
-        if start <= 18 && 18 < end {
-          try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
-        }
-      }
-    }
   }
 
   init() {}
@@ -1542,6 +1331,219 @@ extension ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf._MessageImplementa
     }
     if unknownFields != other.unknownFields {return false}
     return true
+  }
+}
+
+extension ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField {
+  fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
+    switch fieldNumber {
+    case 1:
+      var value: Google_Protobuf_Any?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .anyField(value)
+        return
+      }
+    case 2:
+      var value: Google_Protobuf_Api?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .apiField(value)
+        return
+      }
+    case 3:
+      var value: Google_Protobuf_Duration?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .durationField(value)
+        return
+      }
+    case 4:
+      var value: Google_Protobuf_Empty?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .emptyField(value)
+        return
+      }
+    case 5:
+      var value: Google_Protobuf_FieldMask?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .fieldMaskField(value)
+        return
+      }
+    case 6:
+      var value: Google_Protobuf_SourceContext?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .sourceContextField(value)
+        return
+      }
+    case 7:
+      var value: Google_Protobuf_Struct?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .structField(value)
+        return
+      }
+    case 8:
+      var value: Google_Protobuf_Timestamp?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .timestampField(value)
+        return
+      }
+    case 9:
+      var value: Google_Protobuf_Type?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .typeField(value)
+        return
+      }
+    case 10:
+      var value: Google_Protobuf_DoubleValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .doubleField(value)
+        return
+      }
+    case 11:
+      var value: Google_Protobuf_FloatValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .floatField(value)
+        return
+      }
+    case 12:
+      var value: Google_Protobuf_Int64Value?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .int64Field(value)
+        return
+      }
+    case 13:
+      var value: Google_Protobuf_UInt64Value?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .uint64Field(value)
+        return
+      }
+    case 14:
+      var value: Google_Protobuf_Int32Value?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .int32Field(value)
+        return
+      }
+    case 15:
+      var value: Google_Protobuf_UInt32Value?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .uint32Field(value)
+        return
+      }
+    case 16:
+      var value: Google_Protobuf_BoolValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .boolField(value)
+        return
+      }
+    case 17:
+      var value: Google_Protobuf_StringValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .stringField(value)
+        return
+      }
+    case 18:
+      var value: Google_Protobuf_BytesValue?
+      try decoder.decodeSingularMessageField(value: &value)
+      if let value = value {
+        self = .bytesField(value)
+        return
+      }
+    default:
+      break
+    }
+    return nil
+  }
+
+  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V, start: Int, end: Int) throws {
+    switch self {
+    case .anyField(let v):
+      if start <= 1 && 1 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      }
+    case .apiField(let v):
+      if start <= 2 && 2 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      }
+    case .durationField(let v):
+      if start <= 3 && 3 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      }
+    case .emptyField(let v):
+      if start <= 4 && 4 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      }
+    case .fieldMaskField(let v):
+      if start <= 5 && 5 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      }
+    case .sourceContextField(let v):
+      if start <= 6 && 6 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      }
+    case .structField(let v):
+      if start <= 7 && 7 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      }
+    case .timestampField(let v):
+      if start <= 8 && 8 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+      }
+    case .typeField(let v):
+      if start <= 9 && 9 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+      }
+    case .doubleField(let v):
+      if start <= 10 && 10 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+      }
+    case .floatField(let v):
+      if start <= 11 && 11 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      }
+    case .int64Field(let v):
+      if start <= 12 && 12 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+      }
+    case .uint64Field(let v):
+      if start <= 13 && 13 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+      }
+    case .int32Field(let v):
+      if start <= 14 && 14 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
+      }
+    case .uint32Field(let v):
+      if start <= 15 && 15 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+      }
+    case .boolField(let v):
+      if start <= 16 && 16 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
+      }
+    case .stringField(let v):
+      if start <= 17 && 17 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
+      }
+    case .bytesField(let v):
+      if start <= 18 && 18 < end {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Move the fileprivate impl details down so the enum defintion is shorter
and more likely just want someone reading the source needs.