### PR TITLE
Add message with different field types to perf harness.

### DIFF
--- a/Performance/Harness.cc
+++ b/Performance/Harness.cc
@@ -35,7 +35,6 @@ using std::vector;
 Harness::Harness(std::ostream* results_stream) :
     results_stream(results_stream),
     measurement_count(10),
-    run_count(1000),
     repeated_count(10) {}
 
 void Harness::write_to_log(const string& name,
@@ -47,7 +46,7 @@ void Harness::write_to_log(const string& name,
   (*results_stream) << "\"" << name << "\": [";
   for (const auto& duration : timings) {
     auto micros = duration_cast<microseconds_d>(duration);
-    (*results_stream) << micros.count() / run_count << ", ";
+    (*results_stream) << micros.count() / run_count() << ", ";
   }
   (*results_stream) << "]," << endl;
 }

--- a/Performance/Harness.h
+++ b/Performance/Harness.h
@@ -65,7 +65,7 @@ private:
    * The number of times to loop the body of the run() method.
    * Increase this for better precision.
    */
-  int run_count;
+  int run_count() const;
 
   /** The number of times to measure the function passed to measure(). */
   int measurement_count;
@@ -120,7 +120,7 @@ void Harness::measure(const Function& func) {
   subtask_timings.clear();
   bool displayed_titles = false;
 
-  printf("Running each check %d times, times in µs\n", run_count);
+  printf("Running each check %d times, times in µs\n", run_count());
 
   // Do each measurement multiple times and collect the means and standard
   // deviation to account for noise.
@@ -128,7 +128,7 @@ void Harness::measure(const Function& func) {
     current_subtasks.clear();
 
     auto start = steady_clock::now();
-    for (auto i = 0; i < run_count; i++) {
+    for (auto i = 0; i < run_count(); i++) {
         subtask_names.clear();
         func();
     }
@@ -156,7 +156,7 @@ void Harness::measure(const Function& func) {
     for (const auto& name : subtask_names) {
       const auto& total_interval = current_subtasks[name];
       auto micros = duration_cast<microseconds_d>(total_interval);
-      printf("%9.3f", micros.count() / run_count);
+      printf("%9.3f", micros.count() / run_count());
       subtask_timings[name].push_back(micros);
     }
     printf("\n");

--- a/Performance/Harness.swift
+++ b/Performance/Harness.swift
@@ -18,18 +18,24 @@ private func padded(_ input: String, to width: Int) -> String {
   return input + String(repeating: " ", count: max(0, width - input.characters.count))
 }
 
+/// It is expected that the generator will provide these in an extension.
+protocol GeneratedHarnessMembers {
+  /// The number of times to loop the body of the run() method.
+  /// Increase this to get better precision.
+  var runCount: Int { get }
+
+  /// The main body of the performance harness.
+  func run()
+}
+
 /// Harness used for performance tests.
 ///
 /// The generator script will generate an extension to this class that adds a
 /// run() method, which the main.swift file calls.
-class Harness {
+class Harness: GeneratedHarnessMembers {
 
   /// The number of times to execute the block passed to measure().
   var measurementCount = 10
-
-  /// The number of times to loop the body of the run() method.
-  /// Increase this to get better precision...
-  var runCount = 1000
 
   /// The number of times to call append() for repeated fields.
   let repeatedCount: Int32 = 10

--- a/Performance/generators/cpp.sh
+++ b/Performance/generators/cpp.sh
@@ -22,28 +22,28 @@ function print_cpp_set_field() {
 
   case "$type" in
     repeated\ string)
-      echo "        for (auto i = 0; i < repeated_count; i++) {"
-      echo "          message.add_field$num(\"$((200+num))\");"
-      echo "        }"
+      echo "  for (auto i = 0; i < repeated_count; i++) {"
+      echo "    message.add_field$num(\"$((200+num))\");"
+      echo "  }"
       ;;
     repeated\ bytes)
-      echo "        for (auto i = 0; i < repeated_count; i++) {"
-      echo "          message.add_field$num(std::string(20, (char)$((num))));"
-      echo "        }"
+      echo "  for (auto i = 0; i < repeated_count; i++) {"
+      echo "    message.add_field$num(std::string(20, (char)$((num))));"
+      echo "  }"
       ;;
     repeated\ *)
-      echo "        for (auto i = 0; i < repeated_count; i++) {"
-      echo "          message.add_field$num($((200+num)));"
-      echo "        }"
+      echo "  for (auto i = 0; i < repeated_count; i++) {"
+      echo "    message.add_field$num($((200+num)));"
+      echo "  }"
       ;;
     string)
-      echo "        message.set_field$num(\"$((200+num))\");"
+      echo "  message.set_field$num(\"$((200+num))\");"
       ;;
     bytes)
-      echo "        message.set_field$num(std::string(20, (char)$((num))));"
+      echo "  message.set_field$num(std::string(20, (char)$((num))));"
       ;;
     *)
-      echo "        message.set_field$num($((200+num)));"
+      echo "  message.set_field$num($((200+num)));"
       ;;
   esac
 }
@@ -91,6 +91,10 @@ void Harness::run() {
   type_url = new string(GetTypeUrl(PerfMessage::descriptor()));
 
   measure([&]() {
+      measure_subtask("New message", [&]() {
+        return PerfMessage();
+      });
+
       auto message = PerfMessage();
 
       measure_subtask("Populate fields", [&]() {
@@ -147,11 +151,107 @@ void populate_fields(PerfMessage& message, int repeated_count) {
 
 EOF
 
-  for field_number in $(seq 1 "$field_count"); do
-    print_cpp_set_field "$field_number" "$field_type" >>"$gen_harness_path"
-  done
+  if [[ "$proto_type" == "homogeneous" ]]; then
+    generate_cpp_homogenerous_populate_fields_body
+  else
+    generate_cpp_heterogenerous_populate_fields_body
+  fi
 
   cat >> "$gen_harness_path" <<EOF
 }
+
+int Harness::run_count() const {
+  return ${run_count};
+}
+EOF
+}
+
+function generate_cpp_homogenerous_populate_fields_body() {
+  for field_number in $(seq 1 "$field_count"); do
+    print_cpp_set_field "$field_number" "$field_type" >>"$gen_harness_path"
+  done
+}
+
+function generate_cpp_heterogenerous_populate_fields_body() {
+  cat >> "$gen_harness_path" <<EOF
+  message.set_optional_int32(1);
+  message.set_optional_int64(2);
+  message.set_optional_uint32(3);
+  message.set_optional_uint64(4);
+  message.set_optional_sint32(5);
+  message.set_optional_sint64(6);
+  message.set_optional_fixed32(7);
+  message.set_optional_fixed64(8);
+  message.set_optional_sfixed32(9);
+  message.set_optional_sfixed64(10);
+  message.set_optional_float(11);
+  message.set_optional_double(12);
+  message.set_optional_bool(true);
+  message.set_optional_string("14");
+  message.set_optional_bytes(std::string(20, (char)15));
+  message.set_optional_enum(PerfMessage::FOO);
+
+EOF
+
+  if [[ "$proto_syntax" == "2" ]]; then
+    cat >>"$gen_harness_path" <<EOF
+  message.mutable_optionalgroup()->set_optional_group_int32(101);
+  message.mutable_optionalgroup()->set_optional_group_int64(102);
+  message.mutable_optionalgroup()->set_optional_group_uint32(103);
+  message.mutable_optionalgroup()->set_optional_group_uint64(104);
+  message.mutable_optionalgroup()->set_optional_group_sint32(105);
+  message.mutable_optionalgroup()->set_optional_group_sint64(106);
+  message.mutable_optionalgroup()->set_optional_group_fixed32(107);
+  message.mutable_optionalgroup()->set_optional_group_fixed64(108);
+  message.mutable_optionalgroup()->set_optional_group_sfixed32(109);
+  message.mutable_optionalgroup()->set_optional_group_sfixed64(110);
+  message.mutable_optionalgroup()->set_optional_group_float(111);
+  message.mutable_optionalgroup()->set_optional_group_double(112);
+  message.mutable_optionalgroup()->set_optional_group_bool(true);
+  message.mutable_optionalgroup()->set_optional_group_string("114");
+  message.mutable_optionalgroup()->set_optional_group_bytes(std::string(20, (char)115));
+  message.mutable_optionalgroup()->set_optional_group_enum(PerfMessage::FOO);
+
+EOF
+fi
+
+  cat >>"$gen_harness_path" <<EOF
+  for (auto i = 0; i < repeated_count; i++) {
+    message.add_repeated_int32(201);
+    message.add_repeated_int64(202);
+    message.add_repeated_uint32(203);
+    message.add_repeated_uint64(204);
+    message.add_repeated_sint32(205);
+    message.add_repeated_sint64(206);
+    message.add_repeated_fixed32(207);
+    message.add_repeated_fixed64(208);
+    message.add_repeated_sfixed32(209);
+    message.add_repeated_sfixed64(210);
+    message.add_repeated_float(211);
+    message.add_repeated_double(212);
+    message.add_repeated_bool(true);
+    message.add_repeated_string("214");
+    message.add_repeated_bytes(std::string(20, (char)215));
+    message.add_repeated_enum(PerfMessage::FOO);
+  }
+
+  // Instead of writing a ton of code that populates the nested messages,
+  // just do some bulk assignments from a snapshot of the message we just
+  // populated.
+  auto snapshot = message;
+  *(message.mutable_optional_message()) = snapshot;
+EOF
+
+  if [[ "$proto_syntax" == "2" ]]; then
+    cat >>"$gen_harness_path" <<EOF
+  *(message.mutable_optionalgroup()->mutable_optional_group_message()) = snapshot;
+EOF
+fi
+  
+  cat >>"$gen_harness_path" <<EOF
+  for (auto i = 0; i < repeated_count; i++) {
+    auto element = message.add_repeated_message();
+    *element = snapshot;
+  }
 EOF
 }

--- a/Performance/generators/proto.sh
+++ b/Performance/generators/proto.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# SwiftProtobuf/Performance/generators/proto.sh - Test proto generator
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# -----------------------------------------------------------------------------
+#
+# Functions for generating the test proto.
+#
+# -----------------------------------------------------------------------------
+
+function print_proto_field() {
+  num="$1"
+
+  if [[ "$proto_syntax" == "2" ]] && [[ "$field_type" != repeated* ]]; then
+    type="optional $2"
+  else
+    type="$2"
+  fi
+
+  if [[ -n "$packed" ]]; then
+    echo "  $type field$num = $num [packed=$packed];"
+  else
+    echo "  $type field$num = $num;"
+  fi
+}
+
+# Generates a test proto with multiple fields of a single type.
+function generate_homogeneous_test_proto() {
+  cat >"$gen_message_path" <<EOF
+syntax = "proto$proto_syntax";
+
+message PerfMessage {
+EOF
+
+  for field_number in $(seq 1 "$field_count"); do
+    print_proto_field "$field_number" "$field_type" >>"$gen_message_path"
+  done
+
+  cat >>"$gen_message_path" <<EOF
+}
+EOF
+}
+
+# Generates a test proto with multiple field types.
+function generate_heterogeneous_test_proto() {
+  if [[ "$proto_syntax" == "2" ]]; then
+    optional="optional "
+  else
+    optional=""
+  fi
+
+  cat >"$gen_message_path" <<EOF
+syntax = "proto$proto_syntax";
+
+message PerfMessage {
+  enum PerfEnum {
+    ZERO = 0;
+    FOO = 1;
+    BAR = 2;
+    BAZ = 3;
+    NEG = -1;
+  }
+
+  // Singular
+  $optional    int32 optional_int32    =  1;
+  $optional    int64 optional_int64    =  2;
+  $optional   uint32 optional_uint32   =  3;
+  $optional   uint64 optional_uint64   =  4;
+  $optional   sint32 optional_sint32   =  5;
+  $optional   sint64 optional_sint64   =  6;
+  $optional  fixed32 optional_fixed32  =  7;
+  $optional  fixed64 optional_fixed64  =  8;
+  $optional sfixed32 optional_sfixed32 =  9;
+  $optional sfixed64 optional_sfixed64 = 10;
+  $optional    float optional_float    = 11;
+  $optional   double optional_double   = 12;
+  $optional     bool optional_bool     = 13;
+  $optional   string optional_string   = 14;
+  $optional    bytes optional_bytes    = 15;
+  $optional    PerfEnum optional_enum  = 16;
+  $optional PerfMessage optional_message = 17;
+EOF
+
+  if [[ "$proto_syntax" == "2" ]]; then
+    cat >>"$gen_message_path" <<EOF
+  $optional group OptionalGroup = 100 {
+    $optional    int32 optional_group_int32    = 101;
+    $optional    int64 optional_group_int64    = 102;
+    $optional   uint32 optional_group_uint32   = 103;
+    $optional   uint64 optional_group_uint64   = 104;
+    $optional   sint32 optional_group_sint32   = 105;
+    $optional   sint64 optional_group_sint64   = 106;
+    $optional  fixed32 optional_group_fixed32  = 107;
+    $optional  fixed64 optional_group_fixed64  = 108;
+    $optional sfixed32 optional_group_sfixed32 = 109;
+    $optional sfixed64 optional_group_sfixed64 = 110;
+    $optional    float optional_group_float    = 111;
+    $optional   double optional_group_double   = 112;
+    $optional     bool optional_group_bool     = 113;
+    $optional   string optional_group_string   = 114;
+    $optional    bytes optional_group_bytes    = 115;
+    $optional PerfEnum optional_group_enum     = 116;
+    $optional PerfMessage optional_group_message = 117;
+  }
+EOF
+fi
+
+  cat >>"$gen_message_path" <<EOF
+  // Repeated
+  repeated    int32 repeated_int32    = 201 [packed=${packed:-false}];
+  repeated    int64 repeated_int64    = 202 [packed=${packed:-false}];
+  repeated   uint32 repeated_uint32   = 203 [packed=${packed:-false}];
+  repeated   uint64 repeated_uint64   = 204 [packed=${packed:-false}];
+  repeated   sint32 repeated_sint32   = 205 [packed=${packed:-false}];
+  repeated   sint64 repeated_sint64   = 206 [packed=${packed:-false}];
+  repeated  fixed32 repeated_fixed32  = 207 [packed=${packed:-false}];
+  repeated  fixed64 repeated_fixed64  = 208 [packed=${packed:-false}];
+  repeated sfixed32 repeated_sfixed32 = 209 [packed=${packed:-false}];
+  repeated sfixed64 repeated_sfixed64 = 210 [packed=${packed:-false}];
+  repeated    float repeated_float    = 211 [packed=${packed:-false}];
+  repeated   double repeated_double   = 212 [packed=${packed:-false}];
+  repeated     bool repeated_bool     = 213 [packed=${packed:-false}];
+  repeated   string repeated_string   = 214 [packed=${packed:-false}];
+  repeated    bytes repeated_bytes    = 215 [packed=${packed:-false}];
+  repeated PerfMessage repeated_message = 216 [packed=${packed:-false}];
+  repeated    PerfEnum repeated_enum    = 217 [packed=${packed:-false}];
+
+  oneof oneof_field {
+    uint32 oneof_uint32 = 401;
+    PerfMessage oneof_message = 402;
+    string oneof_string = 403;
+    bytes oneof_bytes = 404;
+  }
+}
+EOF
+}

--- a/Performance/js/harness-visualization.js
+++ b/Performance/js/harness-visualization.js
@@ -2,7 +2,7 @@
   // The benchmarks that we want to display, in the order they should appear
   // on the plot axis.
   var benchmarks = [
-    'Populate fields',
+    'New message', 'Populate fields',
     'Encode binary', 'Decode binary',
     'Encode JSON', 'Decode JSON',
     'Encode text', 'Decode text',
@@ -23,7 +23,7 @@
       ticks: 'outside',
     },
     yaxis: {
-      title: 'Runtime (&micro;s)',
+      title: 'Runtime (&mu;s)',
       autorange: true,
     },
     margin: {

--- a/Performance/perf_runner.sh
+++ b/Performance/perf_runner.sh
@@ -42,7 +42,7 @@ readonly GOOGLE_PROTOBUF_CHECKOUT=${GOOGLE_PROTOBUF_CHECKOUT:-"$script_dir/../..
 function usage() {
   cat >&2 <<EOF
 SYNOPSIS
-    $0 [-c <rev|c++> -c <rev|c++> ...] [-p <true|false>] [-s2|-s3] <field count> <field types...>
+    $0 [-c <rev|c++> -c <rev|c++> ...] [-p <true|false>] [-s2|-s3] [<field count> <field type>]
 
     Currently supported field types:
         int32, sint32, uint32, fixed32, sfixed32,
@@ -50,9 +50,9 @@ SYNOPSIS
         float, double, string,
         ...and repeated variants of the above.
 
-        Additionally, you can specify "all" to run the harness multiple
-        times with all of the (non-repeated) field types listed above.
-        ("all" is not compatible with revision comparisons.)
+        If you omit the field count and type, the harness will run with
+        a message that contains multiple field types -- both singular and
+        repeated -- and nested messages.
 
 OPTIONS
     -c <rev|c++> [-c <rev|c++> ...]
@@ -87,42 +87,13 @@ EXAMPLES
         Runs the Swift harness in its state at commit 4d0b78, the C++
         harness, and then the Swift harness in the current working tree,
         using a proto2 message with 100 bytes fields.
+
+    $0 -c 4d0b78
+        Runs the Swift harness in its state at commit 4d0b78 and then
+        the Swift harness in the current working tree, using a proto3
+        message with multiple field types.
 EOF
   exit 1
-}
-
-# ---------------------------------------------------------------
-# Functions for generating the .proto file.
-
-function print_proto_field() {
-  num="$1"
-  if [[ "$proto_syntax" == "2" ]] && [[ "$field_type" != repeated* ]]; then
-    type="optional $2"
-  else
-    type="$2"
-  fi
-
-  if [[ -n "$packed" ]]; then
-    echo "  $type field$num = $num [packed=$packed];"
-  else
-    echo "  $type field$num = $num;"
-  fi
-}
-
-function generate_test_proto() {
-  cat >"$gen_message_path" <<EOF
-syntax = "proto$proto_syntax";
-
-message PerfMessage {
-EOF
-
-  for field_number in $(seq 1 "$field_count"); do
-    print_proto_field "$field_number" "$field_type" >>"$gen_message_path"
-  done
-
-  cat >>"$gen_message_path" <<EOF
-}
-EOF
 }
 
 # ---------------------------------------------------------------
@@ -236,19 +207,20 @@ if [[ "$proto_syntax" != "2" ]] && [[ "$proto_syntax" != "3" ]]; then
   usage
 fi
 
-if [[ "$#" -lt 2 ]]; then
+if [[ "$#" -eq 0 ]]; then
+  readonly proto_type=heterogeneous
+  readonly run_count=100
+elif [[ "$#" -eq 2 ]]; then
+  readonly proto_type=homogeneous
+  readonly run_count=1000
+  readonly field_count="$1"
+  readonly field_type="$2"
+else
   usage
 fi
 
-readonly field_count="$1"; shift
-if [[ "$1" == "all" ]]; then
-  readonly requested_field_types=( \
-    int32 sint32 uint32 fixed32 sfixed32 \
-    int64 sint64 uint64 fixed64 sfixed64 \
-    float double string \
-  )
-else
-  readonly requested_field_types=( "$@" )
+if [[ "${#comparisons[@]}" -eq 0 ]]; then
+  comparisons+=("c++")
 fi
 
 # ---------------------------------------------------------------
@@ -263,7 +235,8 @@ function cleanup_revision_checkouts() {
 trap cleanup_revision_checkouts EXIT HUP INT QUIT TERM
 
 # ---------------------------------------------------------------
-# Pull in language-specific runners.
+# Pull in language-specific helpers.
+source "$script_dir/generators/proto.sh"
 source "$script_dir/runners/swift.sh"
 
 # ---------------------------------------------------------------
@@ -279,102 +252,103 @@ if [[ ! -f "$results_js" ]]; then
   cp "$script_dir/js/results.js.template" "$results_js"
 fi
 
-# Iterate over the requested field types and run the harnesses.
-# TODO: Get rid of this multi-run; instead, just create a proto like
-# TestAllTypes that tests multiple field types in one message. This is more
-# realistic.
-for field_type in "${requested_field_types[@]}"; do
-  gen_message_path="$script_dir/_generated/message.proto"
+# Generate the harness.
+gen_message_path="$script_dir/_generated/message.proto"
 
+if [[ "$proto_type" == "homogeneous" ]]; then
   echo "Generating test proto with $field_count fields of type $field_type..."
-  generate_test_proto "$field_count" "$field_type"
+  generate_homogeneous_test_proto "$gen_message_path"
+  report_type="$field_count fields of type $field_type"
+  commit_results_suffix="${field_type}_${field_count}"
+else
+  echo "Generating test proto with various fields..."
+  generate_heterogeneous_test_proto "$gen_message_path"
+  report_type="various fields"
+  commit_results_suffix="heterogeneous"
+fi
 
-  # Start a session.
-  partial_results="$script_dir/_results/partial.js"
-  pretty_head_rev="$(git rev-parse --abbrev-ref HEAD)"
-  cat > "$partial_results" <<EOF
-  {
-    date: "$(date -u +"%FT%T.000Z")",
-    type: "$field_count fields of type $field_type",
-    branch: "$pretty_head_rev",
-    commit: "$(git rev-parse HEAD)",
-    uncommitted_changes: $([[ -z $(git status -s) ]] && echo false || echo true),
-    series: [
+# Start a session.
+partial_results="$script_dir/_results/partial.js"
+pretty_head_rev="$(git rev-parse --abbrev-ref HEAD)"
+cat > "$partial_results" <<EOF
+{
+  date: "$(date -u +"%FT%T.000Z")",
+  type: "$report_type",
+  branch: "$pretty_head_rev",
+  commit: "$(git rev-parse HEAD)",
+  uncommitted_changes: $([[ -z $(git status -s) ]] && echo false || echo true),
+  series: [
 EOF
 
-  for comparison in "${comparisons[@]}"; do
-    if [[ "$comparison" == "c++" ]]; then
-      source "$script_dir/runners/cpp.sh"
+for comparison in "${comparisons[@]}"; do
+  if [[ "$comparison" == "c++" ]]; then
+    source "$script_dir/runners/cpp.sh"
 
+    echo
+    echo "==== Building/running C++ harness ===================="
+    echo
+
+    protoc --cpp_out="$script_dir" "$gen_message_path"
+
+    harness_cpp="$script_dir/_generated/harness_cpp"
+    run_cpp_harness "$harness_cpp"
+  else
+    commit_hash="$(git rev-parse $comparison)"
+    commit_results="$script_dir/_results/${commit_hash}_${commit_results_suffix}.js"
+
+    # Check to see if we have past results from that commit cached. If so, we
+    # don't need to run it again.
+    if [[ ! -f "$commit_results" ]]; then
       echo
-      echo "==== Building/running C++ harness ===================="
+      echo "==== Building/running Swift harness ($comparison) ===================="
       echo
 
-      protoc --cpp_out="$script_dir" "$gen_message_path"
+      # Check out the commit to a temporary directory and create its _generated
+      # directory. (Results will still go in the working tree.)
+      tmp_checkout="$(mktemp -d -t swiftprotoperf)"
+      CLEANUP_WHEN_DONE+=("$tmp_checkout")
+      git --work-tree="$tmp_checkout" checkout "$comparison" -- .
+      mkdir "$tmp_checkout/Performance/_generated"
 
-      harness_cpp="$script_dir/_generated/harness_cpp"
-      results_trace="$script_dir/_results/$field_count fields of $field_type (cpp)"
-      run_cpp_harness "$harness_cpp"
+      build_swift_packages "$tmp_checkout" "ForRev"
+      protoc --plugin="$tmp_checkout/.build/release/protoc-gen-swiftForRev" \
+          --swiftForRev_out=FileNaming=DropPath:"$tmp_checkout/Performance/_generated" \
+          "$gen_message_path"
+
+      harness_swift="$tmp_checkout/Performance/_generated/harness_swift"
+      run_swift_harness "$tmp_checkout" "$comparison" "$commit_results"
     else
-      commit_hash="$(git rev-parse $comparison)"
-      commit_results="$script_dir/_results/${commit_hash}_${field_type}_${field_count}.js"
-
-      # Check to see if we have past results from that commit cached. If so, we
-      # don't need to run it again.
-      if [[ ! -f "$commit_results" ]]; then
-        echo
-        echo "==== Building/running Swift harness ($comparison) ===================="
-        echo
-
-        # Check out the commit to a temporary directory and create its _generated
-        # directory. (Results will still go in the working tree.)
-        tmp_checkout="$(mktemp -d -t swiftprotoperf)"
-        CLEANUP_WHEN_DONE+=("$tmp_checkout")
-        git --work-tree="$tmp_checkout" checkout "$comparison" -- .
-        mkdir "$tmp_checkout/Performance/_generated"
-
-        build_swift_packages "$tmp_checkout" "ForRev"
-        protoc --plugin="$tmp_checkout/.build/release/protoc-gen-swiftForRev" \
-            --swiftForRev_out=FileNaming=DropPath:"$tmp_checkout/Performance/_generated" \
-            "$gen_message_path"
-
-        harness_swift="$tmp_checkout/Performance/_generated/harness_swift"
-        results_trace="$script_dir/_results/$field_count fields of $field_type (swift)"
-        run_swift_harness "$tmp_checkout" "$comparison" "$commit_results"
-      else
-        echo
-        echo "==== Found cached results for Swift ($comparison) ===================="
-      fi
-
-      cat "$commit_results" >> "$partial_results"
+      echo
+      echo "==== Found cached results for Swift ($comparison) ===================="
     fi
-  done
 
-  echo
-  echo "==== Building/running Swift harness (working tree) ===================="
-  echo
-
-  build_swift_packages "$script_dir/.." "ForWorkTree"
-  protoc --plugin="$script_dir/../.build/release/protoc-gen-swiftForWorkTree" \
-      --swiftForWorkTree_out=FileNaming=DropPath:"$script_dir/_generated" \
-      --cpp_out="$script_dir" \
-      "$gen_message_path"
-
-  harness_swift="$script_dir/_generated/harness_swift"
-  results_trace="$script_dir/_results/$field_count fields of $field_type (swift)"
-  display_results_trace="$results_trace"
-  run_swift_harness "$script_dir/.." "working tree" "$partial_results"
-
-  # Close out the session.
-  cat >> "$partial_results" <<EOF
-    ],
-  },
-EOF
-
-  insert_visualization_results "$partial_results" "$results_js"
-
-  open -g "$display_results_trace.trace"
+    cat "$commit_results" >> "$partial_results"
+  fi
 done
 
-# Open the HTML once at the end.
+echo
+echo "==== Building/running Swift harness (working tree) ===================="
+echo
+
+build_swift_packages "$script_dir/.." "ForWorkTree"
+protoc --plugin="$script_dir/../.build/release/protoc-gen-swiftForWorkTree" \
+    --swiftForWorkTree_out=FileNaming=DropPath:"$script_dir/_generated" \
+    --cpp_out="$script_dir" \
+    "$gen_message_path"
+
+harness_swift="$script_dir/_generated/harness_swift"
+results_trace="$script_dir/_results/$report_type (swift)"
+display_results_trace="$results_trace"
+run_swift_harness "$script_dir/.." "working tree" "$partial_results"
+
+# Close out the session.
+cat >> "$partial_results" <<EOF
+  ],
+},
+EOF
+
+insert_visualization_results "$partial_results" "$results_js"
+
+# Open the Instruments trace and HTML report at the end.
+open -g "$display_results_trace.trace"
 open -g "$script_dir/harness-visualization.html"

--- a/Performance/runners/cpp.sh
+++ b/Performance/runners/cpp.sh
@@ -24,7 +24,7 @@ function run_cpp_harness() {
 
     echo "Generating C++ harness source..."
     gen_harness_path="$script_dir/_generated/Harness+Generated.cc"
-    generate_cpp_harness "$field_count" "$field_type"
+    generate_cpp_harness
 
     echo "Building C++ test harness..."
     time ( g++ --std=c++11 -O \

--- a/Performance/runners/swift.sh
+++ b/Performance/runners/swift.sh
@@ -33,7 +33,7 @@ function run_swift_harness() {
 
     echo "Generating Swift harness source..."
     gen_harness_path="$perf_dir/_generated/Harness+Generated.swift"
-    generate_swift_harness "$field_count" "$field_type"
+    generate_swift_harness
 
     # Build the dynamic library to use in the tests.
     # TODO: Make the dylib a product again in the package manifest and just use


### PR DESCRIPTION
Borne out of discussion in #457.

This supports both proto2 and proto3 (proto2 includes a group). We may want to have a message that does deeper nesting, but that can be done in a separate PR.

I had to reduce the run count from 1000 to 100 in the heterogeneous case because Instruments was prohibitively slow (as in, about 10 minutes).