### PR TITLE
Performance improvements for String/Data empty values.

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -91,7 +91,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   var protobufPayload: Data {
     get {
       if case .protobufPayload(let v)? = payload { return v }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set { payload = .protobufPayload(newValue) }
   }
@@ -101,7 +101,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   var jsonPayload: String {
     get {
       if case .jsonPayload(let v)? = payload { return v }
-      return ""
+      return String()
     }
     set { payload = .jsonPayload(newValue) }
   }
@@ -161,7 +161,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var parseError: String {
     get {
       if case .parseError(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .parseError(newValue) }
   }
@@ -174,7 +174,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var serializeError: String {
     get {
       if case .serializeError(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .serializeError(newValue) }
   }
@@ -185,7 +185,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var runtimeError: String {
     get {
       if case .runtimeError(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .runtimeError(newValue) }
   }
@@ -195,7 +195,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var protobufPayload: Data {
     get {
       if case .protobufPayload(let v)? = result { return v }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set { result = .protobufPayload(newValue) }
   }
@@ -205,7 +205,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var jsonPayload: String {
     get {
       if case .jsonPayload(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .jsonPayload(newValue) }
   }
@@ -215,7 +215,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var skipped: String {
     get {
       if case .skipped(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .skipped(newValue) }
   }

--- a/Reference/google/protobuf/api.pb.swift
+++ b/Reference/google/protobuf/api.pb.swift
@@ -53,10 +53,10 @@ struct Google_Protobuf_Api: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Api"
 
   fileprivate class _StorageClass {
-    var _name: String = ""
+    var _name: String = String()
     var _methods: [Google_Protobuf_Method] = []
     var _options: [Google_Protobuf_Option] = []
-    var _version: String = ""
+    var _version: String = String()
     var _sourceContext: Google_Protobuf_SourceContext? = nil
     var _mixins: [Google_Protobuf_Mixin] = []
     var _syntax: Google_Protobuf_Syntax = Google_Protobuf_Syntax.proto2
@@ -207,16 +207,16 @@ struct Google_Protobuf_Method: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Method"
 
   /// The simple name of this method.
-  var name: String = ""
+  var name: String = String()
 
   /// A URL of the input message type.
-  var requestTypeURL: String = ""
+  var requestTypeURL: String = String()
 
   /// If true, the request is streamed.
   var requestStreaming: Bool = false
 
   /// The URL of the output message type.
-  var responseTypeURL: String = ""
+  var responseTypeURL: String = String()
 
   /// If true, the response is streamed.
   var responseStreaming: Bool = false
@@ -353,11 +353,11 @@ struct Google_Protobuf_Mixin: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Mixin"
 
   /// The fully qualified name of the API which is included.
-  var name: String = ""
+  var name: String = String()
 
   /// If non-empty specifies a path under which inherited HTTP paths
   /// are rooted.
-  var root: String = ""
+  var root: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Reference/google/protobuf/compiler/plugin.pb.swift
+++ b/Reference/google/protobuf/compiler/plugin.pb.swift
@@ -109,7 +109,7 @@ struct Google_Protobuf_Compiler_Version: SwiftProtobuf.Message {
   /// be empty for mainline stable releases.
   fileprivate var _suffix: String? = nil
   var suffix: String {
-    get {return _suffix ?? ""}
+    get {return _suffix ?? String()}
     set {_suffix = newValue}
   }
   var hasSuffix: Bool {
@@ -191,7 +191,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Message {
 
   /// The generator parameter passed on the command-line.
   var parameter: String {
-    get {return _storage._parameter ?? ""}
+    get {return _storage._parameter ?? String()}
     set {_uniqueStorage()._parameter = newValue}
   }
   var hasParameter: Bool {
@@ -288,7 +288,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message {
   /// exiting with a non-zero status code.
   fileprivate var _error: String? = nil
   var error: String {
-    get {return _error ?? ""}
+    get {return _error ?? String()}
     set {_error = newValue}
   }
   var hasError: Bool {
@@ -319,7 +319,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message {
     /// CodeGeneratorResponse before writing files to disk.
     fileprivate var _name: String? = nil
     var name: String {
-      get {return _name ?? ""}
+      get {return _name ?? String()}
       set {_name = newValue}
     }
     var hasName: Bool {
@@ -368,7 +368,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message {
     /// If |insertion_point| is present, |name| must also be present.
     fileprivate var _insertionPoint: String? = nil
     var insertionPoint: String {
-      get {return _insertionPoint ?? ""}
+      get {return _insertionPoint ?? String()}
       set {_insertionPoint = newValue}
     }
     var hasInsertionPoint: Bool {
@@ -381,7 +381,7 @@ struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Message {
     /// The file contents.
     fileprivate var _content: String? = nil
     var content: String {
-      get {return _content ?? ""}
+      get {return _content ?? String()}
       set {_content = newValue}
     }
     var hasContent: Bool {

--- a/Reference/google/protobuf/descriptor.pb.swift
+++ b/Reference/google/protobuf/descriptor.pb.swift
@@ -137,7 +137,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
 
   /// file name, relative to root of source tree
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -149,7 +149,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
 
   /// e.g. "foo", "foo.bar", etc.
   var package: String {
-    get {return _storage._package ?? ""}
+    get {return _storage._package ?? String()}
     set {_uniqueStorage()._package = newValue}
   }
   var hasPackage: Bool {
@@ -228,7 +228,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
   /// The syntax of the proto file.
   /// The supported values are "proto2" and "proto3".
   var syntax: String {
-    get {return _storage._syntax ?? ""}
+    get {return _storage._syntax ?? String()}
     set {_uniqueStorage()._syntax = newValue}
   }
   var hasSyntax: Bool {
@@ -361,7 +361,7 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -649,7 +649,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -700,7 +700,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// message are searched, then within the parent, on up to the root
   /// namespace).
   var typeName: String {
-    get {return _storage._typeName ?? ""}
+    get {return _storage._typeName ?? String()}
     set {_uniqueStorage()._typeName = newValue}
   }
   var hasTypeName: Bool {
@@ -713,7 +713,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// For extensions, this is the name of the type being extended.  It is
   /// resolved in the same manner as type_name.
   var extendee: String {
-    get {return _storage._extendee ?? ""}
+    get {return _storage._extendee ?? String()}
     set {_uniqueStorage()._extendee = newValue}
   }
   var hasExtendee: Bool {
@@ -729,7 +729,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
   /// TODO(kenton):  Base-64 encode?
   var defaultValue: String {
-    get {return _storage._defaultValue ?? ""}
+    get {return _storage._defaultValue ?? String()}
     set {_uniqueStorage()._defaultValue = newValue}
   }
   var hasDefaultValue: Bool {
@@ -757,7 +757,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// will be used. Otherwise, it's deduced from the field's name by converting
   /// it to camelCase.
   var jsonName: String {
-    get {return _storage._jsonName ?? ""}
+    get {return _storage._jsonName ?? String()}
     set {_uniqueStorage()._jsonName = newValue}
   }
   var hasJsonName: Bool {
@@ -1000,7 +1000,7 @@ struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -1086,7 +1086,7 @@ struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -1182,7 +1182,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -1283,7 +1283,7 @@ struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -1385,7 +1385,7 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -1398,7 +1398,7 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   /// Input and output type names.  These are resolved in the same way as
   /// FieldDescriptorProto.type_name, but must refer to a message type.
   var inputType: String {
-    get {return _storage._inputType ?? ""}
+    get {return _storage._inputType ?? String()}
     set {_uniqueStorage()._inputType = newValue}
   }
   var hasInputType: Bool {
@@ -1409,7 +1409,7 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   }
 
   var outputType: String {
-    get {return _storage._outputType ?? ""}
+    get {return _storage._outputType ?? String()}
     set {_uniqueStorage()._outputType = newValue}
   }
   var hasOutputType: Bool {
@@ -1566,7 +1566,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   /// inappropriate because proto packages do not normally start with backwards
   /// domain names.
   var javaPackage: String {
-    get {return _storage._javaPackage ?? ""}
+    get {return _storage._javaPackage ?? String()}
     set {_uniqueStorage()._javaPackage = newValue}
   }
   var hasJavaPackage: Bool {
@@ -1582,7 +1582,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   /// a .proto always translates to a single class, but you may want to
   /// explicitly choose the class name).
   var javaOuterClassname: String {
-    get {return _storage._javaOuterClassname ?? ""}
+    get {return _storage._javaOuterClassname ?? String()}
     set {_uniqueStorage()._javaOuterClassname = newValue}
   }
   var hasJavaOuterClassname: Bool {
@@ -1655,7 +1655,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   ///   - Otherwise, the package statement in the .proto file, if present.
   ///   - Otherwise, the basename of the .proto file, without extension.
   var goPackage: String {
-    get {return _storage._goPackage ?? ""}
+    get {return _storage._goPackage ?? String()}
     set {_uniqueStorage()._goPackage = newValue}
   }
   var hasGoPackage: Bool {
@@ -1739,7 +1739,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   /// Sets the objective c class prefix which is prepended to all objective c
   /// generated classes from this .proto. There is no default.
   var objcClassPrefix: String {
-    get {return _storage._objcClassPrefix ?? ""}
+    get {return _storage._objcClassPrefix ?? String()}
     set {_uniqueStorage()._objcClassPrefix = newValue}
   }
   var hasObjcClassPrefix: Bool {
@@ -1751,7 +1751,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
 
   /// Namespace for generated classes; defaults to the package.
   var csharpNamespace: String {
-    get {return _storage._csharpNamespace ?? ""}
+    get {return _storage._csharpNamespace ?? String()}
     set {_uniqueStorage()._csharpNamespace = newValue}
   }
   var hasCsharpNamespace: Bool {
@@ -1766,7 +1766,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   /// defined. When this options is provided, they will use this value instead
   /// to prefix the types/symbols defined.
   var swiftPrefix: String {
-    get {return _storage._swiftPrefix ?? ""}
+    get {return _storage._swiftPrefix ?? String()}
     set {_uniqueStorage()._swiftPrefix = newValue}
   }
   var hasSwiftPrefix: Bool {
@@ -1779,7 +1779,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   /// Sets the php class prefix which is prepended to all php generated classes
   /// from this .proto. Default is empty.
   var phpClassPrefix: String {
-    get {return _storage._phpClassPrefix ?? ""}
+    get {return _storage._phpClassPrefix ?? String()}
     set {_uniqueStorage()._phpClassPrefix = newValue}
   }
   var hasPhpClassPrefix: Bool {
@@ -2688,7 +2688,7 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
   /// identified it as during parsing. Exactly one of these should be set.
   fileprivate var _identifierValue: String? = nil
   var identifierValue: String {
-    get {return _identifierValue ?? ""}
+    get {return _identifierValue ?? String()}
     set {_identifierValue = newValue}
   }
   var hasIdentifierValue: Bool {
@@ -2736,7 +2736,7 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
   fileprivate var _stringValue: Data? = nil
   var stringValue: Data {
-    get {return _stringValue ?? Data()}
+    get {return _stringValue ?? SwiftProtobuf.Internal.emptyData}
     set {_stringValue = newValue}
   }
   var hasStringValue: Bool {
@@ -2748,7 +2748,7 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
   fileprivate var _aggregateValue: String? = nil
   var aggregateValue: String {
-    get {return _aggregateValue ?? ""}
+    get {return _aggregateValue ?? String()}
     set {_aggregateValue = newValue}
   }
   var hasAggregateValue: Bool {
@@ -2770,7 +2770,7 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
     fileprivate var _namePart: String? = nil
     var namePart: String {
-      get {return _namePart ?? ""}
+      get {return _namePart ?? String()}
       set {_namePart = newValue}
     }
     var hasNamePart: Bool {
@@ -3007,7 +3007,7 @@ struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
     ///   // ignored detached comments.
     fileprivate var _leadingComments: String? = nil
     var leadingComments: String {
-      get {return _leadingComments ?? ""}
+      get {return _leadingComments ?? String()}
       set {_leadingComments = newValue}
     }
     var hasLeadingComments: Bool {
@@ -3019,7 +3019,7 @@ struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
 
     fileprivate var _trailingComments: String? = nil
     var trailingComments: String {
-      get {return _trailingComments ?? ""}
+      get {return _trailingComments ?? String()}
       set {_trailingComments = newValue}
     }
     var hasTrailingComments: Bool {
@@ -3109,7 +3109,7 @@ struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
     /// Identifies the filesystem path to the original source .proto.
     fileprivate var _sourceFile: String? = nil
     var sourceFile: String {
-      get {return _sourceFile ?? ""}
+      get {return _sourceFile ?? String()}
       set {_sourceFile = newValue}
     }
     var hasSourceFile: Bool {

--- a/Reference/google/protobuf/source_context.pb.swift
+++ b/Reference/google/protobuf/source_context.pb.swift
@@ -55,7 +55,7 @@ struct Google_Protobuf_SourceContext: SwiftProtobuf.Message {
 
   /// The path-qualified name of the .proto file that contained the associated
   /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
-  var fileName: String = ""
+  var fileName: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -174,7 +174,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
       if case .stringValue(let v)? = _storage._kind {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._kind = .stringValue(newValue)

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -110,14 +110,14 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalNestedMessage: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage? = nil
     var _optionalForeignMessage: ProtobufTestMessages_Proto3_ForeignMessage? = nil
     var _optionalNestedEnum: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum.foo
     var _optionalForeignEnum: ProtobufTestMessages_Proto3_ForeignEnum = ProtobufTestMessages_Proto3_ForeignEnum.foreignFoo
-    var _optionalStringPiece: String = ""
-    var _optionalCord: String = ""
+    var _optionalStringPiece: String = String()
+    var _optionalCord: String = String()
     var _recursiveMessage: ProtobufTestMessages_Proto3_TestAllTypes? = nil
     var _repeatedInt32: [Int32] = []
     var _repeatedInt64: [Int64] = []
@@ -695,7 +695,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -707,7 +707,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)

--- a/Reference/google/protobuf/type.pb.swift
+++ b/Reference/google/protobuf/type.pb.swift
@@ -86,7 +86,7 @@ struct Google_Protobuf_Type: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Type"
 
   fileprivate class _StorageClass {
-    var _name: String = ""
+    var _name: String = String()
     var _fields: [Google_Protobuf_Field] = []
     var _oneofs: [String] = []
     var _options: [Google_Protobuf_Option] = []
@@ -216,11 +216,11 @@ struct Google_Protobuf_Field: SwiftProtobuf.Message {
   var number: Int32 = 0
 
   /// The field name.
-  var name: String = ""
+  var name: String = String()
 
   /// The field type URL, without the scheme, for message or enumeration
   /// types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
-  var typeURL: String = ""
+  var typeURL: String = String()
 
   /// The index of the field type in `Type.oneofs`, for message or enumeration
   /// types. The first type has index 1; zero means the type is not in the list.
@@ -233,10 +233,10 @@ struct Google_Protobuf_Field: SwiftProtobuf.Message {
   var options: [Google_Protobuf_Option] = []
 
   /// The field JSON name.
-  var jsonName: String = ""
+  var jsonName: String = String()
 
   /// The string value of the default value of this field. Proto2 syntax only.
-  var defaultValue: String = ""
+  var defaultValue: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -461,7 +461,7 @@ struct Google_Protobuf_Enum: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Enum"
 
   fileprivate class _StorageClass {
-    var _name: String = ""
+    var _name: String = String()
     var _enumvalue: [Google_Protobuf_EnumValue] = []
     var _options: [Google_Protobuf_Option] = []
     var _sourceContext: Google_Protobuf_SourceContext? = nil
@@ -570,7 +570,7 @@ struct Google_Protobuf_EnumValue: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".EnumValue"
 
   /// Enum value name.
-  var name: String = ""
+  var name: String = String()
 
   /// Enum value number.
   var number: Int32 = 0
@@ -613,7 +613,7 @@ struct Google_Protobuf_Option: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".Option"
 
   fileprivate class _StorageClass {
-    var _name: String = ""
+    var _name: String = String()
     var _value: Google_Protobuf_Any? = nil
 
     init() {}

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -469,7 +469,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -480,7 +480,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {
@@ -568,7 +568,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalStringPiece: String {
-    get {return _storage._optionalStringPiece ?? ""}
+    get {return _storage._optionalStringPiece ?? String()}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
   var hasOptionalStringPiece: Bool {
@@ -579,7 +579,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalCord: String {
-    get {return _storage._optionalCord ?? ""}
+    get {return _storage._optionalCord ?? String()}
     set {_uniqueStorage()._optionalCord = newValue}
   }
   var hasOptionalCord: Bool {
@@ -988,7 +988,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -1000,7 +1000,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -1820,7 +1820,7 @@ struct ProtobufUnittest_TestNestedExtension: SwiftProtobuf.Message {
     static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
       _protobuf_fieldNumber: 1003,
       fieldName: "protobuf_unittest.TestNestedExtension.nested_string_extension",
-      defaultValue: ""
+      defaultValue: String()
     )
   }
 
@@ -3409,7 +3409,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message {
   }
 
   var stringField: String {
-    get {return _storage._stringField ?? ""}
+    get {return _storage._stringField ?? String()}
     set {_uniqueStorage()._stringField = newValue}
   }
   var hasStringField: Bool {
@@ -3442,7 +3442,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message {
   }
 
   var stringPieceField: String {
-    get {return _storage._stringPieceField ?? ""}
+    get {return _storage._stringPieceField ?? String()}
     set {_uniqueStorage()._stringPieceField = newValue}
   }
   var hasStringPieceField: Bool {
@@ -3453,7 +3453,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message {
   }
 
   var cordField: String {
-    get {return _storage._cordField ?? ""}
+    get {return _storage._cordField ?? String()}
     set {_uniqueStorage()._cordField = newValue}
   }
   var hasCordField: Bool {
@@ -3594,7 +3594,7 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf
   }
 
   var myString: String {
-    get {return _storage._myString ?? ""}
+    get {return _storage._myString ?? String()}
     set {_uniqueStorage()._myString = newValue}
   }
   var hasMyString: Bool {
@@ -4296,7 +4296,7 @@ struct ProtobufUnittest_OneString: SwiftProtobuf.Message {
 
   fileprivate var _data: String? = nil
   var data: String {
-    get {return _data ?? ""}
+    get {return _data ?? String()}
     set {_data = newValue}
   }
   var hasData: Bool {
@@ -4358,7 +4358,7 @@ struct ProtobufUnittest_OneBytes: SwiftProtobuf.Message {
 
   fileprivate var _data: Data? = nil
   var data: Data {
-    get {return _data ?? Data()}
+    get {return _data ?? SwiftProtobuf.Internal.emptyData}
     set {_data = newValue}
   }
   var hasData: Bool {
@@ -4636,7 +4636,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
       if case .fooString(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooString(newValue)
@@ -4710,7 +4710,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
 
     fileprivate var _b: String? = nil
     var b: String {
-      get {return _b ?? ""}
+      get {return _b ?? String()}
       set {_b = newValue}
     }
     var hasB: Bool {
@@ -4811,7 +4811,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: SwiftProtobuf.Message {
   }
 
   var fooString: String {
-    get {return _storage._fooString ?? ""}
+    get {return _storage._fooString ?? String()}
     set {_uniqueStorage()._fooString = newValue}
   }
   var hasFooString: Bool {
@@ -4862,7 +4862,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: SwiftProtobuf.Message {
 
     fileprivate var _b: String? = nil
     var b: String {
-      get {return _b ?? ""}
+      get {return _b ?? String()}
       set {_b = newValue}
     }
     var hasB: Bool {
@@ -4978,7 +4978,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       if case .fooString(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooString(newValue)
@@ -4990,7 +4990,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       if case .fooCord(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooCord(newValue)
@@ -5002,7 +5002,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       if case .fooStringPiece(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooStringPiece(newValue)
@@ -5014,7 +5014,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       if case .fooBytes(let v)? = _storage._foo {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._foo = .fooBytes(newValue)
@@ -5273,7 +5273,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
 
     fileprivate var _b: String? = nil
     var b: String {
-      get {return _b ?? ""}
+      get {return _b ?? String()}
       set {_b = newValue}
     }
     var hasB: Bool {
@@ -5429,7 +5429,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message {
       if case .fooString(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooString(newValue)
@@ -6886,7 +6886,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -6897,7 +6897,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {
@@ -6963,7 +6963,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -6975,7 +6975,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -7202,13 +7202,13 @@ let ProtobufUnittest_Extensions_optional_bool_extension = SwiftProtobuf.MessageE
 let ProtobufUnittest_Extensions_optional_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 14,
   fieldName: "protobuf_unittest.optional_string_extension",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 15,
   fieldName: "protobuf_unittest.optional_bytes_extension",
-  defaultValue: Data()
+  defaultValue: SwiftProtobuf.Internal.emptyData
 )
 
 let ProtobufUnittest_Extensions_OptionalGroup_extension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
@@ -7256,13 +7256,13 @@ let ProtobufUnittest_Extensions_optional_import_enum_extension = SwiftProtobuf.M
 let ProtobufUnittest_Extensions_optional_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 24,
   fieldName: "protobuf_unittest.optional_string_piece_extension",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 25,
   fieldName: "protobuf_unittest.optional_cord_extension",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_public_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessage>, ProtobufUnittest_TestAllExtensions>(
@@ -7565,19 +7565,19 @@ let ProtobufUnittest_Extensions_oneof_nested_message_extension = SwiftProtobuf.M
 let ProtobufUnittest_Extensions_oneof_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 113,
   fieldName: "protobuf_unittest.oneof_string_extension",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_oneof_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 114,
   fieldName: "protobuf_unittest.oneof_bytes_extension",
-  defaultValue: Data()
+  defaultValue: SwiftProtobuf.Internal.emptyData
 )
 
 let ProtobufUnittest_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestFieldOrderings>(
   _protobuf_fieldNumber: 50,
   fieldName: "protobuf_unittest.my_extension_string",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestFieldOrderings>(
@@ -7779,7 +7779,7 @@ extension ProtobufUnittest_TestAllExtensions {
   /// Used to test if generated extension name is correct when there are
   /// underscores.
   var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
@@ -8014,7 +8014,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringExtension: Bool {
@@ -8027,7 +8027,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalBytesExtension: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension) ?? Data()}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalBytesExtension: Bool {
@@ -8131,7 +8131,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringPieceExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringPieceExtension: Bool {
@@ -8144,7 +8144,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalCordExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalCordExtension: Bool {
@@ -8797,7 +8797,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofStringExtension: Bool {
@@ -8810,7 +8810,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofBytesExtension: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension) ?? Data()}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofBytesExtension: Bool {
@@ -8823,7 +8823,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestFieldOrderings {
   var ProtobufUnittest_myExtensionString: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string, value: newValue)}
   }
   var hasProtobufUnittest_myExtensionString: Bool {

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -111,7 +111,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
 
   fileprivate var _field1: String? = nil
   var field1: String {
-    get {return _field1 ?? ""}
+    get {return _field1 ?? String()}
     set {_field1 = newValue}
   }
   var hasField1: Bool {
@@ -854,7 +854,7 @@ struct ProtobufUnittest_AggregateMessageSetElement: SwiftProtobuf.Message {
 
   fileprivate var _s: String? = nil
   var s: String {
-    get {return _s ?? ""}
+    get {return _s ?? String()}
     set {_s = newValue}
   }
   var hasS: Bool {
@@ -937,7 +937,7 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
   }
 
   var s: String {
-    get {return _storage._s ?? ""}
+    get {return _storage._s ?? String()}
     set {_uniqueStorage()._s = newValue}
   }
   var hasS: Bool {
@@ -1454,13 +1454,13 @@ let ProtobufUnittest_Extensions_double_opt = SwiftProtobuf.MessageExtension<Opti
 let ProtobufUnittest_Extensions_string_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Google_Protobuf_MessageOptions>(
   _protobuf_fieldNumber: 7673285,
   fieldName: "protobuf_unittest.string_opt",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_bytes_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, Google_Protobuf_MessageOptions>(
   _protobuf_fieldNumber: 7673238,
   fieldName: "protobuf_unittest.bytes_opt",
-  defaultValue: Data()
+  defaultValue: SwiftProtobuf.Internal.emptyData
 )
 
 let ProtobufUnittest_Extensions_enum_opt = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_DummyMessageContainingEnum.TestEnumType>, Google_Protobuf_MessageOptions>(
@@ -1913,7 +1913,7 @@ extension Google_Protobuf_MessageOptions {
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_stringOpt: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_string_opt) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_string_opt) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_string_opt, value: newValue)}
   }
   var hasProtobufUnittest_stringOpt: Bool {
@@ -1926,7 +1926,7 @@ extension Google_Protobuf_MessageOptions {
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_bytesOpt: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt) ?? Data()}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt, value: newValue)}
   }
   var hasProtobufUnittest_bytesOpt: Bool {

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -443,7 +443,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -454,7 +454,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {
@@ -542,7 +542,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
   }
 
   var optionalStringPiece: String {
-    get {return _storage._optionalStringPiece ?? ""}
+    get {return _storage._optionalStringPiece ?? String()}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
   var hasOptionalStringPiece: Bool {
@@ -553,7 +553,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
   }
 
   var optionalCord: String {
-    get {return _storage._optionalCord ?? ""}
+    get {return _storage._optionalCord ?? String()}
     set {_uniqueStorage()._optionalCord = newValue}
   }
   var hasOptionalCord: Bool {
@@ -962,7 +962,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -974,7 +974,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -2522,7 +2522,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -2533,7 +2533,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {
@@ -2599,7 +2599,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -2611,7 +2611,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -2838,13 +2838,13 @@ let ProtobufUnittest_Extensions_optional_bool_extension_lite = SwiftProtobuf.Mes
 let ProtobufUnittest_Extensions_optional_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 14,
   fieldName: "protobuf_unittest.optional_string_extension_lite",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 15,
   fieldName: "protobuf_unittest.optional_bytes_extension_lite",
-  defaultValue: Data()
+  defaultValue: SwiftProtobuf.Internal.emptyData
 )
 
 let ProtobufUnittest_Extensions_OptionalGroup_extension_lite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
@@ -2892,13 +2892,13 @@ let ProtobufUnittest_Extensions_optional_import_enum_extension_lite = SwiftProto
 let ProtobufUnittest_Extensions_optional_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 24,
   fieldName: "protobuf_unittest.optional_string_piece_extension_lite",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 25,
   fieldName: "protobuf_unittest.optional_cord_extension_lite",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_public_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
@@ -3201,13 +3201,13 @@ let ProtobufUnittest_Extensions_oneof_nested_message_extension_lite = SwiftProto
 let ProtobufUnittest_Extensions_oneof_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 113,
   fieldName: "protobuf_unittest.oneof_string_extension_lite",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_oneof_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 114,
   fieldName: "protobuf_unittest.oneof_bytes_extension_lite",
-  defaultValue: Data()
+  defaultValue: SwiftProtobuf.Internal.emptyData
 )
 
 let ProtobufUnittest_Extensions_packed_int32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
@@ -3511,7 +3511,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringExtensionLite: Bool {
@@ -3524,7 +3524,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalBytesExtensionLite: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite) ?? Data()}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalBytesExtensionLite: Bool {
@@ -3628,7 +3628,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringPieceExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringPieceExtensionLite: Bool {
@@ -3641,7 +3641,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalCordExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalCordExtensionLite: Bool {
@@ -4294,7 +4294,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofStringExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofStringExtensionLite: Bool {
@@ -4307,7 +4307,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofBytesExtensionLite: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite) ?? Data()}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofBytesExtensionLite: Bool {

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -172,7 +172,7 @@ struct ProtobufUnittest_TestMessageSetExtension2: SwiftProtobuf.Message {
 
   fileprivate var _str: String? = nil
   var str: String {
-    get {return _str ?? ""}
+    get {return _str ?? String()}
     set {_str = newValue}
   }
   var hasStr: Bool {
@@ -237,7 +237,7 @@ struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message {
 
     fileprivate var _message: Data? = nil
     var message: Data {
-      get {return _message ?? Data()}
+      get {return _message ?? SwiftProtobuf.Internal.emptyData}
       set {_message = newValue}
     }
     var hasMessage: Bool {

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -397,7 +397,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -408,7 +408,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {
@@ -496,7 +496,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalStringPiece: String {
-    get {return _storage._optionalStringPiece ?? ""}
+    get {return _storage._optionalStringPiece ?? String()}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
   var hasOptionalStringPiece: Bool {
@@ -507,7 +507,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalCord: String {
-    get {return _storage._optionalCord ?? ""}
+    get {return _storage._optionalCord ?? String()}
     set {_uniqueStorage()._optionalCord = newValue}
   }
   var hasOptionalCord: Bool {
@@ -916,7 +916,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -928,7 +928,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -101,15 +101,15 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage? = nil
     var _optionalForeignMessage: Proto2NofieldpresenceUnittest_ForeignMessage? = nil
     var _optionalProto2Message: ProtobufUnittest_TestAllTypes? = nil
     var _optionalNestedEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum = Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum.foo
     var _optionalForeignEnum: Proto2NofieldpresenceUnittest_ForeignEnum = Proto2NofieldpresenceUnittest_ForeignEnum.foreignFoo
-    var _optionalStringPiece: String = ""
-    var _optionalCord: String = ""
+    var _optionalStringPiece: String = String()
+    var _optionalCord: String = String()
     var _optionalLazyMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage? = nil
     var _repeatedInt32: [Int32] = []
     var _repeatedInt64: [Int64] = []
@@ -488,7 +488,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -120,7 +120,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
       if case .stringField(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .stringField(newValue)

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -192,8 +192,8 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     var _singleFloat: Float = 0
     var _singleDouble: Double = 0
     var _singleBool: Bool = false
-    var _singleString: String = ""
-    var _singleBytes: Data = Data()
+    var _singleString: String = String()
+    var _singleBytes: Data = SwiftProtobuf.Internal.emptyData
     var _singleNestedMessage: Proto3TestAllTypes.NestedMessage? = nil
     var _singleForeignMessage: Proto3ForeignMessage? = nil
     var _singleImportMessage: Proto3ImportMessage? = nil
@@ -562,7 +562,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -574,7 +574,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -1364,7 +1364,7 @@ struct Proto3TestCamelCaseFieldNames: SwiftProtobuf.Message {
 
   fileprivate class _StorageClass {
     var _primitiveField: Int32 = 0
-    var _stringField: String = ""
+    var _stringField: String = String()
     var _enumField: Proto3ForeignEnum = Proto3ForeignEnum.foreignUnspecified
     var _messageField: Proto3ForeignMessage? = nil
     var _repeatedPrimitiveField: [Int32] = []
@@ -1501,7 +1501,7 @@ struct Proto3TestFieldOrderings: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestFieldOrderings"
 
   fileprivate class _StorageClass {
-    var _myString: String = ""
+    var _myString: String = String()
     var _myInt: Int64 = 0
     var _myFloat: Float = 0
     var _singleNestedMessage: Proto3TestFieldOrderings.NestedMessage? = nil
@@ -1654,7 +1654,7 @@ struct Proto3SparseEnumMessage: SwiftProtobuf.Message {
 struct Proto3OneString: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OneString"
 
-  var data: String = ""
+  var data: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1706,7 +1706,7 @@ struct Proto3MoreString: SwiftProtobuf.Message {
 struct Proto3OneBytes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OneBytes"
 
-  var data: Data = Data()
+  var data: Data = SwiftProtobuf.Internal.emptyData
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1732,7 +1732,7 @@ struct Proto3OneBytes: SwiftProtobuf.Message {
 struct Proto3MoreBytes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MoreBytes"
 
-  var data: Data = Data()
+  var data: Data = SwiftProtobuf.Internal.emptyData
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1926,7 +1926,7 @@ struct Proto3TestOneof: SwiftProtobuf.Message {
       if case .fooString(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooString(newValue)
@@ -2271,7 +2271,7 @@ struct Proto3TestCommentInjectionMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestCommentInjectionMessage"
 
   /// */ <- This should not close the generated doc comment
-  var a: String = ""
+  var a: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -102,15 +102,15 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage? = nil
     var _optionalForeignMessage: Proto3ArenaUnittest_ForeignMessage? = nil
     var _optionalImportMessage: ProtobufUnittestImport_ImportMessage? = nil
     var _optionalNestedEnum: Proto3ArenaUnittest_TestAllTypes.NestedEnum = Proto3ArenaUnittest_TestAllTypes.NestedEnum.zero
     var _optionalForeignEnum: Proto3ArenaUnittest_ForeignEnum = Proto3ArenaUnittest_ForeignEnum.foreignZero
-    var _optionalStringPiece: String = ""
-    var _optionalCord: String = ""
+    var _optionalStringPiece: String = String()
+    var _optionalCord: String = String()
     var _optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage? = nil
     var _optionalLazyMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage? = nil
     var _repeatedInt32: [Int32] = []
@@ -498,7 +498,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -510,7 +510,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -102,15 +102,15 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalNestedMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage? = nil
     var _optionalForeignMessage: Proto3ArenaLiteUnittest_ForeignMessage? = nil
     var _optionalImportMessage: ProtobufUnittestImport_ImportMessage? = nil
     var _optionalNestedEnum: Proto3ArenaLiteUnittest_TestAllTypes.NestedEnum = Proto3ArenaLiteUnittest_TestAllTypes.NestedEnum.zero
     var _optionalForeignEnum: Proto3ArenaLiteUnittest_ForeignEnum = Proto3ArenaLiteUnittest_ForeignEnum.foreignZero
-    var _optionalStringPiece: String = ""
-    var _optionalCord: String = ""
+    var _optionalStringPiece: String = String()
+    var _optionalCord: String = String()
     var _optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage? = nil
     var _optionalLazyMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage? = nil
     var _repeatedInt32: [Int32] = []
@@ -498,7 +498,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -510,7 +510,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -102,15 +102,15 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalNestedMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage? = nil
     var _optionalForeignMessage: Proto3LiteUnittest_ForeignMessage? = nil
     var _optionalImportMessage: ProtobufUnittestImport_ImportMessage? = nil
     var _optionalNestedEnum: Proto3LiteUnittest_TestAllTypes.NestedEnum = Proto3LiteUnittest_TestAllTypes.NestedEnum.zero
     var _optionalForeignEnum: Proto3LiteUnittest_ForeignEnum = Proto3LiteUnittest_ForeignEnum.foreignZero
-    var _optionalStringPiece: String = ""
-    var _optionalCord: String = ""
+    var _optionalStringPiece: String = String()
+    var _optionalCord: String = String()
     var _optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage? = nil
     var _optionalLazyMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage? = nil
     var _repeatedInt32: [Int32] = []
@@ -498,7 +498,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -510,7 +510,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)

--- a/Reference/google/protobuf/wrappers.pb.swift
+++ b/Reference/google/protobuf/wrappers.pb.swift
@@ -270,7 +270,7 @@ struct Google_Protobuf_StringValue: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".StringValue"
 
   /// The string value.
-  var value: String = ""
+  var value: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -300,7 +300,7 @@ struct Google_Protobuf_BytesValue: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".BytesValue"
 
   /// The bytes value.
-  var value: Data = Data()
+  var value: Data = SwiftProtobuf.Internal.emptyData
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -310,7 +310,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
   }
 
   var requiredString: String {
-    get {return _storage._requiredString ?? ""}
+    get {return _storage._requiredString ?? String()}
     set {_uniqueStorage()._requiredString = newValue}
   }
   var hasRequiredString: Bool {
@@ -321,7 +321,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
   }
 
   var requiredBytes: Data {
-    get {return _storage._requiredBytes ?? Data()}
+    get {return _storage._requiredBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._requiredBytes = newValue}
   }
   var hasRequiredBytes: Bool {
@@ -409,7 +409,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
   }
 
   var requiredStringPiece: String {
-    get {return _storage._requiredStringPiece ?? ""}
+    get {return _storage._requiredStringPiece ?? String()}
     set {_uniqueStorage()._requiredStringPiece = newValue}
   }
   var hasRequiredStringPiece: Bool {
@@ -420,7 +420,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
   }
 
   var requiredCord: String {
-    get {return _storage._requiredCord ?? ""}
+    get {return _storage._requiredCord ?? String()}
     set {_uniqueStorage()._requiredCord = newValue}
   }
   var hasRequiredCord: Bool {
@@ -703,7 +703,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -715,7 +715,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -1180,7 +1180,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf.Message {
 
   fileprivate var _requiredString: String? = nil
   var requiredString: String {
-    get {return _requiredString ?? ""}
+    get {return _requiredString ?? String()}
     set {_requiredString = newValue}
   }
   var hasRequiredString: Bool {
@@ -1192,7 +1192,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf.Message {
 
   fileprivate var _requiredBytes: Data? = nil
   var requiredBytes: Data {
-    get {return _requiredBytes ?? Data()}
+    get {return _requiredBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_requiredBytes = newValue}
   }
   var hasRequiredBytes: Bool {

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -347,7 +347,7 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
 let ProtobufUnittest_Extend_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 100,
   fieldName: "protobuf_unittest.extend.b",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extend_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -394,7 +394,7 @@ let ProtobufUnittest_Extend_Extensions_ext_d = SwiftProtobuf.MessageExtension<Op
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b, value: newValue)}
   }
   var hasProtobufUnittest_Extend_b: Bool {

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -83,7 +83,7 @@ struct ProtobufUnittest_Extend2_MyMessage: SwiftProtobuf.Message {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 210,
       fieldName: "protobuf_unittest.extend2.MyMessage.b",
-      defaultValue: ""
+      defaultValue: String()
     )
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -144,7 +144,7 @@ struct ProtobufUnittest_Extend2_C: SwiftProtobuf.Message {
 let ProtobufUnittest_Extend2_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 220,
   fieldName: "protobuf_unittest.extend2.b",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -155,7 +155,7 @@ let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<Optio
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_MyMessage_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b, value: newValue)}
   }
   var hasProtobufUnittest_Extend2_MyMessage_b: Bool {
@@ -181,7 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b, value: newValue)}
   }
   var hasProtobufUnittest_Extend2_b: Bool {

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -83,7 +83,7 @@ struct ProtobufUnittest_Extend3_MyMessage: SwiftProtobuf.Message {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 310,
       fieldName: "protobuf_unittest.extend3.MyMessage.b",
-      defaultValue: ""
+      defaultValue: String()
     )
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -144,7 +144,7 @@ struct ProtobufUnittest_Extend3_C: SwiftProtobuf.Message {
 let ProtobufUnittest_Extend3_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 320,
   fieldName: "protobuf_unittest.extend3.b",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -155,7 +155,7 @@ let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<Optio
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_MyMessage_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b, value: newValue)}
   }
   var hasProtobufUnittest_Extend3_MyMessage_b: Bool {
@@ -181,7 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b, value: newValue)}
   }
   var hasProtobufUnittest_Extend3_b: Bool {

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -83,7 +83,7 @@ struct Ext4MyMessage: SwiftProtobuf.Message {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 410,
       fieldName: "protobuf_unittest.extend4.MyMessage.b",
-      defaultValue: ""
+      defaultValue: String()
     )
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -144,7 +144,7 @@ struct Ext4C: SwiftProtobuf.Message {
 let Ext4Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 420,
   fieldName: "protobuf_unittest.extend4.b",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -155,7 +155,7 @@ let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionFiel
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4MyMessage_b: String {
-    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? ""}
+    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: Ext4MyMessage.Extensions.b, value: newValue)}
   }
   var hasExt4MyMessage_b: Bool {
@@ -181,7 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4b: String {
-    get {return getExtensionValue(ext: Ext4Extensions_b) ?? ""}
+    get {return getExtensionValue(ext: Ext4Extensions_b) ?? String()}
     set {setExtensionValue(ext: Ext4Extensions_b, value: newValue)}
   }
   var hasExt4b: Bool {

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -66,7 +66,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
   }
 
   var myString: String {
-    get {return _storage._myString ?? ""}
+    get {return _storage._myString ?? String()}
     set {_uniqueStorage()._myString = newValue}
   }
   var hasMyString: Bool {
@@ -127,7 +127,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
       if case .oneofString(let v)? = _storage._options {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._options = .oneofString(newValue)
@@ -293,7 +293,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
 let Swift_Protobuf_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(
   _protobuf_fieldNumber: 50,
   fieldName: "swift.protobuf.my_extension_string",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(
@@ -304,7 +304,7 @@ let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<
 
 extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionString: String {
-    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string) ?? ""}
+    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string) ?? String()}
     set {setExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string, value: newValue)}
   }
   var hasSwift_Protobuf_myExtensionString: Bool {

--- a/Reference/unittest_swift_performance.pb.swift
+++ b/Reference/unittest_swift_performance.pb.swift
@@ -66,8 +66,8 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _repeatedRecursiveMessage: [Swift_Performance_TestAllTypes] = []
     var _repeatedInt32: [Int32] = []
     var _repeatedInt64: [Int64] = []

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -90,7 +90,7 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
   /// r/o properties on Message, ensure it gets remapped.
   fileprivate var _isInitialized_p: String? = nil
   var isInitialized_p: String {
-    get {return _isInitialized_p ?? ""}
+    get {return _isInitialized_p ?? String()}
     set {_isInitialized_p = newValue}
   }
   var hasIsInitialized_p: Bool {
@@ -102,7 +102,7 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
 
   fileprivate var _hashValue_p: String? = nil
   var hashValue_p: String {
-    get {return _hashValue_p ?? ""}
+    get {return _hashValue_p ?? String()}
     set {_hashValue_p = newValue}
   }
   var hasHashValue_p: Bool {

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -324,7 +324,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -335,7 +335,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -65,8 +65,8 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalMessage: ProtobufUnittest_Message3? = nil
     var _optionalEnum: ProtobufUnittest_Message3.Enum = ProtobufUnittest_Message3.Enum.foo
     var _repeatedInt32: [Int32] = []
@@ -515,7 +515,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._o {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._o = .oneofString(newValue)
@@ -527,7 +527,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._o {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._o = .oneofBytes(newValue)

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -87,7 +87,7 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
     static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
       _protobuf_fieldNumber: 3,
       fieldName: "protobuf_objc_unittest.TestObjCStartupNested.nested_string_extension",
-      defaultValue: ""
+      defaultValue: String()
     )
   }
 
@@ -118,7 +118,7 @@ let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.Mes
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension, value: newValue)}
   }
   var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -91,7 +91,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   var protobufPayload: Data {
     get {
       if case .protobufPayload(let v)? = payload { return v }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set { payload = .protobufPayload(newValue) }
   }
@@ -101,7 +101,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   var jsonPayload: String {
     get {
       if case .jsonPayload(let v)? = payload { return v }
-      return ""
+      return String()
     }
     set { payload = .jsonPayload(newValue) }
   }
@@ -161,7 +161,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var parseError: String {
     get {
       if case .parseError(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .parseError(newValue) }
   }
@@ -174,7 +174,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var serializeError: String {
     get {
       if case .serializeError(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .serializeError(newValue) }
   }
@@ -185,7 +185,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var runtimeError: String {
     get {
       if case .runtimeError(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .runtimeError(newValue) }
   }
@@ -195,7 +195,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var protobufPayload: Data {
     get {
       if case .protobufPayload(let v)? = result { return v }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set { result = .protobufPayload(newValue) }
   }
@@ -205,7 +205,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var jsonPayload: String {
     get {
       if case .jsonPayload(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .jsonPayload(newValue) }
   }
@@ -215,7 +215,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var skipped: String {
     get {
       if case .skipped(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .skipped(newValue) }
   }

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -110,14 +110,14 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalNestedMessage: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage? = nil
     var _optionalForeignMessage: ProtobufTestMessages_Proto3_ForeignMessage? = nil
     var _optionalNestedEnum: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum.foo
     var _optionalForeignEnum: ProtobufTestMessages_Proto3_ForeignEnum = ProtobufTestMessages_Proto3_ForeignEnum.foreignFoo
-    var _optionalStringPiece: String = ""
-    var _optionalCord: String = ""
+    var _optionalStringPiece: String = String()
+    var _optionalCord: String = String()
     var _recursiveMessage: ProtobufTestMessages_Proto3_TestAllTypes? = nil
     var _repeatedInt32: [Int32] = []
     var _repeatedInt64: [Int64] = []
@@ -695,7 +695,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -707,7 +707,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)

--- a/Sources/PluginLibrary/descriptor.pb.swift
+++ b/Sources/PluginLibrary/descriptor.pb.swift
@@ -137,7 +137,7 @@ public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
 
   /// file name, relative to root of source tree
   public var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   public var hasName: Bool {
@@ -149,7 +149,7 @@ public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
 
   /// e.g. "foo", "foo.bar", etc.
   public var package: String {
-    get {return _storage._package ?? ""}
+    get {return _storage._package ?? String()}
     set {_uniqueStorage()._package = newValue}
   }
   public var hasPackage: Bool {
@@ -228,7 +228,7 @@ public struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
   /// The syntax of the proto file.
   /// The supported values are "proto2" and "proto3".
   public var syntax: String {
-    get {return _storage._syntax ?? ""}
+    get {return _storage._syntax ?? String()}
     set {_uniqueStorage()._syntax = newValue}
   }
   public var hasSyntax: Bool {
@@ -361,7 +361,7 @@ public struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
   }
 
   public var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   public var hasName: Bool {
@@ -649,7 +649,7 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   }
 
   public var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   public var hasName: Bool {
@@ -700,7 +700,7 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// message are searched, then within the parent, on up to the root
   /// namespace).
   public var typeName: String {
-    get {return _storage._typeName ?? ""}
+    get {return _storage._typeName ?? String()}
     set {_uniqueStorage()._typeName = newValue}
   }
   public var hasTypeName: Bool {
@@ -713,7 +713,7 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// For extensions, this is the name of the type being extended.  It is
   /// resolved in the same manner as type_name.
   public var extendee: String {
-    get {return _storage._extendee ?? ""}
+    get {return _storage._extendee ?? String()}
     set {_uniqueStorage()._extendee = newValue}
   }
   public var hasExtendee: Bool {
@@ -729,7 +729,7 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
   /// TODO(kenton):  Base-64 encode?
   public var defaultValue: String {
-    get {return _storage._defaultValue ?? ""}
+    get {return _storage._defaultValue ?? String()}
     set {_uniqueStorage()._defaultValue = newValue}
   }
   public var hasDefaultValue: Bool {
@@ -757,7 +757,7 @@ public struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// will be used. Otherwise, it's deduced from the field's name by converting
   /// it to camelCase.
   public var jsonName: String {
-    get {return _storage._jsonName ?? ""}
+    get {return _storage._jsonName ?? String()}
     set {_uniqueStorage()._jsonName = newValue}
   }
   public var hasJsonName: Bool {
@@ -1000,7 +1000,7 @@ public struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message {
   }
 
   public var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   public var hasName: Bool {
@@ -1086,7 +1086,7 @@ public struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message {
   }
 
   public var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   public var hasName: Bool {
@@ -1182,7 +1182,7 @@ public struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message {
   }
 
   public var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   public var hasName: Bool {
@@ -1283,7 +1283,7 @@ public struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message {
   }
 
   public var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   public var hasName: Bool {
@@ -1385,7 +1385,7 @@ public struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   }
 
   public var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   public var hasName: Bool {
@@ -1398,7 +1398,7 @@ public struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   /// Input and output type names.  These are resolved in the same way as
   /// FieldDescriptorProto.type_name, but must refer to a message type.
   public var inputType: String {
-    get {return _storage._inputType ?? ""}
+    get {return _storage._inputType ?? String()}
     set {_uniqueStorage()._inputType = newValue}
   }
   public var hasInputType: Bool {
@@ -1409,7 +1409,7 @@ public struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   }
 
   public var outputType: String {
-    get {return _storage._outputType ?? ""}
+    get {return _storage._outputType ?? String()}
     set {_uniqueStorage()._outputType = newValue}
   }
   public var hasOutputType: Bool {
@@ -1566,7 +1566,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
   /// inappropriate because proto packages do not normally start with backwards
   /// domain names.
   public var javaPackage: String {
-    get {return _storage._javaPackage ?? ""}
+    get {return _storage._javaPackage ?? String()}
     set {_uniqueStorage()._javaPackage = newValue}
   }
   public var hasJavaPackage: Bool {
@@ -1582,7 +1582,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
   /// a .proto always translates to a single class, but you may want to
   /// explicitly choose the class name).
   public var javaOuterClassname: String {
-    get {return _storage._javaOuterClassname ?? ""}
+    get {return _storage._javaOuterClassname ?? String()}
     set {_uniqueStorage()._javaOuterClassname = newValue}
   }
   public var hasJavaOuterClassname: Bool {
@@ -1655,7 +1655,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
   ///   - Otherwise, the package statement in the .proto file, if present.
   ///   - Otherwise, the basename of the .proto file, without extension.
   public var goPackage: String {
-    get {return _storage._goPackage ?? ""}
+    get {return _storage._goPackage ?? String()}
     set {_uniqueStorage()._goPackage = newValue}
   }
   public var hasGoPackage: Bool {
@@ -1739,7 +1739,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
   /// Sets the objective c class prefix which is prepended to all objective c
   /// generated classes from this .proto. There is no default.
   public var objcClassPrefix: String {
-    get {return _storage._objcClassPrefix ?? ""}
+    get {return _storage._objcClassPrefix ?? String()}
     set {_uniqueStorage()._objcClassPrefix = newValue}
   }
   public var hasObjcClassPrefix: Bool {
@@ -1751,7 +1751,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
 
   /// Namespace for generated classes; defaults to the package.
   public var csharpNamespace: String {
-    get {return _storage._csharpNamespace ?? ""}
+    get {return _storage._csharpNamespace ?? String()}
     set {_uniqueStorage()._csharpNamespace = newValue}
   }
   public var hasCsharpNamespace: Bool {
@@ -1766,7 +1766,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
   /// defined. When this options is provided, they will use this value instead
   /// to prefix the types/symbols defined.
   public var swiftPrefix: String {
-    get {return _storage._swiftPrefix ?? ""}
+    get {return _storage._swiftPrefix ?? String()}
     set {_uniqueStorage()._swiftPrefix = newValue}
   }
   public var hasSwiftPrefix: Bool {
@@ -1779,7 +1779,7 @@ public struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.
   /// Sets the php class prefix which is prepended to all php generated classes
   /// from this .proto. Default is empty.
   public var phpClassPrefix: String {
-    get {return _storage._phpClassPrefix ?? ""}
+    get {return _storage._phpClassPrefix ?? String()}
     set {_uniqueStorage()._phpClassPrefix = newValue}
   }
   public var hasPhpClassPrefix: Bool {
@@ -2688,7 +2688,7 @@ public struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
   /// identified it as during parsing. Exactly one of these should be set.
   fileprivate var _identifierValue: String? = nil
   public var identifierValue: String {
-    get {return _identifierValue ?? ""}
+    get {return _identifierValue ?? String()}
     set {_identifierValue = newValue}
   }
   public var hasIdentifierValue: Bool {
@@ -2736,7 +2736,7 @@ public struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
   fileprivate var _stringValue: Data? = nil
   public var stringValue: Data {
-    get {return _stringValue ?? Data()}
+    get {return _stringValue ?? SwiftProtobuf.Internal.emptyData}
     set {_stringValue = newValue}
   }
   public var hasStringValue: Bool {
@@ -2748,7 +2748,7 @@ public struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
   fileprivate var _aggregateValue: String? = nil
   public var aggregateValue: String {
-    get {return _aggregateValue ?? ""}
+    get {return _aggregateValue ?? String()}
     set {_aggregateValue = newValue}
   }
   public var hasAggregateValue: Bool {
@@ -2770,7 +2770,7 @@ public struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
     fileprivate var _namePart: String? = nil
     public var namePart: String {
-      get {return _namePart ?? ""}
+      get {return _namePart ?? String()}
       set {_namePart = newValue}
     }
     public var hasNamePart: Bool {
@@ -3007,7 +3007,7 @@ public struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
     ///   // ignored detached comments.
     fileprivate var _leadingComments: String? = nil
     public var leadingComments: String {
-      get {return _leadingComments ?? ""}
+      get {return _leadingComments ?? String()}
       set {_leadingComments = newValue}
     }
     public var hasLeadingComments: Bool {
@@ -3019,7 +3019,7 @@ public struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
 
     fileprivate var _trailingComments: String? = nil
     public var trailingComments: String {
-      get {return _trailingComments ?? ""}
+      get {return _trailingComments ?? String()}
       set {_trailingComments = newValue}
     }
     public var hasTrailingComments: Bool {
@@ -3109,7 +3109,7 @@ public struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
     /// Identifies the filesystem path to the original source .proto.
     fileprivate var _sourceFile: String? = nil
     public var sourceFile: String {
-      get {return _sourceFile ?? ""}
+      get {return _sourceFile ?? String()}
       set {_sourceFile = newValue}
     }
     public var hasSourceFile: Bool {

--- a/Sources/PluginLibrary/plugin.pb.swift
+++ b/Sources/PluginLibrary/plugin.pb.swift
@@ -109,7 +109,7 @@ public struct Google_Protobuf_Compiler_Version: SwiftProtobuf.Message {
   /// be empty for mainline stable releases.
   fileprivate var _suffix: String? = nil
   public var suffix: String {
-    get {return _suffix ?? ""}
+    get {return _suffix ?? String()}
     set {_suffix = newValue}
   }
   public var hasSuffix: Bool {
@@ -191,7 +191,7 @@ public struct Google_Protobuf_Compiler_CodeGeneratorRequest: SwiftProtobuf.Messa
 
   /// The generator parameter passed on the command-line.
   public var parameter: String {
-    get {return _storage._parameter ?? ""}
+    get {return _storage._parameter ?? String()}
     set {_uniqueStorage()._parameter = newValue}
   }
   public var hasParameter: Bool {
@@ -288,7 +288,7 @@ public struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Mess
   /// exiting with a non-zero status code.
   fileprivate var _error: String? = nil
   public var error: String {
-    get {return _error ?? ""}
+    get {return _error ?? String()}
     set {_error = newValue}
   }
   public var hasError: Bool {
@@ -319,7 +319,7 @@ public struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Mess
     /// CodeGeneratorResponse before writing files to disk.
     fileprivate var _name: String? = nil
     public var name: String {
-      get {return _name ?? ""}
+      get {return _name ?? String()}
       set {_name = newValue}
     }
     public var hasName: Bool {
@@ -368,7 +368,7 @@ public struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Mess
     /// If |insertion_point| is present, |name| must also be present.
     fileprivate var _insertionPoint: String? = nil
     public var insertionPoint: String {
-      get {return _insertionPoint ?? ""}
+      get {return _insertionPoint ?? String()}
       set {_insertionPoint = newValue}
     }
     public var hasInsertionPoint: Bool {
@@ -381,7 +381,7 @@ public struct Google_Protobuf_Compiler_CodeGeneratorResponse: SwiftProtobuf.Mess
     /// The file contents.
     fileprivate var _content: String? = nil
     public var content: String {
-      get {return _content ?? ""}
+      get {return _content ?? String()}
       set {_content = newValue}
     }
     public var hasContent: Bool {

--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -79,7 +79,7 @@ fileprivate func unpack(contentJSON: Data, as messageType: Message.Type) throws 
 
 internal class AnyMessageStorage {
   // The two properties generated Google_Protobuf_Any will reference.
-  var _typeURL: String = ""
+  var _typeURL = String()
   var _value: Data {
     // Remapped to the internal `state`.
     get {
@@ -391,7 +391,7 @@ extension AnyMessageStorage {
   func decodeJSON(from decoder: inout JSONDecoder) throws {
     try decoder.scanner.skipRequiredObjectStart()
     // Reset state
-    _typeURL = ""
+    _typeURL = String()
     state = .binary(Data())
     if decoder.scanner.skipOptionalObjectEnd() {
       return

--- a/Sources/SwiftProtobuf/AnyMessageStorage.swift
+++ b/Sources/SwiftProtobuf/AnyMessageStorage.swift
@@ -90,17 +90,17 @@ internal class AnyMessageStorage {
         do {
           return try message.serializedData(partial: true)
         } catch {
-          return Data()
+          return Internal.emptyData
         }
       case .contentJSON(let contentJSON):
         guard let messageType = Google_Protobuf_Any.messageType(forTypeURL: _typeURL) else {
-          return Data()
+          return Internal.emptyData
         }
         do {
           let m = try unpack(contentJSON: contentJSON, as: messageType)
           return try m.serializedData(partial: true)
         } catch {
-          return Data()
+          return Internal.emptyData
         }
       }
     }
@@ -117,7 +117,7 @@ internal class AnyMessageStorage {
     // parsed JSON with the @type removed
     case contentJSON(Data)
   }
-  var state: InternalState = .binary(Data())
+  var state: InternalState = .binary(Internal.emptyData)
 
   init() {}
 
@@ -392,7 +392,7 @@ extension AnyMessageStorage {
     try decoder.scanner.skipRequiredObjectStart()
     // Reset state
     _typeURL = String()
-    state = .binary(Data())
+    state = .binary(Internal.emptyData)
     if decoder.scanner.skipOptionalObjectEnd() {
       return
     }

--- a/Sources/SwiftProtobuf/ExtensionFields.swift
+++ b/Sources/SwiftProtobuf/ExtensionFields.swift
@@ -78,7 +78,7 @@ public struct OptionalExtensionField<T: FieldType>: ExtensionField {
       if let value = value {
         return String(reflecting: value)
       }
-      return ""
+      return String()
     }
   }
 
@@ -224,7 +224,7 @@ public struct OptionalEnumExtensionField<E: Enum>: ExtensionField where E.RawVal
       if let value = value {
         return String(reflecting: value)
       }
-      return ""
+      return String()
     }
   }
 
@@ -377,7 +377,7 @@ public struct OptionalMessageExtensionField<M: Message & Equatable>:
       if let value = value {
         return String(reflecting: value)
       }
-      return ""
+      return String()
     }
   }
 
@@ -482,7 +482,7 @@ public struct OptionalGroupExtensionField<G: Message & Hashable>:
 
   public var hashValue: Int {return value?.hashValue ?? 0}
 
-  public var debugDescription: String { get {return value?.debugDescription ?? ""} }
+  public var debugDescription: String { get {return value?.debugDescription ?? String()} }
 
   public func isEqual(other: AnyExtensionField) -> Bool {
     let o = other as! OptionalGroupExtensionField<G>

--- a/Sources/SwiftProtobuf/FieldTypes.swift
+++ b/Sources/SwiftProtobuf/FieldTypes.swift
@@ -393,7 +393,7 @@ public struct ProtobufString: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufBytes: FieldType, MapValueType {
     public typealias BaseType = Data
-    static public var proto3DefaultValue: Data {return Data()}
+    static public var proto3DefaultValue: Data {return Internal.emptyData}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularBytesField(value: &value)
     }

--- a/Sources/SwiftProtobuf/FieldTypes.swift
+++ b/Sources/SwiftProtobuf/FieldTypes.swift
@@ -370,7 +370,7 @@ public struct ProtobufBool: FieldType, MapKeyType, MapValueType {
 ///
 public struct ProtobufString: FieldType, MapKeyType, MapValueType {
     public typealias BaseType = String
-    static public var proto3DefaultValue: String {return ""}
+    static public var proto3DefaultValue: String {return String()}
     public static func decodeSingular<D: Decoder>(value: inout BaseType?, from decoder: inout D) throws {
         try decoder.decodeSingularStringField(value: &value)
     }

--- a/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_FieldMask+Extensions.swift
@@ -17,7 +17,7 @@
 // message, intersect two fieldmasks, etc.
 
 private func ProtoToJSON(name: String) -> String? {
-  var jsonPath = ""
+  var jsonPath = String()
   var chars = name.characters.makeIterator()
   while let c = chars.next() {
     switch c {
@@ -42,7 +42,7 @@ private func ProtoToJSON(name: String) -> String? {
 }
 
 private func JSONToProto(name: String) -> String? {
-  var path = ""
+  var path = String()
   for c in name.characters {
     switch c {
     case "_":
@@ -59,7 +59,7 @@ private func JSONToProto(name: String) -> String? {
 
 private func parseJSONFieldNames(names: String) -> [String]? {
   var fieldNameCount = 0
-  var fieldName = ""
+  var fieldName = String()
   var split = [String]()
   for c: Character in names.characters {
     switch c {
@@ -72,7 +72,7 @@ private func parseJSONFieldNames(names: String) -> [String]? {
       } else {
         return nil
       }
-      fieldName = ""
+      fieldName = String()
       fieldNameCount = 0
     default:
       fieldName.append(c)

--- a/Sources/SwiftProtobuf/Internal.swift
+++ b/Sources/SwiftProtobuf/Internal.swift
@@ -20,6 +20,13 @@ import Foundation
 /// implementations. NOT INTENDED TO BE CALLED BY CLIENTS.
 public enum Internal {
 
+  /// A singleton instance of an empty data that is used by the generated code
+  /// for default values. This is a performance enhancement to work around the
+  /// fact that the `Data` type in Swift involves a new heap allocation every
+  /// time an empty instance is initialized, instead of sharing a common empty
+  /// backing storage.
+  public static let emptyData = Data()
+
   /// Helper to loop over a list of Messages to see if they are all
   /// initialized (see Message.isInitialized for what that means).
   public static func areAllInitialized(_ listOfMessages: [Message]) -> Bool {

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -388,7 +388,7 @@ internal struct JSONDecoder: Decoder {
 
   mutating func decodeSingularStringField(value: inout String) throws {
     if scanner.skipOptionalNull() {
-      value = ""
+      value = String()
       return
     }
     value = try scanner.nextQuotedString()

--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -422,7 +422,7 @@ internal struct JSONDecoder: Decoder {
 
   mutating func decodeSingularBytesField(value: inout Data) throws {
     if scanner.skipOptionalNull() {
-      value = Data()
+      value = Internal.emptyData
       return
     }
     value = try scanner.nextBytesValue()

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -118,7 +118,7 @@ internal struct JSONEncodingVisitor: Visitor {
 
   private mutating func _visitRepeated<T>(value: [T], fieldNumber: Int, encode: (T) -> ()) throws {
     try startField(for: fieldNumber)
-    var arraySeparator = ""
+    var arraySeparator = String()
     encoder.append(text: "[")
     for v in value {
       encoder.append(text: arraySeparator)
@@ -227,7 +227,7 @@ internal struct JSONEncodingVisitor: Visitor {
 
   mutating func visitRepeatedEnumField<E: Enum>(value: [E], fieldNumber: Int) throws {
     try startField(for: fieldNumber)
-    var arraySeparator = ""
+    var arraySeparator = String()
     encoder.append(text: "[")
     for v in value {
       encoder.append(text: arraySeparator)
@@ -243,7 +243,7 @@ internal struct JSONEncodingVisitor: Visitor {
 
   mutating func visitRepeatedMessageField<M: Message>(value: [M], fieldNumber: Int) throws {
     try startField(for: fieldNumber)
-    var arraySeparator = ""
+    var arraySeparator = String()
     encoder.append(text: "[")
     for v in value {
       encoder.append(text: arraySeparator)

--- a/Sources/SwiftProtobuf/NameMap.swift
+++ b/Sources/SwiftProtobuf/NameMap.swift
@@ -21,7 +21,7 @@
 /// It does not necessarily need to match protoc's JSON field naming
 /// logic, however.
 private func toJsonFieldName(_ s: String) -> String {
-    var result = ""
+    var result = String()
     var capitalizeNext = false
 
     for c in s.characters {

--- a/Sources/SwiftProtobuf/StringUtils.swift
+++ b/Sources/SwiftProtobuf/StringUtils.swift
@@ -48,7 +48,7 @@ internal func utf8ToString(
 
 internal func utf8ToString(bytes: UnsafePointer<UInt8>, count: Int) -> String? {
     if count == 0 {
-        return ""
+        return String()
     }
 #if os(Linux)
     // As of March, 2017, the NSString(bytes:length:encoding:)

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -93,7 +93,7 @@ internal struct TextFormatEncodingVisitor: Visitor {
               encoder.endRegularField()
           case .lengthDelimited:
               encoder.emitFieldNumber(number: tag.fieldNumber)
-              var bytes = Data()
+              var bytes = Internal.emptyData
               try decoder.decodeSingularBytesField(value: &bytes)
               bytes.withUnsafeBytes { (p: UnsafePointer<UInt8>) -> () in
                   var testDecoder = BinaryDecoder(forReadingFrom: p, count: bytes.count)

--- a/Sources/SwiftProtobuf/TextFormatScanner.swift
+++ b/Sources/SwiftProtobuf/TextFormatScanner.swift
@@ -251,7 +251,7 @@ private func decodeString(_ s: String) -> String? {
     if let addr = ptr.baseAddress {
         return utf8ToString(bytes: addr, count: ptr.count)
     } else {
-      return ""
+      return String()
     }
   }
 }

--- a/Sources/SwiftProtobuf/UnknownStorage.swift
+++ b/Sources/SwiftProtobuf/UnknownStorage.swift
@@ -24,7 +24,7 @@ import Foundation
 public struct UnknownStorage: Equatable {
   /// The raw protocol buffer binary-encoded bytes that represent the unknown
   /// fields of a decoded message.
-  public private(set) var data = Data()
+  public private(set) var data = Internal.emptyData
 
   public static func ==(lhs: UnknownStorage, rhs: UnknownStorage) -> Bool {
     return lhs.data == rhs.data

--- a/Sources/SwiftProtobuf/api.pb.swift
+++ b/Sources/SwiftProtobuf/api.pb.swift
@@ -53,10 +53,10 @@ public struct Google_Protobuf_Api: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Api"
 
   fileprivate class _StorageClass {
-    var _name: String = ""
+    var _name: String = String()
     var _methods: [Google_Protobuf_Method] = []
     var _options: [Google_Protobuf_Option] = []
-    var _version: String = ""
+    var _version: String = String()
     var _sourceContext: Google_Protobuf_SourceContext? = nil
     var _mixins: [Google_Protobuf_Mixin] = []
     var _syntax: Google_Protobuf_Syntax = Google_Protobuf_Syntax.proto2
@@ -207,16 +207,16 @@ public struct Google_Protobuf_Method: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Method"
 
   /// The simple name of this method.
-  public var name: String = ""
+  public var name: String = String()
 
   /// A URL of the input message type.
-  public var requestTypeURL: String = ""
+  public var requestTypeURL: String = String()
 
   /// If true, the request is streamed.
   public var requestStreaming: Bool = false
 
   /// The URL of the output message type.
-  public var responseTypeURL: String = ""
+  public var responseTypeURL: String = String()
 
   /// If true, the response is streamed.
   public var responseStreaming: Bool = false
@@ -353,11 +353,11 @@ public struct Google_Protobuf_Mixin: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Mixin"
 
   /// The fully qualified name of the API which is included.
-  public var name: String = ""
+  public var name: String = String()
 
   /// If non-empty specifies a path under which inherited HTTP paths
   /// are rooted.
-  public var root: String = ""
+  public var root: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Sources/SwiftProtobuf/source_context.pb.swift
+++ b/Sources/SwiftProtobuf/source_context.pb.swift
@@ -55,7 +55,7 @@ public struct Google_Protobuf_SourceContext: SwiftProtobuf.Message {
 
   /// The path-qualified name of the .proto file that contained the associated
   /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
-  public var fileName: String = ""
+  public var fileName: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -174,7 +174,7 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
       if case .stringValue(let v)? = _storage._kind {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._kind = .stringValue(newValue)

--- a/Sources/SwiftProtobuf/type.pb.swift
+++ b/Sources/SwiftProtobuf/type.pb.swift
@@ -86,7 +86,7 @@ public struct Google_Protobuf_Type: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Type"
 
   fileprivate class _StorageClass {
-    var _name: String = ""
+    var _name: String = String()
     var _fields: [Google_Protobuf_Field] = []
     var _oneofs: [String] = []
     var _options: [Google_Protobuf_Option] = []
@@ -216,11 +216,11 @@ public struct Google_Protobuf_Field: SwiftProtobuf.Message {
   public var number: Int32 = 0
 
   /// The field name.
-  public var name: String = ""
+  public var name: String = String()
 
   /// The field type URL, without the scheme, for message or enumeration
   /// types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
-  public var typeURL: String = ""
+  public var typeURL: String = String()
 
   /// The index of the field type in `Type.oneofs`, for message or enumeration
   /// types. The first type has index 1; zero means the type is not in the list.
@@ -233,10 +233,10 @@ public struct Google_Protobuf_Field: SwiftProtobuf.Message {
   public var options: [Google_Protobuf_Option] = []
 
   /// The field JSON name.
-  public var jsonName: String = ""
+  public var jsonName: String = String()
 
   /// The string value of the default value of this field. Proto2 syntax only.
-  public var defaultValue: String = ""
+  public var defaultValue: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -461,7 +461,7 @@ public struct Google_Protobuf_Enum: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Enum"
 
   fileprivate class _StorageClass {
-    var _name: String = ""
+    var _name: String = String()
     var _enumvalue: [Google_Protobuf_EnumValue] = []
     var _options: [Google_Protobuf_Option] = []
     var _sourceContext: Google_Protobuf_SourceContext? = nil
@@ -570,7 +570,7 @@ public struct Google_Protobuf_EnumValue: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".EnumValue"
 
   /// Enum value name.
-  public var name: String = ""
+  public var name: String = String()
 
   /// Enum value number.
   public var number: Int32 = 0
@@ -613,7 +613,7 @@ public struct Google_Protobuf_Option: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".Option"
 
   fileprivate class _StorageClass {
-    var _name: String = ""
+    var _name: String = String()
     var _value: Google_Protobuf_Any? = nil
 
     init() {}

--- a/Sources/SwiftProtobuf/wrappers.pb.swift
+++ b/Sources/SwiftProtobuf/wrappers.pb.swift
@@ -270,7 +270,7 @@ public struct Google_Protobuf_StringValue: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".StringValue"
 
   /// The string value.
-  public var value: String = ""
+  public var value: String = String()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Sources/SwiftProtobuf/wrappers.pb.swift
+++ b/Sources/SwiftProtobuf/wrappers.pb.swift
@@ -300,7 +300,7 @@ public struct Google_Protobuf_BytesValue: SwiftProtobuf.Message {
   public static let protoMessageName: String = _protobuf_package + ".BytesValue"
 
   /// The bytes value.
-  public var value: Data = Data()
+  public var value: Data = SwiftProtobuf.Internal.emptyData
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -179,7 +179,7 @@ extension Google_Protobuf_FieldDescriptorProto {
         switch type {
         case .bool: return "false"
         case .string: return "String()"
-        case .bytes: return "Data()"
+        case .bytes: return "SwiftProtobuf.Internal.emptyData"
         case .group, .message:
             return context.getMessageNameForPath(path: typeName)! + "()"
         case .enum:

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -178,7 +178,7 @@ extension Google_Protobuf_FieldDescriptorProto {
         }
         switch type {
         case .bool: return "false"
-        case .string: return "\"\""
+        case .string: return "String()"
         case .bytes: return "Data()"
         case .group, .message:
             return context.getMessageNameForPath(path: typeName)! + "()"

--- a/Sources/protoc-gen-swift/StringUtils.swift
+++ b/Sources/protoc-gen-swift/StringUtils.swift
@@ -252,6 +252,9 @@ func escapedToDataLiteral(_ s: String) -> String {
 private let hexdigits = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"]
 
 func stringToEscapedStringLiteral(_ s: String) -> String {
+  if s.isEmpty {
+    return "String()"
+  }
   var out = "\""
   for c in s.unicodeScalars {
     switch c.value {

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -91,7 +91,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   var protobufPayload: Data {
     get {
       if case .protobufPayload(let v)? = payload { return v }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set { payload = .protobufPayload(newValue) }
   }
@@ -101,7 +101,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   var jsonPayload: String {
     get {
       if case .jsonPayload(let v)? = payload { return v }
-      return ""
+      return String()
     }
     set { payload = .jsonPayload(newValue) }
   }
@@ -161,7 +161,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var parseError: String {
     get {
       if case .parseError(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .parseError(newValue) }
   }
@@ -174,7 +174,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var serializeError: String {
     get {
       if case .serializeError(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .serializeError(newValue) }
   }
@@ -185,7 +185,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var runtimeError: String {
     get {
       if case .runtimeError(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .runtimeError(newValue) }
   }
@@ -195,7 +195,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var protobufPayload: Data {
     get {
       if case .protobufPayload(let v)? = result { return v }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set { result = .protobufPayload(newValue) }
   }
@@ -205,7 +205,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var jsonPayload: String {
     get {
       if case .jsonPayload(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .jsonPayload(newValue) }
   }
@@ -215,7 +215,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   var skipped: String {
     get {
       if case .skipped(let v)? = result { return v }
-      return ""
+      return String()
     }
     set { result = .skipped(newValue) }
   }

--- a/Tests/SwiftProtobufTests/descriptor.pb.swift
+++ b/Tests/SwiftProtobufTests/descriptor.pb.swift
@@ -137,7 +137,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
 
   /// file name, relative to root of source tree
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -149,7 +149,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
 
   /// e.g. "foo", "foo.bar", etc.
   var package: String {
-    get {return _storage._package ?? ""}
+    get {return _storage._package ?? String()}
     set {_uniqueStorage()._package = newValue}
   }
   var hasPackage: Bool {
@@ -228,7 +228,7 @@ struct Google_Protobuf_FileDescriptorProto: SwiftProtobuf.Message {
   /// The syntax of the proto file.
   /// The supported values are "proto2" and "proto3".
   var syntax: String {
-    get {return _storage._syntax ?? ""}
+    get {return _storage._syntax ?? String()}
     set {_uniqueStorage()._syntax = newValue}
   }
   var hasSyntax: Bool {
@@ -361,7 +361,7 @@ struct Google_Protobuf_DescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -649,7 +649,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -700,7 +700,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// message are searched, then within the parent, on up to the root
   /// namespace).
   var typeName: String {
-    get {return _storage._typeName ?? ""}
+    get {return _storage._typeName ?? String()}
     set {_uniqueStorage()._typeName = newValue}
   }
   var hasTypeName: Bool {
@@ -713,7 +713,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// For extensions, this is the name of the type being extended.  It is
   /// resolved in the same manner as type_name.
   var extendee: String {
-    get {return _storage._extendee ?? ""}
+    get {return _storage._extendee ?? String()}
     set {_uniqueStorage()._extendee = newValue}
   }
   var hasExtendee: Bool {
@@ -729,7 +729,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
   /// TODO(kenton):  Base-64 encode?
   var defaultValue: String {
-    get {return _storage._defaultValue ?? ""}
+    get {return _storage._defaultValue ?? String()}
     set {_uniqueStorage()._defaultValue = newValue}
   }
   var hasDefaultValue: Bool {
@@ -757,7 +757,7 @@ struct Google_Protobuf_FieldDescriptorProto: SwiftProtobuf.Message {
   /// will be used. Otherwise, it's deduced from the field's name by converting
   /// it to camelCase.
   var jsonName: String {
-    get {return _storage._jsonName ?? ""}
+    get {return _storage._jsonName ?? String()}
     set {_uniqueStorage()._jsonName = newValue}
   }
   var hasJsonName: Bool {
@@ -1000,7 +1000,7 @@ struct Google_Protobuf_OneofDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -1086,7 +1086,7 @@ struct Google_Protobuf_EnumDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -1182,7 +1182,7 @@ struct Google_Protobuf_EnumValueDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -1283,7 +1283,7 @@ struct Google_Protobuf_ServiceDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -1385,7 +1385,7 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   }
 
   var name: String {
-    get {return _storage._name ?? ""}
+    get {return _storage._name ?? String()}
     set {_uniqueStorage()._name = newValue}
   }
   var hasName: Bool {
@@ -1398,7 +1398,7 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   /// Input and output type names.  These are resolved in the same way as
   /// FieldDescriptorProto.type_name, but must refer to a message type.
   var inputType: String {
-    get {return _storage._inputType ?? ""}
+    get {return _storage._inputType ?? String()}
     set {_uniqueStorage()._inputType = newValue}
   }
   var hasInputType: Bool {
@@ -1409,7 +1409,7 @@ struct Google_Protobuf_MethodDescriptorProto: SwiftProtobuf.Message {
   }
 
   var outputType: String {
-    get {return _storage._outputType ?? ""}
+    get {return _storage._outputType ?? String()}
     set {_uniqueStorage()._outputType = newValue}
   }
   var hasOutputType: Bool {
@@ -1566,7 +1566,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   /// inappropriate because proto packages do not normally start with backwards
   /// domain names.
   var javaPackage: String {
-    get {return _storage._javaPackage ?? ""}
+    get {return _storage._javaPackage ?? String()}
     set {_uniqueStorage()._javaPackage = newValue}
   }
   var hasJavaPackage: Bool {
@@ -1582,7 +1582,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   /// a .proto always translates to a single class, but you may want to
   /// explicitly choose the class name).
   var javaOuterClassname: String {
-    get {return _storage._javaOuterClassname ?? ""}
+    get {return _storage._javaOuterClassname ?? String()}
     set {_uniqueStorage()._javaOuterClassname = newValue}
   }
   var hasJavaOuterClassname: Bool {
@@ -1655,7 +1655,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   ///   - Otherwise, the package statement in the .proto file, if present.
   ///   - Otherwise, the basename of the .proto file, without extension.
   var goPackage: String {
-    get {return _storage._goPackage ?? ""}
+    get {return _storage._goPackage ?? String()}
     set {_uniqueStorage()._goPackage = newValue}
   }
   var hasGoPackage: Bool {
@@ -1739,7 +1739,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   /// Sets the objective c class prefix which is prepended to all objective c
   /// generated classes from this .proto. There is no default.
   var objcClassPrefix: String {
-    get {return _storage._objcClassPrefix ?? ""}
+    get {return _storage._objcClassPrefix ?? String()}
     set {_uniqueStorage()._objcClassPrefix = newValue}
   }
   var hasObjcClassPrefix: Bool {
@@ -1751,7 +1751,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
 
   /// Namespace for generated classes; defaults to the package.
   var csharpNamespace: String {
-    get {return _storage._csharpNamespace ?? ""}
+    get {return _storage._csharpNamespace ?? String()}
     set {_uniqueStorage()._csharpNamespace = newValue}
   }
   var hasCsharpNamespace: Bool {
@@ -1766,7 +1766,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   /// defined. When this options is provided, they will use this value instead
   /// to prefix the types/symbols defined.
   var swiftPrefix: String {
-    get {return _storage._swiftPrefix ?? ""}
+    get {return _storage._swiftPrefix ?? String()}
     set {_uniqueStorage()._swiftPrefix = newValue}
   }
   var hasSwiftPrefix: Bool {
@@ -1779,7 +1779,7 @@ struct Google_Protobuf_FileOptions: SwiftProtobuf.Message, SwiftProtobuf.Extensi
   /// Sets the php class prefix which is prepended to all php generated classes
   /// from this .proto. Default is empty.
   var phpClassPrefix: String {
-    get {return _storage._phpClassPrefix ?? ""}
+    get {return _storage._phpClassPrefix ?? String()}
     set {_uniqueStorage()._phpClassPrefix = newValue}
   }
   var hasPhpClassPrefix: Bool {
@@ -2688,7 +2688,7 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
   /// identified it as during parsing. Exactly one of these should be set.
   fileprivate var _identifierValue: String? = nil
   var identifierValue: String {
-    get {return _identifierValue ?? ""}
+    get {return _identifierValue ?? String()}
     set {_identifierValue = newValue}
   }
   var hasIdentifierValue: Bool {
@@ -2736,7 +2736,7 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
   fileprivate var _stringValue: Data? = nil
   var stringValue: Data {
-    get {return _stringValue ?? Data()}
+    get {return _stringValue ?? SwiftProtobuf.Internal.emptyData}
     set {_stringValue = newValue}
   }
   var hasStringValue: Bool {
@@ -2748,7 +2748,7 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
   fileprivate var _aggregateValue: String? = nil
   var aggregateValue: String {
-    get {return _aggregateValue ?? ""}
+    get {return _aggregateValue ?? String()}
     set {_aggregateValue = newValue}
   }
   var hasAggregateValue: Bool {
@@ -2770,7 +2770,7 @@ struct Google_Protobuf_UninterpretedOption: SwiftProtobuf.Message {
 
     fileprivate var _namePart: String? = nil
     var namePart: String {
-      get {return _namePart ?? ""}
+      get {return _namePart ?? String()}
       set {_namePart = newValue}
     }
     var hasNamePart: Bool {
@@ -3007,7 +3007,7 @@ struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
     ///   // ignored detached comments.
     fileprivate var _leadingComments: String? = nil
     var leadingComments: String {
-      get {return _leadingComments ?? ""}
+      get {return _leadingComments ?? String()}
       set {_leadingComments = newValue}
     }
     var hasLeadingComments: Bool {
@@ -3019,7 +3019,7 @@ struct Google_Protobuf_SourceCodeInfo: SwiftProtobuf.Message {
 
     fileprivate var _trailingComments: String? = nil
     var trailingComments: String {
-      get {return _trailingComments ?? ""}
+      get {return _trailingComments ?? String()}
       set {_trailingComments = newValue}
     }
     var hasTrailingComments: Bool {
@@ -3109,7 +3109,7 @@ struct Google_Protobuf_GeneratedCodeInfo: SwiftProtobuf.Message {
     /// Identifies the filesystem path to the original source .proto.
     fileprivate var _sourceFile: String? = nil
     var sourceFile: String {
-      get {return _sourceFile ?? ""}
+      get {return _sourceFile ?? String()}
       set {_sourceFile = newValue}
     }
     var hasSourceFile: Bool {

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -110,14 +110,14 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalNestedMessage: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage? = nil
     var _optionalForeignMessage: ProtobufTestMessages_Proto3_ForeignMessage? = nil
     var _optionalNestedEnum: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum.foo
     var _optionalForeignEnum: ProtobufTestMessages_Proto3_ForeignEnum = ProtobufTestMessages_Proto3_ForeignEnum.foreignFoo
-    var _optionalStringPiece: String = ""
-    var _optionalCord: String = ""
+    var _optionalStringPiece: String = String()
+    var _optionalCord: String = String()
     var _recursiveMessage: ProtobufTestMessages_Proto3_TestAllTypes? = nil
     var _repeatedInt32: [Int32] = []
     var _repeatedInt64: [Int64] = []
@@ -695,7 +695,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -707,7 +707,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -469,7 +469,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -480,7 +480,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {
@@ -568,7 +568,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalStringPiece: String {
-    get {return _storage._optionalStringPiece ?? ""}
+    get {return _storage._optionalStringPiece ?? String()}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
   var hasOptionalStringPiece: Bool {
@@ -579,7 +579,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalCord: String {
-    get {return _storage._optionalCord ?? ""}
+    get {return _storage._optionalCord ?? String()}
     set {_uniqueStorage()._optionalCord = newValue}
   }
   var hasOptionalCord: Bool {
@@ -988,7 +988,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -1000,7 +1000,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -1820,7 +1820,7 @@ struct ProtobufUnittest_TestNestedExtension: SwiftProtobuf.Message {
     static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
       _protobuf_fieldNumber: 1003,
       fieldName: "protobuf_unittest.TestNestedExtension.nested_string_extension",
-      defaultValue: ""
+      defaultValue: String()
     )
   }
 
@@ -3409,7 +3409,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message {
   }
 
   var stringField: String {
-    get {return _storage._stringField ?? ""}
+    get {return _storage._stringField ?? String()}
     set {_uniqueStorage()._stringField = newValue}
   }
   var hasStringField: Bool {
@@ -3442,7 +3442,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message {
   }
 
   var stringPieceField: String {
-    get {return _storage._stringPieceField ?? ""}
+    get {return _storage._stringPieceField ?? String()}
     set {_uniqueStorage()._stringPieceField = newValue}
   }
   var hasStringPieceField: Bool {
@@ -3453,7 +3453,7 @@ struct ProtobufUnittest_TestCamelCaseFieldNames: SwiftProtobuf.Message {
   }
 
   var cordField: String {
-    get {return _storage._cordField ?? ""}
+    get {return _storage._cordField ?? String()}
     set {_uniqueStorage()._cordField = newValue}
   }
   var hasCordField: Bool {
@@ -3594,7 +3594,7 @@ struct ProtobufUnittest_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf
   }
 
   var myString: String {
-    get {return _storage._myString ?? ""}
+    get {return _storage._myString ?? String()}
     set {_uniqueStorage()._myString = newValue}
   }
   var hasMyString: Bool {
@@ -4296,7 +4296,7 @@ struct ProtobufUnittest_OneString: SwiftProtobuf.Message {
 
   fileprivate var _data: String? = nil
   var data: String {
-    get {return _data ?? ""}
+    get {return _data ?? String()}
     set {_data = newValue}
   }
   var hasData: Bool {
@@ -4358,7 +4358,7 @@ struct ProtobufUnittest_OneBytes: SwiftProtobuf.Message {
 
   fileprivate var _data: Data? = nil
   var data: Data {
-    get {return _data ?? Data()}
+    get {return _data ?? SwiftProtobuf.Internal.emptyData}
     set {_data = newValue}
   }
   var hasData: Bool {
@@ -4636,7 +4636,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
       if case .fooString(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooString(newValue)
@@ -4710,7 +4710,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
 
     fileprivate var _b: String? = nil
     var b: String {
-      get {return _b ?? ""}
+      get {return _b ?? String()}
       set {_b = newValue}
     }
     var hasB: Bool {
@@ -4811,7 +4811,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: SwiftProtobuf.Message {
   }
 
   var fooString: String {
-    get {return _storage._fooString ?? ""}
+    get {return _storage._fooString ?? String()}
     set {_uniqueStorage()._fooString = newValue}
   }
   var hasFooString: Bool {
@@ -4862,7 +4862,7 @@ struct ProtobufUnittest_TestOneofBackwardsCompatible: SwiftProtobuf.Message {
 
     fileprivate var _b: String? = nil
     var b: String {
-      get {return _b ?? ""}
+      get {return _b ?? String()}
       set {_b = newValue}
     }
     var hasB: Bool {
@@ -4978,7 +4978,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       if case .fooString(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooString(newValue)
@@ -4990,7 +4990,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       if case .fooCord(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooCord(newValue)
@@ -5002,7 +5002,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       if case .fooStringPiece(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooStringPiece(newValue)
@@ -5014,7 +5014,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
       if case .fooBytes(let v)? = _storage._foo {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._foo = .fooBytes(newValue)
@@ -5273,7 +5273,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
 
     fileprivate var _b: String? = nil
     var b: String {
-      get {return _b ?? ""}
+      get {return _b ?? String()}
       set {_b = newValue}
     }
     var hasB: Bool {
@@ -5429,7 +5429,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message {
       if case .fooString(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooString(newValue)
@@ -6886,7 +6886,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -6897,7 +6897,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {
@@ -6963,7 +6963,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -6975,7 +6975,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -7202,13 +7202,13 @@ let ProtobufUnittest_Extensions_optional_bool_extension = SwiftProtobuf.MessageE
 let ProtobufUnittest_Extensions_optional_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 14,
   fieldName: "protobuf_unittest.optional_string_extension",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 15,
   fieldName: "protobuf_unittest.optional_bytes_extension",
-  defaultValue: Data()
+  defaultValue: SwiftProtobuf.Internal.emptyData
 )
 
 let ProtobufUnittest_Extensions_OptionalGroup_extension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
@@ -7256,13 +7256,13 @@ let ProtobufUnittest_Extensions_optional_import_enum_extension = SwiftProtobuf.M
 let ProtobufUnittest_Extensions_optional_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 24,
   fieldName: "protobuf_unittest.optional_string_piece_extension",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 25,
   fieldName: "protobuf_unittest.optional_cord_extension",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_public_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessage>, ProtobufUnittest_TestAllExtensions>(
@@ -7565,19 +7565,19 @@ let ProtobufUnittest_Extensions_oneof_nested_message_extension = SwiftProtobuf.M
 let ProtobufUnittest_Extensions_oneof_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 113,
   fieldName: "protobuf_unittest.oneof_string_extension",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_oneof_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 114,
   fieldName: "protobuf_unittest.oneof_bytes_extension",
-  defaultValue: Data()
+  defaultValue: SwiftProtobuf.Internal.emptyData
 )
 
 let ProtobufUnittest_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestFieldOrderings>(
   _protobuf_fieldNumber: 50,
   fieldName: "protobuf_unittest.my_extension_string",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestFieldOrderings>(
@@ -7779,7 +7779,7 @@ extension ProtobufUnittest_TestAllExtensions {
   /// Used to test if generated extension name is correct when there are
   /// underscores.
   var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
@@ -8014,7 +8014,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringExtension: Bool {
@@ -8027,7 +8027,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalBytesExtension: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension) ?? Data()}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalBytesExtension: Bool {
@@ -8131,7 +8131,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringPieceExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringPieceExtension: Bool {
@@ -8144,7 +8144,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalCordExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension, value: newValue)}
   }
   var hasProtobufUnittest_optionalCordExtension: Bool {
@@ -8797,7 +8797,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofStringExtension: Bool {
@@ -8810,7 +8810,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofBytesExtension: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension) ?? Data()}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension, value: newValue)}
   }
   var hasProtobufUnittest_oneofBytesExtension: Bool {
@@ -8823,7 +8823,7 @@ extension ProtobufUnittest_TestAllExtensions {
 
 extension ProtobufUnittest_TestFieldOrderings {
   var ProtobufUnittest_myExtensionString: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string, value: newValue)}
   }
   var hasProtobufUnittest_myExtensionString: Bool {

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -111,7 +111,7 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
 
   fileprivate var _field1: String? = nil
   var field1: String {
-    get {return _field1 ?? ""}
+    get {return _field1 ?? String()}
     set {_field1 = newValue}
   }
   var hasField1: Bool {
@@ -854,7 +854,7 @@ struct ProtobufUnittest_AggregateMessageSetElement: SwiftProtobuf.Message {
 
   fileprivate var _s: String? = nil
   var s: String {
-    get {return _s ?? ""}
+    get {return _s ?? String()}
     set {_s = newValue}
   }
   var hasS: Bool {
@@ -937,7 +937,7 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
   }
 
   var s: String {
-    get {return _storage._s ?? ""}
+    get {return _storage._s ?? String()}
     set {_uniqueStorage()._s = newValue}
   }
   var hasS: Bool {
@@ -1454,13 +1454,13 @@ let ProtobufUnittest_Extensions_double_opt = SwiftProtobuf.MessageExtension<Opti
 let ProtobufUnittest_Extensions_string_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Google_Protobuf_MessageOptions>(
   _protobuf_fieldNumber: 7673285,
   fieldName: "protobuf_unittest.string_opt",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_bytes_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, Google_Protobuf_MessageOptions>(
   _protobuf_fieldNumber: 7673238,
   fieldName: "protobuf_unittest.bytes_opt",
-  defaultValue: Data()
+  defaultValue: SwiftProtobuf.Internal.emptyData
 )
 
 let ProtobufUnittest_Extensions_enum_opt = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_DummyMessageContainingEnum.TestEnumType>, Google_Protobuf_MessageOptions>(
@@ -1913,7 +1913,7 @@ extension Google_Protobuf_MessageOptions {
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_stringOpt: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_string_opt) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_string_opt) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_string_opt, value: newValue)}
   }
   var hasProtobufUnittest_stringOpt: Bool {
@@ -1926,7 +1926,7 @@ extension Google_Protobuf_MessageOptions {
 
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_bytesOpt: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt) ?? Data()}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt, value: newValue)}
   }
   var hasProtobufUnittest_bytesOpt: Bool {

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -443,7 +443,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -454,7 +454,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {
@@ -542,7 +542,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
   }
 
   var optionalStringPiece: String {
-    get {return _storage._optionalStringPiece ?? ""}
+    get {return _storage._optionalStringPiece ?? String()}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
   var hasOptionalStringPiece: Bool {
@@ -553,7 +553,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
   }
 
   var optionalCord: String {
-    get {return _storage._optionalCord ?? ""}
+    get {return _storage._optionalCord ?? String()}
     set {_uniqueStorage()._optionalCord = newValue}
   }
   var hasOptionalCord: Bool {
@@ -962,7 +962,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -974,7 +974,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -2522,7 +2522,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -2533,7 +2533,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {
@@ -2599,7 +2599,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -2611,7 +2611,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -2838,13 +2838,13 @@ let ProtobufUnittest_Extensions_optional_bool_extension_lite = SwiftProtobuf.Mes
 let ProtobufUnittest_Extensions_optional_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 14,
   fieldName: "protobuf_unittest.optional_string_extension_lite",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 15,
   fieldName: "protobuf_unittest.optional_bytes_extension_lite",
-  defaultValue: Data()
+  defaultValue: SwiftProtobuf.Internal.emptyData
 )
 
 let ProtobufUnittest_Extensions_OptionalGroup_extension_lite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
@@ -2892,13 +2892,13 @@ let ProtobufUnittest_Extensions_optional_import_enum_extension_lite = SwiftProto
 let ProtobufUnittest_Extensions_optional_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 24,
   fieldName: "protobuf_unittest.optional_string_piece_extension_lite",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 25,
   fieldName: "protobuf_unittest.optional_cord_extension_lite",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_optional_public_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
@@ -3201,13 +3201,13 @@ let ProtobufUnittest_Extensions_oneof_nested_message_extension_lite = SwiftProto
 let ProtobufUnittest_Extensions_oneof_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 113,
   fieldName: "protobuf_unittest.oneof_string_extension_lite",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extensions_oneof_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 114,
   fieldName: "protobuf_unittest.oneof_bytes_extension_lite",
-  defaultValue: Data()
+  defaultValue: SwiftProtobuf.Internal.emptyData
 )
 
 let ProtobufUnittest_Extensions_packed_int32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
@@ -3511,7 +3511,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringExtensionLite: Bool {
@@ -3524,7 +3524,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalBytesExtensionLite: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite) ?? Data()}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalBytesExtensionLite: Bool {
@@ -3628,7 +3628,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringPieceExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalStringPieceExtensionLite: Bool {
@@ -3641,7 +3641,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalCordExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_optionalCordExtensionLite: Bool {
@@ -4294,7 +4294,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofStringExtensionLite: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofStringExtensionLite: Bool {
@@ -4307,7 +4307,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
 
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofBytesExtensionLite: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite) ?? Data()}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite, value: newValue)}
   }
   var hasProtobufUnittest_oneofBytesExtensionLite: Bool {

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -172,7 +172,7 @@ struct ProtobufUnittest_TestMessageSetExtension2: SwiftProtobuf.Message {
 
   fileprivate var _str: String? = nil
   var str: String {
-    get {return _str ?? ""}
+    get {return _str ?? String()}
     set {_str = newValue}
   }
   var hasStr: Bool {
@@ -237,7 +237,7 @@ struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message {
 
     fileprivate var _message: Data? = nil
     var message: Data {
-      get {return _message ?? Data()}
+      get {return _message ?? SwiftProtobuf.Internal.emptyData}
       set {_message = newValue}
     }
     var hasMessage: Bool {

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -397,7 +397,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -408,7 +408,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {
@@ -496,7 +496,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalStringPiece: String {
-    get {return _storage._optionalStringPiece ?? ""}
+    get {return _storage._optionalStringPiece ?? String()}
     set {_uniqueStorage()._optionalStringPiece = newValue}
   }
   var hasOptionalStringPiece: Bool {
@@ -507,7 +507,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
   }
 
   var optionalCord: String {
-    get {return _storage._optionalCord ?? ""}
+    get {return _storage._optionalCord ?? String()}
     set {_uniqueStorage()._optionalCord = newValue}
   }
   var hasOptionalCord: Bool {
@@ -916,7 +916,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -928,7 +928,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -101,15 +101,15 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage? = nil
     var _optionalForeignMessage: Proto2NofieldpresenceUnittest_ForeignMessage? = nil
     var _optionalProto2Message: ProtobufUnittest_TestAllTypes? = nil
     var _optionalNestedEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum = Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum.foo
     var _optionalForeignEnum: Proto2NofieldpresenceUnittest_ForeignEnum = Proto2NofieldpresenceUnittest_ForeignEnum.foreignFoo
-    var _optionalStringPiece: String = ""
-    var _optionalCord: String = ""
+    var _optionalStringPiece: String = String()
+    var _optionalCord: String = String()
     var _optionalLazyMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage? = nil
     var _repeatedInt32: [Int32] = []
     var _repeatedInt64: [Int64] = []
@@ -488,7 +488,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -120,7 +120,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
       if case .stringField(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .stringField(newValue)

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -192,8 +192,8 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     var _singleFloat: Float = 0
     var _singleDouble: Double = 0
     var _singleBool: Bool = false
-    var _singleString: String = ""
-    var _singleBytes: Data = Data()
+    var _singleString: String = String()
+    var _singleBytes: Data = SwiftProtobuf.Internal.emptyData
     var _singleNestedMessage: Proto3TestAllTypes.NestedMessage? = nil
     var _singleForeignMessage: Proto3ForeignMessage? = nil
     var _singleImportMessage: Proto3ImportMessage? = nil
@@ -562,7 +562,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -574,7 +574,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -1364,7 +1364,7 @@ struct Proto3TestCamelCaseFieldNames: SwiftProtobuf.Message {
 
   fileprivate class _StorageClass {
     var _primitiveField: Int32 = 0
-    var _stringField: String = ""
+    var _stringField: String = String()
     var _enumField: Proto3ForeignEnum = Proto3ForeignEnum.foreignUnspecified
     var _messageField: Proto3ForeignMessage? = nil
     var _repeatedPrimitiveField: [Int32] = []
@@ -1501,7 +1501,7 @@ struct Proto3TestFieldOrderings: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestFieldOrderings"
 
   fileprivate class _StorageClass {
-    var _myString: String = ""
+    var _myString: String = String()
     var _myInt: Int64 = 0
     var _myFloat: Float = 0
     var _singleNestedMessage: Proto3TestFieldOrderings.NestedMessage? = nil
@@ -1654,7 +1654,7 @@ struct Proto3SparseEnumMessage: SwiftProtobuf.Message {
 struct Proto3OneString: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OneString"
 
-  var data: String = ""
+  var data: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1706,7 +1706,7 @@ struct Proto3MoreString: SwiftProtobuf.Message {
 struct Proto3OneBytes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".OneBytes"
 
-  var data: Data = Data()
+  var data: Data = SwiftProtobuf.Internal.emptyData
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1732,7 +1732,7 @@ struct Proto3OneBytes: SwiftProtobuf.Message {
 struct Proto3MoreBytes: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".MoreBytes"
 
-  var data: Data = Data()
+  var data: Data = SwiftProtobuf.Internal.emptyData
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1926,7 +1926,7 @@ struct Proto3TestOneof: SwiftProtobuf.Message {
       if case .fooString(let v)? = _storage._foo {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._foo = .fooString(newValue)
@@ -2271,7 +2271,7 @@ struct Proto3TestCommentInjectionMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestCommentInjectionMessage"
 
   /// */ <- This should not close the generated doc comment
-  var a: String = ""
+  var a: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -102,15 +102,15 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage? = nil
     var _optionalForeignMessage: Proto3ArenaUnittest_ForeignMessage? = nil
     var _optionalImportMessage: ProtobufUnittestImport_ImportMessage? = nil
     var _optionalNestedEnum: Proto3ArenaUnittest_TestAllTypes.NestedEnum = Proto3ArenaUnittest_TestAllTypes.NestedEnum.zero
     var _optionalForeignEnum: Proto3ArenaUnittest_ForeignEnum = Proto3ArenaUnittest_ForeignEnum.foreignZero
-    var _optionalStringPiece: String = ""
-    var _optionalCord: String = ""
+    var _optionalStringPiece: String = String()
+    var _optionalCord: String = String()
     var _optionalPublicImportMessage: ProtobufUnittestImport_PublicImportMessage? = nil
     var _optionalLazyMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage? = nil
     var _repeatedInt32: [Int32] = []
@@ -498,7 +498,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -510,7 +510,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -310,7 +310,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
   }
 
   var requiredString: String {
-    get {return _storage._requiredString ?? ""}
+    get {return _storage._requiredString ?? String()}
     set {_uniqueStorage()._requiredString = newValue}
   }
   var hasRequiredString: Bool {
@@ -321,7 +321,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
   }
 
   var requiredBytes: Data {
-    get {return _storage._requiredBytes ?? Data()}
+    get {return _storage._requiredBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._requiredBytes = newValue}
   }
   var hasRequiredBytes: Bool {
@@ -409,7 +409,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
   }
 
   var requiredStringPiece: String {
-    get {return _storage._requiredStringPiece ?? ""}
+    get {return _storage._requiredStringPiece ?? String()}
     set {_uniqueStorage()._requiredStringPiece = newValue}
   }
   var hasRequiredStringPiece: Bool {
@@ -420,7 +420,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
   }
 
   var requiredCord: String {
-    get {return _storage._requiredCord ?? ""}
+    get {return _storage._requiredCord ?? String()}
     set {_uniqueStorage()._requiredCord = newValue}
   }
   var hasRequiredCord: Bool {
@@ -703,7 +703,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._oneofField {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._oneofField = .oneofString(newValue)
@@ -715,7 +715,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._oneofField {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._oneofField = .oneofBytes(newValue)
@@ -1180,7 +1180,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf.Message {
 
   fileprivate var _requiredString: String? = nil
   var requiredString: String {
-    get {return _requiredString ?? ""}
+    get {return _requiredString ?? String()}
     set {_requiredString = newValue}
   }
   var hasRequiredString: Bool {
@@ -1192,7 +1192,7 @@ struct ProtobufUnittest_TestSomeRequiredTypes: SwiftProtobuf.Message {
 
   fileprivate var _requiredBytes: Data? = nil
   var requiredBytes: Data {
-    get {return _requiredBytes ?? Data()}
+    get {return _requiredBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_requiredBytes = newValue}
   }
   var hasRequiredBytes: Bool {

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -347,7 +347,7 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
 let ProtobufUnittest_Extend_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 100,
   fieldName: "protobuf_unittest.extend.b",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extend_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -394,7 +394,7 @@ let ProtobufUnittest_Extend_Extensions_ext_d = SwiftProtobuf.MessageExtension<Op
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b, value: newValue)}
   }
   var hasProtobufUnittest_Extend_b: Bool {

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -83,7 +83,7 @@ struct ProtobufUnittest_Extend2_MyMessage: SwiftProtobuf.Message {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 210,
       fieldName: "protobuf_unittest.extend2.MyMessage.b",
-      defaultValue: ""
+      defaultValue: String()
     )
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -144,7 +144,7 @@ struct ProtobufUnittest_Extend2_C: SwiftProtobuf.Message {
 let ProtobufUnittest_Extend2_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 220,
   fieldName: "protobuf_unittest.extend2.b",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -155,7 +155,7 @@ let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<Optio
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_MyMessage_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b, value: newValue)}
   }
   var hasProtobufUnittest_Extend2_MyMessage_b: Bool {
@@ -181,7 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b, value: newValue)}
   }
   var hasProtobufUnittest_Extend2_b: Bool {

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -83,7 +83,7 @@ struct ProtobufUnittest_Extend3_MyMessage: SwiftProtobuf.Message {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 310,
       fieldName: "protobuf_unittest.extend3.MyMessage.b",
-      defaultValue: ""
+      defaultValue: String()
     )
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -144,7 +144,7 @@ struct ProtobufUnittest_Extend3_C: SwiftProtobuf.Message {
 let ProtobufUnittest_Extend3_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 320,
   fieldName: "protobuf_unittest.extend3.b",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -155,7 +155,7 @@ let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<Optio
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_MyMessage_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b, value: newValue)}
   }
   var hasProtobufUnittest_Extend3_MyMessage_b: Bool {
@@ -181,7 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b) ?? ""}
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b, value: newValue)}
   }
   var hasProtobufUnittest_Extend3_b: Bool {

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -83,7 +83,7 @@ struct Ext4MyMessage: SwiftProtobuf.Message {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 410,
       fieldName: "protobuf_unittest.extend4.MyMessage.b",
-      defaultValue: ""
+      defaultValue: String()
     )
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -144,7 +144,7 @@ struct Ext4C: SwiftProtobuf.Message {
 let Ext4Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 420,
   fieldName: "protobuf_unittest.extend4.b",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
@@ -155,7 +155,7 @@ let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionFiel
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4MyMessage_b: String {
-    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? ""}
+    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: Ext4MyMessage.Extensions.b, value: newValue)}
   }
   var hasExt4MyMessage_b: Bool {
@@ -181,7 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4b: String {
-    get {return getExtensionValue(ext: Ext4Extensions_b) ?? ""}
+    get {return getExtensionValue(ext: Ext4Extensions_b) ?? String()}
     set {setExtensionValue(ext: Ext4Extensions_b, value: newValue)}
   }
   var hasExt4b: Bool {

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -66,7 +66,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
   }
 
   var myString: String {
-    get {return _storage._myString ?? ""}
+    get {return _storage._myString ?? String()}
     set {_uniqueStorage()._myString = newValue}
   }
   var hasMyString: Bool {
@@ -127,7 +127,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
       if case .oneofString(let v)? = _storage._options {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._options = .oneofString(newValue)
@@ -293,7 +293,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
 let Swift_Protobuf_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(
   _protobuf_fieldNumber: 50,
   fieldName: "swift.protobuf.my_extension_string",
-  defaultValue: ""
+  defaultValue: String()
 )
 
 let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(
@@ -304,7 +304,7 @@ let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<
 
 extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionString: String {
-    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string) ?? ""}
+    get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string) ?? String()}
     set {setExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string, value: newValue)}
   }
   var hasSwift_Protobuf_myExtensionString: Bool {

--- a/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_performance.pb.swift
@@ -66,8 +66,8 @@ struct Swift_Performance_TestAllTypes: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _repeatedRecursiveMessage: [Swift_Performance_TestAllTypes] = []
     var _repeatedInt32: [Int32] = []
     var _repeatedInt64: [Int64] = []

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -90,7 +90,7 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
   /// r/o properties on Message, ensure it gets remapped.
   fileprivate var _isInitialized_p: String? = nil
   var isInitialized_p: String {
-    get {return _isInitialized_p ?? ""}
+    get {return _isInitialized_p ?? String()}
     set {_isInitialized_p = newValue}
   }
   var hasIsInitialized_p: Bool {
@@ -102,7 +102,7 @@ struct ProtobufUnittest_SwiftReservedTest: SwiftProtobuf.Message {
 
   fileprivate var _hashValue_p: String? = nil
   var hashValue_p: String {
-    get {return _hashValue_p ?? ""}
+    get {return _hashValue_p ?? String()}
     set {_hashValue_p = newValue}
   }
   var hasHashValue_p: Bool {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -324,7 +324,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
   }
 
   var optionalString: String {
-    get {return _storage._optionalString ?? ""}
+    get {return _storage._optionalString ?? String()}
     set {_uniqueStorage()._optionalString = newValue}
   }
   var hasOptionalString: Bool {
@@ -335,7 +335,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
   }
 
   var optionalBytes: Data {
-    get {return _storage._optionalBytes ?? Data()}
+    get {return _storage._optionalBytes ?? SwiftProtobuf.Internal.emptyData}
     set {_uniqueStorage()._optionalBytes = newValue}
   }
   var hasOptionalBytes: Bool {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -65,8 +65,8 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
     var _optionalFloat: Float = 0
     var _optionalDouble: Double = 0
     var _optionalBool: Bool = false
-    var _optionalString: String = ""
-    var _optionalBytes: Data = Data()
+    var _optionalString: String = String()
+    var _optionalBytes: Data = SwiftProtobuf.Internal.emptyData
     var _optionalMessage: ProtobufUnittest_Message3? = nil
     var _optionalEnum: ProtobufUnittest_Message3.Enum = ProtobufUnittest_Message3.Enum.foo
     var _repeatedInt32: [Int32] = []
@@ -515,7 +515,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
       if case .oneofString(let v)? = _storage._o {
         return v
       }
-      return ""
+      return String()
     }
     set {
       _uniqueStorage()._o = .oneofString(newValue)
@@ -527,7 +527,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
       if case .oneofBytes(let v)? = _storage._o {
         return v
       }
-      return Data()
+      return SwiftProtobuf.Internal.emptyData
     }
     set {
       _uniqueStorage()._o = .oneofBytes(newValue)

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -87,7 +87,7 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
     static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
       _protobuf_fieldNumber: 3,
       fieldName: "protobuf_objc_unittest.TestObjCStartupNested.nested_string_extension",
-      defaultValue: ""
+      defaultValue: String()
     )
   }
 
@@ -118,7 +118,7 @@ let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.Mes
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? ""}
+    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension, value: newValue)}
   }
   var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {


### PR DESCRIPTION
I've replaced `""` with `String()` throughout the runtime and generated code, and `Data()` with a static singleton `Internal.emptyData`.

The speedup for strings is about 1.3x across the board. The speedup for data varies, with a whopping 14x speedup for creating empty messages with lots of `Data` fields.

Click below for pretty graphs:
![Perf visualization](http://i.imgur.com/m7iWn1J.png)

Partially addresses #457 (still need to do statics for non-empty defaults).