### PR TITLE
Ignore explicit defaults on strings and bytes that are the default.

### DIFF
--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -249,8 +249,22 @@ extension Google_Protobuf_FieldDescriptorProto {
            default: return defaultValue
            }
         case .bool: return defaultValue
-        case .string: return stringToEscapedStringLiteral(defaultValue)
-        case .bytes: return escapedToDataLiteral(defaultValue)
+        case .string:
+          if defaultValue.isEmpty {
+            // proto file listed the default as "", just pretend it wasn't set since
+            // this is the default.
+            return nil
+          } else {
+            return stringToEscapedStringLiteral(defaultValue)
+          }
+        case .bytes:
+          if defaultValue.isEmpty {
+            // proto file listed the default as "", just pretend it wasn't set since
+            // this is the default.
+            return nil
+          } else {
+            return escapedToDataLiteral(defaultValue)
+          }
         case .enum:
             return context.getSwiftNameForEnumCase(path: typeName, caseName: defaultValue)
         default: return defaultValue


### PR DESCRIPTION
Over time we've seen a bunch of proto files where folks list the default
value as the standard default.  This picks those off and pretend there
wasn't an explicit default set, this way any optimizations done with
static instances for empty String()/Data() will still apply.