### PR TITLE
Extension generation factoring

### DIFF
--- a/Protos/unittest_swift_reserved.proto
+++ b/Protos/unittest_swift_reserved.proto
@@ -65,7 +65,7 @@ extend SwiftReservedTest.class {
 
 message SwiftReservedTestExt {
     extend SwiftReservedTest.class {
-        // This will end up in the "struct Extensions" to scope it, but there
+        // This will end up in the "enum Extensions" to scope it, but there
         // the raw form is used ("hash_value", not the Swift one "hashValue"),
         // so there is no conflict, and no renaming happens.
         optional bool hash_value = 1001;

--- a/Protos/unittest_swift_reserved_ext.proto
+++ b/Protos/unittest_swift_reserved_ext.proto
@@ -37,7 +37,7 @@ message SwiftReservedTestExt2 {
     extend protobuf_unittest.SwiftReservedTest.Type {
         optional bool hashValue = 1001;
 
-        // Reserved words, since these end up in the "struct Extensions", they
+        // Reserved words, since these end up in the "enum Extensions", they
         // can't just be get their names, and sanitation kicks.
         optional bool as = 1022;
         optional bool var = 1023;

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -1625,25 +1625,6 @@ struct ProtobufUnittest_TestNestedExtension: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    /// Check for bug where string extensions declared in tested scope did not
-    /// compile.
-    static let test = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-      _protobuf_fieldNumber: 1002,
-      fieldName: "protobuf_unittest.TestNestedExtension.test",
-      defaultValue: "test"
-    )
-
-    /// Used to test if generated extension name is correct when there are
-    /// underscores.
-    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-      _protobuf_fieldNumber: 1003,
-      fieldName: "protobuf_unittest.TestNestedExtension.nested_string_extension",
-      defaultValue: String()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -2032,21 +2013,6 @@ struct ProtobufUnittest_TestRequired: SwiftProtobuf.Message {
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  struct Extensions {
-
-    static let single = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(
-      _protobuf_fieldNumber: 1000,
-      fieldName: "protobuf_unittest.TestRequired.single",
-      defaultValue: ProtobufUnittest_TestRequired()
-    )
-
-    static let multi = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(
-      _protobuf_fieldNumber: 1001,
-      fieldName: "protobuf_unittest.TestRequired.multi",
-      defaultValue: []
-    )
-  }
 
   init() {}
 
@@ -5717,21 +5683,6 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.E
     }
   }
 
-  struct Extensions {
-
-    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
-      _protobuf_fieldNumber: 1000,
-      fieldName: "protobuf_unittest.TestParsingMerge.optional_ext",
-      defaultValue: ProtobufUnittest_TestAllTypes()
-    )
-
-    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
-      _protobuf_fieldNumber: 1001,
-      fieldName: "protobuf_unittest.TestParsingMerge.repeated_ext",
-      defaultValue: []
-    )
-  }
-
   init() {}
 
   public var isInitialized: Bool {
@@ -6323,646 +6274,6 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
-
-/// Singular
-let ProtobufUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "protobuf_unittest.optional_int32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "protobuf_unittest.optional_int64_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "protobuf_unittest.optional_uint32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 4,
-  fieldName: "protobuf_unittest.optional_uint64_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 5,
-  fieldName: "protobuf_unittest.optional_sint32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 6,
-  fieldName: "protobuf_unittest.optional_sint64_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 7,
-  fieldName: "protobuf_unittest.optional_fixed32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 8,
-  fieldName: "protobuf_unittest.optional_fixed64_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 9,
-  fieldName: "protobuf_unittest.optional_sfixed32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 10,
-  fieldName: "protobuf_unittest.optional_sfixed64_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 11,
-  fieldName: "protobuf_unittest.optional_float_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 12,
-  fieldName: "protobuf_unittest.optional_double_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 13,
-  fieldName: "protobuf_unittest.optional_bool_extension",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_optional_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 14,
-  fieldName: "protobuf_unittest.optional_string_extension",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 15,
-  fieldName: "protobuf_unittest.optional_bytes_extension",
-  defaultValue: SwiftProtobuf.Internal.emptyData
-)
-
-let ProtobufUnittest_Extensions_OptionalGroup_extension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 16,
-  fieldName: "protobuf_unittest.OptionalGroup_extension",
-  defaultValue: ProtobufUnittest_OptionalGroup_extension()
-)
-
-let ProtobufUnittest_Extensions_optional_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 18,
-  fieldName: "protobuf_unittest.optional_nested_message_extension",
-  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
-)
-
-let ProtobufUnittest_Extensions_optional_foreign_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 19,
-  fieldName: "protobuf_unittest.optional_foreign_message_extension",
-  defaultValue: ProtobufUnittest_ForeignMessage()
-)
-
-let ProtobufUnittest_Extensions_optional_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 20,
-  fieldName: "protobuf_unittest.optional_import_message_extension",
-  defaultValue: ProtobufUnittestImport_ImportMessage()
-)
-
-let ProtobufUnittest_Extensions_optional_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 21,
-  fieldName: "protobuf_unittest.optional_nested_enum_extension",
-  defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.foo
-)
-
-let ProtobufUnittest_Extensions_optional_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 22,
-  fieldName: "protobuf_unittest.optional_foreign_enum_extension",
-  defaultValue: ProtobufUnittest_ForeignEnum.foreignFoo
-)
-
-let ProtobufUnittest_Extensions_optional_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 23,
-  fieldName: "protobuf_unittest.optional_import_enum_extension",
-  defaultValue: ProtobufUnittestImport_ImportEnum.importFoo
-)
-
-let ProtobufUnittest_Extensions_optional_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 24,
-  fieldName: "protobuf_unittest.optional_string_piece_extension",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 25,
-  fieldName: "protobuf_unittest.optional_cord_extension",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_public_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 26,
-  fieldName: "protobuf_unittest.optional_public_import_message_extension",
-  defaultValue: ProtobufUnittestImport_PublicImportMessage()
-)
-
-let ProtobufUnittest_Extensions_optional_lazy_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 27,
-  fieldName: "protobuf_unittest.optional_lazy_message_extension",
-  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
-)
-
-/// Repeated
-let ProtobufUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 31,
-  fieldName: "protobuf_unittest.repeated_int32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 32,
-  fieldName: "protobuf_unittest.repeated_int64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 33,
-  fieldName: "protobuf_unittest.repeated_uint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 34,
-  fieldName: "protobuf_unittest.repeated_uint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 35,
-  fieldName: "protobuf_unittest.repeated_sint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 36,
-  fieldName: "protobuf_unittest.repeated_sint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 37,
-  fieldName: "protobuf_unittest.repeated_fixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 38,
-  fieldName: "protobuf_unittest.repeated_fixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 39,
-  fieldName: "protobuf_unittest.repeated_sfixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 40,
-  fieldName: "protobuf_unittest.repeated_sfixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 41,
-  fieldName: "protobuf_unittest.repeated_float_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 42,
-  fieldName: "protobuf_unittest.repeated_double_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 43,
-  fieldName: "protobuf_unittest.repeated_bool_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_string_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 44,
-  fieldName: "protobuf_unittest.repeated_string_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_bytes_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 45,
-  fieldName: "protobuf_unittest.repeated_bytes_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_RepeatedGroup_extension = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 46,
-  fieldName: "protobuf_unittest.RepeatedGroup_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_nested_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 48,
-  fieldName: "protobuf_unittest.repeated_nested_message_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_foreign_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 49,
-  fieldName: "protobuf_unittest.repeated_foreign_message_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_import_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 50,
-  fieldName: "protobuf_unittest.repeated_import_message_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_nested_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 51,
-  fieldName: "protobuf_unittest.repeated_nested_enum_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_foreign_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 52,
-  fieldName: "protobuf_unittest.repeated_foreign_enum_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_import_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 53,
-  fieldName: "protobuf_unittest.repeated_import_enum_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_string_piece_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 54,
-  fieldName: "protobuf_unittest.repeated_string_piece_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_cord_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 55,
-  fieldName: "protobuf_unittest.repeated_cord_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_lazy_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 57,
-  fieldName: "protobuf_unittest.repeated_lazy_message_extension",
-  defaultValue: []
-)
-
-/// Singular with defaults
-let ProtobufUnittest_Extensions_default_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 61,
-  fieldName: "protobuf_unittest.default_int32_extension",
-  defaultValue: 41
-)
-
-let ProtobufUnittest_Extensions_default_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 62,
-  fieldName: "protobuf_unittest.default_int64_extension",
-  defaultValue: 42
-)
-
-let ProtobufUnittest_Extensions_default_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 63,
-  fieldName: "protobuf_unittest.default_uint32_extension",
-  defaultValue: 43
-)
-
-let ProtobufUnittest_Extensions_default_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 64,
-  fieldName: "protobuf_unittest.default_uint64_extension",
-  defaultValue: 44
-)
-
-let ProtobufUnittest_Extensions_default_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 65,
-  fieldName: "protobuf_unittest.default_sint32_extension",
-  defaultValue: -45
-)
-
-let ProtobufUnittest_Extensions_default_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 66,
-  fieldName: "protobuf_unittest.default_sint64_extension",
-  defaultValue: 46
-)
-
-let ProtobufUnittest_Extensions_default_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 67,
-  fieldName: "protobuf_unittest.default_fixed32_extension",
-  defaultValue: 47
-)
-
-let ProtobufUnittest_Extensions_default_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 68,
-  fieldName: "protobuf_unittest.default_fixed64_extension",
-  defaultValue: 48
-)
-
-let ProtobufUnittest_Extensions_default_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 69,
-  fieldName: "protobuf_unittest.default_sfixed32_extension",
-  defaultValue: 49
-)
-
-let ProtobufUnittest_Extensions_default_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 70,
-  fieldName: "protobuf_unittest.default_sfixed64_extension",
-  defaultValue: -50
-)
-
-let ProtobufUnittest_Extensions_default_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 71,
-  fieldName: "protobuf_unittest.default_float_extension",
-  defaultValue: 51.5
-)
-
-let ProtobufUnittest_Extensions_default_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 72,
-  fieldName: "protobuf_unittest.default_double_extension",
-  defaultValue: 52000
-)
-
-let ProtobufUnittest_Extensions_default_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 73,
-  fieldName: "protobuf_unittest.default_bool_extension",
-  defaultValue: true
-)
-
-let ProtobufUnittest_Extensions_default_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 74,
-  fieldName: "protobuf_unittest.default_string_extension",
-  defaultValue: "hello"
-)
-
-let ProtobufUnittest_Extensions_default_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 75,
-  fieldName: "protobuf_unittest.default_bytes_extension",
-  defaultValue: Data(bytes: [119, 111, 114, 108, 100])
-)
-
-let ProtobufUnittest_Extensions_default_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 81,
-  fieldName: "protobuf_unittest.default_nested_enum_extension",
-  defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.bar
-)
-
-let ProtobufUnittest_Extensions_default_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 82,
-  fieldName: "protobuf_unittest.default_foreign_enum_extension",
-  defaultValue: ProtobufUnittest_ForeignEnum.foreignBar
-)
-
-let ProtobufUnittest_Extensions_default_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 83,
-  fieldName: "protobuf_unittest.default_import_enum_extension",
-  defaultValue: ProtobufUnittestImport_ImportEnum.importBar
-)
-
-let ProtobufUnittest_Extensions_default_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 84,
-  fieldName: "protobuf_unittest.default_string_piece_extension",
-  defaultValue: "abc"
-)
-
-let ProtobufUnittest_Extensions_default_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 85,
-  fieldName: "protobuf_unittest.default_cord_extension",
-  defaultValue: "123"
-)
-
-/// For oneof test
-let ProtobufUnittest_Extensions_oneof_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 111,
-  fieldName: "protobuf_unittest.oneof_uint32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_oneof_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 112,
-  fieldName: "protobuf_unittest.oneof_nested_message_extension",
-  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
-)
-
-let ProtobufUnittest_Extensions_oneof_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 113,
-  fieldName: "protobuf_unittest.oneof_string_extension",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_oneof_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 114,
-  fieldName: "protobuf_unittest.oneof_bytes_extension",
-  defaultValue: SwiftProtobuf.Internal.emptyData
-)
-
-let ProtobufUnittest_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestFieldOrderings>(
-  _protobuf_fieldNumber: 50,
-  fieldName: "protobuf_unittest.my_extension_string",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestFieldOrderings>(
-  _protobuf_fieldNumber: 5,
-  fieldName: "protobuf_unittest.my_extension_int",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_packed_int32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 90,
-  fieldName: "protobuf_unittest.packed_int32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_int64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 91,
-  fieldName: "protobuf_unittest.packed_int64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_uint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 92,
-  fieldName: "protobuf_unittest.packed_uint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_uint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 93,
-  fieldName: "protobuf_unittest.packed_uint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 94,
-  fieldName: "protobuf_unittest.packed_sint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 95,
-  fieldName: "protobuf_unittest.packed_sint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_fixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 96,
-  fieldName: "protobuf_unittest.packed_fixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_fixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 97,
-  fieldName: "protobuf_unittest.packed_fixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sfixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 98,
-  fieldName: "protobuf_unittest.packed_sfixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sfixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 99,
-  fieldName: "protobuf_unittest.packed_sfixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_float_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.packed_float_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_double_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.packed_double_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_bool_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "protobuf_unittest.packed_bool_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_enum_extension = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "protobuf_unittest.packed_enum_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 90,
-  fieldName: "protobuf_unittest.unpacked_int32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 91,
-  fieldName: "protobuf_unittest.unpacked_int64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 92,
-  fieldName: "protobuf_unittest.unpacked_uint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 93,
-  fieldName: "protobuf_unittest.unpacked_uint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 94,
-  fieldName: "protobuf_unittest.unpacked_sint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 95,
-  fieldName: "protobuf_unittest.unpacked_sint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 96,
-  fieldName: "protobuf_unittest.unpacked_fixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 97,
-  fieldName: "protobuf_unittest.unpacked_fixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 98,
-  fieldName: "protobuf_unittest.unpacked_sfixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 99,
-  fieldName: "protobuf_unittest.unpacked_sfixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.unpacked_float_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.unpacked_double_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "protobuf_unittest.unpacked_bool_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "protobuf_unittest.unpacked_enum_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestHugeFieldNumbers>(
-  _protobuf_fieldNumber: 536860000,
-  fieldName: "protobuf_unittest.test_all_types",
-  defaultValue: ProtobufUnittest_TestAllTypes()
-)
 
 // MARK: - Extension support defined in unittest.proto.
 
@@ -8548,6 +7859,698 @@ let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestParsingMerge.Extensions.optional_ext,
   ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext
 ]
+
+/// Singular
+let ProtobufUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "protobuf_unittest.optional_int32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "protobuf_unittest.optional_int64_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "protobuf_unittest.optional_uint32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 4,
+  fieldName: "protobuf_unittest.optional_uint64_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 5,
+  fieldName: "protobuf_unittest.optional_sint32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 6,
+  fieldName: "protobuf_unittest.optional_sint64_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 7,
+  fieldName: "protobuf_unittest.optional_fixed32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 8,
+  fieldName: "protobuf_unittest.optional_fixed64_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 9,
+  fieldName: "protobuf_unittest.optional_sfixed32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 10,
+  fieldName: "protobuf_unittest.optional_sfixed64_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 11,
+  fieldName: "protobuf_unittest.optional_float_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 12,
+  fieldName: "protobuf_unittest.optional_double_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 13,
+  fieldName: "protobuf_unittest.optional_bool_extension",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_optional_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 14,
+  fieldName: "protobuf_unittest.optional_string_extension",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 15,
+  fieldName: "protobuf_unittest.optional_bytes_extension",
+  defaultValue: SwiftProtobuf.Internal.emptyData
+)
+
+let ProtobufUnittest_Extensions_OptionalGroup_extension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 16,
+  fieldName: "protobuf_unittest.OptionalGroup_extension",
+  defaultValue: ProtobufUnittest_OptionalGroup_extension()
+)
+
+let ProtobufUnittest_Extensions_optional_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 18,
+  fieldName: "protobuf_unittest.optional_nested_message_extension",
+  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
+)
+
+let ProtobufUnittest_Extensions_optional_foreign_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 19,
+  fieldName: "protobuf_unittest.optional_foreign_message_extension",
+  defaultValue: ProtobufUnittest_ForeignMessage()
+)
+
+let ProtobufUnittest_Extensions_optional_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 20,
+  fieldName: "protobuf_unittest.optional_import_message_extension",
+  defaultValue: ProtobufUnittestImport_ImportMessage()
+)
+
+let ProtobufUnittest_Extensions_optional_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 21,
+  fieldName: "protobuf_unittest.optional_nested_enum_extension",
+  defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.foo
+)
+
+let ProtobufUnittest_Extensions_optional_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 22,
+  fieldName: "protobuf_unittest.optional_foreign_enum_extension",
+  defaultValue: ProtobufUnittest_ForeignEnum.foreignFoo
+)
+
+let ProtobufUnittest_Extensions_optional_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 23,
+  fieldName: "protobuf_unittest.optional_import_enum_extension",
+  defaultValue: ProtobufUnittestImport_ImportEnum.importFoo
+)
+
+let ProtobufUnittest_Extensions_optional_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 24,
+  fieldName: "protobuf_unittest.optional_string_piece_extension",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 25,
+  fieldName: "protobuf_unittest.optional_cord_extension",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_public_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 26,
+  fieldName: "protobuf_unittest.optional_public_import_message_extension",
+  defaultValue: ProtobufUnittestImport_PublicImportMessage()
+)
+
+let ProtobufUnittest_Extensions_optional_lazy_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 27,
+  fieldName: "protobuf_unittest.optional_lazy_message_extension",
+  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
+)
+
+/// Repeated
+let ProtobufUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 31,
+  fieldName: "protobuf_unittest.repeated_int32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 32,
+  fieldName: "protobuf_unittest.repeated_int64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 33,
+  fieldName: "protobuf_unittest.repeated_uint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 34,
+  fieldName: "protobuf_unittest.repeated_uint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 35,
+  fieldName: "protobuf_unittest.repeated_sint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 36,
+  fieldName: "protobuf_unittest.repeated_sint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 37,
+  fieldName: "protobuf_unittest.repeated_fixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 38,
+  fieldName: "protobuf_unittest.repeated_fixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 39,
+  fieldName: "protobuf_unittest.repeated_sfixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 40,
+  fieldName: "protobuf_unittest.repeated_sfixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 41,
+  fieldName: "protobuf_unittest.repeated_float_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 42,
+  fieldName: "protobuf_unittest.repeated_double_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 43,
+  fieldName: "protobuf_unittest.repeated_bool_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_string_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 44,
+  fieldName: "protobuf_unittest.repeated_string_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_bytes_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 45,
+  fieldName: "protobuf_unittest.repeated_bytes_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_RepeatedGroup_extension = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 46,
+  fieldName: "protobuf_unittest.RepeatedGroup_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_nested_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 48,
+  fieldName: "protobuf_unittest.repeated_nested_message_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_foreign_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 49,
+  fieldName: "protobuf_unittest.repeated_foreign_message_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_import_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 50,
+  fieldName: "protobuf_unittest.repeated_import_message_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_nested_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 51,
+  fieldName: "protobuf_unittest.repeated_nested_enum_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_foreign_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 52,
+  fieldName: "protobuf_unittest.repeated_foreign_enum_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_import_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 53,
+  fieldName: "protobuf_unittest.repeated_import_enum_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_string_piece_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 54,
+  fieldName: "protobuf_unittest.repeated_string_piece_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_cord_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 55,
+  fieldName: "protobuf_unittest.repeated_cord_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_lazy_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 57,
+  fieldName: "protobuf_unittest.repeated_lazy_message_extension",
+  defaultValue: []
+)
+
+/// Singular with defaults
+let ProtobufUnittest_Extensions_default_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 61,
+  fieldName: "protobuf_unittest.default_int32_extension",
+  defaultValue: 41
+)
+
+let ProtobufUnittest_Extensions_default_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 62,
+  fieldName: "protobuf_unittest.default_int64_extension",
+  defaultValue: 42
+)
+
+let ProtobufUnittest_Extensions_default_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 63,
+  fieldName: "protobuf_unittest.default_uint32_extension",
+  defaultValue: 43
+)
+
+let ProtobufUnittest_Extensions_default_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 64,
+  fieldName: "protobuf_unittest.default_uint64_extension",
+  defaultValue: 44
+)
+
+let ProtobufUnittest_Extensions_default_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 65,
+  fieldName: "protobuf_unittest.default_sint32_extension",
+  defaultValue: -45
+)
+
+let ProtobufUnittest_Extensions_default_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 66,
+  fieldName: "protobuf_unittest.default_sint64_extension",
+  defaultValue: 46
+)
+
+let ProtobufUnittest_Extensions_default_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 67,
+  fieldName: "protobuf_unittest.default_fixed32_extension",
+  defaultValue: 47
+)
+
+let ProtobufUnittest_Extensions_default_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 68,
+  fieldName: "protobuf_unittest.default_fixed64_extension",
+  defaultValue: 48
+)
+
+let ProtobufUnittest_Extensions_default_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 69,
+  fieldName: "protobuf_unittest.default_sfixed32_extension",
+  defaultValue: 49
+)
+
+let ProtobufUnittest_Extensions_default_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 70,
+  fieldName: "protobuf_unittest.default_sfixed64_extension",
+  defaultValue: -50
+)
+
+let ProtobufUnittest_Extensions_default_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 71,
+  fieldName: "protobuf_unittest.default_float_extension",
+  defaultValue: 51.5
+)
+
+let ProtobufUnittest_Extensions_default_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 72,
+  fieldName: "protobuf_unittest.default_double_extension",
+  defaultValue: 52000
+)
+
+let ProtobufUnittest_Extensions_default_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 73,
+  fieldName: "protobuf_unittest.default_bool_extension",
+  defaultValue: true
+)
+
+let ProtobufUnittest_Extensions_default_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 74,
+  fieldName: "protobuf_unittest.default_string_extension",
+  defaultValue: "hello"
+)
+
+let ProtobufUnittest_Extensions_default_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 75,
+  fieldName: "protobuf_unittest.default_bytes_extension",
+  defaultValue: Data(bytes: [119, 111, 114, 108, 100])
+)
+
+let ProtobufUnittest_Extensions_default_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 81,
+  fieldName: "protobuf_unittest.default_nested_enum_extension",
+  defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.bar
+)
+
+let ProtobufUnittest_Extensions_default_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 82,
+  fieldName: "protobuf_unittest.default_foreign_enum_extension",
+  defaultValue: ProtobufUnittest_ForeignEnum.foreignBar
+)
+
+let ProtobufUnittest_Extensions_default_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 83,
+  fieldName: "protobuf_unittest.default_import_enum_extension",
+  defaultValue: ProtobufUnittestImport_ImportEnum.importBar
+)
+
+let ProtobufUnittest_Extensions_default_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 84,
+  fieldName: "protobuf_unittest.default_string_piece_extension",
+  defaultValue: "abc"
+)
+
+let ProtobufUnittest_Extensions_default_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 85,
+  fieldName: "protobuf_unittest.default_cord_extension",
+  defaultValue: "123"
+)
+
+/// For oneof test
+let ProtobufUnittest_Extensions_oneof_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 111,
+  fieldName: "protobuf_unittest.oneof_uint32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_oneof_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 112,
+  fieldName: "protobuf_unittest.oneof_nested_message_extension",
+  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
+)
+
+let ProtobufUnittest_Extensions_oneof_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 113,
+  fieldName: "protobuf_unittest.oneof_string_extension",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_oneof_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 114,
+  fieldName: "protobuf_unittest.oneof_bytes_extension",
+  defaultValue: SwiftProtobuf.Internal.emptyData
+)
+
+let ProtobufUnittest_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestFieldOrderings>(
+  _protobuf_fieldNumber: 50,
+  fieldName: "protobuf_unittest.my_extension_string",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestFieldOrderings>(
+  _protobuf_fieldNumber: 5,
+  fieldName: "protobuf_unittest.my_extension_int",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_packed_int32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 90,
+  fieldName: "protobuf_unittest.packed_int32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_int64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 91,
+  fieldName: "protobuf_unittest.packed_int64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_uint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 92,
+  fieldName: "protobuf_unittest.packed_uint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_uint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 93,
+  fieldName: "protobuf_unittest.packed_uint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 94,
+  fieldName: "protobuf_unittest.packed_sint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 95,
+  fieldName: "protobuf_unittest.packed_sint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_fixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 96,
+  fieldName: "protobuf_unittest.packed_fixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_fixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 97,
+  fieldName: "protobuf_unittest.packed_fixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sfixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 98,
+  fieldName: "protobuf_unittest.packed_sfixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sfixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 99,
+  fieldName: "protobuf_unittest.packed_sfixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_float_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.packed_float_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_double_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.packed_double_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_bool_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "protobuf_unittest.packed_bool_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_enum_extension = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "protobuf_unittest.packed_enum_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 90,
+  fieldName: "protobuf_unittest.unpacked_int32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 91,
+  fieldName: "protobuf_unittest.unpacked_int64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 92,
+  fieldName: "protobuf_unittest.unpacked_uint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 93,
+  fieldName: "protobuf_unittest.unpacked_uint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 94,
+  fieldName: "protobuf_unittest.unpacked_sint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 95,
+  fieldName: "protobuf_unittest.unpacked_sint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 96,
+  fieldName: "protobuf_unittest.unpacked_fixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 97,
+  fieldName: "protobuf_unittest.unpacked_fixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 98,
+  fieldName: "protobuf_unittest.unpacked_sfixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 99,
+  fieldName: "protobuf_unittest.unpacked_sfixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.unpacked_float_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.unpacked_double_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "protobuf_unittest.unpacked_bool_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "protobuf_unittest.unpacked_enum_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestHugeFieldNumbers>(
+  _protobuf_fieldNumber: 536860000,
+  fieldName: "protobuf_unittest.test_all_types",
+  defaultValue: ProtobufUnittest_TestAllTypes()
+)
+
+extension ProtobufUnittest_TestNestedExtension {
+  struct Extensions {
+    /// Check for bug where string extensions declared in tested scope did not
+    /// compile.
+    static let test = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+      _protobuf_fieldNumber: 1002,
+      fieldName: "protobuf_unittest.TestNestedExtension.test",
+      defaultValue: "test"
+    )
+
+    /// Used to test if generated extension name is correct when there are
+    /// underscores.
+    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+      _protobuf_fieldNumber: 1003,
+      fieldName: "protobuf_unittest.TestNestedExtension.nested_string_extension",
+      defaultValue: String()
+    )
+  }
+}
+
+extension ProtobufUnittest_TestRequired {
+  struct Extensions {
+    static let single = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(
+      _protobuf_fieldNumber: 1000,
+      fieldName: "protobuf_unittest.TestRequired.single",
+      defaultValue: ProtobufUnittest_TestRequired()
+    )
+
+    static let multi = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(
+      _protobuf_fieldNumber: 1001,
+      fieldName: "protobuf_unittest.TestRequired.multi",
+      defaultValue: []
+    )
+  }
+}
+
+extension ProtobufUnittest_TestParsingMerge {
+  struct Extensions {
+    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
+      _protobuf_fieldNumber: 1000,
+      fieldName: "protobuf_unittest.TestParsingMerge.optional_ext",
+      defaultValue: ProtobufUnittest_TestAllTypes()
+    )
+
+    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
+      _protobuf_fieldNumber: 1001,
+      fieldName: "protobuf_unittest.TestParsingMerge.repeated_ext",
+      defaultValue: []
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -8428,6 +8428,10 @@ extension ProtobufUnittest_TestHugeFieldNumbers {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_optional_int32_extension,
   ProtobufUnittest_Extensions_optional_int64_extension,

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -8501,7 +8501,7 @@ let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<
 )
 
 extension ProtobufUnittest_TestNestedExtension {
-  struct Extensions {
+  enum Extensions {
     /// Check for bug where string extensions declared in tested scope did not
     /// compile.
     static let test = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
@@ -8521,7 +8521,7 @@ extension ProtobufUnittest_TestNestedExtension {
 }
 
 extension ProtobufUnittest_TestRequired {
-  struct Extensions {
+  enum Extensions {
     static let single = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(
       _protobuf_fieldNumber: 1000,
       fieldName: "protobuf_unittest.TestRequired.single",
@@ -8537,7 +8537,7 @@ extension ProtobufUnittest_TestRequired {
 }
 
 extension ProtobufUnittest_TestParsingMerge {
-  struct Extensions {
+  enum Extensions {
     static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
       _protobuf_fieldNumber: 1000,
       fieldName: "protobuf_unittest.TestParsingMerge.optional_ext",

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -6278,88 +6278,6 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 // MARK: - Extension support defined in unittest.proto.
 
 extension ProtobufUnittest_TestAllExtensions {
-  /// Check for bug where string extensions declared in tested scope did not
-  /// compile.
-  var ProtobufUnittest_TestNestedExtension_test: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test) ?? "test"}
-    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test, value: newValue)}
-  }
-  var hasProtobufUnittest_TestNestedExtension_test: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test)
-  }
-  mutating func clearProtobufUnittest_TestNestedExtension_test() {
-    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensions {
-  /// Used to test if generated extension name is correct when there are
-  /// underscores.
-  var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? String()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension, value: newValue)}
-  }
-  var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
-  }
-  mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensions {
-  var ProtobufUnittest_TestRequired_single: ProtobufUnittest_TestRequired {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single) ?? ProtobufUnittest_TestRequired()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single, value: newValue)}
-  }
-  var hasProtobufUnittest_TestRequired_single: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single)
-  }
-  mutating func clearProtobufUnittest_TestRequired_single() {
-    clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensions {
-  var ProtobufUnittest_TestRequired_multi: [ProtobufUnittest_TestRequired] {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)}
-    set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi, value: newValue)}
-  }
-  var hasProtobufUnittest_TestRequired_multi: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)
-  }
-  mutating func clearProtobufUnittest_TestRequired_multi() {
-    clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)
-  }
-}
-
-extension ProtobufUnittest_TestParsingMerge {
-  var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypes()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext, value: newValue)}
-  }
-  var hasProtobufUnittest_TestParsingMerge_optionalExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
-  }
-  mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
-  }
-}
-
-extension ProtobufUnittest_TestParsingMerge {
-  var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext, value: newValue)}
-  }
-  var hasProtobufUnittest_TestParsingMerge_repeatedExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
-  }
-  mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensions {
   /// Singular
   var ProtobufUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension) ?? 0}
@@ -7738,6 +7656,88 @@ extension ProtobufUnittest_TestHugeFieldNumbers {
   }
   mutating func clearProtobufUnittest_testAllTypes() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
+  }
+}
+
+extension ProtobufUnittest_TestAllExtensions {
+  /// Check for bug where string extensions declared in tested scope did not
+  /// compile.
+  var ProtobufUnittest_TestNestedExtension_test: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test) ?? "test"}
+    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test, value: newValue)}
+  }
+  var hasProtobufUnittest_TestNestedExtension_test: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test)
+  }
+  mutating func clearProtobufUnittest_TestNestedExtension_test() {
+    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test)
+  }
+}
+
+extension ProtobufUnittest_TestAllExtensions {
+  /// Used to test if generated extension name is correct when there are
+  /// underscores.
+  var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? String()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension, value: newValue)}
+  }
+  var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
+  }
+  mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
+  }
+}
+
+extension ProtobufUnittest_TestAllExtensions {
+  var ProtobufUnittest_TestRequired_single: ProtobufUnittest_TestRequired {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single) ?? ProtobufUnittest_TestRequired()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single, value: newValue)}
+  }
+  var hasProtobufUnittest_TestRequired_single: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single)
+  }
+  mutating func clearProtobufUnittest_TestRequired_single() {
+    clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single)
+  }
+}
+
+extension ProtobufUnittest_TestAllExtensions {
+  var ProtobufUnittest_TestRequired_multi: [ProtobufUnittest_TestRequired] {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)}
+    set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi, value: newValue)}
+  }
+  var hasProtobufUnittest_TestRequired_multi: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)
+  }
+  mutating func clearProtobufUnittest_TestRequired_multi() {
+    clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)
+  }
+}
+
+extension ProtobufUnittest_TestParsingMerge {
+  var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypes()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext, value: newValue)}
+  }
+  var hasProtobufUnittest_TestParsingMerge_optionalExt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
+  }
+  mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
+  }
+}
+
+extension ProtobufUnittest_TestParsingMerge {
+  var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext, value: newValue)}
+  }
+  var hasProtobufUnittest_TestParsingMerge_repeatedExt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
+  }
+  mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
   }
 }
 

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -6964,6 +6964,8 @@ let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<
   defaultValue: ProtobufUnittest_TestAllTypes()
 )
 
+// MARK: - Extension support defined in unittest.proto.
+
 extension ProtobufUnittest_TestAllExtensions {
   /// Check for bug where string extensions declared in tested scope did not
   /// compile.

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -2104,6 +2104,10 @@ extension Google_Protobuf_MessageOptions {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_file_opt1,
   ProtobufUnittest_Extensions_message_opt1,

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -1216,58 +1216,6 @@ struct ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf.Message
 
 // MARK: - Extension support defined in unittest_custom_options.proto.
 
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
-    get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
-    set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4, value: newValue)}
-  }
-  var hasProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
-  }
-  mutating func clearProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4() {
-    clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
-  }
-}
-
-extension ProtobufUnittest_AggregateMessageSet {
-  var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
-    get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension) ?? ProtobufUnittest_AggregateMessageSetElement()}
-    set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension, value: newValue)}
-  }
-  var hasProtobufUnittest_AggregateMessageSetElement_messageSetExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
-  }
-  mutating func clearProtobufUnittest_AggregateMessageSetElement_messageSetExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
-  }
-}
-
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested, value: newValue)}
-  }
-  var hasProtobufUnittest_Aggregate_nested: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
-  }
-  mutating func clearProtobufUnittest_Aggregate_nested() {
-    clearExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
-  }
-}
-
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension, value: newValue)}
-  }
-  var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
-  }
-  mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
-  }
-}
-
 extension Google_Protobuf_FileOptions {
   var ProtobufUnittest_fileOpt1: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1) ?? 0}
@@ -1813,6 +1761,58 @@ extension Google_Protobuf_MessageOptions {
   }
   mutating func clearProtobufUnittest_requiredEnumOpt() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt)
+  }
+}
+
+extension Google_Protobuf_MessageOptions {
+  var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
+    get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
+    set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4, value: newValue)}
+  }
+  var hasProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
+  }
+  mutating func clearProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4() {
+    clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
+  }
+}
+
+extension ProtobufUnittest_AggregateMessageSet {
+  var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
+    get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension) ?? ProtobufUnittest_AggregateMessageSetElement()}
+    set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension, value: newValue)}
+  }
+  var hasProtobufUnittest_AggregateMessageSetElement_messageSetExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
+  }
+  mutating func clearProtobufUnittest_AggregateMessageSetElement_messageSetExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
+  }
+}
+
+extension Google_Protobuf_FileOptions {
+  var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested, value: newValue)}
+  }
+  var hasProtobufUnittest_Aggregate_nested: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  }
+  mutating func clearProtobufUnittest_Aggregate_nested() {
+    clearExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  }
+}
+
+extension Google_Protobuf_FileOptions {
+  var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension, value: newValue)}
+  }
+  var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
+  }
+  mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
   }
 }
 

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -2124,7 +2124,7 @@ let ProtobufUnittest_Extensions_required_enum_opt = SwiftProtobuf.MessageExtensi
 )
 
 extension ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
-  struct Extensions {
+  enum Extensions {
     static let complex_opt4 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2.ComplexOptionType4>, Google_Protobuf_MessageOptions>(
       _protobuf_fieldNumber: 7633546,
       fieldName: "protobuf_unittest.ComplexOptionType2.ComplexOptionType4.complex_opt4",
@@ -2134,7 +2134,7 @@ extension ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
 }
 
 extension ProtobufUnittest_AggregateMessageSetElement {
-  struct Extensions {
+  enum Extensions {
     static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_AggregateMessageSetElement>, ProtobufUnittest_AggregateMessageSet>(
       _protobuf_fieldNumber: 15447542,
       fieldName: "protobuf_unittest.AggregateMessageSetElement.message_set_extension",
@@ -2144,7 +2144,7 @@ extension ProtobufUnittest_AggregateMessageSetElement {
 }
 
 extension ProtobufUnittest_Aggregate {
-  struct Extensions {
+  enum Extensions {
     static let nested = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(
       _protobuf_fieldNumber: 15476903,
       fieldName: "protobuf_unittest.Aggregate.nested",
@@ -2154,7 +2154,7 @@ extension ProtobufUnittest_Aggregate {
 }
 
 extension ProtobufUnittest_NestedOptionType {
-  struct Extensions {
+  enum Extensions {
     static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FileOptions>(
       _protobuf_fieldNumber: 7912573,
       fieldName: "protobuf_unittest.NestedOptionType.nested_extension",

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -1504,6 +1504,8 @@ let ProtobufUnittest_Extensions_required_enum_opt = SwiftProtobuf.MessageExtensi
   defaultValue: ProtobufUnittest_OldOptionType()
 )
 
+// MARK: - Extension support defined in unittest_custom_options.proto.
+
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -555,15 +555,6 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.Message, SwiftProtobuf
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    struct Extensions {
-
-      static let complex_opt4 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2.ComplexOptionType4>, Google_Protobuf_MessageOptions>(
-        _protobuf_fieldNumber: 7633546,
-        fieldName: "protobuf_unittest.ComplexOptionType2.ComplexOptionType4.complex_opt4",
-        defaultValue: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()
-      )
-    }
-
     init() {}
 
     mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -824,15 +815,6 @@ struct ProtobufUnittest_AggregateMessageSetElement: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_AggregateMessageSetElement>, ProtobufUnittest_AggregateMessageSet>(
-      _protobuf_fieldNumber: 15447542,
-      fieldName: "protobuf_unittest.AggregateMessageSetElement.message_set_extension",
-      defaultValue: ProtobufUnittest_AggregateMessageSetElement()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -917,15 +899,6 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  struct Extensions {
-
-    static let nested = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(
-      _protobuf_fieldNumber: 15476903,
-      fieldName: "protobuf_unittest.Aggregate.nested",
-      defaultValue: ProtobufUnittest_Aggregate()
-    )
-  }
 
   init() {}
 
@@ -1075,15 +1048,6 @@ struct ProtobufUnittest_NestedOptionType: SwiftProtobuf.Message {
       }
       try unknownFields.traverse(visitor: &visitor)
     }
-  }
-
-  struct Extensions {
-
-    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FileOptions>(
-      _protobuf_fieldNumber: 7912573,
-      fieldName: "protobuf_unittest.NestedOptionType.nested_extension",
-      defaultValue: 0
-    )
   }
 
   init() {}
@@ -1249,260 +1213,6 @@ struct ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf.Message
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-let ProtobufUnittest_Extensions_file_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_FileOptions>(
-  _protobuf_fieldNumber: 7736974,
-  fieldName: "protobuf_unittest.file_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_message_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7739036,
-  fieldName: "protobuf_unittest.message_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_field_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_FieldOptions>(
-  _protobuf_fieldNumber: 7740936,
-  fieldName: "protobuf_unittest.field_opt1",
-  defaultValue: 0
-)
-
-/// This is useful for testing that we correctly register default values for
-/// extension options.
-let ProtobufUnittest_Extensions_field_opt2 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FieldOptions>(
-  _protobuf_fieldNumber: 7753913,
-  fieldName: "protobuf_unittest.field_opt2",
-  defaultValue: 42
-)
-
-let ProtobufUnittest_Extensions_oneof_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_OneofOptions>(
-  _protobuf_fieldNumber: 7740111,
-  fieldName: "protobuf_unittest.oneof_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_enum_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_EnumOptions>(
-  _protobuf_fieldNumber: 7753576,
-  fieldName: "protobuf_unittest.enum_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_enum_value_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_EnumValueOptions>(
-  _protobuf_fieldNumber: 1560678,
-  fieldName: "protobuf_unittest.enum_value_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_service_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_ServiceOptions>(
-  _protobuf_fieldNumber: 7887650,
-  fieldName: "protobuf_unittest.service_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_method_opt1 = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_MethodOpt1>, Google_Protobuf_MethodOptions>(
-  _protobuf_fieldNumber: 7890860,
-  fieldName: "protobuf_unittest.method_opt1",
-  defaultValue: ProtobufUnittest_MethodOpt1.val1
-)
-
-let ProtobufUnittest_Extensions_bool_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7706090,
-  fieldName: "protobuf_unittest.bool_opt",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_int32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7705709,
-  fieldName: "protobuf_unittest.int32_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_int64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7705542,
-  fieldName: "protobuf_unittest.int64_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_uint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7704880,
-  fieldName: "protobuf_unittest.uint32_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_uint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7702367,
-  fieldName: "protobuf_unittest.uint64_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_sint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7701568,
-  fieldName: "protobuf_unittest.sint32_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_sint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7700863,
-  fieldName: "protobuf_unittest.sint64_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_fixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7700307,
-  fieldName: "protobuf_unittest.fixed32_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_fixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7700194,
-  fieldName: "protobuf_unittest.fixed64_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_sfixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7698645,
-  fieldName: "protobuf_unittest.sfixed32_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_sfixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7685475,
-  fieldName: "protobuf_unittest.sfixed64_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_float_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7675390,
-  fieldName: "protobuf_unittest.float_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_double_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7673293,
-  fieldName: "protobuf_unittest.double_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_string_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7673285,
-  fieldName: "protobuf_unittest.string_opt",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_bytes_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7673238,
-  fieldName: "protobuf_unittest.bytes_opt",
-  defaultValue: SwiftProtobuf.Internal.emptyData
-)
-
-let ProtobufUnittest_Extensions_enum_opt = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_DummyMessageContainingEnum.TestEnumType>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7673233,
-  fieldName: "protobuf_unittest.enum_opt",
-  defaultValue: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1
-)
-
-let ProtobufUnittest_Extensions_message_type_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_DummyMessageInvalidAsOptionType>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7665967,
-  fieldName: "protobuf_unittest.message_type_opt",
-  defaultValue: ProtobufUnittest_DummyMessageInvalidAsOptionType()
-)
-
-let ProtobufUnittest_Extensions_quux = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_ComplexOptionType1>(
-  _protobuf_fieldNumber: 7663707,
-  fieldName: "protobuf_unittest.quux",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_corge = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, ProtobufUnittest_ComplexOptionType1>(
-  _protobuf_fieldNumber: 7663442,
-  fieldName: "protobuf_unittest.corge",
-  defaultValue: ProtobufUnittest_ComplexOptionType3()
-)
-
-let ProtobufUnittest_Extensions_grault = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_ComplexOptionType2>(
-  _protobuf_fieldNumber: 7650927,
-  fieldName: "protobuf_unittest.grault",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_garply = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, ProtobufUnittest_ComplexOptionType2>(
-  _protobuf_fieldNumber: 7649992,
-  fieldName: "protobuf_unittest.garply",
-  defaultValue: ProtobufUnittest_ComplexOptionType1()
-)
-
-let ProtobufUnittest_Extensions_complex_opt1 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7646756,
-  fieldName: "protobuf_unittest.complex_opt1",
-  defaultValue: ProtobufUnittest_ComplexOptionType1()
-)
-
-let ProtobufUnittest_Extensions_complex_opt2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7636949,
-  fieldName: "protobuf_unittest.complex_opt2",
-  defaultValue: ProtobufUnittest_ComplexOptionType2()
-)
-
-let ProtobufUnittest_Extensions_complex_opt3 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7636463,
-  fieldName: "protobuf_unittest.complex_opt3",
-  defaultValue: ProtobufUnittest_ComplexOptionType3()
-)
-
-let ProtobufUnittest_Extensions_ComplexOpt6 = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_ComplexOpt6>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7595468,
-  fieldName: "protobuf_unittest.ComplexOpt6",
-  defaultValue: ProtobufUnittest_ComplexOpt6()
-)
-
-let ProtobufUnittest_Extensions_fileopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(
-  _protobuf_fieldNumber: 15478479,
-  fieldName: "protobuf_unittest.fileopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_msgopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 15480088,
-  fieldName: "protobuf_unittest.msgopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_fieldopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FieldOptions>(
-  _protobuf_fieldNumber: 15481374,
-  fieldName: "protobuf_unittest.fieldopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_enumopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_EnumOptions>(
-  _protobuf_fieldNumber: 15483218,
-  fieldName: "protobuf_unittest.enumopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_enumvalopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_EnumValueOptions>(
-  _protobuf_fieldNumber: 15486921,
-  fieldName: "protobuf_unittest.enumvalopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_serviceopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_ServiceOptions>(
-  _protobuf_fieldNumber: 15497145,
-  fieldName: "protobuf_unittest.serviceopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_methodopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_MethodOptions>(
-  _protobuf_fieldNumber: 15512713,
-  fieldName: "protobuf_unittest.methodopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_required_enum_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 106161807,
-  fieldName: "protobuf_unittest.required_enum_opt",
-  defaultValue: ProtobufUnittest_OldOptionType()
-)
 
 // MARK: - Extension support defined in unittest_custom_options.proto.
 
@@ -2158,6 +1868,300 @@ let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.SimpleExten
   ProtobufUnittest_Aggregate.Extensions.nested,
   ProtobufUnittest_NestedOptionType.Extensions.nested_extension
 ]
+
+let ProtobufUnittest_Extensions_file_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_FileOptions>(
+  _protobuf_fieldNumber: 7736974,
+  fieldName: "protobuf_unittest.file_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_message_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7739036,
+  fieldName: "protobuf_unittest.message_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_field_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_FieldOptions>(
+  _protobuf_fieldNumber: 7740936,
+  fieldName: "protobuf_unittest.field_opt1",
+  defaultValue: 0
+)
+
+/// This is useful for testing that we correctly register default values for
+/// extension options.
+let ProtobufUnittest_Extensions_field_opt2 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FieldOptions>(
+  _protobuf_fieldNumber: 7753913,
+  fieldName: "protobuf_unittest.field_opt2",
+  defaultValue: 42
+)
+
+let ProtobufUnittest_Extensions_oneof_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_OneofOptions>(
+  _protobuf_fieldNumber: 7740111,
+  fieldName: "protobuf_unittest.oneof_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_enum_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_EnumOptions>(
+  _protobuf_fieldNumber: 7753576,
+  fieldName: "protobuf_unittest.enum_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_enum_value_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_EnumValueOptions>(
+  _protobuf_fieldNumber: 1560678,
+  fieldName: "protobuf_unittest.enum_value_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_service_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_ServiceOptions>(
+  _protobuf_fieldNumber: 7887650,
+  fieldName: "protobuf_unittest.service_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_method_opt1 = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_MethodOpt1>, Google_Protobuf_MethodOptions>(
+  _protobuf_fieldNumber: 7890860,
+  fieldName: "protobuf_unittest.method_opt1",
+  defaultValue: ProtobufUnittest_MethodOpt1.val1
+)
+
+let ProtobufUnittest_Extensions_bool_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7706090,
+  fieldName: "protobuf_unittest.bool_opt",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_int32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7705709,
+  fieldName: "protobuf_unittest.int32_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_int64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7705542,
+  fieldName: "protobuf_unittest.int64_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_uint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7704880,
+  fieldName: "protobuf_unittest.uint32_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_uint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7702367,
+  fieldName: "protobuf_unittest.uint64_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_sint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7701568,
+  fieldName: "protobuf_unittest.sint32_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_sint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7700863,
+  fieldName: "protobuf_unittest.sint64_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_fixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7700307,
+  fieldName: "protobuf_unittest.fixed32_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_fixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7700194,
+  fieldName: "protobuf_unittest.fixed64_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_sfixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7698645,
+  fieldName: "protobuf_unittest.sfixed32_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_sfixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7685475,
+  fieldName: "protobuf_unittest.sfixed64_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_float_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7675390,
+  fieldName: "protobuf_unittest.float_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_double_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7673293,
+  fieldName: "protobuf_unittest.double_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_string_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7673285,
+  fieldName: "protobuf_unittest.string_opt",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_bytes_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7673238,
+  fieldName: "protobuf_unittest.bytes_opt",
+  defaultValue: SwiftProtobuf.Internal.emptyData
+)
+
+let ProtobufUnittest_Extensions_enum_opt = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_DummyMessageContainingEnum.TestEnumType>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7673233,
+  fieldName: "protobuf_unittest.enum_opt",
+  defaultValue: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1
+)
+
+let ProtobufUnittest_Extensions_message_type_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_DummyMessageInvalidAsOptionType>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7665967,
+  fieldName: "protobuf_unittest.message_type_opt",
+  defaultValue: ProtobufUnittest_DummyMessageInvalidAsOptionType()
+)
+
+let ProtobufUnittest_Extensions_quux = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_ComplexOptionType1>(
+  _protobuf_fieldNumber: 7663707,
+  fieldName: "protobuf_unittest.quux",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_corge = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, ProtobufUnittest_ComplexOptionType1>(
+  _protobuf_fieldNumber: 7663442,
+  fieldName: "protobuf_unittest.corge",
+  defaultValue: ProtobufUnittest_ComplexOptionType3()
+)
+
+let ProtobufUnittest_Extensions_grault = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_ComplexOptionType2>(
+  _protobuf_fieldNumber: 7650927,
+  fieldName: "protobuf_unittest.grault",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_garply = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, ProtobufUnittest_ComplexOptionType2>(
+  _protobuf_fieldNumber: 7649992,
+  fieldName: "protobuf_unittest.garply",
+  defaultValue: ProtobufUnittest_ComplexOptionType1()
+)
+
+let ProtobufUnittest_Extensions_complex_opt1 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7646756,
+  fieldName: "protobuf_unittest.complex_opt1",
+  defaultValue: ProtobufUnittest_ComplexOptionType1()
+)
+
+let ProtobufUnittest_Extensions_complex_opt2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7636949,
+  fieldName: "protobuf_unittest.complex_opt2",
+  defaultValue: ProtobufUnittest_ComplexOptionType2()
+)
+
+let ProtobufUnittest_Extensions_complex_opt3 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7636463,
+  fieldName: "protobuf_unittest.complex_opt3",
+  defaultValue: ProtobufUnittest_ComplexOptionType3()
+)
+
+let ProtobufUnittest_Extensions_ComplexOpt6 = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_ComplexOpt6>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7595468,
+  fieldName: "protobuf_unittest.ComplexOpt6",
+  defaultValue: ProtobufUnittest_ComplexOpt6()
+)
+
+let ProtobufUnittest_Extensions_fileopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(
+  _protobuf_fieldNumber: 15478479,
+  fieldName: "protobuf_unittest.fileopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_msgopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 15480088,
+  fieldName: "protobuf_unittest.msgopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_fieldopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FieldOptions>(
+  _protobuf_fieldNumber: 15481374,
+  fieldName: "protobuf_unittest.fieldopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_enumopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_EnumOptions>(
+  _protobuf_fieldNumber: 15483218,
+  fieldName: "protobuf_unittest.enumopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_enumvalopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_EnumValueOptions>(
+  _protobuf_fieldNumber: 15486921,
+  fieldName: "protobuf_unittest.enumvalopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_serviceopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_ServiceOptions>(
+  _protobuf_fieldNumber: 15497145,
+  fieldName: "protobuf_unittest.serviceopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_methodopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_MethodOptions>(
+  _protobuf_fieldNumber: 15512713,
+  fieldName: "protobuf_unittest.methodopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_required_enum_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 106161807,
+  fieldName: "protobuf_unittest.required_enum_opt",
+  defaultValue: ProtobufUnittest_OldOptionType()
+)
+
+extension ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
+  struct Extensions {
+    static let complex_opt4 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2.ComplexOptionType4>, Google_Protobuf_MessageOptions>(
+      _protobuf_fieldNumber: 7633546,
+      fieldName: "protobuf_unittest.ComplexOptionType2.ComplexOptionType4.complex_opt4",
+      defaultValue: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()
+    )
+  }
+}
+
+extension ProtobufUnittest_AggregateMessageSetElement {
+  struct Extensions {
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_AggregateMessageSetElement>, ProtobufUnittest_AggregateMessageSet>(
+      _protobuf_fieldNumber: 15447542,
+      fieldName: "protobuf_unittest.AggregateMessageSetElement.message_set_extension",
+      defaultValue: ProtobufUnittest_AggregateMessageSetElement()
+    )
+  }
+}
+
+extension ProtobufUnittest_Aggregate {
+  struct Extensions {
+    static let nested = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(
+      _protobuf_fieldNumber: 15476903,
+      fieldName: "protobuf_unittest.Aggregate.nested",
+      defaultValue: ProtobufUnittest_Aggregate()
+    )
+  }
+}
+
+extension ProtobufUnittest_NestedOptionType {
+  struct Extensions {
+    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FileOptions>(
+      _protobuf_fieldNumber: 7912573,
+      fieldName: "protobuf_unittest.NestedOptionType.nested_extension",
+      defaultValue: 0
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -4222,6 +4222,10 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_optional_int32_extension_lite,
   ProtobufUnittest_Extensions_optional_int64_extension_lite,

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -4301,7 +4301,7 @@ let ProtobufUnittest_Extensions_test_all_types_lite = SwiftProtobuf.MessageExten
 )
 
 extension ProtobufUnittest_TestNestedExtensionLite {
-  struct Extensions {
+  enum Extensions {
     static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
       _protobuf_fieldNumber: 12345,
       fieldName: "protobuf_unittest.TestNestedExtensionLite.nested_extension",
@@ -4311,7 +4311,7 @@ extension ProtobufUnittest_TestNestedExtensionLite {
 }
 
 extension ProtobufUnittest_TestParsingMergeLite {
-  struct Extensions {
+  enum Extensions {
     static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
       _protobuf_fieldNumber: 1000,
       fieldName: "protobuf_unittest.TestParsingMergeLite.optional_ext",

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -2444,45 +2444,6 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 // MARK: - Extension support defined in unittest_lite.proto.
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension, value: newValue)}
-  }
-  var hasProtobufUnittest_TestNestedExtensionLite_nestedExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
-  }
-  mutating func clearProtobufUnittest_TestNestedExtensionLite_nestedExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
-  }
-}
-
-extension ProtobufUnittest_TestParsingMergeLite {
-  var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypesLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext, value: newValue)}
-  }
-  var hasProtobufUnittest_TestParsingMergeLite_optionalExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
-  }
-  mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
-  }
-}
-
-extension ProtobufUnittest_TestParsingMergeLite {
-  var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext, value: newValue)}
-  }
-  var hasProtobufUnittest_TestParsingMergeLite_repeatedExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
-  }
-  mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensionsLite {
   /// Singular
   var ProtobufUnittest_optionalInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite) ?? 0}
@@ -3653,6 +3614,45 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite {
   }
   mutating func clearProtobufUnittest_testAllTypesLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
+  }
+}
+
+extension ProtobufUnittest_TestAllExtensionsLite {
+  var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension, value: newValue)}
+  }
+  var hasProtobufUnittest_TestNestedExtensionLite_nestedExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
+  }
+  mutating func clearProtobufUnittest_TestNestedExtensionLite_nestedExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
+  }
+}
+
+extension ProtobufUnittest_TestParsingMergeLite {
+  var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypesLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext, value: newValue)}
+  }
+  var hasProtobufUnittest_TestParsingMergeLite_optionalExt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
+  }
+  mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
+  }
+}
+
+extension ProtobufUnittest_TestParsingMergeLite {
+  var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext, value: newValue)}
+  }
+  var hasProtobufUnittest_TestParsingMergeLite_repeatedExt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
+  }
+  mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
   }
 }
 

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -1612,15 +1612,6 @@ struct ProtobufUnittest_TestNestedExtensionLite: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-      _protobuf_fieldNumber: 12345,
-      fieldName: "protobuf_unittest.TestNestedExtensionLite.nested_extension",
-      defaultValue: 0
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1950,21 +1941,6 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
       }
       try unknownFields.traverse(visitor: &visitor)
     }
-  }
-
-  struct Extensions {
-
-    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
-      _protobuf_fieldNumber: 1000,
-      fieldName: "protobuf_unittest.TestParsingMergeLite.optional_ext",
-      defaultValue: ProtobufUnittest_TestAllTypesLite()
-    )
-
-    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
-      _protobuf_fieldNumber: 1001,
-      fieldName: "protobuf_unittest.TestParsingMergeLite.repeated_ext",
-      defaultValue: []
-    )
   }
 
   init() {}
@@ -2464,550 +2440,6 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
-
-/// Singular
-let ProtobufUnittest_Extensions_optional_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "protobuf_unittest.optional_int32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "protobuf_unittest.optional_int64_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "protobuf_unittest.optional_uint32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 4,
-  fieldName: "protobuf_unittest.optional_uint64_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 5,
-  fieldName: "protobuf_unittest.optional_sint32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 6,
-  fieldName: "protobuf_unittest.optional_sint64_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 7,
-  fieldName: "protobuf_unittest.optional_fixed32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 8,
-  fieldName: "protobuf_unittest.optional_fixed64_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 9,
-  fieldName: "protobuf_unittest.optional_sfixed32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 10,
-  fieldName: "protobuf_unittest.optional_sfixed64_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 11,
-  fieldName: "protobuf_unittest.optional_float_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 12,
-  fieldName: "protobuf_unittest.optional_double_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 13,
-  fieldName: "protobuf_unittest.optional_bool_extension_lite",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_optional_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 14,
-  fieldName: "protobuf_unittest.optional_string_extension_lite",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 15,
-  fieldName: "protobuf_unittest.optional_bytes_extension_lite",
-  defaultValue: SwiftProtobuf.Internal.emptyData
-)
-
-let ProtobufUnittest_Extensions_OptionalGroup_extension_lite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 16,
-  fieldName: "protobuf_unittest.OptionalGroup_extension_lite",
-  defaultValue: ProtobufUnittest_OptionalGroup_extension_lite()
-)
-
-let ProtobufUnittest_Extensions_optional_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 18,
-  fieldName: "protobuf_unittest.optional_nested_message_extension_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
-)
-
-let ProtobufUnittest_Extensions_optional_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 19,
-  fieldName: "protobuf_unittest.optional_foreign_message_extension_lite",
-  defaultValue: ProtobufUnittest_ForeignMessageLite()
-)
-
-let ProtobufUnittest_Extensions_optional_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 20,
-  fieldName: "protobuf_unittest.optional_import_message_extension_lite",
-  defaultValue: ProtobufUnittestImport_ImportMessageLite()
-)
-
-let ProtobufUnittest_Extensions_optional_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 21,
-  fieldName: "protobuf_unittest.optional_nested_enum_extension_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.foo
-)
-
-let ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 22,
-  fieldName: "protobuf_unittest.optional_foreign_enum_extension_lite",
-  defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteFoo
-)
-
-let ProtobufUnittest_Extensions_optional_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 23,
-  fieldName: "protobuf_unittest.optional_import_enum_extension_lite",
-  defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteFoo
-)
-
-let ProtobufUnittest_Extensions_optional_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 24,
-  fieldName: "protobuf_unittest.optional_string_piece_extension_lite",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 25,
-  fieldName: "protobuf_unittest.optional_cord_extension_lite",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_public_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 26,
-  fieldName: "protobuf_unittest.optional_public_import_message_extension_lite",
-  defaultValue: ProtobufUnittestImport_PublicImportMessageLite()
-)
-
-let ProtobufUnittest_Extensions_optional_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 27,
-  fieldName: "protobuf_unittest.optional_lazy_message_extension_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
-)
-
-/// Repeated
-let ProtobufUnittest_Extensions_repeated_int32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 31,
-  fieldName: "protobuf_unittest.repeated_int32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_int64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 32,
-  fieldName: "protobuf_unittest.repeated_int64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_uint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 33,
-  fieldName: "protobuf_unittest.repeated_uint32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_uint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 34,
-  fieldName: "protobuf_unittest.repeated_uint64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 35,
-  fieldName: "protobuf_unittest.repeated_sint32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 36,
-  fieldName: "protobuf_unittest.repeated_sint64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_fixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 37,
-  fieldName: "protobuf_unittest.repeated_fixed32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_fixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 38,
-  fieldName: "protobuf_unittest.repeated_fixed64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 39,
-  fieldName: "protobuf_unittest.repeated_sfixed32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 40,
-  fieldName: "protobuf_unittest.repeated_sfixed64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_float_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 41,
-  fieldName: "protobuf_unittest.repeated_float_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_double_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 42,
-  fieldName: "protobuf_unittest.repeated_double_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_bool_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 43,
-  fieldName: "protobuf_unittest.repeated_bool_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_string_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 44,
-  fieldName: "protobuf_unittest.repeated_string_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_bytes_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 45,
-  fieldName: "protobuf_unittest.repeated_bytes_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_RepeatedGroup_extension_lite = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 46,
-  fieldName: "protobuf_unittest.RepeatedGroup_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_nested_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 48,
-  fieldName: "protobuf_unittest.repeated_nested_message_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 49,
-  fieldName: "protobuf_unittest.repeated_foreign_message_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_import_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 50,
-  fieldName: "protobuf_unittest.repeated_import_message_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 51,
-  fieldName: "protobuf_unittest.repeated_nested_enum_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 52,
-  fieldName: "protobuf_unittest.repeated_foreign_enum_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_import_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 53,
-  fieldName: "protobuf_unittest.repeated_import_enum_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_string_piece_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 54,
-  fieldName: "protobuf_unittest.repeated_string_piece_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_cord_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 55,
-  fieldName: "protobuf_unittest.repeated_cord_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 57,
-  fieldName: "protobuf_unittest.repeated_lazy_message_extension_lite",
-  defaultValue: []
-)
-
-/// Singular with defaults
-let ProtobufUnittest_Extensions_default_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 61,
-  fieldName: "protobuf_unittest.default_int32_extension_lite",
-  defaultValue: 41
-)
-
-let ProtobufUnittest_Extensions_default_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 62,
-  fieldName: "protobuf_unittest.default_int64_extension_lite",
-  defaultValue: 42
-)
-
-let ProtobufUnittest_Extensions_default_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 63,
-  fieldName: "protobuf_unittest.default_uint32_extension_lite",
-  defaultValue: 43
-)
-
-let ProtobufUnittest_Extensions_default_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 64,
-  fieldName: "protobuf_unittest.default_uint64_extension_lite",
-  defaultValue: 44
-)
-
-let ProtobufUnittest_Extensions_default_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 65,
-  fieldName: "protobuf_unittest.default_sint32_extension_lite",
-  defaultValue: -45
-)
-
-let ProtobufUnittest_Extensions_default_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 66,
-  fieldName: "protobuf_unittest.default_sint64_extension_lite",
-  defaultValue: 46
-)
-
-let ProtobufUnittest_Extensions_default_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 67,
-  fieldName: "protobuf_unittest.default_fixed32_extension_lite",
-  defaultValue: 47
-)
-
-let ProtobufUnittest_Extensions_default_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 68,
-  fieldName: "protobuf_unittest.default_fixed64_extension_lite",
-  defaultValue: 48
-)
-
-let ProtobufUnittest_Extensions_default_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 69,
-  fieldName: "protobuf_unittest.default_sfixed32_extension_lite",
-  defaultValue: 49
-)
-
-let ProtobufUnittest_Extensions_default_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 70,
-  fieldName: "protobuf_unittest.default_sfixed64_extension_lite",
-  defaultValue: -50
-)
-
-let ProtobufUnittest_Extensions_default_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 71,
-  fieldName: "protobuf_unittest.default_float_extension_lite",
-  defaultValue: 51.5
-)
-
-let ProtobufUnittest_Extensions_default_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 72,
-  fieldName: "protobuf_unittest.default_double_extension_lite",
-  defaultValue: 52000
-)
-
-let ProtobufUnittest_Extensions_default_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 73,
-  fieldName: "protobuf_unittest.default_bool_extension_lite",
-  defaultValue: true
-)
-
-let ProtobufUnittest_Extensions_default_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 74,
-  fieldName: "protobuf_unittest.default_string_extension_lite",
-  defaultValue: "hello"
-)
-
-let ProtobufUnittest_Extensions_default_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 75,
-  fieldName: "protobuf_unittest.default_bytes_extension_lite",
-  defaultValue: Data(bytes: [119, 111, 114, 108, 100])
-)
-
-let ProtobufUnittest_Extensions_default_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 81,
-  fieldName: "protobuf_unittest.default_nested_enum_extension_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.bar
-)
-
-let ProtobufUnittest_Extensions_default_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 82,
-  fieldName: "protobuf_unittest.default_foreign_enum_extension_lite",
-  defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteBar
-)
-
-let ProtobufUnittest_Extensions_default_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 83,
-  fieldName: "protobuf_unittest.default_import_enum_extension_lite",
-  defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteBar
-)
-
-let ProtobufUnittest_Extensions_default_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 84,
-  fieldName: "protobuf_unittest.default_string_piece_extension_lite",
-  defaultValue: "abc"
-)
-
-let ProtobufUnittest_Extensions_default_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 85,
-  fieldName: "protobuf_unittest.default_cord_extension_lite",
-  defaultValue: "123"
-)
-
-/// For oneof test
-let ProtobufUnittest_Extensions_oneof_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 111,
-  fieldName: "protobuf_unittest.oneof_uint32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_oneof_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 112,
-  fieldName: "protobuf_unittest.oneof_nested_message_extension_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
-)
-
-let ProtobufUnittest_Extensions_oneof_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 113,
-  fieldName: "protobuf_unittest.oneof_string_extension_lite",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_oneof_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 114,
-  fieldName: "protobuf_unittest.oneof_bytes_extension_lite",
-  defaultValue: SwiftProtobuf.Internal.emptyData
-)
-
-let ProtobufUnittest_Extensions_packed_int32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 90,
-  fieldName: "protobuf_unittest.packed_int32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_int64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 91,
-  fieldName: "protobuf_unittest.packed_int64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_uint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 92,
-  fieldName: "protobuf_unittest.packed_uint32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_uint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 93,
-  fieldName: "protobuf_unittest.packed_uint64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 94,
-  fieldName: "protobuf_unittest.packed_sint32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 95,
-  fieldName: "protobuf_unittest.packed_sint64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_fixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 96,
-  fieldName: "protobuf_unittest.packed_fixed32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_fixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 97,
-  fieldName: "protobuf_unittest.packed_fixed64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 98,
-  fieldName: "protobuf_unittest.packed_sfixed32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 99,
-  fieldName: "protobuf_unittest.packed_sfixed64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_float_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.packed_float_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_double_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.packed_double_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_bool_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "protobuf_unittest.packed_bool_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_enum_extension_lite = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "protobuf_unittest.packed_enum_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_test_all_types_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestHugeFieldNumbersLite>(
-  _protobuf_fieldNumber: 536860000,
-  fieldName: "protobuf_unittest.test_all_types_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite()
-)
 
 // MARK: - Extension support defined in unittest_lite.proto.
 
@@ -4323,6 +3755,576 @@ let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.SimpleExtensionMap =
   ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext,
   ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext
 ]
+
+/// Singular
+let ProtobufUnittest_Extensions_optional_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "protobuf_unittest.optional_int32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "protobuf_unittest.optional_int64_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "protobuf_unittest.optional_uint32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 4,
+  fieldName: "protobuf_unittest.optional_uint64_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 5,
+  fieldName: "protobuf_unittest.optional_sint32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 6,
+  fieldName: "protobuf_unittest.optional_sint64_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 7,
+  fieldName: "protobuf_unittest.optional_fixed32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 8,
+  fieldName: "protobuf_unittest.optional_fixed64_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 9,
+  fieldName: "protobuf_unittest.optional_sfixed32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 10,
+  fieldName: "protobuf_unittest.optional_sfixed64_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 11,
+  fieldName: "protobuf_unittest.optional_float_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 12,
+  fieldName: "protobuf_unittest.optional_double_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 13,
+  fieldName: "protobuf_unittest.optional_bool_extension_lite",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_optional_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 14,
+  fieldName: "protobuf_unittest.optional_string_extension_lite",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 15,
+  fieldName: "protobuf_unittest.optional_bytes_extension_lite",
+  defaultValue: SwiftProtobuf.Internal.emptyData
+)
+
+let ProtobufUnittest_Extensions_OptionalGroup_extension_lite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 16,
+  fieldName: "protobuf_unittest.OptionalGroup_extension_lite",
+  defaultValue: ProtobufUnittest_OptionalGroup_extension_lite()
+)
+
+let ProtobufUnittest_Extensions_optional_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 18,
+  fieldName: "protobuf_unittest.optional_nested_message_extension_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
+)
+
+let ProtobufUnittest_Extensions_optional_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 19,
+  fieldName: "protobuf_unittest.optional_foreign_message_extension_lite",
+  defaultValue: ProtobufUnittest_ForeignMessageLite()
+)
+
+let ProtobufUnittest_Extensions_optional_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 20,
+  fieldName: "protobuf_unittest.optional_import_message_extension_lite",
+  defaultValue: ProtobufUnittestImport_ImportMessageLite()
+)
+
+let ProtobufUnittest_Extensions_optional_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 21,
+  fieldName: "protobuf_unittest.optional_nested_enum_extension_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.foo
+)
+
+let ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 22,
+  fieldName: "protobuf_unittest.optional_foreign_enum_extension_lite",
+  defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteFoo
+)
+
+let ProtobufUnittest_Extensions_optional_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 23,
+  fieldName: "protobuf_unittest.optional_import_enum_extension_lite",
+  defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteFoo
+)
+
+let ProtobufUnittest_Extensions_optional_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 24,
+  fieldName: "protobuf_unittest.optional_string_piece_extension_lite",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 25,
+  fieldName: "protobuf_unittest.optional_cord_extension_lite",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_public_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 26,
+  fieldName: "protobuf_unittest.optional_public_import_message_extension_lite",
+  defaultValue: ProtobufUnittestImport_PublicImportMessageLite()
+)
+
+let ProtobufUnittest_Extensions_optional_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 27,
+  fieldName: "protobuf_unittest.optional_lazy_message_extension_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
+)
+
+/// Repeated
+let ProtobufUnittest_Extensions_repeated_int32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 31,
+  fieldName: "protobuf_unittest.repeated_int32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_int64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 32,
+  fieldName: "protobuf_unittest.repeated_int64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_uint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 33,
+  fieldName: "protobuf_unittest.repeated_uint32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_uint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 34,
+  fieldName: "protobuf_unittest.repeated_uint64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 35,
+  fieldName: "protobuf_unittest.repeated_sint32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 36,
+  fieldName: "protobuf_unittest.repeated_sint64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_fixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 37,
+  fieldName: "protobuf_unittest.repeated_fixed32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_fixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 38,
+  fieldName: "protobuf_unittest.repeated_fixed64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 39,
+  fieldName: "protobuf_unittest.repeated_sfixed32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 40,
+  fieldName: "protobuf_unittest.repeated_sfixed64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_float_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 41,
+  fieldName: "protobuf_unittest.repeated_float_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_double_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 42,
+  fieldName: "protobuf_unittest.repeated_double_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_bool_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 43,
+  fieldName: "protobuf_unittest.repeated_bool_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_string_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 44,
+  fieldName: "protobuf_unittest.repeated_string_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_bytes_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 45,
+  fieldName: "protobuf_unittest.repeated_bytes_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_RepeatedGroup_extension_lite = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 46,
+  fieldName: "protobuf_unittest.RepeatedGroup_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_nested_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 48,
+  fieldName: "protobuf_unittest.repeated_nested_message_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 49,
+  fieldName: "protobuf_unittest.repeated_foreign_message_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_import_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 50,
+  fieldName: "protobuf_unittest.repeated_import_message_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 51,
+  fieldName: "protobuf_unittest.repeated_nested_enum_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 52,
+  fieldName: "protobuf_unittest.repeated_foreign_enum_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_import_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 53,
+  fieldName: "protobuf_unittest.repeated_import_enum_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_string_piece_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 54,
+  fieldName: "protobuf_unittest.repeated_string_piece_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_cord_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 55,
+  fieldName: "protobuf_unittest.repeated_cord_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 57,
+  fieldName: "protobuf_unittest.repeated_lazy_message_extension_lite",
+  defaultValue: []
+)
+
+/// Singular with defaults
+let ProtobufUnittest_Extensions_default_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 61,
+  fieldName: "protobuf_unittest.default_int32_extension_lite",
+  defaultValue: 41
+)
+
+let ProtobufUnittest_Extensions_default_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 62,
+  fieldName: "protobuf_unittest.default_int64_extension_lite",
+  defaultValue: 42
+)
+
+let ProtobufUnittest_Extensions_default_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 63,
+  fieldName: "protobuf_unittest.default_uint32_extension_lite",
+  defaultValue: 43
+)
+
+let ProtobufUnittest_Extensions_default_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 64,
+  fieldName: "protobuf_unittest.default_uint64_extension_lite",
+  defaultValue: 44
+)
+
+let ProtobufUnittest_Extensions_default_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 65,
+  fieldName: "protobuf_unittest.default_sint32_extension_lite",
+  defaultValue: -45
+)
+
+let ProtobufUnittest_Extensions_default_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 66,
+  fieldName: "protobuf_unittest.default_sint64_extension_lite",
+  defaultValue: 46
+)
+
+let ProtobufUnittest_Extensions_default_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 67,
+  fieldName: "protobuf_unittest.default_fixed32_extension_lite",
+  defaultValue: 47
+)
+
+let ProtobufUnittest_Extensions_default_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 68,
+  fieldName: "protobuf_unittest.default_fixed64_extension_lite",
+  defaultValue: 48
+)
+
+let ProtobufUnittest_Extensions_default_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 69,
+  fieldName: "protobuf_unittest.default_sfixed32_extension_lite",
+  defaultValue: 49
+)
+
+let ProtobufUnittest_Extensions_default_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 70,
+  fieldName: "protobuf_unittest.default_sfixed64_extension_lite",
+  defaultValue: -50
+)
+
+let ProtobufUnittest_Extensions_default_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 71,
+  fieldName: "protobuf_unittest.default_float_extension_lite",
+  defaultValue: 51.5
+)
+
+let ProtobufUnittest_Extensions_default_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 72,
+  fieldName: "protobuf_unittest.default_double_extension_lite",
+  defaultValue: 52000
+)
+
+let ProtobufUnittest_Extensions_default_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 73,
+  fieldName: "protobuf_unittest.default_bool_extension_lite",
+  defaultValue: true
+)
+
+let ProtobufUnittest_Extensions_default_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 74,
+  fieldName: "protobuf_unittest.default_string_extension_lite",
+  defaultValue: "hello"
+)
+
+let ProtobufUnittest_Extensions_default_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 75,
+  fieldName: "protobuf_unittest.default_bytes_extension_lite",
+  defaultValue: Data(bytes: [119, 111, 114, 108, 100])
+)
+
+let ProtobufUnittest_Extensions_default_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 81,
+  fieldName: "protobuf_unittest.default_nested_enum_extension_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.bar
+)
+
+let ProtobufUnittest_Extensions_default_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 82,
+  fieldName: "protobuf_unittest.default_foreign_enum_extension_lite",
+  defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteBar
+)
+
+let ProtobufUnittest_Extensions_default_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 83,
+  fieldName: "protobuf_unittest.default_import_enum_extension_lite",
+  defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteBar
+)
+
+let ProtobufUnittest_Extensions_default_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 84,
+  fieldName: "protobuf_unittest.default_string_piece_extension_lite",
+  defaultValue: "abc"
+)
+
+let ProtobufUnittest_Extensions_default_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 85,
+  fieldName: "protobuf_unittest.default_cord_extension_lite",
+  defaultValue: "123"
+)
+
+/// For oneof test
+let ProtobufUnittest_Extensions_oneof_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 111,
+  fieldName: "protobuf_unittest.oneof_uint32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_oneof_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 112,
+  fieldName: "protobuf_unittest.oneof_nested_message_extension_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
+)
+
+let ProtobufUnittest_Extensions_oneof_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 113,
+  fieldName: "protobuf_unittest.oneof_string_extension_lite",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_oneof_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 114,
+  fieldName: "protobuf_unittest.oneof_bytes_extension_lite",
+  defaultValue: SwiftProtobuf.Internal.emptyData
+)
+
+let ProtobufUnittest_Extensions_packed_int32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 90,
+  fieldName: "protobuf_unittest.packed_int32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_int64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 91,
+  fieldName: "protobuf_unittest.packed_int64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_uint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 92,
+  fieldName: "protobuf_unittest.packed_uint32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_uint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 93,
+  fieldName: "protobuf_unittest.packed_uint64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 94,
+  fieldName: "protobuf_unittest.packed_sint32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 95,
+  fieldName: "protobuf_unittest.packed_sint64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_fixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 96,
+  fieldName: "protobuf_unittest.packed_fixed32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_fixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 97,
+  fieldName: "protobuf_unittest.packed_fixed64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 98,
+  fieldName: "protobuf_unittest.packed_sfixed32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 99,
+  fieldName: "protobuf_unittest.packed_sfixed64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_float_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.packed_float_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_double_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.packed_double_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_bool_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "protobuf_unittest.packed_bool_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_enum_extension_lite = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "protobuf_unittest.packed_enum_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_test_all_types_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestHugeFieldNumbersLite>(
+  _protobuf_fieldNumber: 536860000,
+  fieldName: "protobuf_unittest.test_all_types_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite()
+)
+
+extension ProtobufUnittest_TestNestedExtensionLite {
+  struct Extensions {
+    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+      _protobuf_fieldNumber: 12345,
+      fieldName: "protobuf_unittest.TestNestedExtensionLite.nested_extension",
+      defaultValue: 0
+    )
+  }
+}
+
+extension ProtobufUnittest_TestParsingMergeLite {
+  struct Extensions {
+    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
+      _protobuf_fieldNumber: 1000,
+      fieldName: "protobuf_unittest.TestParsingMergeLite.optional_ext",
+      defaultValue: ProtobufUnittest_TestAllTypesLite()
+    )
+
+    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
+      _protobuf_fieldNumber: 1001,
+      fieldName: "protobuf_unittest.TestParsingMergeLite.repeated_ext",
+      defaultValue: []
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -3009,6 +3009,8 @@ let ProtobufUnittest_Extensions_test_all_types_lite = SwiftProtobuf.MessageExten
   defaultValue: ProtobufUnittest_TestAllTypesLite()
 )
 
+// MARK: - Extension support defined in unittest_lite.proto.
+
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension) ?? 0}

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -122,15 +122,6 @@ struct ProtobufUnittest_TestMessageSetExtension1: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension1>, Proto2WireformatUnittest_TestMessageSet>(
-      _protobuf_fieldNumber: 1545008,
-      fieldName: "protobuf_unittest.TestMessageSetExtension1.message_set_extension",
-      defaultValue: ProtobufUnittest_TestMessageSetExtension1()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -166,15 +157,6 @@ struct ProtobufUnittest_TestMessageSetExtension2: SwiftProtobuf.Message {
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  struct Extensions {
-
-    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension2>, Proto2WireformatUnittest_TestMessageSet>(
-      _protobuf_fieldNumber: 1547769,
-      fieldName: "protobuf_unittest.TestMessageSetExtension2.message_set_extension",
-      defaultValue: ProtobufUnittest_TestMessageSetExtension2()
-    )
-  }
 
   init() {}
 
@@ -321,6 +303,26 @@ let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.SimpleExtensionMap =
   ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension,
   ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension
 ]
+
+extension ProtobufUnittest_TestMessageSetExtension1 {
+  struct Extensions {
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension1>, Proto2WireformatUnittest_TestMessageSet>(
+      _protobuf_fieldNumber: 1545008,
+      fieldName: "protobuf_unittest.TestMessageSetExtension1.message_set_extension",
+      defaultValue: ProtobufUnittest_TestMessageSetExtension1()
+    )
+  }
+}
+
+extension ProtobufUnittest_TestMessageSetExtension2 {
+  struct Extensions {
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension2>, Proto2WireformatUnittest_TestMessageSet>(
+      _protobuf_fieldNumber: 1547769,
+      fieldName: "protobuf_unittest.TestMessageSetExtension2.message_set_extension",
+      defaultValue: ProtobufUnittest_TestMessageSetExtension2()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -305,7 +305,7 @@ let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.SimpleExtensionMap =
 ]
 
 extension ProtobufUnittest_TestMessageSetExtension1 {
-  struct Extensions {
+  enum Extensions {
     static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension1>, Proto2WireformatUnittest_TestMessageSet>(
       _protobuf_fieldNumber: 1545008,
       fieldName: "protobuf_unittest.TestMessageSetExtension1.message_set_extension",
@@ -315,7 +315,7 @@ extension ProtobufUnittest_TestMessageSetExtension1 {
 }
 
 extension ProtobufUnittest_TestMessageSetExtension2 {
-  struct Extensions {
+  enum Extensions {
     static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension2>, Proto2WireformatUnittest_TestMessageSet>(
       _protobuf_fieldNumber: 1547769,
       fieldName: "protobuf_unittest.TestMessageSetExtension2.message_set_extension",

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -311,6 +311,10 @@ extension Proto2WireformatUnittest_TestMessageSet {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension,
   ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -285,6 +285,8 @@ struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message {
   }
 }
 
+// MARK: - Extension support defined in unittest_mset.proto.
+
 extension Proto2WireformatUnittest_TestMessageSet {
   var ProtobufUnittest_TestMessageSetExtension1_messageSetExtension: ProtobufUnittest_TestMessageSetExtension1 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension) ?? ProtobufUnittest_TestMessageSetExtension1()}

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -139,6 +139,10 @@ extension Google_Protobuf_NoGenericServicesTest_TestMessage {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Google_Protobuf_NoGenericServicesTest_Extensions_test_extension
 ]

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -120,12 +120,6 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf.Message,
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-let Google_Protobuf_NoGenericServicesTest_Extensions_test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_NoGenericServicesTest_TestMessage>(
-  _protobuf_fieldNumber: 1000,
-  fieldName: "google.protobuf.no_generic_services_test.test_extension",
-  defaultValue: 0
-)
-
 // MARK: - Extension support defined in unittest_no_generic_services.proto.
 
 extension Google_Protobuf_NoGenericServicesTest_TestMessage {
@@ -148,6 +142,12 @@ extension Google_Protobuf_NoGenericServicesTest_TestMessage {
 let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Google_Protobuf_NoGenericServicesTest_Extensions_test_extension
 ]
+
+let Google_Protobuf_NoGenericServicesTest_Extensions_test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_NoGenericServicesTest_TestMessage>(
+  _protobuf_fieldNumber: 1000,
+  fieldName: "google.protobuf.no_generic_services_test.test_extension",
+  defaultValue: 0
+)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -126,6 +126,8 @@ let Google_Protobuf_NoGenericServicesTest_Extensions_test_extension = SwiftProto
   defaultValue: 0
 )
 
+// MARK: - Extension support defined in unittest_no_generic_services.proto.
+
 extension Google_Protobuf_NoGenericServicesTest_TestMessage {
   var Google_Protobuf_NoGenericServicesTest_testExtension: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension) ?? 0}

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -300,7 +300,7 @@ let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.SimpleExtensi
 ]
 
 extension ProtobufUnittest_TestOptimizedForSize {
-  struct Extensions {
+  enum Extensions {
     static let test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestOptimizedForSize>(
       _protobuf_fieldNumber: 1234,
       fieldName: "protobuf_unittest.TestOptimizedForSize.test_extension",

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -277,6 +277,8 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message {
   }
 }
 
+// MARK: - Extension support defined in unittest_optimize_for.proto.
+
 extension ProtobufUnittest_TestOptimizedForSize {
   var ProtobufUnittest_TestOptimizedForSize_testExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension) ?? 0}

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -128,21 +128,6 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     }
   }
 
-  struct Extensions {
-
-    static let test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestOptimizedForSize>(
-      _protobuf_fieldNumber: 1234,
-      fieldName: "protobuf_unittest.TestOptimizedForSize.test_extension",
-      defaultValue: 0
-    )
-
-    static let test_extension2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequiredOptimizedForSize>, ProtobufUnittest_TestOptimizedForSize>(
-      _protobuf_fieldNumber: 1235,
-      fieldName: "protobuf_unittest.TestOptimizedForSize.test_extension2",
-      defaultValue: ProtobufUnittest_TestRequiredOptimizedForSize()
-    )
-  }
-
   init() {}
 
   public var isInitialized: Bool {
@@ -313,6 +298,22 @@ let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.SimpleExtensi
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension,
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2
 ]
+
+extension ProtobufUnittest_TestOptimizedForSize {
+  struct Extensions {
+    static let test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestOptimizedForSize>(
+      _protobuf_fieldNumber: 1234,
+      fieldName: "protobuf_unittest.TestOptimizedForSize.test_extension",
+      defaultValue: 0
+    )
+
+    static let test_extension2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequiredOptimizedForSize>, ProtobufUnittest_TestOptimizedForSize>(
+      _protobuf_fieldNumber: 1235,
+      fieldName: "protobuf_unittest.TestOptimizedForSize.test_extension2",
+      defaultValue: ProtobufUnittest_TestRequiredOptimizedForSize()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -303,6 +303,10 @@ extension ProtobufUnittest_TestOptimizedForSize {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension,
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -477,6 +477,10 @@ extension ProtobufUnittest_Extend_MsgUsesStorage {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend_Extensions_b,
   ProtobufUnittest_Extend_Extensions_C,

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -325,54 +325,6 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-let ProtobufUnittest_Extend_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.extend.b",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extend_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.extend.C",
-  defaultValue: ProtobufUnittest_Extend_C()
-)
-
-let ProtobufUnittest_Extend_Extensions_a_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg1>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "protobuf_unittest.extend.a_b",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extend_Extensions_aB = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg2>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "protobuf_unittest.extend.aB",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extend_Extensions_ext_a = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgNoStorage>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.extend.ext_a",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extend_Extensions_ext_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgNoStorage>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.extend.ext_b",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extend_Extensions_ext_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgUsesStorage>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.extend.ext_c",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extend_Extensions_ext_d = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgUsesStorage>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.extend.ext_d",
-  defaultValue: 0
-)
-
 // MARK: - Extension support defined in unittest_swift_extension.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
@@ -493,6 +445,54 @@ let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: SwiftProtobuf.Sim
   ProtobufUnittest_Extend_Extensions_ext_c,
   ProtobufUnittest_Extend_Extensions_ext_d
 ]
+
+let ProtobufUnittest_Extend_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.extend.b",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extend_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.extend.C",
+  defaultValue: ProtobufUnittest_Extend_C()
+)
+
+let ProtobufUnittest_Extend_Extensions_a_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg1>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "protobuf_unittest.extend.a_b",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_aB = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg2>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "protobuf_unittest.extend.aB",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_ext_a = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgNoStorage>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.extend.ext_a",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_ext_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgNoStorage>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.extend.ext_b",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_ext_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgUsesStorage>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.extend.ext_c",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_ext_d = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgUsesStorage>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.extend.ext_d",
+  defaultValue: 0
+)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -373,6 +373,8 @@ let ProtobufUnittest_Extend_Extensions_ext_d = SwiftProtobuf.MessageExtension<Op
   defaultValue: 0
 )
 
+// MARK: - Extension support defined in unittest_swift_extension.proto.
+
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b) ?? String()}

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -78,21 +78,6 @@ struct ProtobufUnittest_Extend2_MyMessage: SwiftProtobuf.Message {
     }
   }
 
-  struct Extensions {
-
-    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 210,
-      fieldName: "protobuf_unittest.extend2.MyMessage.b",
-      defaultValue: String()
-    )
-
-    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 211,
-      fieldName: "protobuf_unittest.extend2.MyMessage.C",
-      defaultValue: ProtobufUnittest_Extend2_MyMessage.C()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -140,18 +125,6 @@ struct ProtobufUnittest_Extend2_C: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-let ProtobufUnittest_Extend2_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 220,
-  fieldName: "protobuf_unittest.extend2.b",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 221,
-  fieldName: "protobuf_unittest.extend2.C",
-  defaultValue: ProtobufUnittest_Extend2_C()
-)
 
 // MARK: - Extension support defined in unittest_swift_extension2.proto.
 
@@ -217,6 +190,34 @@ let ProtobufUnittest_Extend2_UnittestSwiftExtension2_Extensions: SwiftProtobuf.S
   ProtobufUnittest_Extend2_MyMessage.Extensions.b,
   ProtobufUnittest_Extend2_MyMessage.Extensions.C
 ]
+
+let ProtobufUnittest_Extend2_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 220,
+  fieldName: "protobuf_unittest.extend2.b",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 221,
+  fieldName: "protobuf_unittest.extend2.C",
+  defaultValue: ProtobufUnittest_Extend2_C()
+)
+
+extension ProtobufUnittest_Extend2_MyMessage {
+  struct Extensions {
+    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 210,
+      fieldName: "protobuf_unittest.extend2.MyMessage.b",
+      defaultValue: String()
+    )
+
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 211,
+      fieldName: "protobuf_unittest.extend2.MyMessage.C",
+      defaultValue: ProtobufUnittest_Extend2_MyMessage.C()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -204,7 +204,7 @@ let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<Optio
 )
 
 extension ProtobufUnittest_Extend2_MyMessage {
-  struct Extensions {
+  enum Extensions {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 210,
       fieldName: "protobuf_unittest.extend2.MyMessage.b",

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -205,6 +205,10 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_Extend2_UnittestSwiftExtension2_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend2_Extensions_b,
   ProtobufUnittest_Extend2_Extensions_C,

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -153,6 +153,8 @@ let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<Optio
   defaultValue: ProtobufUnittest_Extend2_C()
 )
 
+// MARK: - Extension support defined in unittest_swift_extension2.proto.
+
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_MyMessage_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? String()}

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -129,32 +129,6 @@ struct ProtobufUnittest_Extend2_C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension2.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var ProtobufUnittest_Extend2_MyMessage_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? String()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b, value: newValue)}
-  }
-  var hasProtobufUnittest_Extend2_MyMessage_b: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b)
-  }
-  mutating func clearProtobufUnittest_Extend2_MyMessage_b() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var ProtobufUnittest_Extend2_MyMessage_c: ProtobufUnittest_Extend2_MyMessage.C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend2_MyMessage.C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C, value: newValue)}
-  }
-  var hasProtobufUnittest_Extend2_MyMessage_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
-  }
-  mutating func clearProtobufUnittest_Extend2_MyMessage_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b, value: newValue)}
@@ -177,6 +151,32 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
   mutating func clearProtobufUnittest_Extend2_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var ProtobufUnittest_Extend2_MyMessage_b: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? String()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend2_MyMessage_b: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b)
+  }
+  mutating func clearProtobufUnittest_Extend2_MyMessage_b() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var ProtobufUnittest_Extend2_MyMessage_c: ProtobufUnittest_Extend2_MyMessage.C {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend2_MyMessage.C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend2_MyMessage_c: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
+  }
+  mutating func clearProtobufUnittest_Extend2_MyMessage_c() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
   }
 }
 

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -153,6 +153,8 @@ let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<Optio
   defaultValue: ProtobufUnittest_Extend3_C()
 )
 
+// MARK: - Extension support defined in unittest_swift_extension3.proto.
+
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_MyMessage_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? String()}

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -205,6 +205,10 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_Extend3_UnittestSwiftExtension3_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend3_Extensions_b,
   ProtobufUnittest_Extend3_Extensions_C,

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -204,7 +204,7 @@ let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<Optio
 )
 
 extension ProtobufUnittest_Extend3_MyMessage {
-  struct Extensions {
+  enum Extensions {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 310,
       fieldName: "protobuf_unittest.extend3.MyMessage.b",

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -129,32 +129,6 @@ struct ProtobufUnittest_Extend3_C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension3.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var ProtobufUnittest_Extend3_MyMessage_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? String()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b, value: newValue)}
-  }
-  var hasProtobufUnittest_Extend3_MyMessage_b: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b)
-  }
-  mutating func clearProtobufUnittest_Extend3_MyMessage_b() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var ProtobufUnittest_Extend3_MyMessage_c: ProtobufUnittest_Extend3_MyMessage.C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend3_MyMessage.C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C, value: newValue)}
-  }
-  var hasProtobufUnittest_Extend3_MyMessage_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
-  }
-  mutating func clearProtobufUnittest_Extend3_MyMessage_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b, value: newValue)}
@@ -177,6 +151,32 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
   mutating func clearProtobufUnittest_Extend3_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var ProtobufUnittest_Extend3_MyMessage_b: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? String()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend3_MyMessage_b: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b)
+  }
+  mutating func clearProtobufUnittest_Extend3_MyMessage_b() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var ProtobufUnittest_Extend3_MyMessage_c: ProtobufUnittest_Extend3_MyMessage.C {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend3_MyMessage.C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend3_MyMessage_c: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
+  }
+  mutating func clearProtobufUnittest_Extend3_MyMessage_c() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
   }
 }
 

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -78,21 +78,6 @@ struct ProtobufUnittest_Extend3_MyMessage: SwiftProtobuf.Message {
     }
   }
 
-  struct Extensions {
-
-    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 310,
-      fieldName: "protobuf_unittest.extend3.MyMessage.b",
-      defaultValue: String()
-    )
-
-    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 311,
-      fieldName: "protobuf_unittest.extend3.MyMessage.C",
-      defaultValue: ProtobufUnittest_Extend3_MyMessage.C()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -140,18 +125,6 @@ struct ProtobufUnittest_Extend3_C: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-let ProtobufUnittest_Extend3_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 320,
-  fieldName: "protobuf_unittest.extend3.b",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 321,
-  fieldName: "protobuf_unittest.extend3.C",
-  defaultValue: ProtobufUnittest_Extend3_C()
-)
 
 // MARK: - Extension support defined in unittest_swift_extension3.proto.
 
@@ -217,6 +190,34 @@ let ProtobufUnittest_Extend3_UnittestSwiftExtension3_Extensions: SwiftProtobuf.S
   ProtobufUnittest_Extend3_MyMessage.Extensions.b,
   ProtobufUnittest_Extend3_MyMessage.Extensions.C
 ]
+
+let ProtobufUnittest_Extend3_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 320,
+  fieldName: "protobuf_unittest.extend3.b",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 321,
+  fieldName: "protobuf_unittest.extend3.C",
+  defaultValue: ProtobufUnittest_Extend3_C()
+)
+
+extension ProtobufUnittest_Extend3_MyMessage {
+  struct Extensions {
+    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 310,
+      fieldName: "protobuf_unittest.extend3.MyMessage.b",
+      defaultValue: String()
+    )
+
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 311,
+      fieldName: "protobuf_unittest.extend3.MyMessage.C",
+      defaultValue: ProtobufUnittest_Extend3_MyMessage.C()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -153,6 +153,8 @@ let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionFiel
   defaultValue: Ext4C()
 )
 
+// MARK: - Extension support defined in unittest_swift_extension4.proto.
+
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4MyMessage_b: String {
     get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? String()}

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -204,7 +204,7 @@ let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionFiel
 )
 
 extension Ext4MyMessage {
-  struct Extensions {
+  enum Extensions {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 410,
       fieldName: "protobuf_unittest.extend4.MyMessage.b",

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -205,6 +205,10 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let Ext4UnittestSwiftExtension4_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Ext4Extensions_b,
   Ext4Extensions_C,

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -129,32 +129,6 @@ struct Ext4C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension4.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var Ext4MyMessage_b: String {
-    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? String()}
-    set {setExtensionValue(ext: Ext4MyMessage.Extensions.b, value: newValue)}
-  }
-  var hasExt4MyMessage_b: Bool {
-    return hasExtensionValue(ext: Ext4MyMessage.Extensions.b)
-  }
-  mutating func clearExt4MyMessage_b() {
-    clearExtensionValue(ext: Ext4MyMessage.Extensions.b)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var Ext4MyMessage_c: Ext4MyMessage.C {
-    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.C) ?? Ext4MyMessage.C()}
-    set {setExtensionValue(ext: Ext4MyMessage.Extensions.C, value: newValue)}
-  }
-  var hasExt4MyMessage_c: Bool {
-    return hasExtensionValue(ext: Ext4MyMessage.Extensions.C)
-  }
-  mutating func clearExt4MyMessage_c() {
-    clearExtensionValue(ext: Ext4MyMessage.Extensions.C)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4b: String {
     get {return getExtensionValue(ext: Ext4Extensions_b) ?? String()}
     set {setExtensionValue(ext: Ext4Extensions_b, value: newValue)}
@@ -177,6 +151,32 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
   mutating func clearExt4c() {
     clearExtensionValue(ext: Ext4Extensions_C)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var Ext4MyMessage_b: String {
+    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? String()}
+    set {setExtensionValue(ext: Ext4MyMessage.Extensions.b, value: newValue)}
+  }
+  var hasExt4MyMessage_b: Bool {
+    return hasExtensionValue(ext: Ext4MyMessage.Extensions.b)
+  }
+  mutating func clearExt4MyMessage_b() {
+    clearExtensionValue(ext: Ext4MyMessage.Extensions.b)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var Ext4MyMessage_c: Ext4MyMessage.C {
+    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.C) ?? Ext4MyMessage.C()}
+    set {setExtensionValue(ext: Ext4MyMessage.Extensions.C, value: newValue)}
+  }
+  var hasExt4MyMessage_c: Bool {
+    return hasExtensionValue(ext: Ext4MyMessage.Extensions.C)
+  }
+  mutating func clearExt4MyMessage_c() {
+    clearExtensionValue(ext: Ext4MyMessage.Extensions.C)
   }
 }
 

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -78,21 +78,6 @@ struct Ext4MyMessage: SwiftProtobuf.Message {
     }
   }
 
-  struct Extensions {
-
-    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 410,
-      fieldName: "protobuf_unittest.extend4.MyMessage.b",
-      defaultValue: String()
-    )
-
-    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 411,
-      fieldName: "protobuf_unittest.extend4.MyMessage.C",
-      defaultValue: Ext4MyMessage.C()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -140,18 +125,6 @@ struct Ext4C: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-let Ext4Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 420,
-  fieldName: "protobuf_unittest.extend4.b",
-  defaultValue: String()
-)
-
-let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 421,
-  fieldName: "protobuf_unittest.extend4.C",
-  defaultValue: Ext4C()
-)
 
 // MARK: - Extension support defined in unittest_swift_extension4.proto.
 
@@ -217,6 +190,34 @@ let Ext4UnittestSwiftExtension4_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Ext4MyMessage.Extensions.b,
   Ext4MyMessage.Extensions.C
 ]
+
+let Ext4Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 420,
+  fieldName: "protobuf_unittest.extend4.b",
+  defaultValue: String()
+)
+
+let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 421,
+  fieldName: "protobuf_unittest.extend4.C",
+  defaultValue: Ext4C()
+)
+
+extension Ext4MyMessage {
+  struct Extensions {
+    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 410,
+      fieldName: "protobuf_unittest.extend4.MyMessage.b",
+      defaultValue: String()
+    )
+
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 411,
+      fieldName: "protobuf_unittest.extend4.MyMessage.C",
+      defaultValue: Ext4MyMessage.C()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -265,18 +265,6 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-let Swift_Protobuf_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(
-  _protobuf_fieldNumber: 50,
-  fieldName: "swift.protobuf.my_extension_string",
-  defaultValue: String()
-)
-
-let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(
-  _protobuf_fieldNumber: 5,
-  fieldName: "swift.protobuf.my_extension_int",
-  defaultValue: 0
-)
-
 // MARK: - Extension support defined in unittest_swift_fieldorder.proto.
 
 extension Swift_Protobuf_TestFieldOrderings {
@@ -313,6 +301,18 @@ let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: SwiftProtobuf.SimpleExten
   Swift_Protobuf_Extensions_my_extension_string,
   Swift_Protobuf_Extensions_my_extension_int
 ]
+
+let Swift_Protobuf_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(
+  _protobuf_fieldNumber: 50,
+  fieldName: "swift.protobuf.my_extension_string",
+  defaultValue: String()
+)
+
+let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(
+  _protobuf_fieldNumber: 5,
+  fieldName: "swift.protobuf.my_extension_int",
+  defaultValue: 0
+)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -277,6 +277,8 @@ let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<
   defaultValue: 0
 )
 
+// MARK: - Extension support defined in unittest_swift_fieldorder.proto.
+
 extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionString: String {
     get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string) ?? String()}

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -303,6 +303,10 @@ extension Swift_Protobuf_TestFieldOrderings {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Swift_Protobuf_Extensions_my_extension_string,
   Swift_Protobuf_Extensions_my_extension_int

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -479,6 +479,10 @@ extension SwiftTestGroupExtensions {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let UnittestSwiftGroups_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_ExtensionGroup,
   Extensions_RepeatedExtensionGroup

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -441,18 +441,6 @@ struct SwiftTestNestingGroupsMessage: SwiftProtobuf.Message {
   }
 }
 
-let Extensions_ExtensionGroup = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ExtensionGroup>, SwiftTestGroupExtensions>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "ExtensionGroup",
-  defaultValue: ExtensionGroup()
-)
-
-let Extensions_RepeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "RepeatedExtensionGroup",
-  defaultValue: []
-)
-
 // MARK: - Extension support defined in unittest_swift_groups.proto.
 
 extension SwiftTestGroupExtensions {
@@ -489,6 +477,18 @@ let UnittestSwiftGroups_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_ExtensionGroup,
   Extensions_RepeatedExtensionGroup
 ]
+
+let Extensions_ExtensionGroup = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ExtensionGroup>, SwiftTestGroupExtensions>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "ExtensionGroup",
+  defaultValue: ExtensionGroup()
+)
+
+let Extensions_RepeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "RepeatedExtensionGroup",
+  defaultValue: []
+)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -453,6 +453,8 @@ let Extensions_RepeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedG
   defaultValue: []
 )
 
+// MARK: - Extension support defined in unittest_swift_groups.proto.
+
 extension SwiftTestGroupExtensions {
   var extensionGroup: ExtensionGroup {
     get {return getExtensionValue(ext: Extensions_ExtensionGroup) ?? ExtensionGroup()}

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -17181,487 +17181,6 @@ struct SwiftUnittest_Names_ExtensionNamingInitialsWordCase: SwiftProtobuf.Messag
 
 // MARK: - Extension support defined in unittest_swift_naming.proto.
 
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_aBC: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_aBC: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_aBC() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
-  }
-}
-
 extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_http: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_http) ?? 0}
@@ -18140,6 +17659,487 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   }
   mutating func clearSwiftUnittest_Names_theURL() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrl)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_aBC: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_aBC: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_aBC() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
   }
 }
 

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -17049,87 +17049,6 @@ struct SwiftUnittest_Names_Lowers: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 1,
-      fieldName: "swift_unittest.names.Lowers.http",
-      defaultValue: 0
-    )
-
-    static let http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 2,
-      fieldName: "swift_unittest.names.Lowers.http_request",
-      defaultValue: 0
-    )
-
-    static let the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 3,
-      fieldName: "swift_unittest.names.Lowers.the_http_request",
-      defaultValue: 0
-    )
-
-    static let the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 4,
-      fieldName: "swift_unittest.names.Lowers.the_http",
-      defaultValue: 0
-    )
-
-    static let https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 11,
-      fieldName: "swift_unittest.names.Lowers.https",
-      defaultValue: 0
-    )
-
-    static let https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 12,
-      fieldName: "swift_unittest.names.Lowers.https_request",
-      defaultValue: 0
-    )
-
-    static let the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 13,
-      fieldName: "swift_unittest.names.Lowers.the_https_request",
-      defaultValue: 0
-    )
-
-    static let the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 14,
-      fieldName: "swift_unittest.names.Lowers.the_https",
-      defaultValue: 0
-    )
-
-    static let url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 21,
-      fieldName: "swift_unittest.names.Lowers.url",
-      defaultValue: 0
-    )
-
-    static let url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 22,
-      fieldName: "swift_unittest.names.Lowers.url_value",
-      defaultValue: 0
-    )
-
-    static let the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 23,
-      fieldName: "swift_unittest.names.Lowers.the_url_value",
-      defaultValue: 0
-    )
-
-    static let the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 24,
-      fieldName: "swift_unittest.names.Lowers.the_url",
-      defaultValue: 0
-    )
-
-    static let a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 31,
-      fieldName: "swift_unittest.names.Lowers.a_b_c",
-      defaultValue: 0
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -17147,81 +17066,6 @@ struct SwiftUnittest_Names_Uppers: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 101,
-      fieldName: "swift_unittest.names.Uppers.HTTP",
-      defaultValue: 0
-    )
-
-    static let HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 102,
-      fieldName: "swift_unittest.names.Uppers.HTTP_request",
-      defaultValue: 0
-    )
-
-    static let the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 103,
-      fieldName: "swift_unittest.names.Uppers.the_HTTP_request",
-      defaultValue: 0
-    )
-
-    static let the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 104,
-      fieldName: "swift_unittest.names.Uppers.the_HTTP",
-      defaultValue: 0
-    )
-
-    static let HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 111,
-      fieldName: "swift_unittest.names.Uppers.HTTPS",
-      defaultValue: 0
-    )
-
-    static let HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 112,
-      fieldName: "swift_unittest.names.Uppers.HTTPS_request",
-      defaultValue: 0
-    )
-
-    static let the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 113,
-      fieldName: "swift_unittest.names.Uppers.the_HTTPS_request",
-      defaultValue: 0
-    )
-
-    static let the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 114,
-      fieldName: "swift_unittest.names.Uppers.the_HTTPS",
-      defaultValue: 0
-    )
-
-    static let URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 121,
-      fieldName: "swift_unittest.names.Uppers.URL",
-      defaultValue: 0
-    )
-
-    static let URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 122,
-      fieldName: "swift_unittest.names.Uppers.URL_value",
-      defaultValue: 0
-    )
-
-    static let the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 123,
-      fieldName: "swift_unittest.names.Uppers.the_URL_value",
-      defaultValue: 0
-    )
-
-    static let the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 124,
-      fieldName: "swift_unittest.names.Uppers.the_URL",
-      defaultValue: 0
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -17238,81 +17082,6 @@ struct SwiftUnittest_Names_WordCase: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".WordCase"
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  struct Extensions {
-
-    static let Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 201,
-      fieldName: "swift_unittest.names.WordCase.Http",
-      defaultValue: 0
-    )
-
-    static let HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 202,
-      fieldName: "swift_unittest.names.WordCase.HttpRequest",
-      defaultValue: 0
-    )
-
-    static let TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 203,
-      fieldName: "swift_unittest.names.WordCase.TheHttpRequest",
-      defaultValue: 0
-    )
-
-    static let TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 204,
-      fieldName: "swift_unittest.names.WordCase.TheHttp",
-      defaultValue: 0
-    )
-
-    static let Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 211,
-      fieldName: "swift_unittest.names.WordCase.Https",
-      defaultValue: 0
-    )
-
-    static let HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 212,
-      fieldName: "swift_unittest.names.WordCase.HttpsRequest",
-      defaultValue: 0
-    )
-
-    static let TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 213,
-      fieldName: "swift_unittest.names.WordCase.TheHttpsRequest",
-      defaultValue: 0
-    )
-
-    static let TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 214,
-      fieldName: "swift_unittest.names.WordCase.TheHttps",
-      defaultValue: 0
-    )
-
-    static let Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 221,
-      fieldName: "swift_unittest.names.WordCase.Url",
-      defaultValue: 0
-    )
-
-    static let UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 222,
-      fieldName: "swift_unittest.names.WordCase.UrlValue",
-      defaultValue: 0
-    )
-
-    static let TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 223,
-      fieldName: "swift_unittest.names.WordCase.TheUrlValue",
-      defaultValue: 0
-    )
-
-    static let TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 224,
-      fieldName: "swift_unittest.names.WordCase.TheUrl",
-      defaultValue: 0
-    )
-  }
 
   init() {}
 
@@ -17409,228 +17178,6 @@ struct SwiftUnittest_Names_ExtensionNamingInitialsWordCase: SwiftProtobuf.Messag
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
-
-let SwiftUnittest_Names_Extensions_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "swift_unittest.names.http",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "swift_unittest.names.http_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "swift_unittest.names.the_http_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 4,
-  fieldName: "swift_unittest.names.the_http",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 11,
-  fieldName: "swift_unittest.names.https",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 12,
-  fieldName: "swift_unittest.names.https_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 13,
-  fieldName: "swift_unittest.names.the_https_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 14,
-  fieldName: "swift_unittest.names.the_https",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 21,
-  fieldName: "swift_unittest.names.url",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 22,
-  fieldName: "swift_unittest.names.url_value",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 23,
-  fieldName: "swift_unittest.names.the_url_value",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 24,
-  fieldName: "swift_unittest.names.the_url",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 31,
-  fieldName: "swift_unittest.names.a_b_c",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "swift_unittest.names.HTTP",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "swift_unittest.names.HTTP_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "swift_unittest.names.the_HTTP_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 4,
-  fieldName: "swift_unittest.names.the_HTTP",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 11,
-  fieldName: "swift_unittest.names.HTTPS",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 12,
-  fieldName: "swift_unittest.names.HTTPS_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 13,
-  fieldName: "swift_unittest.names.the_HTTPS_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 14,
-  fieldName: "swift_unittest.names.the_HTTPS",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 21,
-  fieldName: "swift_unittest.names.URL",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 22,
-  fieldName: "swift_unittest.names.URL_value",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 23,
-  fieldName: "swift_unittest.names.the_URL_value",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 24,
-  fieldName: "swift_unittest.names.the_URL",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "swift_unittest.names.Http",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "swift_unittest.names.HttpRequest",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "swift_unittest.names.TheHttpRequest",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 4,
-  fieldName: "swift_unittest.names.TheHttp",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 11,
-  fieldName: "swift_unittest.names.Https",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 12,
-  fieldName: "swift_unittest.names.HttpsRequest",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 13,
-  fieldName: "swift_unittest.names.TheHttpsRequest",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 14,
-  fieldName: "swift_unittest.names.TheHttps",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 21,
-  fieldName: "swift_unittest.names.Url",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 22,
-  fieldName: "swift_unittest.names.UrlValue",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 23,
-  fieldName: "swift_unittest.names.TheUrlValue",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 24,
-  fieldName: "swift_unittest.names.TheUrl",
-  defaultValue: 0
-)
 
 // MARK: - Extension support defined in unittest_swift_naming.proto.
 
@@ -18676,6 +18223,462 @@ let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.SimpleExte
   SwiftUnittest_Names_WordCase.Extensions.TheUrlValue,
   SwiftUnittest_Names_WordCase.Extensions.TheUrl
 ]
+
+let SwiftUnittest_Names_Extensions_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "swift_unittest.names.http",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "swift_unittest.names.http_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "swift_unittest.names.the_http_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 4,
+  fieldName: "swift_unittest.names.the_http",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 11,
+  fieldName: "swift_unittest.names.https",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 12,
+  fieldName: "swift_unittest.names.https_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 13,
+  fieldName: "swift_unittest.names.the_https_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 14,
+  fieldName: "swift_unittest.names.the_https",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 21,
+  fieldName: "swift_unittest.names.url",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 22,
+  fieldName: "swift_unittest.names.url_value",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 23,
+  fieldName: "swift_unittest.names.the_url_value",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 24,
+  fieldName: "swift_unittest.names.the_url",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 31,
+  fieldName: "swift_unittest.names.a_b_c",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "swift_unittest.names.HTTP",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "swift_unittest.names.HTTP_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "swift_unittest.names.the_HTTP_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 4,
+  fieldName: "swift_unittest.names.the_HTTP",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 11,
+  fieldName: "swift_unittest.names.HTTPS",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 12,
+  fieldName: "swift_unittest.names.HTTPS_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 13,
+  fieldName: "swift_unittest.names.the_HTTPS_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 14,
+  fieldName: "swift_unittest.names.the_HTTPS",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 21,
+  fieldName: "swift_unittest.names.URL",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 22,
+  fieldName: "swift_unittest.names.URL_value",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 23,
+  fieldName: "swift_unittest.names.the_URL_value",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 24,
+  fieldName: "swift_unittest.names.the_URL",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "swift_unittest.names.Http",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "swift_unittest.names.HttpRequest",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "swift_unittest.names.TheHttpRequest",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 4,
+  fieldName: "swift_unittest.names.TheHttp",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 11,
+  fieldName: "swift_unittest.names.Https",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 12,
+  fieldName: "swift_unittest.names.HttpsRequest",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 13,
+  fieldName: "swift_unittest.names.TheHttpsRequest",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 14,
+  fieldName: "swift_unittest.names.TheHttps",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 21,
+  fieldName: "swift_unittest.names.Url",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 22,
+  fieldName: "swift_unittest.names.UrlValue",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 23,
+  fieldName: "swift_unittest.names.TheUrlValue",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 24,
+  fieldName: "swift_unittest.names.TheUrl",
+  defaultValue: 0
+)
+
+extension SwiftUnittest_Names_Lowers {
+  struct Extensions {
+    static let http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 1,
+      fieldName: "swift_unittest.names.Lowers.http",
+      defaultValue: 0
+    )
+
+    static let http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 2,
+      fieldName: "swift_unittest.names.Lowers.http_request",
+      defaultValue: 0
+    )
+
+    static let the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 3,
+      fieldName: "swift_unittest.names.Lowers.the_http_request",
+      defaultValue: 0
+    )
+
+    static let the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 4,
+      fieldName: "swift_unittest.names.Lowers.the_http",
+      defaultValue: 0
+    )
+
+    static let https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 11,
+      fieldName: "swift_unittest.names.Lowers.https",
+      defaultValue: 0
+    )
+
+    static let https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 12,
+      fieldName: "swift_unittest.names.Lowers.https_request",
+      defaultValue: 0
+    )
+
+    static let the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 13,
+      fieldName: "swift_unittest.names.Lowers.the_https_request",
+      defaultValue: 0
+    )
+
+    static let the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 14,
+      fieldName: "swift_unittest.names.Lowers.the_https",
+      defaultValue: 0
+    )
+
+    static let url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 21,
+      fieldName: "swift_unittest.names.Lowers.url",
+      defaultValue: 0
+    )
+
+    static let url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 22,
+      fieldName: "swift_unittest.names.Lowers.url_value",
+      defaultValue: 0
+    )
+
+    static let the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 23,
+      fieldName: "swift_unittest.names.Lowers.the_url_value",
+      defaultValue: 0
+    )
+
+    static let the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 24,
+      fieldName: "swift_unittest.names.Lowers.the_url",
+      defaultValue: 0
+    )
+
+    static let a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 31,
+      fieldName: "swift_unittest.names.Lowers.a_b_c",
+      defaultValue: 0
+    )
+  }
+}
+
+extension SwiftUnittest_Names_Uppers {
+  struct Extensions {
+    static let HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 101,
+      fieldName: "swift_unittest.names.Uppers.HTTP",
+      defaultValue: 0
+    )
+
+    static let HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 102,
+      fieldName: "swift_unittest.names.Uppers.HTTP_request",
+      defaultValue: 0
+    )
+
+    static let the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 103,
+      fieldName: "swift_unittest.names.Uppers.the_HTTP_request",
+      defaultValue: 0
+    )
+
+    static let the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 104,
+      fieldName: "swift_unittest.names.Uppers.the_HTTP",
+      defaultValue: 0
+    )
+
+    static let HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 111,
+      fieldName: "swift_unittest.names.Uppers.HTTPS",
+      defaultValue: 0
+    )
+
+    static let HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 112,
+      fieldName: "swift_unittest.names.Uppers.HTTPS_request",
+      defaultValue: 0
+    )
+
+    static let the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 113,
+      fieldName: "swift_unittest.names.Uppers.the_HTTPS_request",
+      defaultValue: 0
+    )
+
+    static let the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 114,
+      fieldName: "swift_unittest.names.Uppers.the_HTTPS",
+      defaultValue: 0
+    )
+
+    static let URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 121,
+      fieldName: "swift_unittest.names.Uppers.URL",
+      defaultValue: 0
+    )
+
+    static let URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 122,
+      fieldName: "swift_unittest.names.Uppers.URL_value",
+      defaultValue: 0
+    )
+
+    static let the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 123,
+      fieldName: "swift_unittest.names.Uppers.the_URL_value",
+      defaultValue: 0
+    )
+
+    static let the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 124,
+      fieldName: "swift_unittest.names.Uppers.the_URL",
+      defaultValue: 0
+    )
+  }
+}
+
+extension SwiftUnittest_Names_WordCase {
+  struct Extensions {
+    static let Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 201,
+      fieldName: "swift_unittest.names.WordCase.Http",
+      defaultValue: 0
+    )
+
+    static let HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 202,
+      fieldName: "swift_unittest.names.WordCase.HttpRequest",
+      defaultValue: 0
+    )
+
+    static let TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 203,
+      fieldName: "swift_unittest.names.WordCase.TheHttpRequest",
+      defaultValue: 0
+    )
+
+    static let TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 204,
+      fieldName: "swift_unittest.names.WordCase.TheHttp",
+      defaultValue: 0
+    )
+
+    static let Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 211,
+      fieldName: "swift_unittest.names.WordCase.Https",
+      defaultValue: 0
+    )
+
+    static let HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 212,
+      fieldName: "swift_unittest.names.WordCase.HttpsRequest",
+      defaultValue: 0
+    )
+
+    static let TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 213,
+      fieldName: "swift_unittest.names.WordCase.TheHttpsRequest",
+      defaultValue: 0
+    )
+
+    static let TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 214,
+      fieldName: "swift_unittest.names.WordCase.TheHttps",
+      defaultValue: 0
+    )
+
+    static let Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 221,
+      fieldName: "swift_unittest.names.WordCase.Url",
+      defaultValue: 0
+    )
+
+    static let UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 222,
+      fieldName: "swift_unittest.names.WordCase.UrlValue",
+      defaultValue: 0
+    )
+
+    static let TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 223,
+      fieldName: "swift_unittest.names.WordCase.TheUrlValue",
+      defaultValue: 0
+    )
+
+    static let TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 224,
+      fieldName: "swift_unittest.names.WordCase.TheUrl",
+      defaultValue: 0
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -18447,7 +18447,7 @@ let SwiftUnittest_Names_Extensions_TheUrl = SwiftProtobuf.MessageExtension<Optio
 )
 
 extension SwiftUnittest_Names_Lowers {
-  struct Extensions {
+  enum Extensions {
     static let http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       _protobuf_fieldNumber: 1,
       fieldName: "swift_unittest.names.Lowers.http",
@@ -18529,7 +18529,7 @@ extension SwiftUnittest_Names_Lowers {
 }
 
 extension SwiftUnittest_Names_Uppers {
-  struct Extensions {
+  enum Extensions {
     static let HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       _protobuf_fieldNumber: 101,
       fieldName: "swift_unittest.names.Uppers.HTTP",
@@ -18605,7 +18605,7 @@ extension SwiftUnittest_Names_Uppers {
 }
 
 extension SwiftUnittest_Names_WordCase {
-  struct Extensions {
+  enum Extensions {
     static let Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       _protobuf_fieldNumber: 201,
       fieldName: "swift_unittest.names.WordCase.Http",

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -17632,6 +17632,8 @@ let SwiftUnittest_Names_Extensions_TheUrl = SwiftProtobuf.MessageExtension<Optio
   defaultValue: 0
 )
 
+// MARK: - Extension support defined in unittest_swift_naming.proto.
+
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_http: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http) ?? 0}

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -18594,6 +18594,10 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   SwiftUnittest_Names_Extensions_http,
   SwiftUnittest_Names_Extensions_http_request,

--- a/Reference/unittest_swift_naming_no_prefix.pb.swift
+++ b/Reference/unittest_swift_naming_no_prefix.pb.swift
@@ -35,228 +35,6 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _1
 }
 
-let Extensions_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "http",
-  defaultValue: 0
-)
-
-let Extensions_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "http_request",
-  defaultValue: 0
-)
-
-let Extensions_the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "the_http_request",
-  defaultValue: 0
-)
-
-let Extensions_the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 104,
-  fieldName: "the_http",
-  defaultValue: 0
-)
-
-let Extensions_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 111,
-  fieldName: "https",
-  defaultValue: 0
-)
-
-let Extensions_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 112,
-  fieldName: "https_request",
-  defaultValue: 0
-)
-
-let Extensions_the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 113,
-  fieldName: "the_https_request",
-  defaultValue: 0
-)
-
-let Extensions_the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 114,
-  fieldName: "the_https",
-  defaultValue: 0
-)
-
-let Extensions_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 121,
-  fieldName: "url",
-  defaultValue: 0
-)
-
-let Extensions_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 122,
-  fieldName: "url_value",
-  defaultValue: 0
-)
-
-let Extensions_the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 123,
-  fieldName: "the_url_value",
-  defaultValue: 0
-)
-
-let Extensions_the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 124,
-  fieldName: "the_url",
-  defaultValue: 0
-)
-
-let Extensions_a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 131,
-  fieldName: "a_b_c",
-  defaultValue: 0
-)
-
-let Extensions_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "HTTP",
-  defaultValue: 0
-)
-
-let Extensions_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "HTTP_request",
-  defaultValue: 0
-)
-
-let Extensions_the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "the_HTTP_request",
-  defaultValue: 0
-)
-
-let Extensions_the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 104,
-  fieldName: "the_HTTP",
-  defaultValue: 0
-)
-
-let Extensions_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 111,
-  fieldName: "HTTPS",
-  defaultValue: 0
-)
-
-let Extensions_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 112,
-  fieldName: "HTTPS_request",
-  defaultValue: 0
-)
-
-let Extensions_the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 113,
-  fieldName: "the_HTTPS_request",
-  defaultValue: 0
-)
-
-let Extensions_the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 114,
-  fieldName: "the_HTTPS",
-  defaultValue: 0
-)
-
-let Extensions_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 121,
-  fieldName: "URL",
-  defaultValue: 0
-)
-
-let Extensions_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 122,
-  fieldName: "URL_value",
-  defaultValue: 0
-)
-
-let Extensions_the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 123,
-  fieldName: "the_URL_value",
-  defaultValue: 0
-)
-
-let Extensions_the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 124,
-  fieldName: "the_URL",
-  defaultValue: 0
-)
-
-let Extensions_Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "Http",
-  defaultValue: 0
-)
-
-let Extensions_HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "HttpRequest",
-  defaultValue: 0
-)
-
-let Extensions_TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "TheHttpRequest",
-  defaultValue: 0
-)
-
-let Extensions_TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 104,
-  fieldName: "TheHttp",
-  defaultValue: 0
-)
-
-let Extensions_Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 111,
-  fieldName: "Https",
-  defaultValue: 0
-)
-
-let Extensions_HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 112,
-  fieldName: "HttpsRequest",
-  defaultValue: 0
-)
-
-let Extensions_TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 113,
-  fieldName: "TheHttpsRequest",
-  defaultValue: 0
-)
-
-let Extensions_TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 114,
-  fieldName: "TheHttps",
-  defaultValue: 0
-)
-
-let Extensions_Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 121,
-  fieldName: "Url",
-  defaultValue: 0
-)
-
-let Extensions_UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 122,
-  fieldName: "UrlValue",
-  defaultValue: 0
-)
-
-let Extensions_TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 123,
-  fieldName: "TheUrlValue",
-  defaultValue: 0
-)
-
-let Extensions_TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 124,
-  fieldName: "TheUrl",
-  defaultValue: 0
-)
-
 // MARK: - Extension support defined in unittest_swift_naming_no_prefix.proto.
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
@@ -783,3 +561,225 @@ let UnittestSwiftNamingNoPrefix_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_TheUrlValue,
   Extensions_TheUrl
 ]
+
+let Extensions_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "http",
+  defaultValue: 0
+)
+
+let Extensions_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "http_request",
+  defaultValue: 0
+)
+
+let Extensions_the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "the_http_request",
+  defaultValue: 0
+)
+
+let Extensions_the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 104,
+  fieldName: "the_http",
+  defaultValue: 0
+)
+
+let Extensions_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 111,
+  fieldName: "https",
+  defaultValue: 0
+)
+
+let Extensions_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 112,
+  fieldName: "https_request",
+  defaultValue: 0
+)
+
+let Extensions_the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 113,
+  fieldName: "the_https_request",
+  defaultValue: 0
+)
+
+let Extensions_the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 114,
+  fieldName: "the_https",
+  defaultValue: 0
+)
+
+let Extensions_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 121,
+  fieldName: "url",
+  defaultValue: 0
+)
+
+let Extensions_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 122,
+  fieldName: "url_value",
+  defaultValue: 0
+)
+
+let Extensions_the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 123,
+  fieldName: "the_url_value",
+  defaultValue: 0
+)
+
+let Extensions_the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 124,
+  fieldName: "the_url",
+  defaultValue: 0
+)
+
+let Extensions_a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 131,
+  fieldName: "a_b_c",
+  defaultValue: 0
+)
+
+let Extensions_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "HTTP",
+  defaultValue: 0
+)
+
+let Extensions_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "HTTP_request",
+  defaultValue: 0
+)
+
+let Extensions_the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "the_HTTP_request",
+  defaultValue: 0
+)
+
+let Extensions_the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 104,
+  fieldName: "the_HTTP",
+  defaultValue: 0
+)
+
+let Extensions_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 111,
+  fieldName: "HTTPS",
+  defaultValue: 0
+)
+
+let Extensions_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 112,
+  fieldName: "HTTPS_request",
+  defaultValue: 0
+)
+
+let Extensions_the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 113,
+  fieldName: "the_HTTPS_request",
+  defaultValue: 0
+)
+
+let Extensions_the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 114,
+  fieldName: "the_HTTPS",
+  defaultValue: 0
+)
+
+let Extensions_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 121,
+  fieldName: "URL",
+  defaultValue: 0
+)
+
+let Extensions_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 122,
+  fieldName: "URL_value",
+  defaultValue: 0
+)
+
+let Extensions_the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 123,
+  fieldName: "the_URL_value",
+  defaultValue: 0
+)
+
+let Extensions_the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 124,
+  fieldName: "the_URL",
+  defaultValue: 0
+)
+
+let Extensions_Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "Http",
+  defaultValue: 0
+)
+
+let Extensions_HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "HttpRequest",
+  defaultValue: 0
+)
+
+let Extensions_TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "TheHttpRequest",
+  defaultValue: 0
+)
+
+let Extensions_TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 104,
+  fieldName: "TheHttp",
+  defaultValue: 0
+)
+
+let Extensions_Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 111,
+  fieldName: "Https",
+  defaultValue: 0
+)
+
+let Extensions_HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 112,
+  fieldName: "HttpsRequest",
+  defaultValue: 0
+)
+
+let Extensions_TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 113,
+  fieldName: "TheHttpsRequest",
+  defaultValue: 0
+)
+
+let Extensions_TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 114,
+  fieldName: "TheHttps",
+  defaultValue: 0
+)
+
+let Extensions_Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 121,
+  fieldName: "Url",
+  defaultValue: 0
+)
+
+let Extensions_UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 122,
+  fieldName: "UrlValue",
+  defaultValue: 0
+)
+
+let Extensions_TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 123,
+  fieldName: "TheUrlValue",
+  defaultValue: 0
+)
+
+let Extensions_TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 124,
+  fieldName: "TheUrl",
+  defaultValue: 0
+)

--- a/Reference/unittest_swift_naming_no_prefix.pb.swift
+++ b/Reference/unittest_swift_naming_no_prefix.pb.swift
@@ -738,6 +738,10 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let UnittestSwiftNamingNoPrefix_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_http,
   Extensions_http_request,

--- a/Reference/unittest_swift_naming_no_prefix.pb.swift
+++ b/Reference/unittest_swift_naming_no_prefix.pb.swift
@@ -257,6 +257,8 @@ let Extensions_TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<Sw
   defaultValue: 0
 )
 
+// MARK: - Extension support defined in unittest_swift_naming_no_prefix.proto.
+
 extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var http: Int32 {
     get {return getExtensionValue(ext: Extensions_http) ?? 0}

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -403,6 +403,8 @@ let ProtobufUnittest_Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExt
   defaultValue: false
 )
 
+// MARK: - Extension support defined in unittest_swift_reserved.proto.
+
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
   /// This will end up in the "struct Extensions" to scope it, but there
   /// the raw form is used ("hash_value", not the Swift one "hashValue"),

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -567,6 +567,10 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_UnittestSwiftReserved_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_debug_description,
   ProtobufUnittest_Extensions_as,

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -308,50 +308,6 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    /// This will end up in the "struct Extensions" to scope it, but there
-    /// the raw form is used ("hash_value", not the Swift one "hashValue"),
-    /// so there is no conflict, and no renaming happens.
-    static let hash_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1001,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.hash_value",
-      defaultValue: false
-    )
-
-    /// Reserved words, since these end up in the "struct Extensions", they
-    /// can't just be get their names, and sanitation kicks.
-    static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1022,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.as",
-      defaultValue: false
-    )
-
-    static let `var` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1023,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.var",
-      defaultValue: false
-    )
-
-    static let `try` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1024,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.try",
-      defaultValue: false
-    )
-
-    static let `do` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1025,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.do",
-      defaultValue: false
-    )
-
-    static let `nil` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1026,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.nil",
-      defaultValue: false
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -363,45 +319,6 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-/// Won't get _p added because it is fully qualified.
-let ProtobufUnittest_Extensions_debug_description = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1000,
-  fieldName: "protobuf_unittest.debug_description",
-  defaultValue: false
-)
-
-/// These are scoped to the file, so the package prefix (or a Swift prefix)
-/// will get added to them to they aren't going to get renamed.
-let ProtobufUnittest_Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1012,
-  fieldName: "protobuf_unittest.as",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_var = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1013,
-  fieldName: "protobuf_unittest.var",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_try = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1014,
-  fieldName: "protobuf_unittest.try",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_do = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1015,
-  fieldName: "protobuf_unittest.do",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1016,
-  fieldName: "protobuf_unittest.nil",
-  defaultValue: false
-)
 
 // MARK: - Extension support defined in unittest_swift_reserved.proto.
 
@@ -587,6 +504,90 @@ let ProtobufUnittest_UnittestSwiftReserved_Extensions: SwiftProtobuf.SimpleExten
   ProtobufUnittest_SwiftReservedTestExt.Extensions.do,
   ProtobufUnittest_SwiftReservedTestExt.Extensions.nil
 ]
+
+/// Won't get _p added because it is fully qualified.
+let ProtobufUnittest_Extensions_debug_description = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1000,
+  fieldName: "protobuf_unittest.debug_description",
+  defaultValue: false
+)
+
+/// These are scoped to the file, so the package prefix (or a Swift prefix)
+/// will get added to them to they aren't going to get renamed.
+let ProtobufUnittest_Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1012,
+  fieldName: "protobuf_unittest.as",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_var = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1013,
+  fieldName: "protobuf_unittest.var",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_try = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1014,
+  fieldName: "protobuf_unittest.try",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_do = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1015,
+  fieldName: "protobuf_unittest.do",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1016,
+  fieldName: "protobuf_unittest.nil",
+  defaultValue: false
+)
+
+extension ProtobufUnittest_SwiftReservedTestExt {
+  struct Extensions {
+    /// This will end up in the "struct Extensions" to scope it, but there
+    /// the raw form is used ("hash_value", not the Swift one "hashValue"),
+    /// so there is no conflict, and no renaming happens.
+    static let hash_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1001,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.hash_value",
+      defaultValue: false
+    )
+
+    /// Reserved words, since these end up in the "struct Extensions", they
+    /// can't just be get their names, and sanitation kicks.
+    static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1022,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.as",
+      defaultValue: false
+    )
+
+    static let `var` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1023,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.var",
+      defaultValue: false
+    )
+
+    static let `try` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1024,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.try",
+      defaultValue: false
+    )
+
+    static let `do` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1025,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.do",
+      defaultValue: false
+    )
+
+    static let `nil` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1026,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.nil",
+      defaultValue: false
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -323,6 +323,87 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_reserved.proto.
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  /// Won't get _p added because it is fully qualified.
+  var ProtobufUnittest_debugDescription: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debug_description) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_debug_description, value: newValue)}
+  }
+  var hasProtobufUnittest_debugDescription: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
+  }
+  mutating func clearProtobufUnittest_debugDescription() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  /// These are scoped to the file, so the package prefix (or a Swift prefix)
+  /// will get added to them to they aren't going to get renamed.
+  var ProtobufUnittest_as: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_as) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_as, value: newValue)}
+  }
+  var hasProtobufUnittest_as: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_as)
+  }
+  mutating func clearProtobufUnittest_as() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_as)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  var ProtobufUnittest_var: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_var) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_var, value: newValue)}
+  }
+  var hasProtobufUnittest_var: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_var)
+  }
+  mutating func clearProtobufUnittest_var() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_var)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  var ProtobufUnittest_try: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_try) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_try, value: newValue)}
+  }
+  var hasProtobufUnittest_try: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_try)
+  }
+  mutating func clearProtobufUnittest_try() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_try)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  var ProtobufUnittest_do: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_do) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_do, value: newValue)}
+  }
+  var hasProtobufUnittest_do: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_do)
+  }
+  mutating func clearProtobufUnittest_do() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_do)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  var ProtobufUnittest_nil: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_nil) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_nil, value: newValue)}
+  }
+  var hasProtobufUnittest_nil: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_nil)
+  }
+  mutating func clearProtobufUnittest_nil() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_nil)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
   /// This will end up in the "struct Extensions" to scope it, but there
   /// the raw form is used ("hash_value", not the Swift one "hashValue"),
   /// so there is no conflict, and no renaming happens.
@@ -402,87 +483,6 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   }
   mutating func clearProtobufUnittest_SwiftReservedTestExt_nil() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.nil)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  /// Won't get _p added because it is fully qualified.
-  var ProtobufUnittest_debugDescription: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debug_description) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_debug_description, value: newValue)}
-  }
-  var hasProtobufUnittest_debugDescription: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
-  }
-  mutating func clearProtobufUnittest_debugDescription() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  /// These are scoped to the file, so the package prefix (or a Swift prefix)
-  /// will get added to them to they aren't going to get renamed.
-  var ProtobufUnittest_as: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_as) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_as, value: newValue)}
-  }
-  var hasProtobufUnittest_as: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_as)
-  }
-  mutating func clearProtobufUnittest_as() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_as)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  var ProtobufUnittest_var: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_var) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_var, value: newValue)}
-  }
-  var hasProtobufUnittest_var: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_var)
-  }
-  mutating func clearProtobufUnittest_var() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_var)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  var ProtobufUnittest_try: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_try) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_try, value: newValue)}
-  }
-  var hasProtobufUnittest_try: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_try)
-  }
-  mutating func clearProtobufUnittest_try() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_try)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  var ProtobufUnittest_do: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_do) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_do, value: newValue)}
-  }
-  var hasProtobufUnittest_do: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_do)
-  }
-  mutating func clearProtobufUnittest_do() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_do)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  var ProtobufUnittest_nil: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_nil) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_nil, value: newValue)}
-  }
-  var hasProtobufUnittest_nil: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_nil)
-  }
-  mutating func clearProtobufUnittest_nil() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_nil)
   }
 }
 

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -404,7 +404,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  /// This will end up in the "struct Extensions" to scope it, but there
+  /// This will end up in the "enum Extensions" to scope it, but there
   /// the raw form is used ("hash_value", not the Swift one "hashValue"),
   /// so there is no conflict, and no renaming happens.
   var ProtobufUnittest_SwiftReservedTestExt_hashValue: Bool {
@@ -545,8 +545,8 @@ let ProtobufUnittest_Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExt
 )
 
 extension ProtobufUnittest_SwiftReservedTestExt {
-  struct Extensions {
-    /// This will end up in the "struct Extensions" to scope it, but there
+  enum Extensions {
+    /// This will end up in the "enum Extensions" to scope it, but there
     /// the raw form is used ("hash_value", not the Swift one "hashValue"),
     /// so there is no conflict, and no renaming happens.
     static let hash_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(

--- a/Reference/unittest_swift_reserved_ext.pb.swift
+++ b/Reference/unittest_swift_reserved_ext.pb.swift
@@ -293,6 +293,10 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let UnittestSwiftReservedExt_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_debugDescription,
   Extensions_as,

--- a/Reference/unittest_swift_reserved_ext.pb.swift
+++ b/Reference/unittest_swift_reserved_ext.pb.swift
@@ -40,47 +40,6 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let hashValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1001,
-      fieldName: "SwiftReservedTestExt2.hashValue",
-      defaultValue: false
-    )
-
-    /// Reserved words, since these end up in the "struct Extensions", they
-    /// can't just be get their names, and sanitation kicks.
-    static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1022,
-      fieldName: "SwiftReservedTestExt2.as",
-      defaultValue: false
-    )
-
-    static let `var` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1023,
-      fieldName: "SwiftReservedTestExt2.var",
-      defaultValue: false
-    )
-
-    static let `try` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1024,
-      fieldName: "SwiftReservedTestExt2.try",
-      defaultValue: false
-    )
-
-    static let `do` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1025,
-      fieldName: "SwiftReservedTestExt2.do",
-      defaultValue: false
-    )
-
-    static let `nil` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1026,
-      fieldName: "SwiftReservedTestExt2.nil",
-      defaultValue: false
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -92,45 +51,6 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-/// Will get _p added because it has no package/swift prefix to scope and
-/// would otherwise be a problem when added to the message.
-let Extensions_debugDescription = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1000,
-  fieldName: "debugDescription",
-  defaultValue: false
-)
-
-/// These will get _p added for the same reasoning.
-let Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1012,
-  fieldName: "as",
-  defaultValue: false
-)
-
-let Extensions_var = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1013,
-  fieldName: "var",
-  defaultValue: false
-)
-
-let Extensions_try = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1014,
-  fieldName: "try",
-  defaultValue: false
-)
-
-let Extensions_do = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1015,
-  fieldName: "do",
-  defaultValue: false
-)
-
-let Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1016,
-  fieldName: "nil",
-  defaultValue: false
-)
 
 // MARK: - Extension support defined in unittest_swift_reserved_ext.proto.
 
@@ -313,6 +233,87 @@ let UnittestSwiftReservedExt_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   SwiftReservedTestExt2.Extensions.do,
   SwiftReservedTestExt2.Extensions.nil
 ]
+
+/// Will get _p added because it has no package/swift prefix to scope and
+/// would otherwise be a problem when added to the message.
+let Extensions_debugDescription = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1000,
+  fieldName: "debugDescription",
+  defaultValue: false
+)
+
+/// These will get _p added for the same reasoning.
+let Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1012,
+  fieldName: "as",
+  defaultValue: false
+)
+
+let Extensions_var = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1013,
+  fieldName: "var",
+  defaultValue: false
+)
+
+let Extensions_try = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1014,
+  fieldName: "try",
+  defaultValue: false
+)
+
+let Extensions_do = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1015,
+  fieldName: "do",
+  defaultValue: false
+)
+
+let Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1016,
+  fieldName: "nil",
+  defaultValue: false
+)
+
+extension SwiftReservedTestExt2 {
+  struct Extensions {
+    static let hashValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1001,
+      fieldName: "SwiftReservedTestExt2.hashValue",
+      defaultValue: false
+    )
+
+    /// Reserved words, since these end up in the "struct Extensions", they
+    /// can't just be get their names, and sanitation kicks.
+    static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1022,
+      fieldName: "SwiftReservedTestExt2.as",
+      defaultValue: false
+    )
+
+    static let `var` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1023,
+      fieldName: "SwiftReservedTestExt2.var",
+      defaultValue: false
+    )
+
+    static let `try` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1024,
+      fieldName: "SwiftReservedTestExt2.try",
+      defaultValue: false
+    )
+
+    static let `do` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1025,
+      fieldName: "SwiftReservedTestExt2.do",
+      defaultValue: false
+    )
+
+    static let `nil` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1026,
+      fieldName: "SwiftReservedTestExt2.nil",
+      defaultValue: false
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/unittest_swift_reserved_ext.pb.swift
+++ b/Reference/unittest_swift_reserved_ext.pb.swift
@@ -132,6 +132,8 @@ let Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<Swift
   defaultValue: false
 )
 
+// MARK: - Extension support defined in unittest_swift_reserved_ext.proto.
+
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_hashValue: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue) ?? false}

--- a/Reference/unittest_swift_reserved_ext.pb.swift
+++ b/Reference/unittest_swift_reserved_ext.pb.swift
@@ -149,7 +149,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  /// Reserved words, since these end up in the "struct Extensions", they
+  /// Reserved words, since these end up in the "enum Extensions", they
   /// can't just be get their names, and sanitation kicks.
   var SwiftReservedTestExt2_as: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.as) ?? false}
@@ -274,14 +274,14 @@ let Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<Swift
 )
 
 extension SwiftReservedTestExt2 {
-  struct Extensions {
+  enum Extensions {
     static let hashValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
       _protobuf_fieldNumber: 1001,
       fieldName: "SwiftReservedTestExt2.hashValue",
       defaultValue: false
     )
 
-    /// Reserved words, since these end up in the "struct Extensions", they
+    /// Reserved words, since these end up in the "enum Extensions", they
     /// can't just be get their names, and sanitation kicks.
     static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
       _protobuf_fieldNumber: 1022,

--- a/Reference/unittest_swift_reserved_ext.pb.swift
+++ b/Reference/unittest_swift_reserved_ext.pb.swift
@@ -55,86 +55,6 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_reserved_ext.proto.
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  var SwiftReservedTestExt2_hashValue: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_hashValue: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue)
-  }
-  mutating func clearSwiftReservedTestExt2_hashValue() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  /// Reserved words, since these end up in the "struct Extensions", they
-  /// can't just be get their names, and sanitation kicks.
-  var SwiftReservedTestExt2_as: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.as) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.as, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_as: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.as)
-  }
-  mutating func clearSwiftReservedTestExt2_as() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.as)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  var SwiftReservedTestExt2_var: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.var) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.var, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_var: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.var)
-  }
-  mutating func clearSwiftReservedTestExt2_var() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.var)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  var SwiftReservedTestExt2_try: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.try) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.try, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_try: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.try)
-  }
-  mutating func clearSwiftReservedTestExt2_try() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.try)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  var SwiftReservedTestExt2_do: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.do) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.do, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_do: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.do)
-  }
-  mutating func clearSwiftReservedTestExt2_do() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.do)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  var SwiftReservedTestExt2_nil: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_nil: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil)
-  }
-  mutating func clearSwiftReservedTestExt2_nil() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   /// Will get _p added because it has no package/swift prefix to scope and
   /// would otherwise be a problem when added to the message.
   var debugDescription_p: Bool {
@@ -212,6 +132,86 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   }
   mutating func clearNil_p() {
     clearExtensionValue(ext: Extensions_nil)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  var SwiftReservedTestExt2_hashValue: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_hashValue: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue)
+  }
+  mutating func clearSwiftReservedTestExt2_hashValue() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  /// Reserved words, since these end up in the "struct Extensions", they
+  /// can't just be get their names, and sanitation kicks.
+  var SwiftReservedTestExt2_as: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.as) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.as, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_as: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.as)
+  }
+  mutating func clearSwiftReservedTestExt2_as() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.as)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  var SwiftReservedTestExt2_var: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.var) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.var, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_var: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.var)
+  }
+  mutating func clearSwiftReservedTestExt2_var() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.var)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  var SwiftReservedTestExt2_try: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.try) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.try, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_try: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.try)
+  }
+  mutating func clearSwiftReservedTestExt2_try() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.try)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  var SwiftReservedTestExt2_do: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.do) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.do, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_do: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.do)
+  }
+  mutating func clearSwiftReservedTestExt2_do() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.do)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  var SwiftReservedTestExt2_nil: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_nil: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil)
+  }
+  mutating func clearSwiftReservedTestExt2_nil() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil)
   }
 }
 

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -156,6 +156,10 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufObjcUnittest_Extensions_optional_int32_extension,
   ProtobufObjcUnittest_Extensions_repeated_int32_extension,

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -116,6 +116,8 @@ let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.Mes
   defaultValue: []
 )
 
+// MARK: - Extension support defined in unittest_swift_startup.proto.
+
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? String()}

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -82,15 +82,6 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
-      _protobuf_fieldNumber: 3,
-      fieldName: "protobuf_objc_unittest.TestObjCStartupNested.nested_string_extension",
-      defaultValue: String()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -102,19 +93,6 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-/// Singular
-let ProtobufObjcUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "protobuf_objc_unittest.optional_int32_extension",
-  defaultValue: 0
-)
-
-let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "protobuf_objc_unittest.repeated_int32_extension",
-  defaultValue: []
-)
 
 // MARK: - Extension support defined in unittest_swift_startup.proto.
 
@@ -167,6 +145,29 @@ let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: SwiftProtobuf.SimpleEx
   ProtobufObjcUnittest_Extensions_repeated_int32_extension,
   ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension
 ]
+
+/// Singular
+let ProtobufObjcUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "protobuf_objc_unittest.optional_int32_extension",
+  defaultValue: 0
+)
+
+let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "protobuf_objc_unittest.repeated_int32_extension",
+  defaultValue: []
+)
+
+extension ProtobufObjcUnittest_TestObjCStartupNested {
+  struct Extensions {
+    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+      _protobuf_fieldNumber: 3,
+      fieldName: "protobuf_objc_unittest.TestObjCStartupNested.nested_string_extension",
+      defaultValue: String()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -160,7 +160,7 @@ let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.Mes
 )
 
 extension ProtobufObjcUnittest_TestObjCStartupNested {
-  struct Extensions {
+  enum Extensions {
     static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
       _protobuf_fieldNumber: 3,
       fieldName: "protobuf_objc_unittest.TestObjCStartupNested.nested_string_extension",

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -97,19 +97,6 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_startup.proto.
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
-  var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? String()}
-    set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension, value: newValue)}
-  }
-  var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
-  }
-  mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
-    clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
-  }
-}
-
-extension ProtobufObjcUnittest_TestObjCStartupMessage {
   /// Singular
   var ProtobufObjcUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension) ?? 0}
@@ -133,6 +120,19 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   }
   mutating func clearProtobufObjcUnittest_repeatedInt32Extension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension)
+  }
+}
+
+extension ProtobufObjcUnittest_TestObjCStartupMessage {
+  var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
+    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? String()}
+    set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension, value: newValue)}
+  }
+  var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {
+    return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
+  }
+  mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
+    clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
   }
 }
 

--- a/Sources/protoc-gen-swift/ExtensionGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionGenerator.swift
@@ -154,7 +154,7 @@ struct ExtensionGenerator {
         p.print(")\n")
     }
 
-    func generateTopLevel(printer p: inout CodePrinter) {
+    func generateMessageSwiftExtensionForProtobufExtensions(printer p: inout CodePrinter) {
         p.print("\n")
         p.print("extension \(swiftExtendedMessageName) {\n")
         p.indent()

--- a/Sources/protoc-gen-swift/ExtensionGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionGenerator.swift
@@ -137,8 +137,7 @@ struct ExtensionGenerator {
         }
     }
 
-    func generateNested(printer p: inout CodePrinter) {
-        p.print("\n")
+    func generateProtobufExtensionDeclarations(printer p: inout CodePrinter) {
         if !comments.isEmpty {
             p.print(comments)
         }

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -340,10 +340,6 @@ class FileGenerator {
             m.generateMainStruct(printer: &p, file: self, parent: nil)
         }
 
-        for e in extensions {
-            e.generateNested(printer: &p)
-        }
-
         var registry = [String]()
         for e in extensions {
             registry.append(e.swiftFullExtensionName)
@@ -384,6 +380,18 @@ class FileGenerator {
             p.print("\n")
             p.outdent()
             p.print("]\n")
+
+            // Generate the Extension's declarations (used by the two above things).
+            // This is done after the other two as the only time developers will need
+            // these symbols is if they are manually building their own ExtensionMap;
+            // so the others are assumed more interesting.
+            for e in extensions {
+                p.print("\n")
+                e.generateProtobufExtensionDeclarations(printer: &p)
+            }
+            for m in messages {
+                m.generateProtobufExtensionDeclarations(printer: &p)
+            }
         }
 
         let needsProtoPackage: Bool = !protoPackageName.isEmpty && !messages.isEmpty

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -344,14 +344,6 @@ class FileGenerator {
             e.generateNested(printer: &p)
         }
 
-        for m in messages {
-            m.generateTopLevel(printer: &p)
-        }
-
-        for e in extensions {
-            e.generateTopLevel(printer: &p)
-        }
-
         var registry = [String]()
         for e in extensions {
             registry.append(e.swiftFullExtensionName)
@@ -360,7 +352,22 @@ class FileGenerator {
             m.registerExtensions(registry: &registry)
         }
         if !registry.isEmpty {
-            let filenameAsIdentifer = toUpperCamelCase(baseFilename)
+            let pathParts = splitPath(pathname: descriptor.name)
+            let filename = pathParts.base + pathParts.suffix
+            p.print("\n")
+            p.print("// MARK: - Extension support defined in \(filename).\n")
+
+            // Generate the Swift Extensions on the Messages that provide the api
+            // for using the protobuf extension.
+            for m in messages {
+                m.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
+            }
+            for e in extensions {
+                e.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
+            }
+
+            // Generate a registry for the file.
+            let filenameAsIdentifer = toUpperCamelCase(pathParts.base)
             p.print("\n")
             p.print("/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by\n")
             p.print("/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed\n")

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -355,11 +355,11 @@ class FileGenerator {
 
             // Generate the Swift Extensions on the Messages that provide the api
             // for using the protobuf extension.
-            for m in messages {
-                m.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
-            }
             for e in extensions {
                 e.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
+            }
+            for m in messages {
+                m.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
             }
 
             // Generate a registry for the file.

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -360,9 +360,13 @@ class FileGenerator {
             m.registerExtensions(registry: &registry)
         }
         if !registry.isEmpty {
-            let filename = toUpperCamelCase(baseFilename)
+            let filenameAsIdentifer = toUpperCamelCase(baseFilename)
             p.print("\n")
-            p.print("\(generatorOptions.visibilitySourceSnippet)let \(descriptor.swiftPrefix)\(filename)_Extensions: SwiftProtobuf.SimpleExtensionMap = [\n")
+            p.print("/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by\n")
+            p.print("/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed\n")
+            p.print("/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create\n")
+            p.print("/// a larger `SwiftProtobuf.SimpleExtensionMap`.\n")
+            p.print("\(generatorOptions.visibilitySourceSnippet)let \(descriptor.swiftPrefix)\(filenameAsIdentifer)_Extensions: SwiftProtobuf.SimpleExtensionMap = [\n")
             p.indent()
             var separator = ""
             for e in registry {

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -263,15 +263,15 @@ class MessageGenerator {
     p.print("}\n")
   }
 
-  func generateTopLevel(printer p: inout CodePrinter) {
+  func generateMessageSwiftExtensionForProtobufExtensions(printer p: inout CodePrinter) {
     // nested messages
     for m in messages {
-      m.generateTopLevel(printer: &p)
+      m.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
     }
 
     // nested extensions
     for e in extensions {
-      e.generateTopLevel(printer: &p)
+      e.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
     }
   }
 

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -226,18 +226,6 @@ class MessageGenerator {
       m.generateMainStruct(printer: &p, file: file, parent: self)
     }
 
-    // Nested extension declarations
-    if !extensions.isEmpty {
-      p.print("\n")
-      p.print("struct Extensions {\n")
-      p.indent()
-      for e in extensions {
-          e.generateNested(printer: &p)
-      }
-      p.outdent()
-      p.print("}\n")
-    }
-
     // Generate the default initializer. If we don't, Swift seems to sometimes
     // generate it along with others that can take public proprerties. When it
     // generates the others doesn't seem to be documented.
@@ -261,6 +249,32 @@ class MessageGenerator {
 
     p.outdent()
     p.print("}\n")
+  }
+
+  func generateProtobufExtensionDeclarations(printer p: inout CodePrinter) {
+    if !extensions.isEmpty {
+      p.print("\n")
+      p.print("extension \(swiftFullName) {\n")
+      p.indent()
+      p.print("struct Extensions {\n")
+      p.indent()
+      var addNewline = false
+      for e in extensions {
+        if addNewline {
+          p.print("\n")
+        } else {
+          addNewline = true
+        }
+        e.generateProtobufExtensionDeclarations(printer: &p)
+      }
+      p.outdent()
+      p.print("}\n")
+      p.outdent()
+      p.print("}\n")
+    }
+    for m in messages {
+      m.generateProtobufExtensionDeclarations(printer: &p)
+    }
   }
 
   func generateMessageSwiftExtensionForProtobufExtensions(printer p: inout CodePrinter) {

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -256,7 +256,7 @@ class MessageGenerator {
       p.print("\n")
       p.print("extension \(swiftFullName) {\n")
       p.indent()
-      p.print("struct Extensions {\n")
+      p.print("enum Extensions {\n")
       p.indent()
       var addNewline = false
       for e in extensions {

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -278,14 +278,11 @@ class MessageGenerator {
   }
 
   func generateMessageSwiftExtensionForProtobufExtensions(printer p: inout CodePrinter) {
-    // nested messages
-    for m in messages {
-      m.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
-    }
-
-    // nested extensions
     for e in extensions {
       e.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
+    }
+    for m in messages {
+      m.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
     }
   }
 

--- a/Sources/protoc-gen-swift/ReservedWords.swift
+++ b/Sources/protoc-gen-swift/ReservedWords.swift
@@ -192,7 +192,7 @@ func sanitizeEnumCase(_ s: String) -> String {
 }
 
 func sanitizeMessageScopedExtensionName(_ s: String, skipBackticks: Bool = false) -> String {
-  // Since thing else is added to the "struct Extensions" for scoped
+  // Since thing else is added to the "enum Extensions" for scoped
   // extensions, there is no need to have a reserved list.
   if quotableMessageScopedExtensionNames.contains(s) {
     if skipBackticks {

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -1625,25 +1625,6 @@ struct ProtobufUnittest_TestNestedExtension: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    /// Check for bug where string extensions declared in tested scope did not
-    /// compile.
-    static let test = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-      _protobuf_fieldNumber: 1002,
-      fieldName: "protobuf_unittest.TestNestedExtension.test",
-      defaultValue: "test"
-    )
-
-    /// Used to test if generated extension name is correct when there are
-    /// underscores.
-    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-      _protobuf_fieldNumber: 1003,
-      fieldName: "protobuf_unittest.TestNestedExtension.nested_string_extension",
-      defaultValue: String()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -2032,21 +2013,6 @@ struct ProtobufUnittest_TestRequired: SwiftProtobuf.Message {
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  struct Extensions {
-
-    static let single = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(
-      _protobuf_fieldNumber: 1000,
-      fieldName: "protobuf_unittest.TestRequired.single",
-      defaultValue: ProtobufUnittest_TestRequired()
-    )
-
-    static let multi = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(
-      _protobuf_fieldNumber: 1001,
-      fieldName: "protobuf_unittest.TestRequired.multi",
-      defaultValue: []
-    )
-  }
 
   init() {}
 
@@ -5717,21 +5683,6 @@ struct ProtobufUnittest_TestParsingMerge: SwiftProtobuf.Message, SwiftProtobuf.E
     }
   }
 
-  struct Extensions {
-
-    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
-      _protobuf_fieldNumber: 1000,
-      fieldName: "protobuf_unittest.TestParsingMerge.optional_ext",
-      defaultValue: ProtobufUnittest_TestAllTypes()
-    )
-
-    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
-      _protobuf_fieldNumber: 1001,
-      fieldName: "protobuf_unittest.TestParsingMerge.repeated_ext",
-      defaultValue: []
-    )
-  }
-
   init() {}
 
   public var isInitialized: Bool {
@@ -6323,646 +6274,6 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
-
-/// Singular
-let ProtobufUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "protobuf_unittest.optional_int32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "protobuf_unittest.optional_int64_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "protobuf_unittest.optional_uint32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 4,
-  fieldName: "protobuf_unittest.optional_uint64_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 5,
-  fieldName: "protobuf_unittest.optional_sint32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 6,
-  fieldName: "protobuf_unittest.optional_sint64_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 7,
-  fieldName: "protobuf_unittest.optional_fixed32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 8,
-  fieldName: "protobuf_unittest.optional_fixed64_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 9,
-  fieldName: "protobuf_unittest.optional_sfixed32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 10,
-  fieldName: "protobuf_unittest.optional_sfixed64_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 11,
-  fieldName: "protobuf_unittest.optional_float_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 12,
-  fieldName: "protobuf_unittest.optional_double_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 13,
-  fieldName: "protobuf_unittest.optional_bool_extension",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_optional_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 14,
-  fieldName: "protobuf_unittest.optional_string_extension",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 15,
-  fieldName: "protobuf_unittest.optional_bytes_extension",
-  defaultValue: SwiftProtobuf.Internal.emptyData
-)
-
-let ProtobufUnittest_Extensions_OptionalGroup_extension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 16,
-  fieldName: "protobuf_unittest.OptionalGroup_extension",
-  defaultValue: ProtobufUnittest_OptionalGroup_extension()
-)
-
-let ProtobufUnittest_Extensions_optional_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 18,
-  fieldName: "protobuf_unittest.optional_nested_message_extension",
-  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
-)
-
-let ProtobufUnittest_Extensions_optional_foreign_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 19,
-  fieldName: "protobuf_unittest.optional_foreign_message_extension",
-  defaultValue: ProtobufUnittest_ForeignMessage()
-)
-
-let ProtobufUnittest_Extensions_optional_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 20,
-  fieldName: "protobuf_unittest.optional_import_message_extension",
-  defaultValue: ProtobufUnittestImport_ImportMessage()
-)
-
-let ProtobufUnittest_Extensions_optional_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 21,
-  fieldName: "protobuf_unittest.optional_nested_enum_extension",
-  defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.foo
-)
-
-let ProtobufUnittest_Extensions_optional_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 22,
-  fieldName: "protobuf_unittest.optional_foreign_enum_extension",
-  defaultValue: ProtobufUnittest_ForeignEnum.foreignFoo
-)
-
-let ProtobufUnittest_Extensions_optional_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 23,
-  fieldName: "protobuf_unittest.optional_import_enum_extension",
-  defaultValue: ProtobufUnittestImport_ImportEnum.importFoo
-)
-
-let ProtobufUnittest_Extensions_optional_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 24,
-  fieldName: "protobuf_unittest.optional_string_piece_extension",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 25,
-  fieldName: "protobuf_unittest.optional_cord_extension",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_public_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 26,
-  fieldName: "protobuf_unittest.optional_public_import_message_extension",
-  defaultValue: ProtobufUnittestImport_PublicImportMessage()
-)
-
-let ProtobufUnittest_Extensions_optional_lazy_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 27,
-  fieldName: "protobuf_unittest.optional_lazy_message_extension",
-  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
-)
-
-/// Repeated
-let ProtobufUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 31,
-  fieldName: "protobuf_unittest.repeated_int32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 32,
-  fieldName: "protobuf_unittest.repeated_int64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 33,
-  fieldName: "protobuf_unittest.repeated_uint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 34,
-  fieldName: "protobuf_unittest.repeated_uint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 35,
-  fieldName: "protobuf_unittest.repeated_sint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 36,
-  fieldName: "protobuf_unittest.repeated_sint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 37,
-  fieldName: "protobuf_unittest.repeated_fixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 38,
-  fieldName: "protobuf_unittest.repeated_fixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 39,
-  fieldName: "protobuf_unittest.repeated_sfixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 40,
-  fieldName: "protobuf_unittest.repeated_sfixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 41,
-  fieldName: "protobuf_unittest.repeated_float_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 42,
-  fieldName: "protobuf_unittest.repeated_double_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 43,
-  fieldName: "protobuf_unittest.repeated_bool_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_string_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 44,
-  fieldName: "protobuf_unittest.repeated_string_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_bytes_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 45,
-  fieldName: "protobuf_unittest.repeated_bytes_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_RepeatedGroup_extension = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 46,
-  fieldName: "protobuf_unittest.RepeatedGroup_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_nested_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 48,
-  fieldName: "protobuf_unittest.repeated_nested_message_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_foreign_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 49,
-  fieldName: "protobuf_unittest.repeated_foreign_message_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_import_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 50,
-  fieldName: "protobuf_unittest.repeated_import_message_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_nested_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 51,
-  fieldName: "protobuf_unittest.repeated_nested_enum_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_foreign_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 52,
-  fieldName: "protobuf_unittest.repeated_foreign_enum_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_import_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 53,
-  fieldName: "protobuf_unittest.repeated_import_enum_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_string_piece_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 54,
-  fieldName: "protobuf_unittest.repeated_string_piece_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_cord_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 55,
-  fieldName: "protobuf_unittest.repeated_cord_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_lazy_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 57,
-  fieldName: "protobuf_unittest.repeated_lazy_message_extension",
-  defaultValue: []
-)
-
-/// Singular with defaults
-let ProtobufUnittest_Extensions_default_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 61,
-  fieldName: "protobuf_unittest.default_int32_extension",
-  defaultValue: 41
-)
-
-let ProtobufUnittest_Extensions_default_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 62,
-  fieldName: "protobuf_unittest.default_int64_extension",
-  defaultValue: 42
-)
-
-let ProtobufUnittest_Extensions_default_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 63,
-  fieldName: "protobuf_unittest.default_uint32_extension",
-  defaultValue: 43
-)
-
-let ProtobufUnittest_Extensions_default_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 64,
-  fieldName: "protobuf_unittest.default_uint64_extension",
-  defaultValue: 44
-)
-
-let ProtobufUnittest_Extensions_default_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 65,
-  fieldName: "protobuf_unittest.default_sint32_extension",
-  defaultValue: -45
-)
-
-let ProtobufUnittest_Extensions_default_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 66,
-  fieldName: "protobuf_unittest.default_sint64_extension",
-  defaultValue: 46
-)
-
-let ProtobufUnittest_Extensions_default_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 67,
-  fieldName: "protobuf_unittest.default_fixed32_extension",
-  defaultValue: 47
-)
-
-let ProtobufUnittest_Extensions_default_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 68,
-  fieldName: "protobuf_unittest.default_fixed64_extension",
-  defaultValue: 48
-)
-
-let ProtobufUnittest_Extensions_default_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 69,
-  fieldName: "protobuf_unittest.default_sfixed32_extension",
-  defaultValue: 49
-)
-
-let ProtobufUnittest_Extensions_default_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 70,
-  fieldName: "protobuf_unittest.default_sfixed64_extension",
-  defaultValue: -50
-)
-
-let ProtobufUnittest_Extensions_default_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 71,
-  fieldName: "protobuf_unittest.default_float_extension",
-  defaultValue: 51.5
-)
-
-let ProtobufUnittest_Extensions_default_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 72,
-  fieldName: "protobuf_unittest.default_double_extension",
-  defaultValue: 52000
-)
-
-let ProtobufUnittest_Extensions_default_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 73,
-  fieldName: "protobuf_unittest.default_bool_extension",
-  defaultValue: true
-)
-
-let ProtobufUnittest_Extensions_default_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 74,
-  fieldName: "protobuf_unittest.default_string_extension",
-  defaultValue: "hello"
-)
-
-let ProtobufUnittest_Extensions_default_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 75,
-  fieldName: "protobuf_unittest.default_bytes_extension",
-  defaultValue: Data(bytes: [119, 111, 114, 108, 100])
-)
-
-let ProtobufUnittest_Extensions_default_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 81,
-  fieldName: "protobuf_unittest.default_nested_enum_extension",
-  defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.bar
-)
-
-let ProtobufUnittest_Extensions_default_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 82,
-  fieldName: "protobuf_unittest.default_foreign_enum_extension",
-  defaultValue: ProtobufUnittest_ForeignEnum.foreignBar
-)
-
-let ProtobufUnittest_Extensions_default_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 83,
-  fieldName: "protobuf_unittest.default_import_enum_extension",
-  defaultValue: ProtobufUnittestImport_ImportEnum.importBar
-)
-
-let ProtobufUnittest_Extensions_default_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 84,
-  fieldName: "protobuf_unittest.default_string_piece_extension",
-  defaultValue: "abc"
-)
-
-let ProtobufUnittest_Extensions_default_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 85,
-  fieldName: "protobuf_unittest.default_cord_extension",
-  defaultValue: "123"
-)
-
-/// For oneof test
-let ProtobufUnittest_Extensions_oneof_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 111,
-  fieldName: "protobuf_unittest.oneof_uint32_extension",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_oneof_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 112,
-  fieldName: "protobuf_unittest.oneof_nested_message_extension",
-  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
-)
-
-let ProtobufUnittest_Extensions_oneof_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 113,
-  fieldName: "protobuf_unittest.oneof_string_extension",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_oneof_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
-  _protobuf_fieldNumber: 114,
-  fieldName: "protobuf_unittest.oneof_bytes_extension",
-  defaultValue: SwiftProtobuf.Internal.emptyData
-)
-
-let ProtobufUnittest_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestFieldOrderings>(
-  _protobuf_fieldNumber: 50,
-  fieldName: "protobuf_unittest.my_extension_string",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestFieldOrderings>(
-  _protobuf_fieldNumber: 5,
-  fieldName: "protobuf_unittest.my_extension_int",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_packed_int32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 90,
-  fieldName: "protobuf_unittest.packed_int32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_int64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 91,
-  fieldName: "protobuf_unittest.packed_int64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_uint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 92,
-  fieldName: "protobuf_unittest.packed_uint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_uint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 93,
-  fieldName: "protobuf_unittest.packed_uint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 94,
-  fieldName: "protobuf_unittest.packed_sint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 95,
-  fieldName: "protobuf_unittest.packed_sint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_fixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 96,
-  fieldName: "protobuf_unittest.packed_fixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_fixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 97,
-  fieldName: "protobuf_unittest.packed_fixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sfixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 98,
-  fieldName: "protobuf_unittest.packed_sfixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sfixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 99,
-  fieldName: "protobuf_unittest.packed_sfixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_float_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.packed_float_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_double_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.packed_double_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_bool_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "protobuf_unittest.packed_bool_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_enum_extension = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestPackedExtensions>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "protobuf_unittest.packed_enum_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 90,
-  fieldName: "protobuf_unittest.unpacked_int32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 91,
-  fieldName: "protobuf_unittest.unpacked_int64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 92,
-  fieldName: "protobuf_unittest.unpacked_uint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 93,
-  fieldName: "protobuf_unittest.unpacked_uint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 94,
-  fieldName: "protobuf_unittest.unpacked_sint32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 95,
-  fieldName: "protobuf_unittest.unpacked_sint64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 96,
-  fieldName: "protobuf_unittest.unpacked_fixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 97,
-  fieldName: "protobuf_unittest.unpacked_fixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 98,
-  fieldName: "protobuf_unittest.unpacked_sfixed32_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 99,
-  fieldName: "protobuf_unittest.unpacked_sfixed64_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.unpacked_float_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.unpacked_double_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "protobuf_unittest.unpacked_bool_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_unpacked_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestUnpackedExtensions>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "protobuf_unittest.unpacked_enum_extension",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestHugeFieldNumbers>(
-  _protobuf_fieldNumber: 536860000,
-  fieldName: "protobuf_unittest.test_all_types",
-  defaultValue: ProtobufUnittest_TestAllTypes()
-)
 
 // MARK: - Extension support defined in unittest.proto.
 
@@ -8548,6 +7859,698 @@ let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestParsingMerge.Extensions.optional_ext,
   ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext
 ]
+
+/// Singular
+let ProtobufUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "protobuf_unittest.optional_int32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "protobuf_unittest.optional_int64_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "protobuf_unittest.optional_uint32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 4,
+  fieldName: "protobuf_unittest.optional_uint64_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 5,
+  fieldName: "protobuf_unittest.optional_sint32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 6,
+  fieldName: "protobuf_unittest.optional_sint64_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 7,
+  fieldName: "protobuf_unittest.optional_fixed32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 8,
+  fieldName: "protobuf_unittest.optional_fixed64_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 9,
+  fieldName: "protobuf_unittest.optional_sfixed32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 10,
+  fieldName: "protobuf_unittest.optional_sfixed64_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 11,
+  fieldName: "protobuf_unittest.optional_float_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 12,
+  fieldName: "protobuf_unittest.optional_double_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 13,
+  fieldName: "protobuf_unittest.optional_bool_extension",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_optional_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 14,
+  fieldName: "protobuf_unittest.optional_string_extension",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 15,
+  fieldName: "protobuf_unittest.optional_bytes_extension",
+  defaultValue: SwiftProtobuf.Internal.emptyData
+)
+
+let ProtobufUnittest_Extensions_OptionalGroup_extension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 16,
+  fieldName: "protobuf_unittest.OptionalGroup_extension",
+  defaultValue: ProtobufUnittest_OptionalGroup_extension()
+)
+
+let ProtobufUnittest_Extensions_optional_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 18,
+  fieldName: "protobuf_unittest.optional_nested_message_extension",
+  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
+)
+
+let ProtobufUnittest_Extensions_optional_foreign_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 19,
+  fieldName: "protobuf_unittest.optional_foreign_message_extension",
+  defaultValue: ProtobufUnittest_ForeignMessage()
+)
+
+let ProtobufUnittest_Extensions_optional_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 20,
+  fieldName: "protobuf_unittest.optional_import_message_extension",
+  defaultValue: ProtobufUnittestImport_ImportMessage()
+)
+
+let ProtobufUnittest_Extensions_optional_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 21,
+  fieldName: "protobuf_unittest.optional_nested_enum_extension",
+  defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.foo
+)
+
+let ProtobufUnittest_Extensions_optional_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 22,
+  fieldName: "protobuf_unittest.optional_foreign_enum_extension",
+  defaultValue: ProtobufUnittest_ForeignEnum.foreignFoo
+)
+
+let ProtobufUnittest_Extensions_optional_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 23,
+  fieldName: "protobuf_unittest.optional_import_enum_extension",
+  defaultValue: ProtobufUnittestImport_ImportEnum.importFoo
+)
+
+let ProtobufUnittest_Extensions_optional_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 24,
+  fieldName: "protobuf_unittest.optional_string_piece_extension",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 25,
+  fieldName: "protobuf_unittest.optional_cord_extension",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_public_import_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 26,
+  fieldName: "protobuf_unittest.optional_public_import_message_extension",
+  defaultValue: ProtobufUnittestImport_PublicImportMessage()
+)
+
+let ProtobufUnittest_Extensions_optional_lazy_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 27,
+  fieldName: "protobuf_unittest.optional_lazy_message_extension",
+  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
+)
+
+/// Repeated
+let ProtobufUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 31,
+  fieldName: "protobuf_unittest.repeated_int32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 32,
+  fieldName: "protobuf_unittest.repeated_int64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 33,
+  fieldName: "protobuf_unittest.repeated_uint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 34,
+  fieldName: "protobuf_unittest.repeated_uint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 35,
+  fieldName: "protobuf_unittest.repeated_sint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 36,
+  fieldName: "protobuf_unittest.repeated_sint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 37,
+  fieldName: "protobuf_unittest.repeated_fixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 38,
+  fieldName: "protobuf_unittest.repeated_fixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 39,
+  fieldName: "protobuf_unittest.repeated_sfixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 40,
+  fieldName: "protobuf_unittest.repeated_sfixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 41,
+  fieldName: "protobuf_unittest.repeated_float_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 42,
+  fieldName: "protobuf_unittest.repeated_double_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 43,
+  fieldName: "protobuf_unittest.repeated_bool_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_string_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 44,
+  fieldName: "protobuf_unittest.repeated_string_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_bytes_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 45,
+  fieldName: "protobuf_unittest.repeated_bytes_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_RepeatedGroup_extension = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 46,
+  fieldName: "protobuf_unittest.RepeatedGroup_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_nested_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 48,
+  fieldName: "protobuf_unittest.repeated_nested_message_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_foreign_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 49,
+  fieldName: "protobuf_unittest.repeated_foreign_message_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_import_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 50,
+  fieldName: "protobuf_unittest.repeated_import_message_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_nested_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 51,
+  fieldName: "protobuf_unittest.repeated_nested_enum_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_foreign_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 52,
+  fieldName: "protobuf_unittest.repeated_foreign_enum_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_import_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 53,
+  fieldName: "protobuf_unittest.repeated_import_enum_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_string_piece_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 54,
+  fieldName: "protobuf_unittest.repeated_string_piece_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_cord_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 55,
+  fieldName: "protobuf_unittest.repeated_cord_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_lazy_message_extension = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 57,
+  fieldName: "protobuf_unittest.repeated_lazy_message_extension",
+  defaultValue: []
+)
+
+/// Singular with defaults
+let ProtobufUnittest_Extensions_default_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 61,
+  fieldName: "protobuf_unittest.default_int32_extension",
+  defaultValue: 41
+)
+
+let ProtobufUnittest_Extensions_default_int64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 62,
+  fieldName: "protobuf_unittest.default_int64_extension",
+  defaultValue: 42
+)
+
+let ProtobufUnittest_Extensions_default_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 63,
+  fieldName: "protobuf_unittest.default_uint32_extension",
+  defaultValue: 43
+)
+
+let ProtobufUnittest_Extensions_default_uint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 64,
+  fieldName: "protobuf_unittest.default_uint64_extension",
+  defaultValue: 44
+)
+
+let ProtobufUnittest_Extensions_default_sint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 65,
+  fieldName: "protobuf_unittest.default_sint32_extension",
+  defaultValue: -45
+)
+
+let ProtobufUnittest_Extensions_default_sint64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 66,
+  fieldName: "protobuf_unittest.default_sint64_extension",
+  defaultValue: 46
+)
+
+let ProtobufUnittest_Extensions_default_fixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 67,
+  fieldName: "protobuf_unittest.default_fixed32_extension",
+  defaultValue: 47
+)
+
+let ProtobufUnittest_Extensions_default_fixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 68,
+  fieldName: "protobuf_unittest.default_fixed64_extension",
+  defaultValue: 48
+)
+
+let ProtobufUnittest_Extensions_default_sfixed32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 69,
+  fieldName: "protobuf_unittest.default_sfixed32_extension",
+  defaultValue: 49
+)
+
+let ProtobufUnittest_Extensions_default_sfixed64_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 70,
+  fieldName: "protobuf_unittest.default_sfixed64_extension",
+  defaultValue: -50
+)
+
+let ProtobufUnittest_Extensions_default_float_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 71,
+  fieldName: "protobuf_unittest.default_float_extension",
+  defaultValue: 51.5
+)
+
+let ProtobufUnittest_Extensions_default_double_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 72,
+  fieldName: "protobuf_unittest.default_double_extension",
+  defaultValue: 52000
+)
+
+let ProtobufUnittest_Extensions_default_bool_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 73,
+  fieldName: "protobuf_unittest.default_bool_extension",
+  defaultValue: true
+)
+
+let ProtobufUnittest_Extensions_default_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 74,
+  fieldName: "protobuf_unittest.default_string_extension",
+  defaultValue: "hello"
+)
+
+let ProtobufUnittest_Extensions_default_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 75,
+  fieldName: "protobuf_unittest.default_bytes_extension",
+  defaultValue: Data(bytes: [119, 111, 114, 108, 100])
+)
+
+let ProtobufUnittest_Extensions_default_nested_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypes.NestedEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 81,
+  fieldName: "protobuf_unittest.default_nested_enum_extension",
+  defaultValue: ProtobufUnittest_TestAllTypes.NestedEnum.bar
+)
+
+let ProtobufUnittest_Extensions_default_foreign_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 82,
+  fieldName: "protobuf_unittest.default_foreign_enum_extension",
+  defaultValue: ProtobufUnittest_ForeignEnum.foreignBar
+)
+
+let ProtobufUnittest_Extensions_default_import_enum_extension = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnum>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 83,
+  fieldName: "protobuf_unittest.default_import_enum_extension",
+  defaultValue: ProtobufUnittestImport_ImportEnum.importBar
+)
+
+let ProtobufUnittest_Extensions_default_string_piece_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 84,
+  fieldName: "protobuf_unittest.default_string_piece_extension",
+  defaultValue: "abc"
+)
+
+let ProtobufUnittest_Extensions_default_cord_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 85,
+  fieldName: "protobuf_unittest.default_cord_extension",
+  defaultValue: "123"
+)
+
+/// For oneof test
+let ProtobufUnittest_Extensions_oneof_uint32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 111,
+  fieldName: "protobuf_unittest.oneof_uint32_extension",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_oneof_nested_message_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes.NestedMessage>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 112,
+  fieldName: "protobuf_unittest.oneof_nested_message_extension",
+  defaultValue: ProtobufUnittest_TestAllTypes.NestedMessage()
+)
+
+let ProtobufUnittest_Extensions_oneof_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 113,
+  fieldName: "protobuf_unittest.oneof_string_extension",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_oneof_bytes_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensions>(
+  _protobuf_fieldNumber: 114,
+  fieldName: "protobuf_unittest.oneof_bytes_extension",
+  defaultValue: SwiftProtobuf.Internal.emptyData
+)
+
+let ProtobufUnittest_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestFieldOrderings>(
+  _protobuf_fieldNumber: 50,
+  fieldName: "protobuf_unittest.my_extension_string",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestFieldOrderings>(
+  _protobuf_fieldNumber: 5,
+  fieldName: "protobuf_unittest.my_extension_int",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_packed_int32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 90,
+  fieldName: "protobuf_unittest.packed_int32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_int64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 91,
+  fieldName: "protobuf_unittest.packed_int64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_uint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 92,
+  fieldName: "protobuf_unittest.packed_uint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_uint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 93,
+  fieldName: "protobuf_unittest.packed_uint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sint32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 94,
+  fieldName: "protobuf_unittest.packed_sint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sint64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 95,
+  fieldName: "protobuf_unittest.packed_sint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_fixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 96,
+  fieldName: "protobuf_unittest.packed_fixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_fixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 97,
+  fieldName: "protobuf_unittest.packed_fixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sfixed32_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 98,
+  fieldName: "protobuf_unittest.packed_sfixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sfixed64_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 99,
+  fieldName: "protobuf_unittest.packed_sfixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_float_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.packed_float_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_double_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.packed_double_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_bool_extension = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "protobuf_unittest.packed_bool_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_enum_extension = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestPackedExtensions>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "protobuf_unittest.packed_enum_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 90,
+  fieldName: "protobuf_unittest.unpacked_int32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_int64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 91,
+  fieldName: "protobuf_unittest.unpacked_int64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_uint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 92,
+  fieldName: "protobuf_unittest.unpacked_uint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_uint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 93,
+  fieldName: "protobuf_unittest.unpacked_uint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_sint32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 94,
+  fieldName: "protobuf_unittest.unpacked_sint32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_sint64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 95,
+  fieldName: "protobuf_unittest.unpacked_sint64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_fixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 96,
+  fieldName: "protobuf_unittest.unpacked_fixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_fixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 97,
+  fieldName: "protobuf_unittest.unpacked_fixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_sfixed32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 98,
+  fieldName: "protobuf_unittest.unpacked_sfixed32_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_sfixed64_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 99,
+  fieldName: "protobuf_unittest.unpacked_sfixed64_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_float_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.unpacked_float_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_double_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.unpacked_double_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_bool_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "protobuf_unittest.unpacked_bool_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_unpacked_enum_extension = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnum>, ProtobufUnittest_TestUnpackedExtensions>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "protobuf_unittest.unpacked_enum_extension",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestHugeFieldNumbers>(
+  _protobuf_fieldNumber: 536860000,
+  fieldName: "protobuf_unittest.test_all_types",
+  defaultValue: ProtobufUnittest_TestAllTypes()
+)
+
+extension ProtobufUnittest_TestNestedExtension {
+  struct Extensions {
+    /// Check for bug where string extensions declared in tested scope did not
+    /// compile.
+    static let test = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+      _protobuf_fieldNumber: 1002,
+      fieldName: "protobuf_unittest.TestNestedExtension.test",
+      defaultValue: "test"
+    )
+
+    /// Used to test if generated extension name is correct when there are
+    /// underscores.
+    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
+      _protobuf_fieldNumber: 1003,
+      fieldName: "protobuf_unittest.TestNestedExtension.nested_string_extension",
+      defaultValue: String()
+    )
+  }
+}
+
+extension ProtobufUnittest_TestRequired {
+  struct Extensions {
+    static let single = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(
+      _protobuf_fieldNumber: 1000,
+      fieldName: "protobuf_unittest.TestRequired.single",
+      defaultValue: ProtobufUnittest_TestRequired()
+    )
+
+    static let multi = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(
+      _protobuf_fieldNumber: 1001,
+      fieldName: "protobuf_unittest.TestRequired.multi",
+      defaultValue: []
+    )
+  }
+}
+
+extension ProtobufUnittest_TestParsingMerge {
+  struct Extensions {
+    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
+      _protobuf_fieldNumber: 1000,
+      fieldName: "protobuf_unittest.TestParsingMerge.optional_ext",
+      defaultValue: ProtobufUnittest_TestAllTypes()
+    )
+
+    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
+      _protobuf_fieldNumber: 1001,
+      fieldName: "protobuf_unittest.TestParsingMerge.repeated_ext",
+      defaultValue: []
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -8428,6 +8428,10 @@ extension ProtobufUnittest_TestHugeFieldNumbers {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_Unittest_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_optional_int32_extension,
   ProtobufUnittest_Extensions_optional_int64_extension,

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -8501,7 +8501,7 @@ let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<
 )
 
 extension ProtobufUnittest_TestNestedExtension {
-  struct Extensions {
+  enum Extensions {
     /// Check for bug where string extensions declared in tested scope did not
     /// compile.
     static let test = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensions>(
@@ -8521,7 +8521,7 @@ extension ProtobufUnittest_TestNestedExtension {
 }
 
 extension ProtobufUnittest_TestRequired {
-  struct Extensions {
+  enum Extensions {
     static let single = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequired>, ProtobufUnittest_TestAllExtensions>(
       _protobuf_fieldNumber: 1000,
       fieldName: "protobuf_unittest.TestRequired.single",
@@ -8537,7 +8537,7 @@ extension ProtobufUnittest_TestRequired {
 }
 
 extension ProtobufUnittest_TestParsingMerge {
-  struct Extensions {
+  enum Extensions {
     static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypes>, ProtobufUnittest_TestParsingMerge>(
       _protobuf_fieldNumber: 1000,
       fieldName: "protobuf_unittest.TestParsingMerge.optional_ext",

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -6278,88 +6278,6 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 // MARK: - Extension support defined in unittest.proto.
 
 extension ProtobufUnittest_TestAllExtensions {
-  /// Check for bug where string extensions declared in tested scope did not
-  /// compile.
-  var ProtobufUnittest_TestNestedExtension_test: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test) ?? "test"}
-    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test, value: newValue)}
-  }
-  var hasProtobufUnittest_TestNestedExtension_test: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test)
-  }
-  mutating func clearProtobufUnittest_TestNestedExtension_test() {
-    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensions {
-  /// Used to test if generated extension name is correct when there are
-  /// underscores.
-  var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? String()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension, value: newValue)}
-  }
-  var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
-  }
-  mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensions {
-  var ProtobufUnittest_TestRequired_single: ProtobufUnittest_TestRequired {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single) ?? ProtobufUnittest_TestRequired()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single, value: newValue)}
-  }
-  var hasProtobufUnittest_TestRequired_single: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single)
-  }
-  mutating func clearProtobufUnittest_TestRequired_single() {
-    clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensions {
-  var ProtobufUnittest_TestRequired_multi: [ProtobufUnittest_TestRequired] {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)}
-    set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi, value: newValue)}
-  }
-  var hasProtobufUnittest_TestRequired_multi: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)
-  }
-  mutating func clearProtobufUnittest_TestRequired_multi() {
-    clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)
-  }
-}
-
-extension ProtobufUnittest_TestParsingMerge {
-  var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypes()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext, value: newValue)}
-  }
-  var hasProtobufUnittest_TestParsingMerge_optionalExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
-  }
-  mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
-  }
-}
-
-extension ProtobufUnittest_TestParsingMerge {
-  var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext, value: newValue)}
-  }
-  var hasProtobufUnittest_TestParsingMerge_repeatedExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
-  }
-  mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensions {
   /// Singular
   var ProtobufUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension) ?? 0}
@@ -7738,6 +7656,88 @@ extension ProtobufUnittest_TestHugeFieldNumbers {
   }
   mutating func clearProtobufUnittest_testAllTypes() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
+  }
+}
+
+extension ProtobufUnittest_TestAllExtensions {
+  /// Check for bug where string extensions declared in tested scope did not
+  /// compile.
+  var ProtobufUnittest_TestNestedExtension_test: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test) ?? "test"}
+    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test, value: newValue)}
+  }
+  var hasProtobufUnittest_TestNestedExtension_test: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test)
+  }
+  mutating func clearProtobufUnittest_TestNestedExtension_test() {
+    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test)
+  }
+}
+
+extension ProtobufUnittest_TestAllExtensions {
+  /// Used to test if generated extension name is correct when there are
+  /// underscores.
+  var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension) ?? String()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension, value: newValue)}
+  }
+  var hasProtobufUnittest_TestNestedExtension_nestedStringExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
+  }
+  mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
+  }
+}
+
+extension ProtobufUnittest_TestAllExtensions {
+  var ProtobufUnittest_TestRequired_single: ProtobufUnittest_TestRequired {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single) ?? ProtobufUnittest_TestRequired()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single, value: newValue)}
+  }
+  var hasProtobufUnittest_TestRequired_single: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single)
+  }
+  mutating func clearProtobufUnittest_TestRequired_single() {
+    clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single)
+  }
+}
+
+extension ProtobufUnittest_TestAllExtensions {
+  var ProtobufUnittest_TestRequired_multi: [ProtobufUnittest_TestRequired] {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)}
+    set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi, value: newValue)}
+  }
+  var hasProtobufUnittest_TestRequired_multi: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)
+  }
+  mutating func clearProtobufUnittest_TestRequired_multi() {
+    clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi)
+  }
+}
+
+extension ProtobufUnittest_TestParsingMerge {
+  var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypes()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext, value: newValue)}
+  }
+  var hasProtobufUnittest_TestParsingMerge_optionalExt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
+  }
+  mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
+  }
+}
+
+extension ProtobufUnittest_TestParsingMerge {
+  var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext, value: newValue)}
+  }
+  var hasProtobufUnittest_TestParsingMerge_repeatedExt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
+  }
+  mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -6964,6 +6964,8 @@ let ProtobufUnittest_Extensions_test_all_types = SwiftProtobuf.MessageExtension<
   defaultValue: ProtobufUnittest_TestAllTypes()
 )
 
+// MARK: - Extension support defined in unittest.proto.
+
 extension ProtobufUnittest_TestAllExtensions {
   /// Check for bug where string extensions declared in tested scope did not
   /// compile.

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -2104,6 +2104,10 @@ extension Google_Protobuf_MessageOptions {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_file_opt1,
   ProtobufUnittest_Extensions_message_opt1,

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -1216,58 +1216,6 @@ struct ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf.Message
 
 // MARK: - Extension support defined in unittest_custom_options.proto.
 
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
-    get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
-    set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4, value: newValue)}
-  }
-  var hasProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
-  }
-  mutating func clearProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4() {
-    clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
-  }
-}
-
-extension ProtobufUnittest_AggregateMessageSet {
-  var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
-    get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension) ?? ProtobufUnittest_AggregateMessageSetElement()}
-    set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension, value: newValue)}
-  }
-  var hasProtobufUnittest_AggregateMessageSetElement_messageSetExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
-  }
-  mutating func clearProtobufUnittest_AggregateMessageSetElement_messageSetExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
-  }
-}
-
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested, value: newValue)}
-  }
-  var hasProtobufUnittest_Aggregate_nested: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
-  }
-  mutating func clearProtobufUnittest_Aggregate_nested() {
-    clearExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
-  }
-}
-
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension, value: newValue)}
-  }
-  var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
-  }
-  mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
-  }
-}
-
 extension Google_Protobuf_FileOptions {
   var ProtobufUnittest_fileOpt1: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1) ?? 0}
@@ -1813,6 +1761,58 @@ extension Google_Protobuf_MessageOptions {
   }
   mutating func clearProtobufUnittest_requiredEnumOpt() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt)
+  }
+}
+
+extension Google_Protobuf_MessageOptions {
+  var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
+    get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
+    set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4, value: newValue)}
+  }
+  var hasProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
+  }
+  mutating func clearProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4() {
+    clearExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4)
+  }
+}
+
+extension ProtobufUnittest_AggregateMessageSet {
+  var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
+    get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension) ?? ProtobufUnittest_AggregateMessageSetElement()}
+    set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension, value: newValue)}
+  }
+  var hasProtobufUnittest_AggregateMessageSetElement_messageSetExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
+  }
+  mutating func clearProtobufUnittest_AggregateMessageSetElement_messageSetExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension)
+  }
+}
+
+extension Google_Protobuf_FileOptions {
+  var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested, value: newValue)}
+  }
+  var hasProtobufUnittest_Aggregate_nested: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  }
+  mutating func clearProtobufUnittest_Aggregate_nested() {
+    clearExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  }
+}
+
+extension Google_Protobuf_FileOptions {
+  var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension, value: newValue)}
+  }
+  var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
+  }
+  mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -2124,7 +2124,7 @@ let ProtobufUnittest_Extensions_required_enum_opt = SwiftProtobuf.MessageExtensi
 )
 
 extension ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
-  struct Extensions {
+  enum Extensions {
     static let complex_opt4 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2.ComplexOptionType4>, Google_Protobuf_MessageOptions>(
       _protobuf_fieldNumber: 7633546,
       fieldName: "protobuf_unittest.ComplexOptionType2.ComplexOptionType4.complex_opt4",
@@ -2134,7 +2134,7 @@ extension ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
 }
 
 extension ProtobufUnittest_AggregateMessageSetElement {
-  struct Extensions {
+  enum Extensions {
     static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_AggregateMessageSetElement>, ProtobufUnittest_AggregateMessageSet>(
       _protobuf_fieldNumber: 15447542,
       fieldName: "protobuf_unittest.AggregateMessageSetElement.message_set_extension",
@@ -2144,7 +2144,7 @@ extension ProtobufUnittest_AggregateMessageSetElement {
 }
 
 extension ProtobufUnittest_Aggregate {
-  struct Extensions {
+  enum Extensions {
     static let nested = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(
       _protobuf_fieldNumber: 15476903,
       fieldName: "protobuf_unittest.Aggregate.nested",
@@ -2154,7 +2154,7 @@ extension ProtobufUnittest_Aggregate {
 }
 
 extension ProtobufUnittest_NestedOptionType {
-  struct Extensions {
+  enum Extensions {
     static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FileOptions>(
       _protobuf_fieldNumber: 7912573,
       fieldName: "protobuf_unittest.NestedOptionType.nested_extension",

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -1504,6 +1504,8 @@ let ProtobufUnittest_Extensions_required_enum_opt = SwiftProtobuf.MessageExtensi
   defaultValue: ProtobufUnittest_OldOptionType()
 )
 
+// MARK: - Extension support defined in unittest_custom_options.proto.
+
 extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -555,15 +555,6 @@ struct ProtobufUnittest_ComplexOptionType2: SwiftProtobuf.Message, SwiftProtobuf
 
     var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    struct Extensions {
-
-      static let complex_opt4 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2.ComplexOptionType4>, Google_Protobuf_MessageOptions>(
-        _protobuf_fieldNumber: 7633546,
-        fieldName: "protobuf_unittest.ComplexOptionType2.ComplexOptionType4.complex_opt4",
-        defaultValue: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()
-      )
-    }
-
     init() {}
 
     mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -824,15 +815,6 @@ struct ProtobufUnittest_AggregateMessageSetElement: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_AggregateMessageSetElement>, ProtobufUnittest_AggregateMessageSet>(
-      _protobuf_fieldNumber: 15447542,
-      fieldName: "protobuf_unittest.AggregateMessageSetElement.message_set_extension",
-      defaultValue: ProtobufUnittest_AggregateMessageSetElement()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -917,15 +899,6 @@ struct ProtobufUnittest_Aggregate: SwiftProtobuf.Message {
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  struct Extensions {
-
-    static let nested = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(
-      _protobuf_fieldNumber: 15476903,
-      fieldName: "protobuf_unittest.Aggregate.nested",
-      defaultValue: ProtobufUnittest_Aggregate()
-    )
-  }
 
   init() {}
 
@@ -1075,15 +1048,6 @@ struct ProtobufUnittest_NestedOptionType: SwiftProtobuf.Message {
       }
       try unknownFields.traverse(visitor: &visitor)
     }
-  }
-
-  struct Extensions {
-
-    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FileOptions>(
-      _protobuf_fieldNumber: 7912573,
-      fieldName: "protobuf_unittest.NestedOptionType.nested_extension",
-      defaultValue: 0
-    )
   }
 
   init() {}
@@ -1249,260 +1213,6 @@ struct ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf.Message
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-let ProtobufUnittest_Extensions_file_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_FileOptions>(
-  _protobuf_fieldNumber: 7736974,
-  fieldName: "protobuf_unittest.file_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_message_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7739036,
-  fieldName: "protobuf_unittest.message_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_field_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_FieldOptions>(
-  _protobuf_fieldNumber: 7740936,
-  fieldName: "protobuf_unittest.field_opt1",
-  defaultValue: 0
-)
-
-/// This is useful for testing that we correctly register default values for
-/// extension options.
-let ProtobufUnittest_Extensions_field_opt2 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FieldOptions>(
-  _protobuf_fieldNumber: 7753913,
-  fieldName: "protobuf_unittest.field_opt2",
-  defaultValue: 42
-)
-
-let ProtobufUnittest_Extensions_oneof_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_OneofOptions>(
-  _protobuf_fieldNumber: 7740111,
-  fieldName: "protobuf_unittest.oneof_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_enum_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_EnumOptions>(
-  _protobuf_fieldNumber: 7753576,
-  fieldName: "protobuf_unittest.enum_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_enum_value_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_EnumValueOptions>(
-  _protobuf_fieldNumber: 1560678,
-  fieldName: "protobuf_unittest.enum_value_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_service_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_ServiceOptions>(
-  _protobuf_fieldNumber: 7887650,
-  fieldName: "protobuf_unittest.service_opt1",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_method_opt1 = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_MethodOpt1>, Google_Protobuf_MethodOptions>(
-  _protobuf_fieldNumber: 7890860,
-  fieldName: "protobuf_unittest.method_opt1",
-  defaultValue: ProtobufUnittest_MethodOpt1.val1
-)
-
-let ProtobufUnittest_Extensions_bool_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7706090,
-  fieldName: "protobuf_unittest.bool_opt",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_int32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7705709,
-  fieldName: "protobuf_unittest.int32_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_int64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7705542,
-  fieldName: "protobuf_unittest.int64_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_uint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7704880,
-  fieldName: "protobuf_unittest.uint32_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_uint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7702367,
-  fieldName: "protobuf_unittest.uint64_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_sint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7701568,
-  fieldName: "protobuf_unittest.sint32_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_sint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7700863,
-  fieldName: "protobuf_unittest.sint64_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_fixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7700307,
-  fieldName: "protobuf_unittest.fixed32_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_fixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7700194,
-  fieldName: "protobuf_unittest.fixed64_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_sfixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7698645,
-  fieldName: "protobuf_unittest.sfixed32_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_sfixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7685475,
-  fieldName: "protobuf_unittest.sfixed64_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_float_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7675390,
-  fieldName: "protobuf_unittest.float_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_double_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7673293,
-  fieldName: "protobuf_unittest.double_opt",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_string_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7673285,
-  fieldName: "protobuf_unittest.string_opt",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_bytes_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7673238,
-  fieldName: "protobuf_unittest.bytes_opt",
-  defaultValue: SwiftProtobuf.Internal.emptyData
-)
-
-let ProtobufUnittest_Extensions_enum_opt = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_DummyMessageContainingEnum.TestEnumType>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7673233,
-  fieldName: "protobuf_unittest.enum_opt",
-  defaultValue: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1
-)
-
-let ProtobufUnittest_Extensions_message_type_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_DummyMessageInvalidAsOptionType>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7665967,
-  fieldName: "protobuf_unittest.message_type_opt",
-  defaultValue: ProtobufUnittest_DummyMessageInvalidAsOptionType()
-)
-
-let ProtobufUnittest_Extensions_quux = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_ComplexOptionType1>(
-  _protobuf_fieldNumber: 7663707,
-  fieldName: "protobuf_unittest.quux",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_corge = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, ProtobufUnittest_ComplexOptionType1>(
-  _protobuf_fieldNumber: 7663442,
-  fieldName: "protobuf_unittest.corge",
-  defaultValue: ProtobufUnittest_ComplexOptionType3()
-)
-
-let ProtobufUnittest_Extensions_grault = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_ComplexOptionType2>(
-  _protobuf_fieldNumber: 7650927,
-  fieldName: "protobuf_unittest.grault",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_garply = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, ProtobufUnittest_ComplexOptionType2>(
-  _protobuf_fieldNumber: 7649992,
-  fieldName: "protobuf_unittest.garply",
-  defaultValue: ProtobufUnittest_ComplexOptionType1()
-)
-
-let ProtobufUnittest_Extensions_complex_opt1 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7646756,
-  fieldName: "protobuf_unittest.complex_opt1",
-  defaultValue: ProtobufUnittest_ComplexOptionType1()
-)
-
-let ProtobufUnittest_Extensions_complex_opt2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7636949,
-  fieldName: "protobuf_unittest.complex_opt2",
-  defaultValue: ProtobufUnittest_ComplexOptionType2()
-)
-
-let ProtobufUnittest_Extensions_complex_opt3 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7636463,
-  fieldName: "protobuf_unittest.complex_opt3",
-  defaultValue: ProtobufUnittest_ComplexOptionType3()
-)
-
-let ProtobufUnittest_Extensions_ComplexOpt6 = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_ComplexOpt6>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 7595468,
-  fieldName: "protobuf_unittest.ComplexOpt6",
-  defaultValue: ProtobufUnittest_ComplexOpt6()
-)
-
-let ProtobufUnittest_Extensions_fileopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(
-  _protobuf_fieldNumber: 15478479,
-  fieldName: "protobuf_unittest.fileopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_msgopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 15480088,
-  fieldName: "protobuf_unittest.msgopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_fieldopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FieldOptions>(
-  _protobuf_fieldNumber: 15481374,
-  fieldName: "protobuf_unittest.fieldopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_enumopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_EnumOptions>(
-  _protobuf_fieldNumber: 15483218,
-  fieldName: "protobuf_unittest.enumopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_enumvalopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_EnumValueOptions>(
-  _protobuf_fieldNumber: 15486921,
-  fieldName: "protobuf_unittest.enumvalopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_serviceopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_ServiceOptions>(
-  _protobuf_fieldNumber: 15497145,
-  fieldName: "protobuf_unittest.serviceopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_methodopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_MethodOptions>(
-  _protobuf_fieldNumber: 15512713,
-  fieldName: "protobuf_unittest.methodopt",
-  defaultValue: ProtobufUnittest_Aggregate()
-)
-
-let ProtobufUnittest_Extensions_required_enum_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(
-  _protobuf_fieldNumber: 106161807,
-  fieldName: "protobuf_unittest.required_enum_opt",
-  defaultValue: ProtobufUnittest_OldOptionType()
-)
 
 // MARK: - Extension support defined in unittest_custom_options.proto.
 
@@ -2158,6 +1868,300 @@ let ProtobufUnittest_UnittestCustomOptions_Extensions: SwiftProtobuf.SimpleExten
   ProtobufUnittest_Aggregate.Extensions.nested,
   ProtobufUnittest_NestedOptionType.Extensions.nested_extension
 ]
+
+let ProtobufUnittest_Extensions_file_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_FileOptions>(
+  _protobuf_fieldNumber: 7736974,
+  fieldName: "protobuf_unittest.file_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_message_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7739036,
+  fieldName: "protobuf_unittest.message_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_field_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_FieldOptions>(
+  _protobuf_fieldNumber: 7740936,
+  fieldName: "protobuf_unittest.field_opt1",
+  defaultValue: 0
+)
+
+/// This is useful for testing that we correctly register default values for
+/// extension options.
+let ProtobufUnittest_Extensions_field_opt2 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FieldOptions>(
+  _protobuf_fieldNumber: 7753913,
+  fieldName: "protobuf_unittest.field_opt2",
+  defaultValue: 42
+)
+
+let ProtobufUnittest_Extensions_oneof_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_OneofOptions>(
+  _protobuf_fieldNumber: 7740111,
+  fieldName: "protobuf_unittest.oneof_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_enum_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_EnumOptions>(
+  _protobuf_fieldNumber: 7753576,
+  fieldName: "protobuf_unittest.enum_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_enum_value_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_EnumValueOptions>(
+  _protobuf_fieldNumber: 1560678,
+  fieldName: "protobuf_unittest.enum_value_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_service_opt1 = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_ServiceOptions>(
+  _protobuf_fieldNumber: 7887650,
+  fieldName: "protobuf_unittest.service_opt1",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_method_opt1 = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_MethodOpt1>, Google_Protobuf_MethodOptions>(
+  _protobuf_fieldNumber: 7890860,
+  fieldName: "protobuf_unittest.method_opt1",
+  defaultValue: ProtobufUnittest_MethodOpt1.val1
+)
+
+let ProtobufUnittest_Extensions_bool_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7706090,
+  fieldName: "protobuf_unittest.bool_opt",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_int32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7705709,
+  fieldName: "protobuf_unittest.int32_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_int64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7705542,
+  fieldName: "protobuf_unittest.int64_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_uint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7704880,
+  fieldName: "protobuf_unittest.uint32_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_uint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7702367,
+  fieldName: "protobuf_unittest.uint64_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_sint32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7701568,
+  fieldName: "protobuf_unittest.sint32_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_sint64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7700863,
+  fieldName: "protobuf_unittest.sint64_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_fixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7700307,
+  fieldName: "protobuf_unittest.fixed32_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_fixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7700194,
+  fieldName: "protobuf_unittest.fixed64_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_sfixed32_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7698645,
+  fieldName: "protobuf_unittest.sfixed32_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_sfixed64_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7685475,
+  fieldName: "protobuf_unittest.sfixed64_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_float_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7675390,
+  fieldName: "protobuf_unittest.float_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_double_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7673293,
+  fieldName: "protobuf_unittest.double_opt",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_string_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7673285,
+  fieldName: "protobuf_unittest.string_opt",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_bytes_opt = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7673238,
+  fieldName: "protobuf_unittest.bytes_opt",
+  defaultValue: SwiftProtobuf.Internal.emptyData
+)
+
+let ProtobufUnittest_Extensions_enum_opt = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_DummyMessageContainingEnum.TestEnumType>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7673233,
+  fieldName: "protobuf_unittest.enum_opt",
+  defaultValue: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType.testOptionEnumType1
+)
+
+let ProtobufUnittest_Extensions_message_type_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_DummyMessageInvalidAsOptionType>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7665967,
+  fieldName: "protobuf_unittest.message_type_opt",
+  defaultValue: ProtobufUnittest_DummyMessageInvalidAsOptionType()
+)
+
+let ProtobufUnittest_Extensions_quux = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_ComplexOptionType1>(
+  _protobuf_fieldNumber: 7663707,
+  fieldName: "protobuf_unittest.quux",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_corge = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, ProtobufUnittest_ComplexOptionType1>(
+  _protobuf_fieldNumber: 7663442,
+  fieldName: "protobuf_unittest.corge",
+  defaultValue: ProtobufUnittest_ComplexOptionType3()
+)
+
+let ProtobufUnittest_Extensions_grault = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_ComplexOptionType2>(
+  _protobuf_fieldNumber: 7650927,
+  fieldName: "protobuf_unittest.grault",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_garply = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, ProtobufUnittest_ComplexOptionType2>(
+  _protobuf_fieldNumber: 7649992,
+  fieldName: "protobuf_unittest.garply",
+  defaultValue: ProtobufUnittest_ComplexOptionType1()
+)
+
+let ProtobufUnittest_Extensions_complex_opt1 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType1>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7646756,
+  fieldName: "protobuf_unittest.complex_opt1",
+  defaultValue: ProtobufUnittest_ComplexOptionType1()
+)
+
+let ProtobufUnittest_Extensions_complex_opt2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7636949,
+  fieldName: "protobuf_unittest.complex_opt2",
+  defaultValue: ProtobufUnittest_ComplexOptionType2()
+)
+
+let ProtobufUnittest_Extensions_complex_opt3 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType3>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7636463,
+  fieldName: "protobuf_unittest.complex_opt3",
+  defaultValue: ProtobufUnittest_ComplexOptionType3()
+)
+
+let ProtobufUnittest_Extensions_ComplexOpt6 = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_ComplexOpt6>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 7595468,
+  fieldName: "protobuf_unittest.ComplexOpt6",
+  defaultValue: ProtobufUnittest_ComplexOpt6()
+)
+
+let ProtobufUnittest_Extensions_fileopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(
+  _protobuf_fieldNumber: 15478479,
+  fieldName: "protobuf_unittest.fileopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_msgopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 15480088,
+  fieldName: "protobuf_unittest.msgopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_fieldopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FieldOptions>(
+  _protobuf_fieldNumber: 15481374,
+  fieldName: "protobuf_unittest.fieldopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_enumopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_EnumOptions>(
+  _protobuf_fieldNumber: 15483218,
+  fieldName: "protobuf_unittest.enumopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_enumvalopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_EnumValueOptions>(
+  _protobuf_fieldNumber: 15486921,
+  fieldName: "protobuf_unittest.enumvalopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_serviceopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_ServiceOptions>(
+  _protobuf_fieldNumber: 15497145,
+  fieldName: "protobuf_unittest.serviceopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_methodopt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_MethodOptions>(
+  _protobuf_fieldNumber: 15512713,
+  fieldName: "protobuf_unittest.methodopt",
+  defaultValue: ProtobufUnittest_Aggregate()
+)
+
+let ProtobufUnittest_Extensions_required_enum_opt = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_OldOptionType>, Google_Protobuf_MessageOptions>(
+  _protobuf_fieldNumber: 106161807,
+  fieldName: "protobuf_unittest.required_enum_opt",
+  defaultValue: ProtobufUnittest_OldOptionType()
+)
+
+extension ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
+  struct Extensions {
+    static let complex_opt4 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ComplexOptionType2.ComplexOptionType4>, Google_Protobuf_MessageOptions>(
+      _protobuf_fieldNumber: 7633546,
+      fieldName: "protobuf_unittest.ComplexOptionType2.ComplexOptionType4.complex_opt4",
+      defaultValue: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()
+    )
+  }
+}
+
+extension ProtobufUnittest_AggregateMessageSetElement {
+  struct Extensions {
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_AggregateMessageSetElement>, ProtobufUnittest_AggregateMessageSet>(
+      _protobuf_fieldNumber: 15447542,
+      fieldName: "protobuf_unittest.AggregateMessageSetElement.message_set_extension",
+      defaultValue: ProtobufUnittest_AggregateMessageSetElement()
+    )
+  }
+}
+
+extension ProtobufUnittest_Aggregate {
+  struct Extensions {
+    static let nested = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_Aggregate>, Google_Protobuf_FileOptions>(
+      _protobuf_fieldNumber: 15476903,
+      fieldName: "protobuf_unittest.Aggregate.nested",
+      defaultValue: ProtobufUnittest_Aggregate()
+    )
+  }
+}
+
+extension ProtobufUnittest_NestedOptionType {
+  struct Extensions {
+    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_FileOptions>(
+      _protobuf_fieldNumber: 7912573,
+      fieldName: "protobuf_unittest.NestedOptionType.nested_extension",
+      defaultValue: 0
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -4222,6 +4222,10 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_optional_int32_extension_lite,
   ProtobufUnittest_Extensions_optional_int64_extension_lite,

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -4301,7 +4301,7 @@ let ProtobufUnittest_Extensions_test_all_types_lite = SwiftProtobuf.MessageExten
 )
 
 extension ProtobufUnittest_TestNestedExtensionLite {
-  struct Extensions {
+  enum Extensions {
     static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
       _protobuf_fieldNumber: 12345,
       fieldName: "protobuf_unittest.TestNestedExtensionLite.nested_extension",
@@ -4311,7 +4311,7 @@ extension ProtobufUnittest_TestNestedExtensionLite {
 }
 
 extension ProtobufUnittest_TestParsingMergeLite {
-  struct Extensions {
+  enum Extensions {
     static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
       _protobuf_fieldNumber: 1000,
       fieldName: "protobuf_unittest.TestParsingMergeLite.optional_ext",

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -2444,45 +2444,6 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 // MARK: - Extension support defined in unittest_lite.proto.
 
 extension ProtobufUnittest_TestAllExtensionsLite {
-  var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension, value: newValue)}
-  }
-  var hasProtobufUnittest_TestNestedExtensionLite_nestedExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
-  }
-  mutating func clearProtobufUnittest_TestNestedExtensionLite_nestedExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
-  }
-}
-
-extension ProtobufUnittest_TestParsingMergeLite {
-  var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypesLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext, value: newValue)}
-  }
-  var hasProtobufUnittest_TestParsingMergeLite_optionalExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
-  }
-  mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
-  }
-}
-
-extension ProtobufUnittest_TestParsingMergeLite {
-  var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)}
-    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext, value: newValue)}
-  }
-  var hasProtobufUnittest_TestParsingMergeLite_repeatedExt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
-  }
-  mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
-    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensionsLite {
   /// Singular
   var ProtobufUnittest_optionalInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite) ?? 0}
@@ -3653,6 +3614,45 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite {
   }
   mutating func clearProtobufUnittest_testAllTypesLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
+  }
+}
+
+extension ProtobufUnittest_TestAllExtensionsLite {
+  var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension, value: newValue)}
+  }
+  var hasProtobufUnittest_TestNestedExtensionLite_nestedExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
+  }
+  mutating func clearProtobufUnittest_TestNestedExtensionLite_nestedExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension)
+  }
+}
+
+extension ProtobufUnittest_TestParsingMergeLite {
+  var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypesLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext, value: newValue)}
+  }
+  var hasProtobufUnittest_TestParsingMergeLite_optionalExt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
+  }
+  mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
+  }
+}
+
+extension ProtobufUnittest_TestParsingMergeLite {
+  var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
+    get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)}
+    set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext, value: newValue)}
+  }
+  var hasProtobufUnittest_TestParsingMergeLite_repeatedExt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
+  }
+  mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
+    clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -1612,15 +1612,6 @@ struct ProtobufUnittest_TestNestedExtensionLite: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-      _protobuf_fieldNumber: 12345,
-      fieldName: "protobuf_unittest.TestNestedExtensionLite.nested_extension",
-      defaultValue: 0
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1950,21 +1941,6 @@ struct ProtobufUnittest_TestParsingMergeLite: SwiftProtobuf.Message, SwiftProtob
       }
       try unknownFields.traverse(visitor: &visitor)
     }
-  }
-
-  struct Extensions {
-
-    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
-      _protobuf_fieldNumber: 1000,
-      fieldName: "protobuf_unittest.TestParsingMergeLite.optional_ext",
-      defaultValue: ProtobufUnittest_TestAllTypesLite()
-    )
-
-    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
-      _protobuf_fieldNumber: 1001,
-      fieldName: "protobuf_unittest.TestParsingMergeLite.repeated_ext",
-      defaultValue: []
-    )
   }
 
   init() {}
@@ -2464,550 +2440,6 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
-
-/// Singular
-let ProtobufUnittest_Extensions_optional_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "protobuf_unittest.optional_int32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "protobuf_unittest.optional_int64_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "protobuf_unittest.optional_uint32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 4,
-  fieldName: "protobuf_unittest.optional_uint64_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 5,
-  fieldName: "protobuf_unittest.optional_sint32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 6,
-  fieldName: "protobuf_unittest.optional_sint64_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 7,
-  fieldName: "protobuf_unittest.optional_fixed32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 8,
-  fieldName: "protobuf_unittest.optional_fixed64_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 9,
-  fieldName: "protobuf_unittest.optional_sfixed32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 10,
-  fieldName: "protobuf_unittest.optional_sfixed64_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 11,
-  fieldName: "protobuf_unittest.optional_float_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 12,
-  fieldName: "protobuf_unittest.optional_double_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_optional_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 13,
-  fieldName: "protobuf_unittest.optional_bool_extension_lite",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_optional_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 14,
-  fieldName: "protobuf_unittest.optional_string_extension_lite",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 15,
-  fieldName: "protobuf_unittest.optional_bytes_extension_lite",
-  defaultValue: SwiftProtobuf.Internal.emptyData
-)
-
-let ProtobufUnittest_Extensions_OptionalGroup_extension_lite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 16,
-  fieldName: "protobuf_unittest.OptionalGroup_extension_lite",
-  defaultValue: ProtobufUnittest_OptionalGroup_extension_lite()
-)
-
-let ProtobufUnittest_Extensions_optional_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 18,
-  fieldName: "protobuf_unittest.optional_nested_message_extension_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
-)
-
-let ProtobufUnittest_Extensions_optional_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 19,
-  fieldName: "protobuf_unittest.optional_foreign_message_extension_lite",
-  defaultValue: ProtobufUnittest_ForeignMessageLite()
-)
-
-let ProtobufUnittest_Extensions_optional_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 20,
-  fieldName: "protobuf_unittest.optional_import_message_extension_lite",
-  defaultValue: ProtobufUnittestImport_ImportMessageLite()
-)
-
-let ProtobufUnittest_Extensions_optional_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 21,
-  fieldName: "protobuf_unittest.optional_nested_enum_extension_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.foo
-)
-
-let ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 22,
-  fieldName: "protobuf_unittest.optional_foreign_enum_extension_lite",
-  defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteFoo
-)
-
-let ProtobufUnittest_Extensions_optional_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 23,
-  fieldName: "protobuf_unittest.optional_import_enum_extension_lite",
-  defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteFoo
-)
-
-let ProtobufUnittest_Extensions_optional_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 24,
-  fieldName: "protobuf_unittest.optional_string_piece_extension_lite",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 25,
-  fieldName: "protobuf_unittest.optional_cord_extension_lite",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_optional_public_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 26,
-  fieldName: "protobuf_unittest.optional_public_import_message_extension_lite",
-  defaultValue: ProtobufUnittestImport_PublicImportMessageLite()
-)
-
-let ProtobufUnittest_Extensions_optional_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 27,
-  fieldName: "protobuf_unittest.optional_lazy_message_extension_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
-)
-
-/// Repeated
-let ProtobufUnittest_Extensions_repeated_int32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 31,
-  fieldName: "protobuf_unittest.repeated_int32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_int64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 32,
-  fieldName: "protobuf_unittest.repeated_int64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_uint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 33,
-  fieldName: "protobuf_unittest.repeated_uint32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_uint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 34,
-  fieldName: "protobuf_unittest.repeated_uint64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 35,
-  fieldName: "protobuf_unittest.repeated_sint32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 36,
-  fieldName: "protobuf_unittest.repeated_sint64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_fixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 37,
-  fieldName: "protobuf_unittest.repeated_fixed32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_fixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 38,
-  fieldName: "protobuf_unittest.repeated_fixed64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 39,
-  fieldName: "protobuf_unittest.repeated_sfixed32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 40,
-  fieldName: "protobuf_unittest.repeated_sfixed64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_float_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 41,
-  fieldName: "protobuf_unittest.repeated_float_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_double_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 42,
-  fieldName: "protobuf_unittest.repeated_double_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_bool_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 43,
-  fieldName: "protobuf_unittest.repeated_bool_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_string_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 44,
-  fieldName: "protobuf_unittest.repeated_string_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_bytes_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 45,
-  fieldName: "protobuf_unittest.repeated_bytes_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_RepeatedGroup_extension_lite = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 46,
-  fieldName: "protobuf_unittest.RepeatedGroup_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_nested_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 48,
-  fieldName: "protobuf_unittest.repeated_nested_message_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 49,
-  fieldName: "protobuf_unittest.repeated_foreign_message_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_import_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 50,
-  fieldName: "protobuf_unittest.repeated_import_message_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 51,
-  fieldName: "protobuf_unittest.repeated_nested_enum_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 52,
-  fieldName: "protobuf_unittest.repeated_foreign_enum_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_import_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 53,
-  fieldName: "protobuf_unittest.repeated_import_enum_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_string_piece_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 54,
-  fieldName: "protobuf_unittest.repeated_string_piece_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_cord_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 55,
-  fieldName: "protobuf_unittest.repeated_cord_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 57,
-  fieldName: "protobuf_unittest.repeated_lazy_message_extension_lite",
-  defaultValue: []
-)
-
-/// Singular with defaults
-let ProtobufUnittest_Extensions_default_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 61,
-  fieldName: "protobuf_unittest.default_int32_extension_lite",
-  defaultValue: 41
-)
-
-let ProtobufUnittest_Extensions_default_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 62,
-  fieldName: "protobuf_unittest.default_int64_extension_lite",
-  defaultValue: 42
-)
-
-let ProtobufUnittest_Extensions_default_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 63,
-  fieldName: "protobuf_unittest.default_uint32_extension_lite",
-  defaultValue: 43
-)
-
-let ProtobufUnittest_Extensions_default_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 64,
-  fieldName: "protobuf_unittest.default_uint64_extension_lite",
-  defaultValue: 44
-)
-
-let ProtobufUnittest_Extensions_default_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 65,
-  fieldName: "protobuf_unittest.default_sint32_extension_lite",
-  defaultValue: -45
-)
-
-let ProtobufUnittest_Extensions_default_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 66,
-  fieldName: "protobuf_unittest.default_sint64_extension_lite",
-  defaultValue: 46
-)
-
-let ProtobufUnittest_Extensions_default_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 67,
-  fieldName: "protobuf_unittest.default_fixed32_extension_lite",
-  defaultValue: 47
-)
-
-let ProtobufUnittest_Extensions_default_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 68,
-  fieldName: "protobuf_unittest.default_fixed64_extension_lite",
-  defaultValue: 48
-)
-
-let ProtobufUnittest_Extensions_default_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 69,
-  fieldName: "protobuf_unittest.default_sfixed32_extension_lite",
-  defaultValue: 49
-)
-
-let ProtobufUnittest_Extensions_default_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 70,
-  fieldName: "protobuf_unittest.default_sfixed64_extension_lite",
-  defaultValue: -50
-)
-
-let ProtobufUnittest_Extensions_default_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 71,
-  fieldName: "protobuf_unittest.default_float_extension_lite",
-  defaultValue: 51.5
-)
-
-let ProtobufUnittest_Extensions_default_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 72,
-  fieldName: "protobuf_unittest.default_double_extension_lite",
-  defaultValue: 52000
-)
-
-let ProtobufUnittest_Extensions_default_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 73,
-  fieldName: "protobuf_unittest.default_bool_extension_lite",
-  defaultValue: true
-)
-
-let ProtobufUnittest_Extensions_default_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 74,
-  fieldName: "protobuf_unittest.default_string_extension_lite",
-  defaultValue: "hello"
-)
-
-let ProtobufUnittest_Extensions_default_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 75,
-  fieldName: "protobuf_unittest.default_bytes_extension_lite",
-  defaultValue: Data(bytes: [119, 111, 114, 108, 100])
-)
-
-let ProtobufUnittest_Extensions_default_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 81,
-  fieldName: "protobuf_unittest.default_nested_enum_extension_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.bar
-)
-
-let ProtobufUnittest_Extensions_default_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 82,
-  fieldName: "protobuf_unittest.default_foreign_enum_extension_lite",
-  defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteBar
-)
-
-let ProtobufUnittest_Extensions_default_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 83,
-  fieldName: "protobuf_unittest.default_import_enum_extension_lite",
-  defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteBar
-)
-
-let ProtobufUnittest_Extensions_default_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 84,
-  fieldName: "protobuf_unittest.default_string_piece_extension_lite",
-  defaultValue: "abc"
-)
-
-let ProtobufUnittest_Extensions_default_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 85,
-  fieldName: "protobuf_unittest.default_cord_extension_lite",
-  defaultValue: "123"
-)
-
-/// For oneof test
-let ProtobufUnittest_Extensions_oneof_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 111,
-  fieldName: "protobuf_unittest.oneof_uint32_extension_lite",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extensions_oneof_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 112,
-  fieldName: "protobuf_unittest.oneof_nested_message_extension_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
-)
-
-let ProtobufUnittest_Extensions_oneof_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 113,
-  fieldName: "protobuf_unittest.oneof_string_extension_lite",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extensions_oneof_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
-  _protobuf_fieldNumber: 114,
-  fieldName: "protobuf_unittest.oneof_bytes_extension_lite",
-  defaultValue: SwiftProtobuf.Internal.emptyData
-)
-
-let ProtobufUnittest_Extensions_packed_int32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 90,
-  fieldName: "protobuf_unittest.packed_int32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_int64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 91,
-  fieldName: "protobuf_unittest.packed_int64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_uint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 92,
-  fieldName: "protobuf_unittest.packed_uint32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_uint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 93,
-  fieldName: "protobuf_unittest.packed_uint64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 94,
-  fieldName: "protobuf_unittest.packed_sint32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 95,
-  fieldName: "protobuf_unittest.packed_sint64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_fixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 96,
-  fieldName: "protobuf_unittest.packed_fixed32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_fixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 97,
-  fieldName: "protobuf_unittest.packed_fixed64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 98,
-  fieldName: "protobuf_unittest.packed_sfixed32_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 99,
-  fieldName: "protobuf_unittest.packed_sfixed64_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_float_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.packed_float_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_double_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.packed_double_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_bool_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "protobuf_unittest.packed_bool_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_packed_enum_extension_lite = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestPackedExtensionsLite>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "protobuf_unittest.packed_enum_extension_lite",
-  defaultValue: []
-)
-
-let ProtobufUnittest_Extensions_test_all_types_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestHugeFieldNumbersLite>(
-  _protobuf_fieldNumber: 536860000,
-  fieldName: "protobuf_unittest.test_all_types_lite",
-  defaultValue: ProtobufUnittest_TestAllTypesLite()
-)
 
 // MARK: - Extension support defined in unittest_lite.proto.
 
@@ -4323,6 +3755,576 @@ let ProtobufUnittest_UnittestLite_Extensions: SwiftProtobuf.SimpleExtensionMap =
   ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext,
   ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext
 ]
+
+/// Singular
+let ProtobufUnittest_Extensions_optional_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "protobuf_unittest.optional_int32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "protobuf_unittest.optional_int64_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "protobuf_unittest.optional_uint32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 4,
+  fieldName: "protobuf_unittest.optional_uint64_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 5,
+  fieldName: "protobuf_unittest.optional_sint32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 6,
+  fieldName: "protobuf_unittest.optional_sint64_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 7,
+  fieldName: "protobuf_unittest.optional_fixed32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 8,
+  fieldName: "protobuf_unittest.optional_fixed64_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 9,
+  fieldName: "protobuf_unittest.optional_sfixed32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 10,
+  fieldName: "protobuf_unittest.optional_sfixed64_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 11,
+  fieldName: "protobuf_unittest.optional_float_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 12,
+  fieldName: "protobuf_unittest.optional_double_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_optional_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 13,
+  fieldName: "protobuf_unittest.optional_bool_extension_lite",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_optional_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 14,
+  fieldName: "protobuf_unittest.optional_string_extension_lite",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 15,
+  fieldName: "protobuf_unittest.optional_bytes_extension_lite",
+  defaultValue: SwiftProtobuf.Internal.emptyData
+)
+
+let ProtobufUnittest_Extensions_OptionalGroup_extension_lite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 16,
+  fieldName: "protobuf_unittest.OptionalGroup_extension_lite",
+  defaultValue: ProtobufUnittest_OptionalGroup_extension_lite()
+)
+
+let ProtobufUnittest_Extensions_optional_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 18,
+  fieldName: "protobuf_unittest.optional_nested_message_extension_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
+)
+
+let ProtobufUnittest_Extensions_optional_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 19,
+  fieldName: "protobuf_unittest.optional_foreign_message_extension_lite",
+  defaultValue: ProtobufUnittest_ForeignMessageLite()
+)
+
+let ProtobufUnittest_Extensions_optional_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 20,
+  fieldName: "protobuf_unittest.optional_import_message_extension_lite",
+  defaultValue: ProtobufUnittestImport_ImportMessageLite()
+)
+
+let ProtobufUnittest_Extensions_optional_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 21,
+  fieldName: "protobuf_unittest.optional_nested_enum_extension_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.foo
+)
+
+let ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 22,
+  fieldName: "protobuf_unittest.optional_foreign_enum_extension_lite",
+  defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteFoo
+)
+
+let ProtobufUnittest_Extensions_optional_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 23,
+  fieldName: "protobuf_unittest.optional_import_enum_extension_lite",
+  defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteFoo
+)
+
+let ProtobufUnittest_Extensions_optional_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 24,
+  fieldName: "protobuf_unittest.optional_string_piece_extension_lite",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 25,
+  fieldName: "protobuf_unittest.optional_cord_extension_lite",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_optional_public_import_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittestImport_PublicImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 26,
+  fieldName: "protobuf_unittest.optional_public_import_message_extension_lite",
+  defaultValue: ProtobufUnittestImport_PublicImportMessageLite()
+)
+
+let ProtobufUnittest_Extensions_optional_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 27,
+  fieldName: "protobuf_unittest.optional_lazy_message_extension_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
+)
+
+/// Repeated
+let ProtobufUnittest_Extensions_repeated_int32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 31,
+  fieldName: "protobuf_unittest.repeated_int32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_int64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 32,
+  fieldName: "protobuf_unittest.repeated_int64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_uint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 33,
+  fieldName: "protobuf_unittest.repeated_uint32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_uint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 34,
+  fieldName: "protobuf_unittest.repeated_uint64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sint32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 35,
+  fieldName: "protobuf_unittest.repeated_sint32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sint64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 36,
+  fieldName: "protobuf_unittest.repeated_sint64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_fixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 37,
+  fieldName: "protobuf_unittest.repeated_fixed32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_fixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 38,
+  fieldName: "protobuf_unittest.repeated_fixed64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 39,
+  fieldName: "protobuf_unittest.repeated_sfixed32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 40,
+  fieldName: "protobuf_unittest.repeated_sfixed64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_float_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 41,
+  fieldName: "protobuf_unittest.repeated_float_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_double_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 42,
+  fieldName: "protobuf_unittest.repeated_double_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_bool_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 43,
+  fieldName: "protobuf_unittest.repeated_bool_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_string_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 44,
+  fieldName: "protobuf_unittest.repeated_string_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_bytes_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 45,
+  fieldName: "protobuf_unittest.repeated_bytes_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_RepeatedGroup_extension_lite = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 46,
+  fieldName: "protobuf_unittest.RepeatedGroup_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_nested_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 48,
+  fieldName: "protobuf_unittest.repeated_nested_message_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_ForeignMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 49,
+  fieldName: "protobuf_unittest.repeated_foreign_message_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_import_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittestImport_ImportMessageLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 50,
+  fieldName: "protobuf_unittest.repeated_import_message_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 51,
+  fieldName: "protobuf_unittest.repeated_nested_enum_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 52,
+  fieldName: "protobuf_unittest.repeated_foreign_enum_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_import_enum_extension_lite = SwiftProtobuf.MessageExtension<RepeatedEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 53,
+  fieldName: "protobuf_unittest.repeated_import_enum_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_string_piece_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 54,
+  fieldName: "protobuf_unittest.repeated_string_piece_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_cord_extension_lite = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 55,
+  fieldName: "protobuf_unittest.repeated_cord_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 57,
+  fieldName: "protobuf_unittest.repeated_lazy_message_extension_lite",
+  defaultValue: []
+)
+
+/// Singular with defaults
+let ProtobufUnittest_Extensions_default_int32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 61,
+  fieldName: "protobuf_unittest.default_int32_extension_lite",
+  defaultValue: 41
+)
+
+let ProtobufUnittest_Extensions_default_int64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 62,
+  fieldName: "protobuf_unittest.default_int64_extension_lite",
+  defaultValue: 42
+)
+
+let ProtobufUnittest_Extensions_default_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 63,
+  fieldName: "protobuf_unittest.default_uint32_extension_lite",
+  defaultValue: 43
+)
+
+let ProtobufUnittest_Extensions_default_uint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 64,
+  fieldName: "protobuf_unittest.default_uint64_extension_lite",
+  defaultValue: 44
+)
+
+let ProtobufUnittest_Extensions_default_sint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 65,
+  fieldName: "protobuf_unittest.default_sint32_extension_lite",
+  defaultValue: -45
+)
+
+let ProtobufUnittest_Extensions_default_sint64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 66,
+  fieldName: "protobuf_unittest.default_sint64_extension_lite",
+  defaultValue: 46
+)
+
+let ProtobufUnittest_Extensions_default_fixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 67,
+  fieldName: "protobuf_unittest.default_fixed32_extension_lite",
+  defaultValue: 47
+)
+
+let ProtobufUnittest_Extensions_default_fixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 68,
+  fieldName: "protobuf_unittest.default_fixed64_extension_lite",
+  defaultValue: 48
+)
+
+let ProtobufUnittest_Extensions_default_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 69,
+  fieldName: "protobuf_unittest.default_sfixed32_extension_lite",
+  defaultValue: 49
+)
+
+let ProtobufUnittest_Extensions_default_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 70,
+  fieldName: "protobuf_unittest.default_sfixed64_extension_lite",
+  defaultValue: -50
+)
+
+let ProtobufUnittest_Extensions_default_float_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 71,
+  fieldName: "protobuf_unittest.default_float_extension_lite",
+  defaultValue: 51.5
+)
+
+let ProtobufUnittest_Extensions_default_double_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 72,
+  fieldName: "protobuf_unittest.default_double_extension_lite",
+  defaultValue: 52000
+)
+
+let ProtobufUnittest_Extensions_default_bool_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 73,
+  fieldName: "protobuf_unittest.default_bool_extension_lite",
+  defaultValue: true
+)
+
+let ProtobufUnittest_Extensions_default_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 74,
+  fieldName: "protobuf_unittest.default_string_extension_lite",
+  defaultValue: "hello"
+)
+
+let ProtobufUnittest_Extensions_default_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 75,
+  fieldName: "protobuf_unittest.default_bytes_extension_lite",
+  defaultValue: Data(bytes: [119, 111, 114, 108, 100])
+)
+
+let ProtobufUnittest_Extensions_default_nested_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_TestAllTypesLite.NestedEnum>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 81,
+  fieldName: "protobuf_unittest.default_nested_enum_extension_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedEnum.bar
+)
+
+let ProtobufUnittest_Extensions_default_foreign_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 82,
+  fieldName: "protobuf_unittest.default_foreign_enum_extension_lite",
+  defaultValue: ProtobufUnittest_ForeignEnumLite.foreignLiteBar
+)
+
+let ProtobufUnittest_Extensions_default_import_enum_extension_lite = SwiftProtobuf.MessageExtension<OptionalEnumExtensionField<ProtobufUnittestImport_ImportEnumLite>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 83,
+  fieldName: "protobuf_unittest.default_import_enum_extension_lite",
+  defaultValue: ProtobufUnittestImport_ImportEnumLite.importLiteBar
+)
+
+let ProtobufUnittest_Extensions_default_string_piece_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 84,
+  fieldName: "protobuf_unittest.default_string_piece_extension_lite",
+  defaultValue: "abc"
+)
+
+let ProtobufUnittest_Extensions_default_cord_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 85,
+  fieldName: "protobuf_unittest.default_cord_extension_lite",
+  defaultValue: "123"
+)
+
+/// For oneof test
+let ProtobufUnittest_Extensions_oneof_uint32_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 111,
+  fieldName: "protobuf_unittest.oneof_uint32_extension_lite",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extensions_oneof_nested_message_extension_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite.NestedMessage>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 112,
+  fieldName: "protobuf_unittest.oneof_nested_message_extension_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite.NestedMessage()
+)
+
+let ProtobufUnittest_Extensions_oneof_string_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 113,
+  fieldName: "protobuf_unittest.oneof_string_extension_lite",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extensions_oneof_bytes_extension_lite = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBytes>, ProtobufUnittest_TestAllExtensionsLite>(
+  _protobuf_fieldNumber: 114,
+  fieldName: "protobuf_unittest.oneof_bytes_extension_lite",
+  defaultValue: SwiftProtobuf.Internal.emptyData
+)
+
+let ProtobufUnittest_Extensions_packed_int32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 90,
+  fieldName: "protobuf_unittest.packed_int32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_int64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 91,
+  fieldName: "protobuf_unittest.packed_int64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_uint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 92,
+  fieldName: "protobuf_unittest.packed_uint32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_uint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufUInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 93,
+  fieldName: "protobuf_unittest.packed_uint64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sint32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt32>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 94,
+  fieldName: "protobuf_unittest.packed_sint32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sint64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSInt64>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 95,
+  fieldName: "protobuf_unittest.packed_sint64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_fixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 96,
+  fieldName: "protobuf_unittest.packed_fixed32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_fixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 97,
+  fieldName: "protobuf_unittest.packed_fixed64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sfixed32_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed32>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 98,
+  fieldName: "protobuf_unittest.packed_sfixed32_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_sfixed64_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufSFixed64>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 99,
+  fieldName: "protobuf_unittest.packed_sfixed64_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_float_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufFloat>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.packed_float_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_double_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufDouble>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.packed_double_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_bool_extension_lite = SwiftProtobuf.MessageExtension<PackedExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "protobuf_unittest.packed_bool_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_packed_enum_extension_lite = SwiftProtobuf.MessageExtension<PackedEnumExtensionField<ProtobufUnittest_ForeignEnumLite>, ProtobufUnittest_TestPackedExtensionsLite>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "protobuf_unittest.packed_enum_extension_lite",
+  defaultValue: []
+)
+
+let ProtobufUnittest_Extensions_test_all_types_lite = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestHugeFieldNumbersLite>(
+  _protobuf_fieldNumber: 536860000,
+  fieldName: "protobuf_unittest.test_all_types_lite",
+  defaultValue: ProtobufUnittest_TestAllTypesLite()
+)
+
+extension ProtobufUnittest_TestNestedExtensionLite {
+  struct Extensions {
+    static let nested_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestAllExtensionsLite>(
+      _protobuf_fieldNumber: 12345,
+      fieldName: "protobuf_unittest.TestNestedExtensionLite.nested_extension",
+      defaultValue: 0
+    )
+  }
+}
+
+extension ProtobufUnittest_TestParsingMergeLite {
+  struct Extensions {
+    static let optional_ext = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
+      _protobuf_fieldNumber: 1000,
+      fieldName: "protobuf_unittest.TestParsingMergeLite.optional_ext",
+      defaultValue: ProtobufUnittest_TestAllTypesLite()
+    )
+
+    static let repeated_ext = SwiftProtobuf.MessageExtension<RepeatedMessageExtensionField<ProtobufUnittest_TestAllTypesLite>, ProtobufUnittest_TestParsingMergeLite>(
+      _protobuf_fieldNumber: 1001,
+      fieldName: "protobuf_unittest.TestParsingMergeLite.repeated_ext",
+      defaultValue: []
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -3009,6 +3009,8 @@ let ProtobufUnittest_Extensions_test_all_types_lite = SwiftProtobuf.MessageExten
   defaultValue: ProtobufUnittest_TestAllTypesLite()
 )
 
+// MARK: - Extension support defined in unittest_lite.proto.
+
 extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension) ?? 0}

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -122,15 +122,6 @@ struct ProtobufUnittest_TestMessageSetExtension1: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension1>, Proto2WireformatUnittest_TestMessageSet>(
-      _protobuf_fieldNumber: 1545008,
-      fieldName: "protobuf_unittest.TestMessageSetExtension1.message_set_extension",
-      defaultValue: ProtobufUnittest_TestMessageSetExtension1()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -166,15 +157,6 @@ struct ProtobufUnittest_TestMessageSetExtension2: SwiftProtobuf.Message {
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  struct Extensions {
-
-    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension2>, Proto2WireformatUnittest_TestMessageSet>(
-      _protobuf_fieldNumber: 1547769,
-      fieldName: "protobuf_unittest.TestMessageSetExtension2.message_set_extension",
-      defaultValue: ProtobufUnittest_TestMessageSetExtension2()
-    )
-  }
 
   init() {}
 
@@ -321,6 +303,26 @@ let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.SimpleExtensionMap =
   ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension,
   ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension
 ]
+
+extension ProtobufUnittest_TestMessageSetExtension1 {
+  struct Extensions {
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension1>, Proto2WireformatUnittest_TestMessageSet>(
+      _protobuf_fieldNumber: 1545008,
+      fieldName: "protobuf_unittest.TestMessageSetExtension1.message_set_extension",
+      defaultValue: ProtobufUnittest_TestMessageSetExtension1()
+    )
+  }
+}
+
+extension ProtobufUnittest_TestMessageSetExtension2 {
+  struct Extensions {
+    static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension2>, Proto2WireformatUnittest_TestMessageSet>(
+      _protobuf_fieldNumber: 1547769,
+      fieldName: "protobuf_unittest.TestMessageSetExtension2.message_set_extension",
+      defaultValue: ProtobufUnittest_TestMessageSetExtension2()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -305,7 +305,7 @@ let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.SimpleExtensionMap =
 ]
 
 extension ProtobufUnittest_TestMessageSetExtension1 {
-  struct Extensions {
+  enum Extensions {
     static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension1>, Proto2WireformatUnittest_TestMessageSet>(
       _protobuf_fieldNumber: 1545008,
       fieldName: "protobuf_unittest.TestMessageSetExtension1.message_set_extension",
@@ -315,7 +315,7 @@ extension ProtobufUnittest_TestMessageSetExtension1 {
 }
 
 extension ProtobufUnittest_TestMessageSetExtension2 {
-  struct Extensions {
+  enum Extensions {
     static let message_set_extension = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestMessageSetExtension2>, Proto2WireformatUnittest_TestMessageSet>(
       _protobuf_fieldNumber: 1547769,
       fieldName: "protobuf_unittest.TestMessageSetExtension2.message_set_extension",

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -311,6 +311,10 @@ extension Proto2WireformatUnittest_TestMessageSet {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_UnittestMset_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension,
   ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -285,6 +285,8 @@ struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message {
   }
 }
 
+// MARK: - Extension support defined in unittest_mset.proto.
+
 extension Proto2WireformatUnittest_TestMessageSet {
   var ProtobufUnittest_TestMessageSetExtension1_messageSetExtension: ProtobufUnittest_TestMessageSetExtension1 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension) ?? ProtobufUnittest_TestMessageSetExtension1()}

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -139,6 +139,10 @@ extension Google_Protobuf_NoGenericServicesTest_TestMessage {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Google_Protobuf_NoGenericServicesTest_Extensions_test_extension
 ]

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -120,12 +120,6 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf.Message,
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-let Google_Protobuf_NoGenericServicesTest_Extensions_test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_NoGenericServicesTest_TestMessage>(
-  _protobuf_fieldNumber: 1000,
-  fieldName: "google.protobuf.no_generic_services_test.test_extension",
-  defaultValue: 0
-)
-
 // MARK: - Extension support defined in unittest_no_generic_services.proto.
 
 extension Google_Protobuf_NoGenericServicesTest_TestMessage {
@@ -148,6 +142,12 @@ extension Google_Protobuf_NoGenericServicesTest_TestMessage {
 let Google_Protobuf_NoGenericServicesTest_UnittestNoGenericServices_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Google_Protobuf_NoGenericServicesTest_Extensions_test_extension
 ]
+
+let Google_Protobuf_NoGenericServicesTest_Extensions_test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Google_Protobuf_NoGenericServicesTest_TestMessage>(
+  _protobuf_fieldNumber: 1000,
+  fieldName: "google.protobuf.no_generic_services_test.test_extension",
+  defaultValue: 0
+)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -126,6 +126,8 @@ let Google_Protobuf_NoGenericServicesTest_Extensions_test_extension = SwiftProto
   defaultValue: 0
 )
 
+// MARK: - Extension support defined in unittest_no_generic_services.proto.
+
 extension Google_Protobuf_NoGenericServicesTest_TestMessage {
   var Google_Protobuf_NoGenericServicesTest_testExtension: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension) ?? 0}

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -300,7 +300,7 @@ let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.SimpleExtensi
 ]
 
 extension ProtobufUnittest_TestOptimizedForSize {
-  struct Extensions {
+  enum Extensions {
     static let test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestOptimizedForSize>(
       _protobuf_fieldNumber: 1234,
       fieldName: "protobuf_unittest.TestOptimizedForSize.test_extension",

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -277,6 +277,8 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message {
   }
 }
 
+// MARK: - Extension support defined in unittest_optimize_for.proto.
+
 extension ProtobufUnittest_TestOptimizedForSize {
   var ProtobufUnittest_TestOptimizedForSize_testExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension) ?? 0}

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -128,21 +128,6 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
     }
   }
 
-  struct Extensions {
-
-    static let test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestOptimizedForSize>(
-      _protobuf_fieldNumber: 1234,
-      fieldName: "protobuf_unittest.TestOptimizedForSize.test_extension",
-      defaultValue: 0
-    )
-
-    static let test_extension2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequiredOptimizedForSize>, ProtobufUnittest_TestOptimizedForSize>(
-      _protobuf_fieldNumber: 1235,
-      fieldName: "protobuf_unittest.TestOptimizedForSize.test_extension2",
-      defaultValue: ProtobufUnittest_TestRequiredOptimizedForSize()
-    )
-  }
-
   init() {}
 
   public var isInitialized: Bool {
@@ -313,6 +298,22 @@ let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.SimpleExtensi
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension,
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2
 ]
+
+extension ProtobufUnittest_TestOptimizedForSize {
+  struct Extensions {
+    static let test_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_TestOptimizedForSize>(
+      _protobuf_fieldNumber: 1234,
+      fieldName: "protobuf_unittest.TestOptimizedForSize.test_extension",
+      defaultValue: 0
+    )
+
+    static let test_extension2 = SwiftProtobuf.MessageExtension<OptionalMessageExtensionField<ProtobufUnittest_TestRequiredOptimizedForSize>, ProtobufUnittest_TestOptimizedForSize>(
+      _protobuf_fieldNumber: 1235,
+      fieldName: "protobuf_unittest.TestOptimizedForSize.test_extension2",
+      defaultValue: ProtobufUnittest_TestRequiredOptimizedForSize()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -303,6 +303,10 @@ extension ProtobufUnittest_TestOptimizedForSize {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_UnittestOptimizeFor_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension,
   ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -477,6 +477,10 @@ extension ProtobufUnittest_Extend_MsgUsesStorage {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend_Extensions_b,
   ProtobufUnittest_Extend_Extensions_C,

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -325,54 +325,6 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-let ProtobufUnittest_Extend_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.extend.b",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extend_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.extend.C",
-  defaultValue: ProtobufUnittest_Extend_C()
-)
-
-let ProtobufUnittest_Extend_Extensions_a_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg1>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "protobuf_unittest.extend.a_b",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extend_Extensions_aB = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg2>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "protobuf_unittest.extend.aB",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extend_Extensions_ext_a = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgNoStorage>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.extend.ext_a",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extend_Extensions_ext_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgNoStorage>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.extend.ext_b",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extend_Extensions_ext_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgUsesStorage>(
-  _protobuf_fieldNumber: 100,
-  fieldName: "protobuf_unittest.extend.ext_c",
-  defaultValue: 0
-)
-
-let ProtobufUnittest_Extend_Extensions_ext_d = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgUsesStorage>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.extend.ext_d",
-  defaultValue: 0
-)
-
 // MARK: - Extension support defined in unittest_swift_extension.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
@@ -493,6 +445,54 @@ let ProtobufUnittest_Extend_UnittestSwiftExtension_Extensions: SwiftProtobuf.Sim
   ProtobufUnittest_Extend_Extensions_ext_c,
   ProtobufUnittest_Extend_Extensions_ext_d
 ]
+
+let ProtobufUnittest_Extend_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.extend.b",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extend_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.extend.C",
+  defaultValue: ProtobufUnittest_Extend_C()
+)
+
+let ProtobufUnittest_Extend_Extensions_a_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg1>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "protobuf_unittest.extend.a_b",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_aB = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_Msg2>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "protobuf_unittest.extend.aB",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_ext_a = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgNoStorage>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.extend.ext_a",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_ext_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgNoStorage>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.extend.ext_b",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_ext_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgUsesStorage>(
+  _protobuf_fieldNumber: 100,
+  fieldName: "protobuf_unittest.extend.ext_c",
+  defaultValue: 0
+)
+
+let ProtobufUnittest_Extend_Extensions_ext_d = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufUnittest_Extend_MsgUsesStorage>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "protobuf_unittest.extend.ext_d",
+  defaultValue: 0
+)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -373,6 +373,8 @@ let ProtobufUnittest_Extend_Extensions_ext_d = SwiftProtobuf.MessageExtension<Op
   defaultValue: 0
 )
 
+// MARK: - Extension support defined in unittest_swift_extension.proto.
+
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b) ?? String()}

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -78,21 +78,6 @@ struct ProtobufUnittest_Extend2_MyMessage: SwiftProtobuf.Message {
     }
   }
 
-  struct Extensions {
-
-    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 210,
-      fieldName: "protobuf_unittest.extend2.MyMessage.b",
-      defaultValue: String()
-    )
-
-    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 211,
-      fieldName: "protobuf_unittest.extend2.MyMessage.C",
-      defaultValue: ProtobufUnittest_Extend2_MyMessage.C()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -140,18 +125,6 @@ struct ProtobufUnittest_Extend2_C: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-let ProtobufUnittest_Extend2_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 220,
-  fieldName: "protobuf_unittest.extend2.b",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 221,
-  fieldName: "protobuf_unittest.extend2.C",
-  defaultValue: ProtobufUnittest_Extend2_C()
-)
 
 // MARK: - Extension support defined in unittest_swift_extension2.proto.
 
@@ -217,6 +190,34 @@ let ProtobufUnittest_Extend2_UnittestSwiftExtension2_Extensions: SwiftProtobuf.S
   ProtobufUnittest_Extend2_MyMessage.Extensions.b,
   ProtobufUnittest_Extend2_MyMessage.Extensions.C
 ]
+
+let ProtobufUnittest_Extend2_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 220,
+  fieldName: "protobuf_unittest.extend2.b",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 221,
+  fieldName: "protobuf_unittest.extend2.C",
+  defaultValue: ProtobufUnittest_Extend2_C()
+)
+
+extension ProtobufUnittest_Extend2_MyMessage {
+  struct Extensions {
+    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 210,
+      fieldName: "protobuf_unittest.extend2.MyMessage.b",
+      defaultValue: String()
+    )
+
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 211,
+      fieldName: "protobuf_unittest.extend2.MyMessage.C",
+      defaultValue: ProtobufUnittest_Extend2_MyMessage.C()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -204,7 +204,7 @@ let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<Optio
 )
 
 extension ProtobufUnittest_Extend2_MyMessage {
-  struct Extensions {
+  enum Extensions {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 210,
       fieldName: "protobuf_unittest.extend2.MyMessage.b",

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -205,6 +205,10 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_Extend2_UnittestSwiftExtension2_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend2_Extensions_b,
   ProtobufUnittest_Extend2_Extensions_C,

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -153,6 +153,8 @@ let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<Optio
   defaultValue: ProtobufUnittest_Extend2_C()
 )
 
+// MARK: - Extension support defined in unittest_swift_extension2.proto.
+
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_MyMessage_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? String()}

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -129,32 +129,6 @@ struct ProtobufUnittest_Extend2_C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension2.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var ProtobufUnittest_Extend2_MyMessage_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? String()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b, value: newValue)}
-  }
-  var hasProtobufUnittest_Extend2_MyMessage_b: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b)
-  }
-  mutating func clearProtobufUnittest_Extend2_MyMessage_b() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var ProtobufUnittest_Extend2_MyMessage_c: ProtobufUnittest_Extend2_MyMessage.C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend2_MyMessage.C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C, value: newValue)}
-  }
-  var hasProtobufUnittest_Extend2_MyMessage_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
-  }
-  mutating func clearProtobufUnittest_Extend2_MyMessage_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b, value: newValue)}
@@ -177,6 +151,32 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
   mutating func clearProtobufUnittest_Extend2_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var ProtobufUnittest_Extend2_MyMessage_b: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? String()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend2_MyMessage_b: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b)
+  }
+  mutating func clearProtobufUnittest_Extend2_MyMessage_b() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var ProtobufUnittest_Extend2_MyMessage_c: ProtobufUnittest_Extend2_MyMessage.C {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend2_MyMessage.C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend2_MyMessage_c: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
+  }
+  mutating func clearProtobufUnittest_Extend2_MyMessage_c() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -153,6 +153,8 @@ let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<Optio
   defaultValue: ProtobufUnittest_Extend3_C()
 )
 
+// MARK: - Extension support defined in unittest_swift_extension3.proto.
+
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_MyMessage_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? String()}

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -205,6 +205,10 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_Extend3_UnittestSwiftExtension3_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extend3_Extensions_b,
   ProtobufUnittest_Extend3_Extensions_C,

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -204,7 +204,7 @@ let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<Optio
 )
 
 extension ProtobufUnittest_Extend3_MyMessage {
-  struct Extensions {
+  enum Extensions {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 310,
       fieldName: "protobuf_unittest.extend3.MyMessage.b",

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -129,32 +129,6 @@ struct ProtobufUnittest_Extend3_C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension3.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var ProtobufUnittest_Extend3_MyMessage_b: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? String()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b, value: newValue)}
-  }
-  var hasProtobufUnittest_Extend3_MyMessage_b: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b)
-  }
-  mutating func clearProtobufUnittest_Extend3_MyMessage_b() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var ProtobufUnittest_Extend3_MyMessage_c: ProtobufUnittest_Extend3_MyMessage.C {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend3_MyMessage.C()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C, value: newValue)}
-  }
-  var hasProtobufUnittest_Extend3_MyMessage_c: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
-  }
-  mutating func clearProtobufUnittest_Extend3_MyMessage_c() {
-    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b, value: newValue)}
@@ -177,6 +151,32 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
   mutating func clearProtobufUnittest_Extend3_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var ProtobufUnittest_Extend3_MyMessage_b: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? String()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend3_MyMessage_b: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b)
+  }
+  mutating func clearProtobufUnittest_Extend3_MyMessage_b() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var ProtobufUnittest_Extend3_MyMessage_c: ProtobufUnittest_Extend3_MyMessage.C {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend3_MyMessage.C()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C, value: newValue)}
+  }
+  var hasProtobufUnittest_Extend3_MyMessage_c: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
+  }
+  mutating func clearProtobufUnittest_Extend3_MyMessage_c() {
+    clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -78,21 +78,6 @@ struct ProtobufUnittest_Extend3_MyMessage: SwiftProtobuf.Message {
     }
   }
 
-  struct Extensions {
-
-    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 310,
-      fieldName: "protobuf_unittest.extend3.MyMessage.b",
-      defaultValue: String()
-    )
-
-    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 311,
-      fieldName: "protobuf_unittest.extend3.MyMessage.C",
-      defaultValue: ProtobufUnittest_Extend3_MyMessage.C()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -140,18 +125,6 @@ struct ProtobufUnittest_Extend3_C: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-let ProtobufUnittest_Extend3_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 320,
-  fieldName: "protobuf_unittest.extend3.b",
-  defaultValue: String()
-)
-
-let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 321,
-  fieldName: "protobuf_unittest.extend3.C",
-  defaultValue: ProtobufUnittest_Extend3_C()
-)
 
 // MARK: - Extension support defined in unittest_swift_extension3.proto.
 
@@ -217,6 +190,34 @@ let ProtobufUnittest_Extend3_UnittestSwiftExtension3_Extensions: SwiftProtobuf.S
   ProtobufUnittest_Extend3_MyMessage.Extensions.b,
   ProtobufUnittest_Extend3_MyMessage.Extensions.C
 ]
+
+let ProtobufUnittest_Extend3_Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 320,
+  fieldName: "protobuf_unittest.extend3.b",
+  defaultValue: String()
+)
+
+let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 321,
+  fieldName: "protobuf_unittest.extend3.C",
+  defaultValue: ProtobufUnittest_Extend3_C()
+)
+
+extension ProtobufUnittest_Extend3_MyMessage {
+  struct Extensions {
+    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 310,
+      fieldName: "protobuf_unittest.extend3.MyMessage.b",
+      defaultValue: String()
+    )
+
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 311,
+      fieldName: "protobuf_unittest.extend3.MyMessage.C",
+      defaultValue: ProtobufUnittest_Extend3_MyMessage.C()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -153,6 +153,8 @@ let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionFiel
   defaultValue: Ext4C()
 )
 
+// MARK: - Extension support defined in unittest_swift_extension4.proto.
+
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4MyMessage_b: String {
     get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? String()}

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -204,7 +204,7 @@ let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionFiel
 )
 
 extension Ext4MyMessage {
-  struct Extensions {
+  enum Extensions {
     static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 410,
       fieldName: "protobuf_unittest.extend4.MyMessage.b",

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -205,6 +205,10 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let Ext4UnittestSwiftExtension4_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Ext4Extensions_b,
   Ext4Extensions_C,

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -129,32 +129,6 @@ struct Ext4C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension4.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var Ext4MyMessage_b: String {
-    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? String()}
-    set {setExtensionValue(ext: Ext4MyMessage.Extensions.b, value: newValue)}
-  }
-  var hasExt4MyMessage_b: Bool {
-    return hasExtensionValue(ext: Ext4MyMessage.Extensions.b)
-  }
-  mutating func clearExt4MyMessage_b() {
-    clearExtensionValue(ext: Ext4MyMessage.Extensions.b)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
-  var Ext4MyMessage_c: Ext4MyMessage.C {
-    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.C) ?? Ext4MyMessage.C()}
-    set {setExtensionValue(ext: Ext4MyMessage.Extensions.C, value: newValue)}
-  }
-  var hasExt4MyMessage_c: Bool {
-    return hasExtensionValue(ext: Ext4MyMessage.Extensions.C)
-  }
-  mutating func clearExt4MyMessage_c() {
-    clearExtensionValue(ext: Ext4MyMessage.Extensions.C)
-  }
-}
-
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4b: String {
     get {return getExtensionValue(ext: Ext4Extensions_b) ?? String()}
     set {setExtensionValue(ext: Ext4Extensions_b, value: newValue)}
@@ -177,6 +151,32 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   }
   mutating func clearExt4c() {
     clearExtensionValue(ext: Ext4Extensions_C)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var Ext4MyMessage_b: String {
+    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? String()}
+    set {setExtensionValue(ext: Ext4MyMessage.Extensions.b, value: newValue)}
+  }
+  var hasExt4MyMessage_b: Bool {
+    return hasExtensionValue(ext: Ext4MyMessage.Extensions.b)
+  }
+  mutating func clearExt4MyMessage_b() {
+    clearExtensionValue(ext: Ext4MyMessage.Extensions.b)
+  }
+}
+
+extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+  var Ext4MyMessage_c: Ext4MyMessage.C {
+    get {return getExtensionValue(ext: Ext4MyMessage.Extensions.C) ?? Ext4MyMessage.C()}
+    set {setExtensionValue(ext: Ext4MyMessage.Extensions.C, value: newValue)}
+  }
+  var hasExt4MyMessage_c: Bool {
+    return hasExtensionValue(ext: Ext4MyMessage.Extensions.C)
+  }
+  mutating func clearExt4MyMessage_c() {
+    clearExtensionValue(ext: Ext4MyMessage.Extensions.C)
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -78,21 +78,6 @@ struct Ext4MyMessage: SwiftProtobuf.Message {
     }
   }
 
-  struct Extensions {
-
-    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 410,
-      fieldName: "protobuf_unittest.extend4.MyMessage.b",
-      defaultValue: String()
-    )
-
-    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-      _protobuf_fieldNumber: 411,
-      fieldName: "protobuf_unittest.extend4.MyMessage.C",
-      defaultValue: Ext4MyMessage.C()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -140,18 +125,6 @@ struct Ext4C: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-let Ext4Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 420,
-  fieldName: "protobuf_unittest.extend4.b",
-  defaultValue: String()
-)
-
-let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
-  _protobuf_fieldNumber: 421,
-  fieldName: "protobuf_unittest.extend4.C",
-  defaultValue: Ext4C()
-)
 
 // MARK: - Extension support defined in unittest_swift_extension4.proto.
 
@@ -217,6 +190,34 @@ let Ext4UnittestSwiftExtension4_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Ext4MyMessage.Extensions.b,
   Ext4MyMessage.Extensions.C
 ]
+
+let Ext4Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 420,
+  fieldName: "protobuf_unittest.extend4.b",
+  defaultValue: String()
+)
+
+let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+  _protobuf_fieldNumber: 421,
+  fieldName: "protobuf_unittest.extend4.C",
+  defaultValue: Ext4C()
+)
+
+extension Ext4MyMessage {
+  struct Extensions {
+    static let b = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 410,
+      fieldName: "protobuf_unittest.extend4.MyMessage.b",
+      defaultValue: String()
+    )
+
+    static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
+      _protobuf_fieldNumber: 411,
+      fieldName: "protobuf_unittest.extend4.MyMessage.C",
+      defaultValue: Ext4MyMessage.C()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -265,18 +265,6 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
 
-let Swift_Protobuf_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(
-  _protobuf_fieldNumber: 50,
-  fieldName: "swift.protobuf.my_extension_string",
-  defaultValue: String()
-)
-
-let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(
-  _protobuf_fieldNumber: 5,
-  fieldName: "swift.protobuf.my_extension_int",
-  defaultValue: 0
-)
-
 // MARK: - Extension support defined in unittest_swift_fieldorder.proto.
 
 extension Swift_Protobuf_TestFieldOrderings {
@@ -313,6 +301,18 @@ let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: SwiftProtobuf.SimpleExten
   Swift_Protobuf_Extensions_my_extension_string,
   Swift_Protobuf_Extensions_my_extension_int
 ]
+
+let Swift_Protobuf_Extensions_my_extension_string = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, Swift_Protobuf_TestFieldOrderings>(
+  _protobuf_fieldNumber: 50,
+  fieldName: "swift.protobuf.my_extension_string",
+  defaultValue: String()
+)
+
+let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, Swift_Protobuf_TestFieldOrderings>(
+  _protobuf_fieldNumber: 5,
+  fieldName: "swift.protobuf.my_extension_int",
+  defaultValue: 0
+)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -277,6 +277,8 @@ let Swift_Protobuf_Extensions_my_extension_int = SwiftProtobuf.MessageExtension<
   defaultValue: 0
 )
 
+// MARK: - Extension support defined in unittest_swift_fieldorder.proto.
+
 extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionString: String {
     get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string) ?? String()}

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -303,6 +303,10 @@ extension Swift_Protobuf_TestFieldOrderings {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let Swift_Protobuf_UnittestSwiftFieldorder_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Swift_Protobuf_Extensions_my_extension_string,
   Swift_Protobuf_Extensions_my_extension_int

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -479,6 +479,10 @@ extension SwiftTestGroupExtensions {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let UnittestSwiftGroups_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_ExtensionGroup,
   Extensions_RepeatedExtensionGroup

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -441,18 +441,6 @@ struct SwiftTestNestingGroupsMessage: SwiftProtobuf.Message {
   }
 }
 
-let Extensions_ExtensionGroup = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ExtensionGroup>, SwiftTestGroupExtensions>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "ExtensionGroup",
-  defaultValue: ExtensionGroup()
-)
-
-let Extensions_RepeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "RepeatedExtensionGroup",
-  defaultValue: []
-)
-
 // MARK: - Extension support defined in unittest_swift_groups.proto.
 
 extension SwiftTestGroupExtensions {
@@ -489,6 +477,18 @@ let UnittestSwiftGroups_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_ExtensionGroup,
   Extensions_RepeatedExtensionGroup
 ]
+
+let Extensions_ExtensionGroup = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ExtensionGroup>, SwiftTestGroupExtensions>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "ExtensionGroup",
+  defaultValue: ExtensionGroup()
+)
+
+let Extensions_RepeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "RepeatedExtensionGroup",
+  defaultValue: []
+)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -453,6 +453,8 @@ let Extensions_RepeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedG
   defaultValue: []
 )
 
+// MARK: - Extension support defined in unittest_swift_groups.proto.
+
 extension SwiftTestGroupExtensions {
   var extensionGroup: ExtensionGroup {
     get {return getExtensionValue(ext: Extensions_ExtensionGroup) ?? ExtensionGroup()}

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -17181,487 +17181,6 @@ struct SwiftUnittest_Names_ExtensionNamingInitialsWordCase: SwiftProtobuf.Messag
 
 // MARK: - Extension support defined in unittest_swift_naming.proto.
 
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_aBC: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Lowers_aBC: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
-  }
-  mutating func clearSwiftUnittest_Names_Lowers_aBC() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_Uppers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
-  }
-  mutating func clearSwiftUnittest_Names_Uppers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl, value: newValue)}
-  }
-  var hasSwiftUnittest_Names_WordCase_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
-  }
-  mutating func clearSwiftUnittest_Names_WordCase_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
-  }
-}
-
 extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_http: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_http) ?? 0}
@@ -18140,6 +17659,487 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   }
   mutating func clearSwiftUnittest_Names_theURL() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrl)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Lowers_aBC: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Lowers_aBC: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
+  }
+  mutating func clearSwiftUnittest_Names_Lowers_aBC() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_Uppers_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_Uppers_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
+  }
+  mutating func clearSwiftUnittest_Names_Uppers_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
+  }
+}
+
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+  var SwiftUnittest_Names_WordCase_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl, value: newValue)}
+  }
+  var hasSwiftUnittest_Names_WordCase_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
+  }
+  mutating func clearSwiftUnittest_Names_WordCase_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -17049,87 +17049,6 @@ struct SwiftUnittest_Names_Lowers: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 1,
-      fieldName: "swift_unittest.names.Lowers.http",
-      defaultValue: 0
-    )
-
-    static let http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 2,
-      fieldName: "swift_unittest.names.Lowers.http_request",
-      defaultValue: 0
-    )
-
-    static let the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 3,
-      fieldName: "swift_unittest.names.Lowers.the_http_request",
-      defaultValue: 0
-    )
-
-    static let the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 4,
-      fieldName: "swift_unittest.names.Lowers.the_http",
-      defaultValue: 0
-    )
-
-    static let https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 11,
-      fieldName: "swift_unittest.names.Lowers.https",
-      defaultValue: 0
-    )
-
-    static let https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 12,
-      fieldName: "swift_unittest.names.Lowers.https_request",
-      defaultValue: 0
-    )
-
-    static let the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 13,
-      fieldName: "swift_unittest.names.Lowers.the_https_request",
-      defaultValue: 0
-    )
-
-    static let the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 14,
-      fieldName: "swift_unittest.names.Lowers.the_https",
-      defaultValue: 0
-    )
-
-    static let url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 21,
-      fieldName: "swift_unittest.names.Lowers.url",
-      defaultValue: 0
-    )
-
-    static let url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 22,
-      fieldName: "swift_unittest.names.Lowers.url_value",
-      defaultValue: 0
-    )
-
-    static let the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 23,
-      fieldName: "swift_unittest.names.Lowers.the_url_value",
-      defaultValue: 0
-    )
-
-    static let the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 24,
-      fieldName: "swift_unittest.names.Lowers.the_url",
-      defaultValue: 0
-    )
-
-    static let a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 31,
-      fieldName: "swift_unittest.names.Lowers.a_b_c",
-      defaultValue: 0
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -17147,81 +17066,6 @@ struct SwiftUnittest_Names_Uppers: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 101,
-      fieldName: "swift_unittest.names.Uppers.HTTP",
-      defaultValue: 0
-    )
-
-    static let HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 102,
-      fieldName: "swift_unittest.names.Uppers.HTTP_request",
-      defaultValue: 0
-    )
-
-    static let the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 103,
-      fieldName: "swift_unittest.names.Uppers.the_HTTP_request",
-      defaultValue: 0
-    )
-
-    static let the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 104,
-      fieldName: "swift_unittest.names.Uppers.the_HTTP",
-      defaultValue: 0
-    )
-
-    static let HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 111,
-      fieldName: "swift_unittest.names.Uppers.HTTPS",
-      defaultValue: 0
-    )
-
-    static let HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 112,
-      fieldName: "swift_unittest.names.Uppers.HTTPS_request",
-      defaultValue: 0
-    )
-
-    static let the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 113,
-      fieldName: "swift_unittest.names.Uppers.the_HTTPS_request",
-      defaultValue: 0
-    )
-
-    static let the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 114,
-      fieldName: "swift_unittest.names.Uppers.the_HTTPS",
-      defaultValue: 0
-    )
-
-    static let URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 121,
-      fieldName: "swift_unittest.names.Uppers.URL",
-      defaultValue: 0
-    )
-
-    static let URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 122,
-      fieldName: "swift_unittest.names.Uppers.URL_value",
-      defaultValue: 0
-    )
-
-    static let the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 123,
-      fieldName: "swift_unittest.names.Uppers.the_URL_value",
-      defaultValue: 0
-    )
-
-    static let the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 124,
-      fieldName: "swift_unittest.names.Uppers.the_URL",
-      defaultValue: 0
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -17238,81 +17082,6 @@ struct SwiftUnittest_Names_WordCase: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".WordCase"
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
-
-  struct Extensions {
-
-    static let Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 201,
-      fieldName: "swift_unittest.names.WordCase.Http",
-      defaultValue: 0
-    )
-
-    static let HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 202,
-      fieldName: "swift_unittest.names.WordCase.HttpRequest",
-      defaultValue: 0
-    )
-
-    static let TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 203,
-      fieldName: "swift_unittest.names.WordCase.TheHttpRequest",
-      defaultValue: 0
-    )
-
-    static let TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 204,
-      fieldName: "swift_unittest.names.WordCase.TheHttp",
-      defaultValue: 0
-    )
-
-    static let Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 211,
-      fieldName: "swift_unittest.names.WordCase.Https",
-      defaultValue: 0
-    )
-
-    static let HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 212,
-      fieldName: "swift_unittest.names.WordCase.HttpsRequest",
-      defaultValue: 0
-    )
-
-    static let TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 213,
-      fieldName: "swift_unittest.names.WordCase.TheHttpsRequest",
-      defaultValue: 0
-    )
-
-    static let TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 214,
-      fieldName: "swift_unittest.names.WordCase.TheHttps",
-      defaultValue: 0
-    )
-
-    static let Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 221,
-      fieldName: "swift_unittest.names.WordCase.Url",
-      defaultValue: 0
-    )
-
-    static let UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 222,
-      fieldName: "swift_unittest.names.WordCase.UrlValue",
-      defaultValue: 0
-    )
-
-    static let TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 223,
-      fieldName: "swift_unittest.names.WordCase.TheUrlValue",
-      defaultValue: 0
-    )
-
-    static let TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
-      _protobuf_fieldNumber: 224,
-      fieldName: "swift_unittest.names.WordCase.TheUrl",
-      defaultValue: 0
-    )
-  }
 
   init() {}
 
@@ -17409,228 +17178,6 @@ struct SwiftUnittest_Names_ExtensionNamingInitialsWordCase: SwiftProtobuf.Messag
 
   var _protobuf_extensionFieldValues = SwiftProtobuf.ExtensionFieldValueSet()
 }
-
-let SwiftUnittest_Names_Extensions_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "swift_unittest.names.http",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "swift_unittest.names.http_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "swift_unittest.names.the_http_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 4,
-  fieldName: "swift_unittest.names.the_http",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 11,
-  fieldName: "swift_unittest.names.https",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 12,
-  fieldName: "swift_unittest.names.https_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 13,
-  fieldName: "swift_unittest.names.the_https_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 14,
-  fieldName: "swift_unittest.names.the_https",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 21,
-  fieldName: "swift_unittest.names.url",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 22,
-  fieldName: "swift_unittest.names.url_value",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 23,
-  fieldName: "swift_unittest.names.the_url_value",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 24,
-  fieldName: "swift_unittest.names.the_url",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 31,
-  fieldName: "swift_unittest.names.a_b_c",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "swift_unittest.names.HTTP",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "swift_unittest.names.HTTP_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "swift_unittest.names.the_HTTP_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 4,
-  fieldName: "swift_unittest.names.the_HTTP",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 11,
-  fieldName: "swift_unittest.names.HTTPS",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 12,
-  fieldName: "swift_unittest.names.HTTPS_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 13,
-  fieldName: "swift_unittest.names.the_HTTPS_request",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 14,
-  fieldName: "swift_unittest.names.the_HTTPS",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 21,
-  fieldName: "swift_unittest.names.URL",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 22,
-  fieldName: "swift_unittest.names.URL_value",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 23,
-  fieldName: "swift_unittest.names.the_URL_value",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 24,
-  fieldName: "swift_unittest.names.the_URL",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "swift_unittest.names.Http",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "swift_unittest.names.HttpRequest",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 3,
-  fieldName: "swift_unittest.names.TheHttpRequest",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 4,
-  fieldName: "swift_unittest.names.TheHttp",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 11,
-  fieldName: "swift_unittest.names.Https",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 12,
-  fieldName: "swift_unittest.names.HttpsRequest",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 13,
-  fieldName: "swift_unittest.names.TheHttpsRequest",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 14,
-  fieldName: "swift_unittest.names.TheHttps",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 21,
-  fieldName: "swift_unittest.names.Url",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 22,
-  fieldName: "swift_unittest.names.UrlValue",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 23,
-  fieldName: "swift_unittest.names.TheUrlValue",
-  defaultValue: 0
-)
-
-let SwiftUnittest_Names_Extensions_TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 24,
-  fieldName: "swift_unittest.names.TheUrl",
-  defaultValue: 0
-)
 
 // MARK: - Extension support defined in unittest_swift_naming.proto.
 
@@ -18676,6 +18223,462 @@ let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.SimpleExte
   SwiftUnittest_Names_WordCase.Extensions.TheUrlValue,
   SwiftUnittest_Names_WordCase.Extensions.TheUrl
 ]
+
+let SwiftUnittest_Names_Extensions_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "swift_unittest.names.http",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "swift_unittest.names.http_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "swift_unittest.names.the_http_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 4,
+  fieldName: "swift_unittest.names.the_http",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 11,
+  fieldName: "swift_unittest.names.https",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 12,
+  fieldName: "swift_unittest.names.https_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 13,
+  fieldName: "swift_unittest.names.the_https_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 14,
+  fieldName: "swift_unittest.names.the_https",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 21,
+  fieldName: "swift_unittest.names.url",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 22,
+  fieldName: "swift_unittest.names.url_value",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 23,
+  fieldName: "swift_unittest.names.the_url_value",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 24,
+  fieldName: "swift_unittest.names.the_url",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 31,
+  fieldName: "swift_unittest.names.a_b_c",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "swift_unittest.names.HTTP",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "swift_unittest.names.HTTP_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "swift_unittest.names.the_HTTP_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 4,
+  fieldName: "swift_unittest.names.the_HTTP",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 11,
+  fieldName: "swift_unittest.names.HTTPS",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 12,
+  fieldName: "swift_unittest.names.HTTPS_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 13,
+  fieldName: "swift_unittest.names.the_HTTPS_request",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 14,
+  fieldName: "swift_unittest.names.the_HTTPS",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 21,
+  fieldName: "swift_unittest.names.URL",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 22,
+  fieldName: "swift_unittest.names.URL_value",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 23,
+  fieldName: "swift_unittest.names.the_URL_value",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 24,
+  fieldName: "swift_unittest.names.the_URL",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "swift_unittest.names.Http",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "swift_unittest.names.HttpRequest",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 3,
+  fieldName: "swift_unittest.names.TheHttpRequest",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 4,
+  fieldName: "swift_unittest.names.TheHttp",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 11,
+  fieldName: "swift_unittest.names.Https",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 12,
+  fieldName: "swift_unittest.names.HttpsRequest",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 13,
+  fieldName: "swift_unittest.names.TheHttpsRequest",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 14,
+  fieldName: "swift_unittest.names.TheHttps",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 21,
+  fieldName: "swift_unittest.names.Url",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 22,
+  fieldName: "swift_unittest.names.UrlValue",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 23,
+  fieldName: "swift_unittest.names.TheUrlValue",
+  defaultValue: 0
+)
+
+let SwiftUnittest_Names_Extensions_TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 24,
+  fieldName: "swift_unittest.names.TheUrl",
+  defaultValue: 0
+)
+
+extension SwiftUnittest_Names_Lowers {
+  struct Extensions {
+    static let http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 1,
+      fieldName: "swift_unittest.names.Lowers.http",
+      defaultValue: 0
+    )
+
+    static let http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 2,
+      fieldName: "swift_unittest.names.Lowers.http_request",
+      defaultValue: 0
+    )
+
+    static let the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 3,
+      fieldName: "swift_unittest.names.Lowers.the_http_request",
+      defaultValue: 0
+    )
+
+    static let the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 4,
+      fieldName: "swift_unittest.names.Lowers.the_http",
+      defaultValue: 0
+    )
+
+    static let https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 11,
+      fieldName: "swift_unittest.names.Lowers.https",
+      defaultValue: 0
+    )
+
+    static let https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 12,
+      fieldName: "swift_unittest.names.Lowers.https_request",
+      defaultValue: 0
+    )
+
+    static let the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 13,
+      fieldName: "swift_unittest.names.Lowers.the_https_request",
+      defaultValue: 0
+    )
+
+    static let the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 14,
+      fieldName: "swift_unittest.names.Lowers.the_https",
+      defaultValue: 0
+    )
+
+    static let url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 21,
+      fieldName: "swift_unittest.names.Lowers.url",
+      defaultValue: 0
+    )
+
+    static let url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 22,
+      fieldName: "swift_unittest.names.Lowers.url_value",
+      defaultValue: 0
+    )
+
+    static let the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 23,
+      fieldName: "swift_unittest.names.Lowers.the_url_value",
+      defaultValue: 0
+    )
+
+    static let the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 24,
+      fieldName: "swift_unittest.names.Lowers.the_url",
+      defaultValue: 0
+    )
+
+    static let a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 31,
+      fieldName: "swift_unittest.names.Lowers.a_b_c",
+      defaultValue: 0
+    )
+  }
+}
+
+extension SwiftUnittest_Names_Uppers {
+  struct Extensions {
+    static let HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 101,
+      fieldName: "swift_unittest.names.Uppers.HTTP",
+      defaultValue: 0
+    )
+
+    static let HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 102,
+      fieldName: "swift_unittest.names.Uppers.HTTP_request",
+      defaultValue: 0
+    )
+
+    static let the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 103,
+      fieldName: "swift_unittest.names.Uppers.the_HTTP_request",
+      defaultValue: 0
+    )
+
+    static let the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 104,
+      fieldName: "swift_unittest.names.Uppers.the_HTTP",
+      defaultValue: 0
+    )
+
+    static let HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 111,
+      fieldName: "swift_unittest.names.Uppers.HTTPS",
+      defaultValue: 0
+    )
+
+    static let HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 112,
+      fieldName: "swift_unittest.names.Uppers.HTTPS_request",
+      defaultValue: 0
+    )
+
+    static let the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 113,
+      fieldName: "swift_unittest.names.Uppers.the_HTTPS_request",
+      defaultValue: 0
+    )
+
+    static let the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 114,
+      fieldName: "swift_unittest.names.Uppers.the_HTTPS",
+      defaultValue: 0
+    )
+
+    static let URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 121,
+      fieldName: "swift_unittest.names.Uppers.URL",
+      defaultValue: 0
+    )
+
+    static let URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 122,
+      fieldName: "swift_unittest.names.Uppers.URL_value",
+      defaultValue: 0
+    )
+
+    static let the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 123,
+      fieldName: "swift_unittest.names.Uppers.the_URL_value",
+      defaultValue: 0
+    )
+
+    static let the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 124,
+      fieldName: "swift_unittest.names.Uppers.the_URL",
+      defaultValue: 0
+    )
+  }
+}
+
+extension SwiftUnittest_Names_WordCase {
+  struct Extensions {
+    static let Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 201,
+      fieldName: "swift_unittest.names.WordCase.Http",
+      defaultValue: 0
+    )
+
+    static let HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 202,
+      fieldName: "swift_unittest.names.WordCase.HttpRequest",
+      defaultValue: 0
+    )
+
+    static let TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 203,
+      fieldName: "swift_unittest.names.WordCase.TheHttpRequest",
+      defaultValue: 0
+    )
+
+    static let TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 204,
+      fieldName: "swift_unittest.names.WordCase.TheHttp",
+      defaultValue: 0
+    )
+
+    static let Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 211,
+      fieldName: "swift_unittest.names.WordCase.Https",
+      defaultValue: 0
+    )
+
+    static let HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 212,
+      fieldName: "swift_unittest.names.WordCase.HttpsRequest",
+      defaultValue: 0
+    )
+
+    static let TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 213,
+      fieldName: "swift_unittest.names.WordCase.TheHttpsRequest",
+      defaultValue: 0
+    )
+
+    static let TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 214,
+      fieldName: "swift_unittest.names.WordCase.TheHttps",
+      defaultValue: 0
+    )
+
+    static let Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 221,
+      fieldName: "swift_unittest.names.WordCase.Url",
+      defaultValue: 0
+    )
+
+    static let UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 222,
+      fieldName: "swift_unittest.names.WordCase.UrlValue",
+      defaultValue: 0
+    )
+
+    static let TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 223,
+      fieldName: "swift_unittest.names.WordCase.TheUrlValue",
+      defaultValue: 0
+    )
+
+    static let TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
+      _protobuf_fieldNumber: 224,
+      fieldName: "swift_unittest.names.WordCase.TheUrl",
+      defaultValue: 0
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -18447,7 +18447,7 @@ let SwiftUnittest_Names_Extensions_TheUrl = SwiftProtobuf.MessageExtension<Optio
 )
 
 extension SwiftUnittest_Names_Lowers {
-  struct Extensions {
+  enum Extensions {
     static let http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       _protobuf_fieldNumber: 1,
       fieldName: "swift_unittest.names.Lowers.http",
@@ -18529,7 +18529,7 @@ extension SwiftUnittest_Names_Lowers {
 }
 
 extension SwiftUnittest_Names_Uppers {
-  struct Extensions {
+  enum Extensions {
     static let HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       _protobuf_fieldNumber: 101,
       fieldName: "swift_unittest.names.Uppers.HTTP",
@@ -18605,7 +18605,7 @@ extension SwiftUnittest_Names_Uppers {
 }
 
 extension SwiftUnittest_Names_WordCase {
-  struct Extensions {
+  enum Extensions {
     static let Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitials>(
       _protobuf_fieldNumber: 201,
       fieldName: "swift_unittest.names.WordCase.Http",

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -17632,6 +17632,8 @@ let SwiftUnittest_Names_Extensions_TheUrl = SwiftProtobuf.MessageExtension<Optio
   defaultValue: 0
 )
 
+// MARK: - Extension support defined in unittest_swift_naming.proto.
+
 extension SwiftUnittest_Names_ExtensionNamingInitials {
   var SwiftUnittest_Names_Lowers_http: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http) ?? 0}

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -18594,6 +18594,10 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let SwiftUnittest_Names_UnittestSwiftNaming_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   SwiftUnittest_Names_Extensions_http,
   SwiftUnittest_Names_Extensions_http_request,

--- a/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
@@ -35,228 +35,6 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _1
 }
 
-let Extensions_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "http",
-  defaultValue: 0
-)
-
-let Extensions_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "http_request",
-  defaultValue: 0
-)
-
-let Extensions_the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "the_http_request",
-  defaultValue: 0
-)
-
-let Extensions_the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 104,
-  fieldName: "the_http",
-  defaultValue: 0
-)
-
-let Extensions_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 111,
-  fieldName: "https",
-  defaultValue: 0
-)
-
-let Extensions_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 112,
-  fieldName: "https_request",
-  defaultValue: 0
-)
-
-let Extensions_the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 113,
-  fieldName: "the_https_request",
-  defaultValue: 0
-)
-
-let Extensions_the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 114,
-  fieldName: "the_https",
-  defaultValue: 0
-)
-
-let Extensions_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 121,
-  fieldName: "url",
-  defaultValue: 0
-)
-
-let Extensions_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 122,
-  fieldName: "url_value",
-  defaultValue: 0
-)
-
-let Extensions_the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 123,
-  fieldName: "the_url_value",
-  defaultValue: 0
-)
-
-let Extensions_the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 124,
-  fieldName: "the_url",
-  defaultValue: 0
-)
-
-let Extensions_a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
-  _protobuf_fieldNumber: 131,
-  fieldName: "a_b_c",
-  defaultValue: 0
-)
-
-let Extensions_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "HTTP",
-  defaultValue: 0
-)
-
-let Extensions_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "HTTP_request",
-  defaultValue: 0
-)
-
-let Extensions_the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "the_HTTP_request",
-  defaultValue: 0
-)
-
-let Extensions_the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 104,
-  fieldName: "the_HTTP",
-  defaultValue: 0
-)
-
-let Extensions_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 111,
-  fieldName: "HTTPS",
-  defaultValue: 0
-)
-
-let Extensions_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 112,
-  fieldName: "HTTPS_request",
-  defaultValue: 0
-)
-
-let Extensions_the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 113,
-  fieldName: "the_HTTPS_request",
-  defaultValue: 0
-)
-
-let Extensions_the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 114,
-  fieldName: "the_HTTPS",
-  defaultValue: 0
-)
-
-let Extensions_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 121,
-  fieldName: "URL",
-  defaultValue: 0
-)
-
-let Extensions_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 122,
-  fieldName: "URL_value",
-  defaultValue: 0
-)
-
-let Extensions_the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 123,
-  fieldName: "the_URL_value",
-  defaultValue: 0
-)
-
-let Extensions_the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
-  _protobuf_fieldNumber: 124,
-  fieldName: "the_URL",
-  defaultValue: 0
-)
-
-let Extensions_Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 101,
-  fieldName: "Http",
-  defaultValue: 0
-)
-
-let Extensions_HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 102,
-  fieldName: "HttpRequest",
-  defaultValue: 0
-)
-
-let Extensions_TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 103,
-  fieldName: "TheHttpRequest",
-  defaultValue: 0
-)
-
-let Extensions_TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 104,
-  fieldName: "TheHttp",
-  defaultValue: 0
-)
-
-let Extensions_Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 111,
-  fieldName: "Https",
-  defaultValue: 0
-)
-
-let Extensions_HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 112,
-  fieldName: "HttpsRequest",
-  defaultValue: 0
-)
-
-let Extensions_TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 113,
-  fieldName: "TheHttpsRequest",
-  defaultValue: 0
-)
-
-let Extensions_TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 114,
-  fieldName: "TheHttps",
-  defaultValue: 0
-)
-
-let Extensions_Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 121,
-  fieldName: "Url",
-  defaultValue: 0
-)
-
-let Extensions_UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 122,
-  fieldName: "UrlValue",
-  defaultValue: 0
-)
-
-let Extensions_TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 123,
-  fieldName: "TheUrlValue",
-  defaultValue: 0
-)
-
-let Extensions_TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
-  _protobuf_fieldNumber: 124,
-  fieldName: "TheUrl",
-  defaultValue: 0
-)
-
 // MARK: - Extension support defined in unittest_swift_naming_no_prefix.proto.
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
@@ -783,3 +561,225 @@ let UnittestSwiftNamingNoPrefix_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_TheUrlValue,
   Extensions_TheUrl
 ]
+
+let Extensions_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "http",
+  defaultValue: 0
+)
+
+let Extensions_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "http_request",
+  defaultValue: 0
+)
+
+let Extensions_the_http_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "the_http_request",
+  defaultValue: 0
+)
+
+let Extensions_the_http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 104,
+  fieldName: "the_http",
+  defaultValue: 0
+)
+
+let Extensions_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 111,
+  fieldName: "https",
+  defaultValue: 0
+)
+
+let Extensions_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 112,
+  fieldName: "https_request",
+  defaultValue: 0
+)
+
+let Extensions_the_https_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 113,
+  fieldName: "the_https_request",
+  defaultValue: 0
+)
+
+let Extensions_the_https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 114,
+  fieldName: "the_https",
+  defaultValue: 0
+)
+
+let Extensions_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 121,
+  fieldName: "url",
+  defaultValue: 0
+)
+
+let Extensions_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 122,
+  fieldName: "url_value",
+  defaultValue: 0
+)
+
+let Extensions_the_url_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 123,
+  fieldName: "the_url_value",
+  defaultValue: 0
+)
+
+let Extensions_the_url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 124,
+  fieldName: "the_url",
+  defaultValue: 0
+)
+
+let Extensions_a_b_c = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsLowers>(
+  _protobuf_fieldNumber: 131,
+  fieldName: "a_b_c",
+  defaultValue: 0
+)
+
+let Extensions_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "HTTP",
+  defaultValue: 0
+)
+
+let Extensions_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "HTTP_request",
+  defaultValue: 0
+)
+
+let Extensions_the_HTTP_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "the_HTTP_request",
+  defaultValue: 0
+)
+
+let Extensions_the_HTTP = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 104,
+  fieldName: "the_HTTP",
+  defaultValue: 0
+)
+
+let Extensions_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 111,
+  fieldName: "HTTPS",
+  defaultValue: 0
+)
+
+let Extensions_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 112,
+  fieldName: "HTTPS_request",
+  defaultValue: 0
+)
+
+let Extensions_the_HTTPS_request = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 113,
+  fieldName: "the_HTTPS_request",
+  defaultValue: 0
+)
+
+let Extensions_the_HTTPS = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 114,
+  fieldName: "the_HTTPS",
+  defaultValue: 0
+)
+
+let Extensions_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 121,
+  fieldName: "URL",
+  defaultValue: 0
+)
+
+let Extensions_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 122,
+  fieldName: "URL_value",
+  defaultValue: 0
+)
+
+let Extensions_the_URL_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 123,
+  fieldName: "the_URL_value",
+  defaultValue: 0
+)
+
+let Extensions_the_URL = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsUppers>(
+  _protobuf_fieldNumber: 124,
+  fieldName: "the_URL",
+  defaultValue: 0
+)
+
+let Extensions_Http = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 101,
+  fieldName: "Http",
+  defaultValue: 0
+)
+
+let Extensions_HttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 102,
+  fieldName: "HttpRequest",
+  defaultValue: 0
+)
+
+let Extensions_TheHttpRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 103,
+  fieldName: "TheHttpRequest",
+  defaultValue: 0
+)
+
+let Extensions_TheHttp = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 104,
+  fieldName: "TheHttp",
+  defaultValue: 0
+)
+
+let Extensions_Https = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 111,
+  fieldName: "Https",
+  defaultValue: 0
+)
+
+let Extensions_HttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 112,
+  fieldName: "HttpsRequest",
+  defaultValue: 0
+)
+
+let Extensions_TheHttpsRequest = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 113,
+  fieldName: "TheHttpsRequest",
+  defaultValue: 0
+)
+
+let Extensions_TheHttps = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 114,
+  fieldName: "TheHttps",
+  defaultValue: 0
+)
+
+let Extensions_Url = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 121,
+  fieldName: "Url",
+  defaultValue: 0
+)
+
+let Extensions_UrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 122,
+  fieldName: "UrlValue",
+  defaultValue: 0
+)
+
+let Extensions_TheUrlValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 123,
+  fieldName: "TheUrlValue",
+  defaultValue: 0
+)
+
+let Extensions_TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, SwiftUnittest_Names_ExtensionNamingInitialsWordCase>(
+  _protobuf_fieldNumber: 124,
+  fieldName: "TheUrl",
+  defaultValue: 0
+)

--- a/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
@@ -738,6 +738,10 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let UnittestSwiftNamingNoPrefix_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_http,
   Extensions_http_request,

--- a/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
@@ -257,6 +257,8 @@ let Extensions_TheUrl = SwiftProtobuf.MessageExtension<OptionalExtensionField<Sw
   defaultValue: 0
 )
 
+// MARK: - Extension support defined in unittest_swift_naming_no_prefix.proto.
+
 extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var http: Int32 {
     get {return getExtensionValue(ext: Extensions_http) ?? 0}

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -403,6 +403,8 @@ let ProtobufUnittest_Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExt
   defaultValue: false
 )
 
+// MARK: - Extension support defined in unittest_swift_reserved.proto.
+
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
   /// This will end up in the "struct Extensions" to scope it, but there
   /// the raw form is used ("hash_value", not the Swift one "hashValue"),

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -567,6 +567,10 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufUnittest_UnittestSwiftReserved_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufUnittest_Extensions_debug_description,
   ProtobufUnittest_Extensions_as,

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -308,50 +308,6 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    /// This will end up in the "struct Extensions" to scope it, but there
-    /// the raw form is used ("hash_value", not the Swift one "hashValue"),
-    /// so there is no conflict, and no renaming happens.
-    static let hash_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1001,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.hash_value",
-      defaultValue: false
-    )
-
-    /// Reserved words, since these end up in the "struct Extensions", they
-    /// can't just be get their names, and sanitation kicks.
-    static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1022,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.as",
-      defaultValue: false
-    )
-
-    static let `var` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1023,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.var",
-      defaultValue: false
-    )
-
-    static let `try` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1024,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.try",
-      defaultValue: false
-    )
-
-    static let `do` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1025,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.do",
-      defaultValue: false
-    )
-
-    static let `nil` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-      _protobuf_fieldNumber: 1026,
-      fieldName: "protobuf_unittest.SwiftReservedTestExt.nil",
-      defaultValue: false
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -363,45 +319,6 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-/// Won't get _p added because it is fully qualified.
-let ProtobufUnittest_Extensions_debug_description = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1000,
-  fieldName: "protobuf_unittest.debug_description",
-  defaultValue: false
-)
-
-/// These are scoped to the file, so the package prefix (or a Swift prefix)
-/// will get added to them to they aren't going to get renamed.
-let ProtobufUnittest_Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1012,
-  fieldName: "protobuf_unittest.as",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_var = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1013,
-  fieldName: "protobuf_unittest.var",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_try = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1014,
-  fieldName: "protobuf_unittest.try",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_do = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1015,
-  fieldName: "protobuf_unittest.do",
-  defaultValue: false
-)
-
-let ProtobufUnittest_Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
-  _protobuf_fieldNumber: 1016,
-  fieldName: "protobuf_unittest.nil",
-  defaultValue: false
-)
 
 // MARK: - Extension support defined in unittest_swift_reserved.proto.
 
@@ -587,6 +504,90 @@ let ProtobufUnittest_UnittestSwiftReserved_Extensions: SwiftProtobuf.SimpleExten
   ProtobufUnittest_SwiftReservedTestExt.Extensions.do,
   ProtobufUnittest_SwiftReservedTestExt.Extensions.nil
 ]
+
+/// Won't get _p added because it is fully qualified.
+let ProtobufUnittest_Extensions_debug_description = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1000,
+  fieldName: "protobuf_unittest.debug_description",
+  defaultValue: false
+)
+
+/// These are scoped to the file, so the package prefix (or a Swift prefix)
+/// will get added to them to they aren't going to get renamed.
+let ProtobufUnittest_Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1012,
+  fieldName: "protobuf_unittest.as",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_var = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1013,
+  fieldName: "protobuf_unittest.var",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_try = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1014,
+  fieldName: "protobuf_unittest.try",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_do = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1015,
+  fieldName: "protobuf_unittest.do",
+  defaultValue: false
+)
+
+let ProtobufUnittest_Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+  _protobuf_fieldNumber: 1016,
+  fieldName: "protobuf_unittest.nil",
+  defaultValue: false
+)
+
+extension ProtobufUnittest_SwiftReservedTestExt {
+  struct Extensions {
+    /// This will end up in the "struct Extensions" to scope it, but there
+    /// the raw form is used ("hash_value", not the Swift one "hashValue"),
+    /// so there is no conflict, and no renaming happens.
+    static let hash_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1001,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.hash_value",
+      defaultValue: false
+    )
+
+    /// Reserved words, since these end up in the "struct Extensions", they
+    /// can't just be get their names, and sanitation kicks.
+    static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1022,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.as",
+      defaultValue: false
+    )
+
+    static let `var` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1023,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.var",
+      defaultValue: false
+    )
+
+    static let `try` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1024,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.try",
+      defaultValue: false
+    )
+
+    static let `do` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1025,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.do",
+      defaultValue: false
+    )
+
+    static let `nil` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(
+      _protobuf_fieldNumber: 1026,
+      fieldName: "protobuf_unittest.SwiftReservedTestExt.nil",
+      defaultValue: false
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -323,6 +323,87 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_reserved.proto.
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  /// Won't get _p added because it is fully qualified.
+  var ProtobufUnittest_debugDescription: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debug_description) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_debug_description, value: newValue)}
+  }
+  var hasProtobufUnittest_debugDescription: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
+  }
+  mutating func clearProtobufUnittest_debugDescription() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  /// These are scoped to the file, so the package prefix (or a Swift prefix)
+  /// will get added to them to they aren't going to get renamed.
+  var ProtobufUnittest_as: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_as) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_as, value: newValue)}
+  }
+  var hasProtobufUnittest_as: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_as)
+  }
+  mutating func clearProtobufUnittest_as() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_as)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  var ProtobufUnittest_var: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_var) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_var, value: newValue)}
+  }
+  var hasProtobufUnittest_var: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_var)
+  }
+  mutating func clearProtobufUnittest_var() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_var)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  var ProtobufUnittest_try: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_try) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_try, value: newValue)}
+  }
+  var hasProtobufUnittest_try: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_try)
+  }
+  mutating func clearProtobufUnittest_try() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_try)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  var ProtobufUnittest_do: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_do) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_do, value: newValue)}
+  }
+  var hasProtobufUnittest_do: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_do)
+  }
+  mutating func clearProtobufUnittest_do() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_do)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
+  var ProtobufUnittest_nil: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_nil) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_nil, value: newValue)}
+  }
+  var hasProtobufUnittest_nil: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_nil)
+  }
+  mutating func clearProtobufUnittest_nil() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_nil)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.classMessage {
   /// This will end up in the "struct Extensions" to scope it, but there
   /// the raw form is used ("hash_value", not the Swift one "hashValue"),
   /// so there is no conflict, and no renaming happens.
@@ -402,87 +483,6 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   }
   mutating func clearProtobufUnittest_SwiftReservedTestExt_nil() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.nil)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  /// Won't get _p added because it is fully qualified.
-  var ProtobufUnittest_debugDescription: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debug_description) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_debug_description, value: newValue)}
-  }
-  var hasProtobufUnittest_debugDescription: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
-  }
-  mutating func clearProtobufUnittest_debugDescription() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  /// These are scoped to the file, so the package prefix (or a Swift prefix)
-  /// will get added to them to they aren't going to get renamed.
-  var ProtobufUnittest_as: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_as) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_as, value: newValue)}
-  }
-  var hasProtobufUnittest_as: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_as)
-  }
-  mutating func clearProtobufUnittest_as() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_as)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  var ProtobufUnittest_var: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_var) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_var, value: newValue)}
-  }
-  var hasProtobufUnittest_var: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_var)
-  }
-  mutating func clearProtobufUnittest_var() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_var)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  var ProtobufUnittest_try: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_try) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_try, value: newValue)}
-  }
-  var hasProtobufUnittest_try: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_try)
-  }
-  mutating func clearProtobufUnittest_try() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_try)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  var ProtobufUnittest_do: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_do) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_do, value: newValue)}
-  }
-  var hasProtobufUnittest_do: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_do)
-  }
-  mutating func clearProtobufUnittest_do() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_do)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  var ProtobufUnittest_nil: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_nil) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_nil, value: newValue)}
-  }
-  var hasProtobufUnittest_nil: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_nil)
-  }
-  mutating func clearProtobufUnittest_nil() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_nil)
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -404,7 +404,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
-  /// This will end up in the "struct Extensions" to scope it, but there
+  /// This will end up in the "enum Extensions" to scope it, but there
   /// the raw form is used ("hash_value", not the Swift one "hashValue"),
   /// so there is no conflict, and no renaming happens.
   var ProtobufUnittest_SwiftReservedTestExt_hashValue: Bool {
@@ -545,8 +545,8 @@ let ProtobufUnittest_Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExt
 )
 
 extension ProtobufUnittest_SwiftReservedTestExt {
-  struct Extensions {
-    /// This will end up in the "struct Extensions" to scope it, but there
+  enum Extensions {
+    /// This will end up in the "enum Extensions" to scope it, but there
     /// the raw form is used ("hash_value", not the Swift one "hashValue"),
     /// so there is no conflict, and no renaming happens.
     static let hash_value = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.classMessage>(

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
@@ -293,6 +293,10 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let UnittestSwiftReservedExt_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   Extensions_debugDescription,
   Extensions_as,

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
@@ -40,47 +40,6 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let hashValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1001,
-      fieldName: "SwiftReservedTestExt2.hashValue",
-      defaultValue: false
-    )
-
-    /// Reserved words, since these end up in the "struct Extensions", they
-    /// can't just be get their names, and sanitation kicks.
-    static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1022,
-      fieldName: "SwiftReservedTestExt2.as",
-      defaultValue: false
-    )
-
-    static let `var` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1023,
-      fieldName: "SwiftReservedTestExt2.var",
-      defaultValue: false
-    )
-
-    static let `try` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1024,
-      fieldName: "SwiftReservedTestExt2.try",
-      defaultValue: false
-    )
-
-    static let `do` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1025,
-      fieldName: "SwiftReservedTestExt2.do",
-      defaultValue: false
-    )
-
-    static let `nil` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-      _protobuf_fieldNumber: 1026,
-      fieldName: "SwiftReservedTestExt2.nil",
-      defaultValue: false
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -92,45 +51,6 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-/// Will get _p added because it has no package/swift prefix to scope and
-/// would otherwise be a problem when added to the message.
-let Extensions_debugDescription = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1000,
-  fieldName: "debugDescription",
-  defaultValue: false
-)
-
-/// These will get _p added for the same reasoning.
-let Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1012,
-  fieldName: "as",
-  defaultValue: false
-)
-
-let Extensions_var = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1013,
-  fieldName: "var",
-  defaultValue: false
-)
-
-let Extensions_try = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1014,
-  fieldName: "try",
-  defaultValue: false
-)
-
-let Extensions_do = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1015,
-  fieldName: "do",
-  defaultValue: false
-)
-
-let Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
-  _protobuf_fieldNumber: 1016,
-  fieldName: "nil",
-  defaultValue: false
-)
 
 // MARK: - Extension support defined in unittest_swift_reserved_ext.proto.
 
@@ -313,6 +233,87 @@ let UnittestSwiftReservedExt_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   SwiftReservedTestExt2.Extensions.do,
   SwiftReservedTestExt2.Extensions.nil
 ]
+
+/// Will get _p added because it has no package/swift prefix to scope and
+/// would otherwise be a problem when added to the message.
+let Extensions_debugDescription = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1000,
+  fieldName: "debugDescription",
+  defaultValue: false
+)
+
+/// These will get _p added for the same reasoning.
+let Extensions_as = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1012,
+  fieldName: "as",
+  defaultValue: false
+)
+
+let Extensions_var = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1013,
+  fieldName: "var",
+  defaultValue: false
+)
+
+let Extensions_try = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1014,
+  fieldName: "try",
+  defaultValue: false
+)
+
+let Extensions_do = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1015,
+  fieldName: "do",
+  defaultValue: false
+)
+
+let Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+  _protobuf_fieldNumber: 1016,
+  fieldName: "nil",
+  defaultValue: false
+)
+
+extension SwiftReservedTestExt2 {
+  struct Extensions {
+    static let hashValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1001,
+      fieldName: "SwiftReservedTestExt2.hashValue",
+      defaultValue: false
+    )
+
+    /// Reserved words, since these end up in the "struct Extensions", they
+    /// can't just be get their names, and sanitation kicks.
+    static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1022,
+      fieldName: "SwiftReservedTestExt2.as",
+      defaultValue: false
+    )
+
+    static let `var` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1023,
+      fieldName: "SwiftReservedTestExt2.var",
+      defaultValue: false
+    )
+
+    static let `try` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1024,
+      fieldName: "SwiftReservedTestExt2.try",
+      defaultValue: false
+    )
+
+    static let `do` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1025,
+      fieldName: "SwiftReservedTestExt2.do",
+      defaultValue: false
+    )
+
+    static let `nil` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
+      _protobuf_fieldNumber: 1026,
+      fieldName: "SwiftReservedTestExt2.nil",
+      defaultValue: false
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
@@ -132,6 +132,8 @@ let Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<Swift
   defaultValue: false
 )
 
+// MARK: - Extension support defined in unittest_swift_reserved_ext.proto.
+
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_hashValue: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue) ?? false}

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
@@ -149,7 +149,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
 }
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  /// Reserved words, since these end up in the "struct Extensions", they
+  /// Reserved words, since these end up in the "enum Extensions", they
   /// can't just be get their names, and sanitation kicks.
   var SwiftReservedTestExt2_as: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.as) ?? false}
@@ -274,14 +274,14 @@ let Extensions_nil = SwiftProtobuf.MessageExtension<OptionalExtensionField<Swift
 )
 
 extension SwiftReservedTestExt2 {
-  struct Extensions {
+  enum Extensions {
     static let hashValue = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
       _protobuf_fieldNumber: 1001,
       fieldName: "SwiftReservedTestExt2.hashValue",
       defaultValue: false
     )
 
-    /// Reserved words, since these end up in the "struct Extensions", they
+    /// Reserved words, since these end up in the "enum Extensions", they
     /// can't just be get their names, and sanitation kicks.
     static let `as` = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufBool>, ProtobufUnittest_SwiftReservedTest.TypeMessage>(
       _protobuf_fieldNumber: 1022,

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
@@ -55,86 +55,6 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_reserved_ext.proto.
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  var SwiftReservedTestExt2_hashValue: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_hashValue: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue)
-  }
-  mutating func clearSwiftReservedTestExt2_hashValue() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  /// Reserved words, since these end up in the "struct Extensions", they
-  /// can't just be get their names, and sanitation kicks.
-  var SwiftReservedTestExt2_as: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.as) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.as, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_as: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.as)
-  }
-  mutating func clearSwiftReservedTestExt2_as() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.as)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  var SwiftReservedTestExt2_var: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.var) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.var, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_var: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.var)
-  }
-  mutating func clearSwiftReservedTestExt2_var() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.var)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  var SwiftReservedTestExt2_try: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.try) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.try, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_try: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.try)
-  }
-  mutating func clearSwiftReservedTestExt2_try() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.try)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  var SwiftReservedTestExt2_do: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.do) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.do, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_do: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.do)
-  }
-  mutating func clearSwiftReservedTestExt2_do() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.do)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
-  var SwiftReservedTestExt2_nil: Bool {
-    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil) ?? false}
-    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil, value: newValue)}
-  }
-  var hasSwiftReservedTestExt2_nil: Bool {
-    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil)
-  }
-  mutating func clearSwiftReservedTestExt2_nil() {
-    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil)
-  }
-}
-
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   /// Will get _p added because it has no package/swift prefix to scope and
   /// would otherwise be a problem when added to the message.
   var debugDescription_p: Bool {
@@ -212,6 +132,86 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   }
   mutating func clearNil_p() {
     clearExtensionValue(ext: Extensions_nil)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  var SwiftReservedTestExt2_hashValue: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_hashValue: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue)
+  }
+  mutating func clearSwiftReservedTestExt2_hashValue() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  /// Reserved words, since these end up in the "struct Extensions", they
+  /// can't just be get their names, and sanitation kicks.
+  var SwiftReservedTestExt2_as: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.as) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.as, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_as: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.as)
+  }
+  mutating func clearSwiftReservedTestExt2_as() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.as)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  var SwiftReservedTestExt2_var: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.var) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.var, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_var: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.var)
+  }
+  mutating func clearSwiftReservedTestExt2_var() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.var)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  var SwiftReservedTestExt2_try: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.try) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.try, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_try: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.try)
+  }
+  mutating func clearSwiftReservedTestExt2_try() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.try)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  var SwiftReservedTestExt2_do: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.do) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.do, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_do: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.do)
+  }
+  mutating func clearSwiftReservedTestExt2_do() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.do)
+  }
+}
+
+extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+  var SwiftReservedTestExt2_nil: Bool {
+    get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil) ?? false}
+    set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil, value: newValue)}
+  }
+  var hasSwiftReservedTestExt2_nil: Bool {
+    return hasExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil)
+  }
+  mutating func clearSwiftReservedTestExt2_nil() {
+    clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil)
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -156,6 +156,10 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   }
 }
 
+/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by
+/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed
+/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create
+/// a larger `SwiftProtobuf.SimpleExtensionMap`.
 let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: SwiftProtobuf.SimpleExtensionMap = [
   ProtobufObjcUnittest_Extensions_optional_int32_extension,
   ProtobufObjcUnittest_Extensions_repeated_int32_extension,

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -116,6 +116,8 @@ let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.Mes
   defaultValue: []
 )
 
+// MARK: - Extension support defined in unittest_swift_startup.proto.
+
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? String()}

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -82,15 +82,6 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  struct Extensions {
-
-    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
-      _protobuf_fieldNumber: 3,
-      fieldName: "protobuf_objc_unittest.TestObjCStartupNested.nested_string_extension",
-      defaultValue: String()
-    )
-  }
-
   init() {}
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -102,19 +93,6 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
     try unknownFields.traverse(visitor: &visitor)
   }
 }
-
-/// Singular
-let ProtobufObjcUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
-  _protobuf_fieldNumber: 1,
-  fieldName: "protobuf_objc_unittest.optional_int32_extension",
-  defaultValue: 0
-)
-
-let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
-  _protobuf_fieldNumber: 2,
-  fieldName: "protobuf_objc_unittest.repeated_int32_extension",
-  defaultValue: []
-)
 
 // MARK: - Extension support defined in unittest_swift_startup.proto.
 
@@ -167,6 +145,29 @@ let ProtobufObjcUnittest_UnittestSwiftStartup_Extensions: SwiftProtobuf.SimpleEx
   ProtobufObjcUnittest_Extensions_repeated_int32_extension,
   ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension
 ]
+
+/// Singular
+let ProtobufObjcUnittest_Extensions_optional_int32_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+  _protobuf_fieldNumber: 1,
+  fieldName: "protobuf_objc_unittest.optional_int32_extension",
+  defaultValue: 0
+)
+
+let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.MessageExtension<RepeatedExtensionField<SwiftProtobuf.ProtobufInt32>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+  _protobuf_fieldNumber: 2,
+  fieldName: "protobuf_objc_unittest.repeated_int32_extension",
+  defaultValue: []
+)
+
+extension ProtobufObjcUnittest_TestObjCStartupNested {
+  struct Extensions {
+    static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
+      _protobuf_fieldNumber: 3,
+      fieldName: "protobuf_objc_unittest.TestObjCStartupNested.nested_string_extension",
+      defaultValue: String()
+    )
+  }
+}
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -160,7 +160,7 @@ let ProtobufObjcUnittest_Extensions_repeated_int32_extension = SwiftProtobuf.Mes
 )
 
 extension ProtobufObjcUnittest_TestObjCStartupNested {
-  struct Extensions {
+  enum Extensions {
     static let nested_string_extension = SwiftProtobuf.MessageExtension<OptionalExtensionField<SwiftProtobuf.ProtobufString>, ProtobufObjcUnittest_TestObjCStartupMessage>(
       _protobuf_fieldNumber: 3,
       fieldName: "protobuf_objc_unittest.TestObjCStartupNested.nested_string_extension",

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -97,19 +97,6 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_startup.proto.
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
-  var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
-    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? String()}
-    set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension, value: newValue)}
-  }
-  var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {
-    return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
-  }
-  mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
-    clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
-  }
-}
-
-extension ProtobufObjcUnittest_TestObjCStartupMessage {
   /// Singular
   var ProtobufObjcUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension) ?? 0}
@@ -133,6 +120,19 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   }
   mutating func clearProtobufObjcUnittest_repeatedInt32Extension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension)
+  }
+}
+
+extension ProtobufObjcUnittest_TestObjCStartupMessage {
+  var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
+    get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? String()}
+    set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension, value: newValue)}
+  }
+  var hasProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: Bool {
+    return hasExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
+  }
+  mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
+    clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
   }
 }
 


### PR DESCRIPTION
Move all the generated extension support into a sub section of the file instead of mixing it through the messages and file in general.  It comes after all the types in the file, but before the runtime overhead bits.
