### PR TITLE
Re-add Foundation import to Google_Protobuf_Any extension

### DIFF
--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -12,6 +12,8 @@
 ///
 // -----------------------------------------------------------------------------
 
+// Explicit import of Foundation is necessary on Linux,
+// don't remove unless obsolete on all platforms
 import Foundation
 
 public extension Google_Protobuf_Any {

--- a/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
+++ b/Sources/SwiftProtobuf/Google_Protobuf_Any+Extensions.swift
@@ -12,6 +12,8 @@
 ///
 // -----------------------------------------------------------------------------
 
+import Foundation
+
 public extension Google_Protobuf_Any {
   /// Initialize an Any object from the provided message.
   ///


### PR DESCRIPTION
`import Foundation` is required due to the use of `DispatchQueue`.
This was removed in #417 but makes builds fail on Linux, where explicit import is required.

FYI I've tagged the commit as `0.9.30` to use with SwiftPM on our CI, please let me know if this is an issue. 

Cheers 🙂 