### PR TITLE
Tighten up more oneof generation.

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -90,20 +90,20 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
 
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v)? = payload { return v }
+      if case .protobufPayload(let v)? = payload {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set { payload = .protobufPayload(newValue) }
+    set {payload = .protobufPayload(newValue)}
   }
 
   var payload: Conformance_ConformanceRequest.OneOf_Payload? = nil
 
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v)? = payload { return v }
+      if case .jsonPayload(let v)? = payload {return v}
       return String()
     }
-    set { payload = .jsonPayload(newValue) }
+    set {payload = .jsonPayload(newValue)}
   }
 
   /// Which format should the testee serialize its message to?
@@ -160,10 +160,10 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// test.  Some of the test cases are intentionally invalid input.
   var parseError: String {
     get {
-      if case .parseError(let v)? = result { return v }
+      if case .parseError(let v)? = result {return v}
       return String()
     }
-    set { result = .parseError(newValue) }
+    set {result = .parseError(newValue)}
   }
 
   var result: Conformance_ConformanceResponse.OneOf_Result? = nil
@@ -173,10 +173,10 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// this field.
   var serializeError: String {
     get {
-      if case .serializeError(let v)? = result { return v }
+      if case .serializeError(let v)? = result {return v}
       return String()
     }
-    set { result = .serializeError(newValue) }
+    set {result = .serializeError(newValue)}
   }
 
   /// This should be set if some other error occurred.  This will always
@@ -184,40 +184,40 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// about the failure.
   var runtimeError: String {
     get {
-      if case .runtimeError(let v)? = result { return v }
+      if case .runtimeError(let v)? = result {return v}
       return String()
     }
-    set { result = .runtimeError(newValue) }
+    set {result = .runtimeError(newValue)}
   }
 
   /// If the input was successfully parsed and the requested output was
   /// protobuf, serialize it to protobuf and set it in this field.
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v)? = result { return v }
+      if case .protobufPayload(let v)? = result {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set { result = .protobufPayload(newValue) }
+    set {result = .protobufPayload(newValue)}
   }
 
   /// If the input was successfully parsed and the requested output was JSON,
   /// serialize to JSON and set it in this field.
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v)? = result { return v }
+      if case .jsonPayload(let v)? = result {return v}
       return String()
     }
-    set { result = .jsonPayload(newValue) }
+    set {result = .jsonPayload(newValue)}
   }
 
   /// For when the testee skipped the test, likely because a certain feature
   /// wasn't supported, like JSON input/output.
   var skipped: String {
     get {
-      if case .skipped(let v)? = result { return v }
+      if case .skipped(let v)? = result {return v}
       return String()
     }
-    set { result = .skipped(newValue) }
+    set {result = .skipped(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -128,79 +128,55 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
   /// Represents a null value.
   var nullValue: Google_Protobuf_NullValue {
     get {
-      if case .nullValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .nullValue(let v)? = _storage._kind {return v}
       return Google_Protobuf_NullValue.nullValue
     }
-    set {
-      _uniqueStorage()._kind = .nullValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .nullValue(newValue)}
   }
 
   /// Represents a double value.
   var numberValue: Double {
     get {
-      if case .numberValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .numberValue(let v)? = _storage._kind {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._kind = .numberValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .numberValue(newValue)}
   }
 
   /// Represents a string value.
   var stringValue: String {
     get {
-      if case .stringValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .stringValue(let v)? = _storage._kind {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._kind = .stringValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .stringValue(newValue)}
   }
 
   /// Represents a boolean value.
   var boolValue: Bool {
     get {
-      if case .boolValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .boolValue(let v)? = _storage._kind {return v}
       return false
     }
-    set {
-      _uniqueStorage()._kind = .boolValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .boolValue(newValue)}
   }
 
   /// Represents a structured value.
   var structValue: Google_Protobuf_Struct {
     get {
-      if case .structValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .structValue(let v)? = _storage._kind {return v}
       return Google_Protobuf_Struct()
     }
-    set {
-      _uniqueStorage()._kind = .structValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .structValue(newValue)}
   }
 
   /// Represents a repeated `Value`.
   var listValue: Google_Protobuf_ListValue {
     get {
-      if case .listValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .listValue(let v)? = _storage._kind {return v}
       return Google_Protobuf_ListValue()
     }
-    set {
-      _uniqueStorage()._kind = .listValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .listValue(newValue)}
   }
 
   var kind: OneOf_Kind? {

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -431,110 +431,74 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBool(let v)? = _storage._oneofField {return v}
       return false
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBool(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBool(newValue)}
   }
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint64(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint64(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint64(newValue)}
   }
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofFloat(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofFloat(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofFloat(newValue)}
   }
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofDouble(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofDouble(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofDouble(newValue)}
   }
 
   var oneofEnum: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum {
     get {
-      if case .oneofEnum(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofEnum(let v)? = _storage._oneofField {return v}
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum.foo
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofEnum(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofEnum(newValue)}
   }
 
   /// Well-known types

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -802,50 +802,34 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {
@@ -4047,50 +4031,34 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooInt(let v)? = _storage._foo {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._foo = .fooInt(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooString(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooString(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooString(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestAllTypes {
     get {
-      if case .fooMessage(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooMessage(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestAllTypes()
     }
-    set {
-      _uniqueStorage()._foo = .fooMessage(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooMessage(newValue)}
   }
 
   var fooGroup: ProtobufUnittest_TestOneof.FooGroup {
     get {
-      if case .fooGroup(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooGroup(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestOneof.FooGroup()
     }
-    set {
-      _uniqueStorage()._foo = .fooGroup(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooGroup(newValue)}
   }
 
   var foo: OneOf_Foo? {
@@ -4343,182 +4311,122 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooInt(let v)? = _storage._foo {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._foo = .fooInt(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooString(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooString(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooString(newValue)}
   }
 
   var fooCord: String {
     get {
-      if case .fooCord(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooCord(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooCord(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooCord(newValue)}
   }
 
   var fooStringPiece: String {
     get {
-      if case .fooStringPiece(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooStringPiece(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooStringPiece(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooStringPiece(newValue)}
   }
 
   var fooBytes: Data {
     get {
-      if case .fooBytes(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooBytes(let v)? = _storage._foo {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._foo = .fooBytes(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooBytes(newValue)}
   }
 
   var fooEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .fooEnum(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooEnum(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestOneof2.NestedEnum.foo
     }
-    set {
-      _uniqueStorage()._foo = .fooEnum(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooEnum(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooMessage(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooMessage(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestOneof2.NestedMessage()
     }
-    set {
-      _uniqueStorage()._foo = .fooMessage(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooMessage(newValue)}
   }
 
   var fooGroup: ProtobufUnittest_TestOneof2.FooGroup {
     get {
-      if case .fooGroup(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooGroup(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestOneof2.FooGroup()
     }
-    set {
-      _uniqueStorage()._foo = .fooGroup(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooGroup(newValue)}
   }
 
   var fooLazyMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooLazyMessage(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooLazyMessage(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestOneof2.NestedMessage()
     }
-    set {
-      _uniqueStorage()._foo = .fooLazyMessage(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooLazyMessage(newValue)}
   }
 
   var barInt: Int32 {
     get {
-      if case .barInt(let v)? = _storage._bar {
-        return v
-      }
+      if case .barInt(let v)? = _storage._bar {return v}
       return 5
     }
-    set {
-      _uniqueStorage()._bar = .barInt(newValue)
-    }
+    set {_uniqueStorage()._bar = .barInt(newValue)}
   }
 
   var barString: String {
     get {
-      if case .barString(let v)? = _storage._bar {
-        return v
-      }
+      if case .barString(let v)? = _storage._bar {return v}
       return "STRING"
     }
-    set {
-      _uniqueStorage()._bar = .barString(newValue)
-    }
+    set {_uniqueStorage()._bar = .barString(newValue)}
   }
 
   var barCord: String {
     get {
-      if case .barCord(let v)? = _storage._bar {
-        return v
-      }
+      if case .barCord(let v)? = _storage._bar {return v}
       return "CORD"
     }
-    set {
-      _uniqueStorage()._bar = .barCord(newValue)
-    }
+    set {_uniqueStorage()._bar = .barCord(newValue)}
   }
 
   var barStringPiece: String {
     get {
-      if case .barStringPiece(let v)? = _storage._bar {
-        return v
-      }
+      if case .barStringPiece(let v)? = _storage._bar {return v}
       return "SPIECE"
     }
-    set {
-      _uniqueStorage()._bar = .barStringPiece(newValue)
-    }
+    set {_uniqueStorage()._bar = .barStringPiece(newValue)}
   }
 
   var barBytes: Data {
     get {
-      if case .barBytes(let v)? = _storage._bar {
-        return v
-      }
+      if case .barBytes(let v)? = _storage._bar {return v}
       return Data(bytes: [66, 89, 84, 69, 83])
     }
-    set {
-      _uniqueStorage()._bar = .barBytes(newValue)
-    }
+    set {_uniqueStorage()._bar = .barBytes(newValue)}
   }
 
   var barEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .barEnum(let v)? = _storage._bar {
-        return v
-      }
+      if case .barEnum(let v)? = _storage._bar {return v}
       return ProtobufUnittest_TestOneof2.NestedEnum.bar
     }
-    set {
-      _uniqueStorage()._bar = .barEnum(newValue)
-    }
+    set {_uniqueStorage()._bar = .barEnum(newValue)}
   }
 
   var bazInt: Int32 {
@@ -4777,38 +4685,26 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message {
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooInt(let v)? = _storage._foo {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._foo = .fooInt(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooString(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooString(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooString(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestRequiredOneof.NestedMessage {
     get {
-      if case .fooMessage(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooMessage(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestRequiredOneof.NestedMessage()
     }
-    set {
-      _uniqueStorage()._foo = .fooMessage(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooMessage(newValue)}
   }
 
   var foo: OneOf_Foo? {
@@ -6140,50 +6036,34 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypes {
     get {
-      if case .oneofTestAllTypes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofTestAllTypes(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllTypes()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -123,10 +123,10 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
 
   var oneofField: Int32 {
     get {
-      if case .oneofField(let v)? = anOneof { return v }
+      if case .oneofField(let v)? = anOneof {return v}
       return 0
     }
-    set { anOneof = .oneofField(newValue) }
+    set {anOneof = .oneofField(newValue)}
   }
 
   var anOneof: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof? = nil

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -774,62 +774,42 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllTypesLite.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofLazyNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
-      if case .oneofLazyNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofLazyNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllTypesLite.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofLazyNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofLazyNestedMessage(newValue)}
   }
 
   /// Tests toString for non-repeated fields with a list suffix
@@ -2281,50 +2261,34 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypesLite {
     get {
-      if case .oneofTestAllTypes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofTestAllTypes(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllTypesLite()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -730,62 +730,42 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittestNoArena_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var lazyOneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
-      if case .lazyOneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .lazyOneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittestNoArena_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .lazyOneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .lazyOneofNestedMessage(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -352,50 +352,34 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
     get {
-      if case .oneofEnum(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofEnum(let v)? = _storage._oneofField {return v}
       return Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum.foo
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofEnum(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofEnum(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -84,26 +84,18 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
 
   var integerField: Int32 {
     get {
-      if case .integerField(let v)? = _storage._foo {
-        return v
-      }
+      if case .integerField(let v)? = _storage._foo {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._foo = .integerField(newValue)
-    }
+    set {_uniqueStorage()._foo = .integerField(newValue)}
   }
 
   var stringField: String {
     get {
-      if case .stringField(let v)? = _storage._foo {
-        return v
-      }
+      if case .stringField(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .stringField(newValue)
-    }
+    set {_uniqueStorage()._foo = .stringField(newValue)}
   }
 
   var foo: OneOf_Foo? {

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -128,20 +128,20 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
 
   var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE1(let v)? = o { return v }
+      if case .oneofE1(let v)? = o {return v}
       return Proto3PreserveUnknownEnumUnittest_MyEnum.foo
     }
-    set { o = .oneofE1(newValue) }
+    set {o = .oneofE1(newValue)}
   }
 
   var o: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O? = nil
 
   var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE2(let v)? = o { return v }
+      if case .oneofE2(let v)? = o {return v}
       return Proto3PreserveUnknownEnumUnittest_MyEnum.foo
     }
-    set { o = .oneofE2(newValue) }
+    set {o = .oneofE2(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -209,20 +209,20 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
 
   var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
-      if case .oneofE1(let v)? = o { return v }
+      if case .oneofE1(let v)? = o {return v}
       return Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
     }
-    set { o = .oneofE1(newValue) }
+    set {o = .oneofE1(newValue)}
   }
 
   var o: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O? = nil
 
   var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
-      if case .oneofE2(let v)? = o { return v }
+      if case .oneofE2(let v)? = o {return v}
       return Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
     }
-    set { o = .oneofE2(newValue) }
+    set {o = .oneofE2(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -102,20 +102,20 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
 
   var oneofE1: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE1(let v)? = o { return v }
+      if case .oneofE1(let v)? = o {return v}
       return Proto2PreserveUnknownEnumUnittest_MyEnum.foo
     }
-    set { o = .oneofE1(newValue) }
+    set {o = .oneofE1(newValue)}
   }
 
   var o: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O? = nil
 
   var oneofE2: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE2(let v)? = o { return v }
+      if case .oneofE2(let v)? = o {return v}
       return Proto2PreserveUnknownEnumUnittest_MyEnum.foo
     }
-    set { o = .oneofE2(newValue) }
+    set {o = .oneofE2(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -430,50 +430,34 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: Proto3TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return Proto3TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {
@@ -1642,38 +1626,26 @@ struct Proto3TestOneof: SwiftProtobuf.Message {
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooInt(let v)? = _storage._foo {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._foo = .fooInt(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooString(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooString(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooString(newValue)}
   }
 
   var fooMessage: Proto3TestAllTypes {
     get {
-      if case .fooMessage(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooMessage(let v)? = _storage._foo {return v}
       return Proto3TestAllTypes()
     }
-    set {
-      _uniqueStorage()._foo = .fooMessage(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooMessage(newValue)}
   }
 
   var foo: OneOf_Foo? {

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -360,50 +360,34 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return Proto3ArenaUnittest_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -360,50 +360,34 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -360,50 +360,34 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: Proto3LiteUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return Proto3LiteUnittest_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -533,218 +533,146 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message {
 
   var anyField: Google_Protobuf_Any {
     get {
-      if case .anyField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .anyField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Any()
     }
-    set {
-      _uniqueStorage()._oneofField = .anyField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .anyField(newValue)}
   }
 
   var apiField: Google_Protobuf_Api {
     get {
-      if case .apiField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .apiField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Api()
     }
-    set {
-      _uniqueStorage()._oneofField = .apiField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .apiField(newValue)}
   }
 
   var durationField: Google_Protobuf_Duration {
     get {
-      if case .durationField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .durationField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Duration()
     }
-    set {
-      _uniqueStorage()._oneofField = .durationField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .durationField(newValue)}
   }
 
   var emptyField: Google_Protobuf_Empty {
     get {
-      if case .emptyField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .emptyField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Empty()
     }
-    set {
-      _uniqueStorage()._oneofField = .emptyField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .emptyField(newValue)}
   }
 
   var fieldMaskField: Google_Protobuf_FieldMask {
     get {
-      if case .fieldMaskField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .fieldMaskField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_FieldMask()
     }
-    set {
-      _uniqueStorage()._oneofField = .fieldMaskField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .fieldMaskField(newValue)}
   }
 
   var sourceContextField: Google_Protobuf_SourceContext {
     get {
-      if case .sourceContextField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .sourceContextField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_SourceContext()
     }
-    set {
-      _uniqueStorage()._oneofField = .sourceContextField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .sourceContextField(newValue)}
   }
 
   var structField: Google_Protobuf_Struct {
     get {
-      if case .structField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .structField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Struct()
     }
-    set {
-      _uniqueStorage()._oneofField = .structField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .structField(newValue)}
   }
 
   var timestampField: Google_Protobuf_Timestamp {
     get {
-      if case .timestampField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .timestampField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Timestamp()
     }
-    set {
-      _uniqueStorage()._oneofField = .timestampField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .timestampField(newValue)}
   }
 
   var typeField: Google_Protobuf_Type {
     get {
-      if case .typeField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .typeField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Type()
     }
-    set {
-      _uniqueStorage()._oneofField = .typeField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .typeField(newValue)}
   }
 
   var doubleField: Google_Protobuf_DoubleValue {
     get {
-      if case .doubleField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .doubleField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_DoubleValue()
     }
-    set {
-      _uniqueStorage()._oneofField = .doubleField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .doubleField(newValue)}
   }
 
   var floatField: Google_Protobuf_FloatValue {
     get {
-      if case .floatField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .floatField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_FloatValue()
     }
-    set {
-      _uniqueStorage()._oneofField = .floatField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .floatField(newValue)}
   }
 
   var int64Field: Google_Protobuf_Int64Value {
     get {
-      if case .int64Field(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .int64Field(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Int64Value()
     }
-    set {
-      _uniqueStorage()._oneofField = .int64Field(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .int64Field(newValue)}
   }
 
   var uint64Field: Google_Protobuf_UInt64Value {
     get {
-      if case .uint64Field(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .uint64Field(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_UInt64Value()
     }
-    set {
-      _uniqueStorage()._oneofField = .uint64Field(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .uint64Field(newValue)}
   }
 
   var int32Field: Google_Protobuf_Int32Value {
     get {
-      if case .int32Field(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .int32Field(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Int32Value()
     }
-    set {
-      _uniqueStorage()._oneofField = .int32Field(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .int32Field(newValue)}
   }
 
   var uint32Field: Google_Protobuf_UInt32Value {
     get {
-      if case .uint32Field(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .uint32Field(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_UInt32Value()
     }
-    set {
-      _uniqueStorage()._oneofField = .uint32Field(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .uint32Field(newValue)}
   }
 
   var boolField: Google_Protobuf_BoolValue {
     get {
-      if case .boolField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .boolField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_BoolValue()
     }
-    set {
-      _uniqueStorage()._oneofField = .boolField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .boolField(newValue)}
   }
 
   var stringField: Google_Protobuf_StringValue {
     get {
-      if case .stringField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .stringField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_StringValue()
     }
-    set {
-      _uniqueStorage()._oneofField = .stringField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .stringField(newValue)}
   }
 
   var bytesField: Google_Protobuf_BytesValue {
     get {
-      if case .bytesField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .bytesField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_BytesValue()
     }
-    set {
-      _uniqueStorage()._oneofField = .bytesField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .bytesField(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -567,50 +567,34 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllRequiredTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -75,50 +75,34 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v)? = _storage._options {
-        return v
-      }
+      if case .oneofInt64(let v)? = _storage._options {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._options = .oneofInt64(newValue)
-    }
+    set {_uniqueStorage()._options = .oneofInt64(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._options {
-        return v
-      }
+      if case .oneofBool(let v)? = _storage._options {return v}
       return false
     }
-    set {
-      _uniqueStorage()._options = .oneofBool(newValue)
-    }
+    set {_uniqueStorage()._options = .oneofBool(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._options {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._options {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._options = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._options = .oneofString(newValue)}
   }
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v)? = _storage._options {
-        return v
-      }
+      if case .oneofInt32(let v)? = _storage._options {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._options = .oneofInt32(newValue)
-    }
+    set {_uniqueStorage()._options = .oneofInt32(newValue)}
   }
 
   var optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage {

--- a/Reference/unittest_swift_oneof_all_required.pb.swift
+++ b/Reference/unittest_swift_oneof_all_required.pb.swift
@@ -138,26 +138,18 @@ struct ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message {
 
   var option1: ProtobufUnittest_OneOfOptionMessage1 {
     get {
-      if case .option1(let v)? = _storage._option {
-        return v
-      }
+      if case .option1(let v)? = _storage._option {return v}
       return ProtobufUnittest_OneOfOptionMessage1()
     }
-    set {
-      _uniqueStorage()._option = .option1(newValue)
-    }
+    set {_uniqueStorage()._option = .option1(newValue)}
   }
 
   var option2: ProtobufUnittest_OneOfOptionMessage2 {
     get {
-      if case .option2(let v)? = _storage._option {
-        return v
-      }
+      if case .option2(let v)? = _storage._option {return v}
       return ProtobufUnittest_OneOfOptionMessage2()
     }
-    set {
-      _uniqueStorage()._option = .option2(newValue)
-    }
+    set {_uniqueStorage()._option = .option2(newValue)}
   }
 
   var option: OneOf_Option? {

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -343,218 +343,146 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofInt32(let v)? = _storage._o {return v}
       return 100
     }
-    set {
-      _uniqueStorage()._o = .oneofInt32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofInt32(newValue)}
   }
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofInt64(let v)? = _storage._o {return v}
       return 101
     }
-    set {
-      _uniqueStorage()._o = .oneofInt64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofInt64(newValue)}
   }
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._o {return v}
       return 102
     }
-    set {
-      _uniqueStorage()._o = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofUint32(newValue)}
   }
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofUint64(let v)? = _storage._o {return v}
       return 103
     }
-    set {
-      _uniqueStorage()._o = .oneofUint64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofUint64(newValue)}
   }
 
   var oneofSint32: Int32 {
     get {
-      if case .oneofSint32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSint32(let v)? = _storage._o {return v}
       return 104
     }
-    set {
-      _uniqueStorage()._o = .oneofSint32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSint32(newValue)}
   }
 
   var oneofSint64: Int64 {
     get {
-      if case .oneofSint64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSint64(let v)? = _storage._o {return v}
       return 105
     }
-    set {
-      _uniqueStorage()._o = .oneofSint64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSint64(newValue)}
   }
 
   var oneofFixed32: UInt32 {
     get {
-      if case .oneofFixed32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFixed32(let v)? = _storage._o {return v}
       return 106
     }
-    set {
-      _uniqueStorage()._o = .oneofFixed32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFixed32(newValue)}
   }
 
   var oneofFixed64: UInt64 {
     get {
-      if case .oneofFixed64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFixed64(let v)? = _storage._o {return v}
       return 107
     }
-    set {
-      _uniqueStorage()._o = .oneofFixed64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFixed64(newValue)}
   }
 
   var oneofSfixed32: Int32 {
     get {
-      if case .oneofSfixed32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSfixed32(let v)? = _storage._o {return v}
       return 108
     }
-    set {
-      _uniqueStorage()._o = .oneofSfixed32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSfixed32(newValue)}
   }
 
   var oneofSfixed64: Int64 {
     get {
-      if case .oneofSfixed64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSfixed64(let v)? = _storage._o {return v}
       return 109
     }
-    set {
-      _uniqueStorage()._o = .oneofSfixed64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSfixed64(newValue)}
   }
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFloat(let v)? = _storage._o {return v}
       return 110
     }
-    set {
-      _uniqueStorage()._o = .oneofFloat(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFloat(newValue)}
   }
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofDouble(let v)? = _storage._o {return v}
       return 111
     }
-    set {
-      _uniqueStorage()._o = .oneofDouble(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofDouble(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofBool(let v)? = _storage._o {return v}
       return true
     }
-    set {
-      _uniqueStorage()._o = .oneofBool(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofBool(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._o {return v}
       return "string"
     }
-    set {
-      _uniqueStorage()._o = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._o {return v}
       return Data(bytes: [100, 97, 116, 97])
     }
-    set {
-      _uniqueStorage()._o = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofBytes(newValue)}
   }
 
   var oneofGroup: ProtobufUnittest_Message2.OneofGroup {
     get {
-      if case .oneofGroup(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofGroup(let v)? = _storage._o {return v}
       return ProtobufUnittest_Message2.OneofGroup()
     }
-    set {
-      _uniqueStorage()._o = .oneofGroup(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofGroup(newValue)}
   }
 
   var oneofMessage: ProtobufUnittest_Message2 {
     get {
-      if case .oneofMessage(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofMessage(let v)? = _storage._o {return v}
       return ProtobufUnittest_Message2()
     }
-    set {
-      _uniqueStorage()._o = .oneofMessage(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofMessage(newValue)}
   }
 
   var oneofEnum: ProtobufUnittest_Message2.Enum {
     get {
-      if case .oneofEnum(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofEnum(let v)? = _storage._o {return v}
       return ProtobufUnittest_Message2.Enum.baz
     }
-    set {
-      _uniqueStorage()._o = .oneofEnum(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofEnum(newValue)}
   }
 
   /// Some token map cases, too many combinations to list them all.

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -233,207 +233,139 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofInt32(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofInt32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofInt32(newValue)}
   }
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofInt64(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofInt64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofInt64(newValue)}
   }
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofUint32(newValue)}
   }
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofUint64(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofUint64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofUint64(newValue)}
   }
 
   var oneofSint32: Int32 {
     get {
-      if case .oneofSint32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSint32(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofSint32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSint32(newValue)}
   }
 
   var oneofSint64: Int64 {
     get {
-      if case .oneofSint64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSint64(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofSint64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSint64(newValue)}
   }
 
   var oneofFixed32: UInt32 {
     get {
-      if case .oneofFixed32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFixed32(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofFixed32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFixed32(newValue)}
   }
 
   var oneofFixed64: UInt64 {
     get {
-      if case .oneofFixed64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFixed64(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofFixed64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFixed64(newValue)}
   }
 
   var oneofSfixed32: Int32 {
     get {
-      if case .oneofSfixed32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSfixed32(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofSfixed32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSfixed32(newValue)}
   }
 
   var oneofSfixed64: Int64 {
     get {
-      if case .oneofSfixed64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSfixed64(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofSfixed64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSfixed64(newValue)}
   }
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFloat(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofFloat(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFloat(newValue)}
   }
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofDouble(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofDouble(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofDouble(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofBool(let v)? = _storage._o {return v}
       return false
     }
-    set {
-      _uniqueStorage()._o = .oneofBool(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofBool(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._o {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._o = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._o {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._o = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofBytes(newValue)}
   }
 
   /// No 'group' in proto3.
   var oneofMessage: ProtobufUnittest_Message3 {
     get {
-      if case .oneofMessage(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofMessage(let v)? = _storage._o {return v}
       return ProtobufUnittest_Message3()
     }
-    set {
-      _uniqueStorage()._o = .oneofMessage(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofMessage(newValue)}
   }
 
   var oneofEnum: ProtobufUnittest_Message3.Enum {
     get {
-      if case .oneofEnum(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofEnum(let v)? = _storage._o {return v}
       return ProtobufUnittest_Message3.Enum.foo
     }
-    set {
-      _uniqueStorage()._o = .oneofEnum(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofEnum(newValue)}
   }
 
   /// Some token map cases, too many combinations to list them all.

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -90,20 +90,20 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
 
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v)? = payload { return v }
+      if case .protobufPayload(let v)? = payload {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set { payload = .protobufPayload(newValue) }
+    set {payload = .protobufPayload(newValue)}
   }
 
   var payload: Conformance_ConformanceRequest.OneOf_Payload? = nil
 
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v)? = payload { return v }
+      if case .jsonPayload(let v)? = payload {return v}
       return String()
     }
-    set { payload = .jsonPayload(newValue) }
+    set {payload = .jsonPayload(newValue)}
   }
 
   /// Which format should the testee serialize its message to?
@@ -160,10 +160,10 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// test.  Some of the test cases are intentionally invalid input.
   var parseError: String {
     get {
-      if case .parseError(let v)? = result { return v }
+      if case .parseError(let v)? = result {return v}
       return String()
     }
-    set { result = .parseError(newValue) }
+    set {result = .parseError(newValue)}
   }
 
   var result: Conformance_ConformanceResponse.OneOf_Result? = nil
@@ -173,10 +173,10 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// this field.
   var serializeError: String {
     get {
-      if case .serializeError(let v)? = result { return v }
+      if case .serializeError(let v)? = result {return v}
       return String()
     }
-    set { result = .serializeError(newValue) }
+    set {result = .serializeError(newValue)}
   }
 
   /// This should be set if some other error occurred.  This will always
@@ -184,40 +184,40 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// about the failure.
   var runtimeError: String {
     get {
-      if case .runtimeError(let v)? = result { return v }
+      if case .runtimeError(let v)? = result {return v}
       return String()
     }
-    set { result = .runtimeError(newValue) }
+    set {result = .runtimeError(newValue)}
   }
 
   /// If the input was successfully parsed and the requested output was
   /// protobuf, serialize it to protobuf and set it in this field.
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v)? = result { return v }
+      if case .protobufPayload(let v)? = result {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set { result = .protobufPayload(newValue) }
+    set {result = .protobufPayload(newValue)}
   }
 
   /// If the input was successfully parsed and the requested output was JSON,
   /// serialize to JSON and set it in this field.
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v)? = result { return v }
+      if case .jsonPayload(let v)? = result {return v}
       return String()
     }
-    set { result = .jsonPayload(newValue) }
+    set {result = .jsonPayload(newValue)}
   }
 
   /// For when the testee skipped the test, likely because a certain feature
   /// wasn't supported, like JSON input/output.
   var skipped: String {
     get {
-      if case .skipped(let v)? = result { return v }
+      if case .skipped(let v)? = result {return v}
       return String()
     }
-    set { result = .skipped(newValue) }
+    set {result = .skipped(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -431,110 +431,74 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBool(let v)? = _storage._oneofField {return v}
       return false
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBool(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBool(newValue)}
   }
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint64(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint64(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint64(newValue)}
   }
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofFloat(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofFloat(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofFloat(newValue)}
   }
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofDouble(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofDouble(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofDouble(newValue)}
   }
 
   var oneofEnum: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum {
     get {
-      if case .oneofEnum(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofEnum(let v)? = _storage._oneofField {return v}
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum.foo
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofEnum(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofEnum(newValue)}
   }
 
   /// Well-known types

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -128,79 +128,55 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
   /// Represents a null value.
   public var nullValue: Google_Protobuf_NullValue {
     get {
-      if case .nullValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .nullValue(let v)? = _storage._kind {return v}
       return Google_Protobuf_NullValue.nullValue
     }
-    set {
-      _uniqueStorage()._kind = .nullValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .nullValue(newValue)}
   }
 
   /// Represents a double value.
   public var numberValue: Double {
     get {
-      if case .numberValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .numberValue(let v)? = _storage._kind {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._kind = .numberValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .numberValue(newValue)}
   }
 
   /// Represents a string value.
   public var stringValue: String {
     get {
-      if case .stringValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .stringValue(let v)? = _storage._kind {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._kind = .stringValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .stringValue(newValue)}
   }
 
   /// Represents a boolean value.
   public var boolValue: Bool {
     get {
-      if case .boolValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .boolValue(let v)? = _storage._kind {return v}
       return false
     }
-    set {
-      _uniqueStorage()._kind = .boolValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .boolValue(newValue)}
   }
 
   /// Represents a structured value.
   public var structValue: Google_Protobuf_Struct {
     get {
-      if case .structValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .structValue(let v)? = _storage._kind {return v}
       return Google_Protobuf_Struct()
     }
-    set {
-      _uniqueStorage()._kind = .structValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .structValue(newValue)}
   }
 
   /// Represents a repeated `Value`.
   public var listValue: Google_Protobuf_ListValue {
     get {
-      if case .listValue(let v)? = _storage._kind {
-        return v
-      }
+      if case .listValue(let v)? = _storage._kind {return v}
       return Google_Protobuf_ListValue()
     }
-    set {
-      _uniqueStorage()._kind = .listValue(newValue)
-    }
+    set {_uniqueStorage()._kind = .listValue(newValue)}
   }
 
   public var kind: OneOf_Kind? {

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -422,11 +422,11 @@ struct MessageFieldGenerator {
             p.indent()
             p.print("get {\n")
             p.indent()
-            p.print("if case .\(swiftName)(let v)? = \(oneof.swiftFieldName) { return v }\n")
+            p.print("if case .\(swiftName)(let v)? = \(oneof.swiftFieldName) {return v}\n")
             p.print("return \(swiftDefaultValue)\n")
             p.outdent()
             p.print("}\n")
-            p.print("set { \(oneof.swiftFieldName) = .\(swiftName)(newValue) }\n")
+            p.print("set {\(oneof.swiftFieldName) = .\(swiftName)(newValue)}\n")
             p.outdent()
             p.print("}\n")
         } else if !isRepeated && !isMap && !isProto3 {
@@ -452,19 +452,11 @@ struct MessageFieldGenerator {
         if let oneof = oneof {
             p.print("get {\n")
             p.indent()
-            p.print("if case .\(swiftName)(let v)? = _storage.\(oneof.swiftStorageFieldName) {\n")
-            p.indent()
-            p.print("return v\n")
-            p.outdent()
-            p.print("}\n")
+            p.print("if case .\(swiftName)(let v)? = _storage.\(oneof.swiftStorageFieldName) {return v}\n")
             p.print("return \(swiftDefaultValue)\n")
             p.outdent()
             p.print("}\n")
-            p.print("set {\n")
-            p.indent()
-            p.print("_uniqueStorage().\(oneof.swiftStorageFieldName) = .\(swiftName)(newValue)\n")
-            p.outdent()
-            p.print("}\n")
+            p.print("set {_uniqueStorage().\(oneof.swiftStorageFieldName) = .\(swiftName)(newValue)}\n")
         } else {
             let defaultClause: String
             if isMap || isRepeated {

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -90,20 +90,20 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
 
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v)? = payload { return v }
+      if case .protobufPayload(let v)? = payload {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set { payload = .protobufPayload(newValue) }
+    set {payload = .protobufPayload(newValue)}
   }
 
   var payload: Conformance_ConformanceRequest.OneOf_Payload? = nil
 
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v)? = payload { return v }
+      if case .jsonPayload(let v)? = payload {return v}
       return String()
     }
-    set { payload = .jsonPayload(newValue) }
+    set {payload = .jsonPayload(newValue)}
   }
 
   /// Which format should the testee serialize its message to?
@@ -160,10 +160,10 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// test.  Some of the test cases are intentionally invalid input.
   var parseError: String {
     get {
-      if case .parseError(let v)? = result { return v }
+      if case .parseError(let v)? = result {return v}
       return String()
     }
-    set { result = .parseError(newValue) }
+    set {result = .parseError(newValue)}
   }
 
   var result: Conformance_ConformanceResponse.OneOf_Result? = nil
@@ -173,10 +173,10 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// this field.
   var serializeError: String {
     get {
-      if case .serializeError(let v)? = result { return v }
+      if case .serializeError(let v)? = result {return v}
       return String()
     }
-    set { result = .serializeError(newValue) }
+    set {result = .serializeError(newValue)}
   }
 
   /// This should be set if some other error occurred.  This will always
@@ -184,40 +184,40 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// about the failure.
   var runtimeError: String {
     get {
-      if case .runtimeError(let v)? = result { return v }
+      if case .runtimeError(let v)? = result {return v}
       return String()
     }
-    set { result = .runtimeError(newValue) }
+    set {result = .runtimeError(newValue)}
   }
 
   /// If the input was successfully parsed and the requested output was
   /// protobuf, serialize it to protobuf and set it in this field.
   var protobufPayload: Data {
     get {
-      if case .protobufPayload(let v)? = result { return v }
+      if case .protobufPayload(let v)? = result {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set { result = .protobufPayload(newValue) }
+    set {result = .protobufPayload(newValue)}
   }
 
   /// If the input was successfully parsed and the requested output was JSON,
   /// serialize to JSON and set it in this field.
   var jsonPayload: String {
     get {
-      if case .jsonPayload(let v)? = result { return v }
+      if case .jsonPayload(let v)? = result {return v}
       return String()
     }
-    set { result = .jsonPayload(newValue) }
+    set {result = .jsonPayload(newValue)}
   }
 
   /// For when the testee skipped the test, likely because a certain feature
   /// wasn't supported, like JSON input/output.
   var skipped: String {
     get {
-      if case .skipped(let v)? = result { return v }
+      if case .skipped(let v)? = result {return v}
       return String()
     }
-    set { result = .skipped(newValue) }
+    set {result = .skipped(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -431,110 +431,74 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBool(let v)? = _storage._oneofField {return v}
       return false
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBool(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBool(newValue)}
   }
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint64(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint64(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint64(newValue)}
   }
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofFloat(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofFloat(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofFloat(newValue)}
   }
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofDouble(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofDouble(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofDouble(newValue)}
   }
 
   var oneofEnum: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum {
     get {
-      if case .oneofEnum(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofEnum(let v)? = _storage._oneofField {return v}
       return ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum.foo
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofEnum(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofEnum(newValue)}
   }
 
   /// Well-known types

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -802,50 +802,34 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {
@@ -4047,50 +4031,34 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooInt(let v)? = _storage._foo {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._foo = .fooInt(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooString(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooString(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooString(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestAllTypes {
     get {
-      if case .fooMessage(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooMessage(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestAllTypes()
     }
-    set {
-      _uniqueStorage()._foo = .fooMessage(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooMessage(newValue)}
   }
 
   var fooGroup: ProtobufUnittest_TestOneof.FooGroup {
     get {
-      if case .fooGroup(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooGroup(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestOneof.FooGroup()
     }
-    set {
-      _uniqueStorage()._foo = .fooGroup(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooGroup(newValue)}
   }
 
   var foo: OneOf_Foo? {
@@ -4343,182 +4311,122 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooInt(let v)? = _storage._foo {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._foo = .fooInt(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooString(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooString(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooString(newValue)}
   }
 
   var fooCord: String {
     get {
-      if case .fooCord(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooCord(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooCord(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooCord(newValue)}
   }
 
   var fooStringPiece: String {
     get {
-      if case .fooStringPiece(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooStringPiece(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooStringPiece(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooStringPiece(newValue)}
   }
 
   var fooBytes: Data {
     get {
-      if case .fooBytes(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooBytes(let v)? = _storage._foo {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._foo = .fooBytes(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooBytes(newValue)}
   }
 
   var fooEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .fooEnum(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooEnum(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestOneof2.NestedEnum.foo
     }
-    set {
-      _uniqueStorage()._foo = .fooEnum(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooEnum(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooMessage(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooMessage(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestOneof2.NestedMessage()
     }
-    set {
-      _uniqueStorage()._foo = .fooMessage(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooMessage(newValue)}
   }
 
   var fooGroup: ProtobufUnittest_TestOneof2.FooGroup {
     get {
-      if case .fooGroup(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooGroup(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestOneof2.FooGroup()
     }
-    set {
-      _uniqueStorage()._foo = .fooGroup(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooGroup(newValue)}
   }
 
   var fooLazyMessage: ProtobufUnittest_TestOneof2.NestedMessage {
     get {
-      if case .fooLazyMessage(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooLazyMessage(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestOneof2.NestedMessage()
     }
-    set {
-      _uniqueStorage()._foo = .fooLazyMessage(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooLazyMessage(newValue)}
   }
 
   var barInt: Int32 {
     get {
-      if case .barInt(let v)? = _storage._bar {
-        return v
-      }
+      if case .barInt(let v)? = _storage._bar {return v}
       return 5
     }
-    set {
-      _uniqueStorage()._bar = .barInt(newValue)
-    }
+    set {_uniqueStorage()._bar = .barInt(newValue)}
   }
 
   var barString: String {
     get {
-      if case .barString(let v)? = _storage._bar {
-        return v
-      }
+      if case .barString(let v)? = _storage._bar {return v}
       return "STRING"
     }
-    set {
-      _uniqueStorage()._bar = .barString(newValue)
-    }
+    set {_uniqueStorage()._bar = .barString(newValue)}
   }
 
   var barCord: String {
     get {
-      if case .barCord(let v)? = _storage._bar {
-        return v
-      }
+      if case .barCord(let v)? = _storage._bar {return v}
       return "CORD"
     }
-    set {
-      _uniqueStorage()._bar = .barCord(newValue)
-    }
+    set {_uniqueStorage()._bar = .barCord(newValue)}
   }
 
   var barStringPiece: String {
     get {
-      if case .barStringPiece(let v)? = _storage._bar {
-        return v
-      }
+      if case .barStringPiece(let v)? = _storage._bar {return v}
       return "SPIECE"
     }
-    set {
-      _uniqueStorage()._bar = .barStringPiece(newValue)
-    }
+    set {_uniqueStorage()._bar = .barStringPiece(newValue)}
   }
 
   var barBytes: Data {
     get {
-      if case .barBytes(let v)? = _storage._bar {
-        return v
-      }
+      if case .barBytes(let v)? = _storage._bar {return v}
       return Data(bytes: [66, 89, 84, 69, 83])
     }
-    set {
-      _uniqueStorage()._bar = .barBytes(newValue)
-    }
+    set {_uniqueStorage()._bar = .barBytes(newValue)}
   }
 
   var barEnum: ProtobufUnittest_TestOneof2.NestedEnum {
     get {
-      if case .barEnum(let v)? = _storage._bar {
-        return v
-      }
+      if case .barEnum(let v)? = _storage._bar {return v}
       return ProtobufUnittest_TestOneof2.NestedEnum.bar
     }
-    set {
-      _uniqueStorage()._bar = .barEnum(newValue)
-    }
+    set {_uniqueStorage()._bar = .barEnum(newValue)}
   }
 
   var bazInt: Int32 {
@@ -4777,38 +4685,26 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message {
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooInt(let v)? = _storage._foo {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._foo = .fooInt(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooString(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooString(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooString(newValue)}
   }
 
   var fooMessage: ProtobufUnittest_TestRequiredOneof.NestedMessage {
     get {
-      if case .fooMessage(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooMessage(let v)? = _storage._foo {return v}
       return ProtobufUnittest_TestRequiredOneof.NestedMessage()
     }
-    set {
-      _uniqueStorage()._foo = .fooMessage(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooMessage(newValue)}
   }
 
   var foo: OneOf_Foo? {
@@ -6140,50 +6036,34 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypes {
     get {
-      if case .oneofTestAllTypes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofTestAllTypes(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllTypes()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -123,10 +123,10 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
 
   var oneofField: Int32 {
     get {
-      if case .oneofField(let v)? = anOneof { return v }
+      if case .oneofField(let v)? = anOneof {return v}
       return 0
     }
-    set { anOneof = .oneofField(newValue) }
+    set {anOneof = .oneofField(newValue)}
   }
 
   var anOneof: ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof? = nil

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -774,62 +774,42 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllTypesLite.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofLazyNestedMessage: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {
-      if case .oneofLazyNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofLazyNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllTypesLite.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofLazyNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofLazyNestedMessage(newValue)}
   }
 
   /// Tests toString for non-repeated fields with a list suffix
@@ -2281,50 +2261,34 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofTestAllTypes: ProtobufUnittest_TestAllTypesLite {
     get {
-      if case .oneofTestAllTypes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofTestAllTypes(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllTypesLite()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofTestAllTypes(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -730,62 +730,42 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittestNoArena_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var lazyOneofNestedMessage: ProtobufUnittestNoArena_TestAllTypes.NestedMessage {
     get {
-      if case .lazyOneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .lazyOneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittestNoArena_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .lazyOneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .lazyOneofNestedMessage(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -352,50 +352,34 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofEnum: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum {
     get {
-      if case .oneofEnum(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofEnum(let v)? = _storage._oneofField {return v}
       return Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum.foo
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofEnum(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofEnum(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -84,26 +84,18 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
 
   var integerField: Int32 {
     get {
-      if case .integerField(let v)? = _storage._foo {
-        return v
-      }
+      if case .integerField(let v)? = _storage._foo {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._foo = .integerField(newValue)
-    }
+    set {_uniqueStorage()._foo = .integerField(newValue)}
   }
 
   var stringField: String {
     get {
-      if case .stringField(let v)? = _storage._foo {
-        return v
-      }
+      if case .stringField(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .stringField(newValue)
-    }
+    set {_uniqueStorage()._foo = .stringField(newValue)}
   }
 
   var foo: OneOf_Foo? {

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -128,20 +128,20 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
 
   var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE1(let v)? = o { return v }
+      if case .oneofE1(let v)? = o {return v}
       return Proto3PreserveUnknownEnumUnittest_MyEnum.foo
     }
-    set { o = .oneofE1(newValue) }
+    set {o = .oneofE1(newValue)}
   }
 
   var o: Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O? = nil
 
   var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE2(let v)? = o { return v }
+      if case .oneofE2(let v)? = o {return v}
       return Proto3PreserveUnknownEnumUnittest_MyEnum.foo
     }
-    set { o = .oneofE2(newValue) }
+    set {o = .oneofE2(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -209,20 +209,20 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
 
   var oneofE1: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
-      if case .oneofE1(let v)? = o { return v }
+      if case .oneofE1(let v)? = o {return v}
       return Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
     }
-    set { o = .oneofE1(newValue) }
+    set {o = .oneofE1(newValue)}
   }
 
   var o: Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O? = nil
 
   var oneofE2: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra {
     get {
-      if case .oneofE2(let v)? = o { return v }
+      if case .oneofE2(let v)? = o {return v}
       return Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra.eFoo
     }
-    set { o = .oneofE2(newValue) }
+    set {o = .oneofE2(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -102,20 +102,20 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
 
   var oneofE1: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE1(let v)? = o { return v }
+      if case .oneofE1(let v)? = o {return v}
       return Proto2PreserveUnknownEnumUnittest_MyEnum.foo
     }
-    set { o = .oneofE1(newValue) }
+    set {o = .oneofE1(newValue)}
   }
 
   var o: Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O? = nil
 
   var oneofE2: Proto2PreserveUnknownEnumUnittest_MyEnum {
     get {
-      if case .oneofE2(let v)? = o { return v }
+      if case .oneofE2(let v)? = o {return v}
       return Proto2PreserveUnknownEnumUnittest_MyEnum.foo
     }
-    set { o = .oneofE2(newValue) }
+    set {o = .oneofE2(newValue)}
   }
 
   var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -430,50 +430,34 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: Proto3TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return Proto3TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {
@@ -1642,38 +1626,26 @@ struct Proto3TestOneof: SwiftProtobuf.Message {
 
   var fooInt: Int32 {
     get {
-      if case .fooInt(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooInt(let v)? = _storage._foo {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._foo = .fooInt(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooInt(newValue)}
   }
 
   var fooString: String {
     get {
-      if case .fooString(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooString(let v)? = _storage._foo {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._foo = .fooString(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooString(newValue)}
   }
 
   var fooMessage: Proto3TestAllTypes {
     get {
-      if case .fooMessage(let v)? = _storage._foo {
-        return v
-      }
+      if case .fooMessage(let v)? = _storage._foo {return v}
       return Proto3TestAllTypes()
     }
-    set {
-      _uniqueStorage()._foo = .fooMessage(newValue)
-    }
+    set {_uniqueStorage()._foo = .fooMessage(newValue)}
   }
 
   var foo: OneOf_Foo? {

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -360,50 +360,34 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: Proto3ArenaUnittest_TestAllTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return Proto3ArenaUnittest_TestAllTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -567,50 +567,34 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._oneofField {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofUint32(newValue)}
   }
 
   var oneofNestedMessage: ProtobufUnittest_TestAllRequiredTypes.NestedMessage {
     get {
-      if case .oneofNestedMessage(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofNestedMessage(let v)? = _storage._oneofField {return v}
       return ProtobufUnittest_TestAllRequiredTypes.NestedMessage()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofNestedMessage(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofNestedMessage(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._oneofField {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._oneofField {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._oneofField = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .oneofBytes(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -75,50 +75,34 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v)? = _storage._options {
-        return v
-      }
+      if case .oneofInt64(let v)? = _storage._options {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._options = .oneofInt64(newValue)
-    }
+    set {_uniqueStorage()._options = .oneofInt64(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._options {
-        return v
-      }
+      if case .oneofBool(let v)? = _storage._options {return v}
       return false
     }
-    set {
-      _uniqueStorage()._options = .oneofBool(newValue)
-    }
+    set {_uniqueStorage()._options = .oneofBool(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._options {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._options {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._options = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._options = .oneofString(newValue)}
   }
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v)? = _storage._options {
-        return v
-      }
+      if case .oneofInt32(let v)? = _storage._options {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._options = .oneofInt32(newValue)
-    }
+    set {_uniqueStorage()._options = .oneofInt32(newValue)}
   }
 
   var optionalNestedMessage: Swift_Protobuf_TestFieldOrderings.NestedMessage {

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
@@ -138,26 +138,18 @@ struct ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message {
 
   var option1: ProtobufUnittest_OneOfOptionMessage1 {
     get {
-      if case .option1(let v)? = _storage._option {
-        return v
-      }
+      if case .option1(let v)? = _storage._option {return v}
       return ProtobufUnittest_OneOfOptionMessage1()
     }
-    set {
-      _uniqueStorage()._option = .option1(newValue)
-    }
+    set {_uniqueStorage()._option = .option1(newValue)}
   }
 
   var option2: ProtobufUnittest_OneOfOptionMessage2 {
     get {
-      if case .option2(let v)? = _storage._option {
-        return v
-      }
+      if case .option2(let v)? = _storage._option {return v}
       return ProtobufUnittest_OneOfOptionMessage2()
     }
-    set {
-      _uniqueStorage()._option = .option2(newValue)
-    }
+    set {_uniqueStorage()._option = .option2(newValue)}
   }
 
   var option: OneOf_Option? {

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -343,218 +343,146 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofInt32(let v)? = _storage._o {return v}
       return 100
     }
-    set {
-      _uniqueStorage()._o = .oneofInt32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofInt32(newValue)}
   }
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofInt64(let v)? = _storage._o {return v}
       return 101
     }
-    set {
-      _uniqueStorage()._o = .oneofInt64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofInt64(newValue)}
   }
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._o {return v}
       return 102
     }
-    set {
-      _uniqueStorage()._o = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofUint32(newValue)}
   }
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofUint64(let v)? = _storage._o {return v}
       return 103
     }
-    set {
-      _uniqueStorage()._o = .oneofUint64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofUint64(newValue)}
   }
 
   var oneofSint32: Int32 {
     get {
-      if case .oneofSint32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSint32(let v)? = _storage._o {return v}
       return 104
     }
-    set {
-      _uniqueStorage()._o = .oneofSint32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSint32(newValue)}
   }
 
   var oneofSint64: Int64 {
     get {
-      if case .oneofSint64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSint64(let v)? = _storage._o {return v}
       return 105
     }
-    set {
-      _uniqueStorage()._o = .oneofSint64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSint64(newValue)}
   }
 
   var oneofFixed32: UInt32 {
     get {
-      if case .oneofFixed32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFixed32(let v)? = _storage._o {return v}
       return 106
     }
-    set {
-      _uniqueStorage()._o = .oneofFixed32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFixed32(newValue)}
   }
 
   var oneofFixed64: UInt64 {
     get {
-      if case .oneofFixed64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFixed64(let v)? = _storage._o {return v}
       return 107
     }
-    set {
-      _uniqueStorage()._o = .oneofFixed64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFixed64(newValue)}
   }
 
   var oneofSfixed32: Int32 {
     get {
-      if case .oneofSfixed32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSfixed32(let v)? = _storage._o {return v}
       return 108
     }
-    set {
-      _uniqueStorage()._o = .oneofSfixed32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSfixed32(newValue)}
   }
 
   var oneofSfixed64: Int64 {
     get {
-      if case .oneofSfixed64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSfixed64(let v)? = _storage._o {return v}
       return 109
     }
-    set {
-      _uniqueStorage()._o = .oneofSfixed64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSfixed64(newValue)}
   }
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFloat(let v)? = _storage._o {return v}
       return 110
     }
-    set {
-      _uniqueStorage()._o = .oneofFloat(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFloat(newValue)}
   }
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofDouble(let v)? = _storage._o {return v}
       return 111
     }
-    set {
-      _uniqueStorage()._o = .oneofDouble(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofDouble(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofBool(let v)? = _storage._o {return v}
       return true
     }
-    set {
-      _uniqueStorage()._o = .oneofBool(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofBool(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._o {return v}
       return "string"
     }
-    set {
-      _uniqueStorage()._o = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._o {return v}
       return Data(bytes: [100, 97, 116, 97])
     }
-    set {
-      _uniqueStorage()._o = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofBytes(newValue)}
   }
 
   var oneofGroup: ProtobufUnittest_Message2.OneofGroup {
     get {
-      if case .oneofGroup(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofGroup(let v)? = _storage._o {return v}
       return ProtobufUnittest_Message2.OneofGroup()
     }
-    set {
-      _uniqueStorage()._o = .oneofGroup(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofGroup(newValue)}
   }
 
   var oneofMessage: ProtobufUnittest_Message2 {
     get {
-      if case .oneofMessage(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofMessage(let v)? = _storage._o {return v}
       return ProtobufUnittest_Message2()
     }
-    set {
-      _uniqueStorage()._o = .oneofMessage(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofMessage(newValue)}
   }
 
   var oneofEnum: ProtobufUnittest_Message2.Enum {
     get {
-      if case .oneofEnum(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofEnum(let v)? = _storage._o {return v}
       return ProtobufUnittest_Message2.Enum.baz
     }
-    set {
-      _uniqueStorage()._o = .oneofEnum(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofEnum(newValue)}
   }
 
   /// Some token map cases, too many combinations to list them all.

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -233,207 +233,139 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
 
   var oneofInt32: Int32 {
     get {
-      if case .oneofInt32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofInt32(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofInt32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofInt32(newValue)}
   }
 
   var oneofInt64: Int64 {
     get {
-      if case .oneofInt64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofInt64(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofInt64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofInt64(newValue)}
   }
 
   var oneofUint32: UInt32 {
     get {
-      if case .oneofUint32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofUint32(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofUint32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofUint32(newValue)}
   }
 
   var oneofUint64: UInt64 {
     get {
-      if case .oneofUint64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofUint64(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofUint64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofUint64(newValue)}
   }
 
   var oneofSint32: Int32 {
     get {
-      if case .oneofSint32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSint32(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofSint32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSint32(newValue)}
   }
 
   var oneofSint64: Int64 {
     get {
-      if case .oneofSint64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSint64(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofSint64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSint64(newValue)}
   }
 
   var oneofFixed32: UInt32 {
     get {
-      if case .oneofFixed32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFixed32(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofFixed32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFixed32(newValue)}
   }
 
   var oneofFixed64: UInt64 {
     get {
-      if case .oneofFixed64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFixed64(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofFixed64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFixed64(newValue)}
   }
 
   var oneofSfixed32: Int32 {
     get {
-      if case .oneofSfixed32(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSfixed32(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofSfixed32(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSfixed32(newValue)}
   }
 
   var oneofSfixed64: Int64 {
     get {
-      if case .oneofSfixed64(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofSfixed64(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofSfixed64(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofSfixed64(newValue)}
   }
 
   var oneofFloat: Float {
     get {
-      if case .oneofFloat(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofFloat(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofFloat(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofFloat(newValue)}
   }
 
   var oneofDouble: Double {
     get {
-      if case .oneofDouble(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofDouble(let v)? = _storage._o {return v}
       return 0
     }
-    set {
-      _uniqueStorage()._o = .oneofDouble(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofDouble(newValue)}
   }
 
   var oneofBool: Bool {
     get {
-      if case .oneofBool(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofBool(let v)? = _storage._o {return v}
       return false
     }
-    set {
-      _uniqueStorage()._o = .oneofBool(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofBool(newValue)}
   }
 
   var oneofString: String {
     get {
-      if case .oneofString(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofString(let v)? = _storage._o {return v}
       return String()
     }
-    set {
-      _uniqueStorage()._o = .oneofString(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofString(newValue)}
   }
 
   var oneofBytes: Data {
     get {
-      if case .oneofBytes(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofBytes(let v)? = _storage._o {return v}
       return SwiftProtobuf.Internal.emptyData
     }
-    set {
-      _uniqueStorage()._o = .oneofBytes(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofBytes(newValue)}
   }
 
   /// No 'group' in proto3.
   var oneofMessage: ProtobufUnittest_Message3 {
     get {
-      if case .oneofMessage(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofMessage(let v)? = _storage._o {return v}
       return ProtobufUnittest_Message3()
     }
-    set {
-      _uniqueStorage()._o = .oneofMessage(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofMessage(newValue)}
   }
 
   var oneofEnum: ProtobufUnittest_Message3.Enum {
     get {
-      if case .oneofEnum(let v)? = _storage._o {
-        return v
-      }
+      if case .oneofEnum(let v)? = _storage._o {return v}
       return ProtobufUnittest_Message3.Enum.foo
     }
-    set {
-      _uniqueStorage()._o = .oneofEnum(newValue)
-    }
+    set {_uniqueStorage()._o = .oneofEnum(newValue)}
   }
 
   /// Some token map cases, too many combinations to list them all.

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -533,218 +533,146 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message {
 
   var anyField: Google_Protobuf_Any {
     get {
-      if case .anyField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .anyField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Any()
     }
-    set {
-      _uniqueStorage()._oneofField = .anyField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .anyField(newValue)}
   }
 
   var apiField: Google_Protobuf_Api {
     get {
-      if case .apiField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .apiField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Api()
     }
-    set {
-      _uniqueStorage()._oneofField = .apiField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .apiField(newValue)}
   }
 
   var durationField: Google_Protobuf_Duration {
     get {
-      if case .durationField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .durationField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Duration()
     }
-    set {
-      _uniqueStorage()._oneofField = .durationField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .durationField(newValue)}
   }
 
   var emptyField: Google_Protobuf_Empty {
     get {
-      if case .emptyField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .emptyField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Empty()
     }
-    set {
-      _uniqueStorage()._oneofField = .emptyField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .emptyField(newValue)}
   }
 
   var fieldMaskField: Google_Protobuf_FieldMask {
     get {
-      if case .fieldMaskField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .fieldMaskField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_FieldMask()
     }
-    set {
-      _uniqueStorage()._oneofField = .fieldMaskField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .fieldMaskField(newValue)}
   }
 
   var sourceContextField: Google_Protobuf_SourceContext {
     get {
-      if case .sourceContextField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .sourceContextField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_SourceContext()
     }
-    set {
-      _uniqueStorage()._oneofField = .sourceContextField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .sourceContextField(newValue)}
   }
 
   var structField: Google_Protobuf_Struct {
     get {
-      if case .structField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .structField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Struct()
     }
-    set {
-      _uniqueStorage()._oneofField = .structField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .structField(newValue)}
   }
 
   var timestampField: Google_Protobuf_Timestamp {
     get {
-      if case .timestampField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .timestampField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Timestamp()
     }
-    set {
-      _uniqueStorage()._oneofField = .timestampField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .timestampField(newValue)}
   }
 
   var typeField: Google_Protobuf_Type {
     get {
-      if case .typeField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .typeField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Type()
     }
-    set {
-      _uniqueStorage()._oneofField = .typeField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .typeField(newValue)}
   }
 
   var doubleField: Google_Protobuf_DoubleValue {
     get {
-      if case .doubleField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .doubleField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_DoubleValue()
     }
-    set {
-      _uniqueStorage()._oneofField = .doubleField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .doubleField(newValue)}
   }
 
   var floatField: Google_Protobuf_FloatValue {
     get {
-      if case .floatField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .floatField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_FloatValue()
     }
-    set {
-      _uniqueStorage()._oneofField = .floatField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .floatField(newValue)}
   }
 
   var int64Field: Google_Protobuf_Int64Value {
     get {
-      if case .int64Field(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .int64Field(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Int64Value()
     }
-    set {
-      _uniqueStorage()._oneofField = .int64Field(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .int64Field(newValue)}
   }
 
   var uint64Field: Google_Protobuf_UInt64Value {
     get {
-      if case .uint64Field(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .uint64Field(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_UInt64Value()
     }
-    set {
-      _uniqueStorage()._oneofField = .uint64Field(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .uint64Field(newValue)}
   }
 
   var int32Field: Google_Protobuf_Int32Value {
     get {
-      if case .int32Field(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .int32Field(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_Int32Value()
     }
-    set {
-      _uniqueStorage()._oneofField = .int32Field(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .int32Field(newValue)}
   }
 
   var uint32Field: Google_Protobuf_UInt32Value {
     get {
-      if case .uint32Field(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .uint32Field(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_UInt32Value()
     }
-    set {
-      _uniqueStorage()._oneofField = .uint32Field(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .uint32Field(newValue)}
   }
 
   var boolField: Google_Protobuf_BoolValue {
     get {
-      if case .boolField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .boolField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_BoolValue()
     }
-    set {
-      _uniqueStorage()._oneofField = .boolField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .boolField(newValue)}
   }
 
   var stringField: Google_Protobuf_StringValue {
     get {
-      if case .stringField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .stringField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_StringValue()
     }
-    set {
-      _uniqueStorage()._oneofField = .stringField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .stringField(newValue)}
   }
 
   var bytesField: Google_Protobuf_BytesValue {
     get {
-      if case .bytesField(let v)? = _storage._oneofField {
-        return v
-      }
+      if case .bytesField(let v)? = _storage._oneofField {return v}
       return Google_Protobuf_BytesValue()
     }
-    set {
-      _uniqueStorage()._oneofField = .bytesField(newValue)
-    }
+    set {_uniqueStorage()._oneofField = .bytesField(newValue)}
   }
 
   var oneofField: OneOf_OneofField? {


### PR DESCRIPTION
- Like https://github.com/apple/swift-protobuf/pull/455 did, but collapse lines for when
  there is storage.
- Be consistent in not having spaces in the blocks for the get/set when they are single
  line.