### PR TITLE
Clean up/speed up some Context descriptor lookups.

### DIFF
--- a/Sources/protoc-gen-swift/ExtensionGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionGenerator.swift
@@ -35,7 +35,6 @@ struct ExtensionGenerator {
     let swiftExtendedMessageName: String
     let swiftRelativeExtensionName: String
     let swiftFullExtensionName: String
-    var isProto3: Bool {return false} // Extensions are always proto2
 
     var extensionFieldType: String {
         let label: String
@@ -89,7 +88,7 @@ struct ExtensionGenerator {
 
         let baseName: String
         if descriptor.type == .group {
-            let g = context.getMessageForPath(path: descriptor.typeName)!
+            let g = context.messageDescriptor(forTypeName: descriptor.typeName)
             baseName = g.name
         } else {
             baseName = descriptor.name

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -24,25 +24,6 @@ import SwiftProtobuf
 /// properties.
 ///
 extension Google_Protobuf_FileDescriptorProto {
-    func getMessageForPath(path: String) -> Google_Protobuf_DescriptorProto? {
-        let base: String
-        if !package.isEmpty {
-            base = "." + package
-        } else {
-            base = ""
-        }
-        for m in messageType {
-            let messagePath = base + "." + m.name
-            if messagePath == path {
-                return m
-            }
-            if let n = m.getMessageForPath(path: path, parentPath: messagePath) {
-                return n
-            }
-        }
-        return nil
-    }
-
     func getMessageNameForPath(path: String) -> String? {
         let base: String
         if !package.isEmpty {

--- a/Sources/protoc-gen-swift/Google_Protobuf_DescriptorProto+Extensions.swift
+++ b/Sources/protoc-gen-swift/Google_Protobuf_DescriptorProto+Extensions.swift
@@ -49,19 +49,6 @@ extension Google_Protobuf_DescriptorProto {
     }.joined(separator: " || ")
   }
 
-  func getMessageForPath(path: String, parentPath: String) -> Google_Protobuf_DescriptorProto? {
-    for m in nestedType {
-      let messagePath = parentPath + "." + m.name
-      if messagePath == path {
-        return m
-      }
-      if let n = m.getMessageForPath(path: path, parentPath: messagePath) {
-        return n
-      }
-    }
-    return nil
-  }
-
   func getMessageNameForPath(path: String, parentPath: String, swiftPrefix: String) -> String? {
     for m in nestedType {
       let messagePath = parentPath + "." + m.name

--- a/Sources/protoc-gen-swift/MessageFieldGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageFieldGenerator.swift
@@ -72,7 +72,7 @@ extension Google_Protobuf_FieldDescriptorProto {
 
     func getIsMap(context: Context) -> Bool {
         if type != .message {return false}
-        let m = context.getMessageForPath(path: typeName)!
+        let m = context.messageDescriptor(forTypeName: typeName)
         return m.options.mapEntry
     }
 
@@ -125,7 +125,7 @@ extension Google_Protobuf_FieldDescriptorProto {
 
     func getSwiftApiType(context: Context, isProto3: Bool) -> String {
         if getIsMap(context: context) {
-            let m = context.getMessageForPath(path: typeName)!
+            let m = context.messageDescriptor(forTypeName: typeName)
             let keyField = m.field[0]
             let keyType = keyField.getSwiftBaseType(context: context)
             let valueField = m.field[1]
@@ -141,7 +141,7 @@ extension Google_Protobuf_FieldDescriptorProto {
 
     func getSwiftStorageType(context: Context, isProto3: Bool) -> String {
         if getIsMap(context: context) {
-            let m = context.getMessageForPath(path: typeName)!
+            let m = context.messageDescriptor(forTypeName: typeName)
             let keyField = m.field[0]
             let keyType = keyField.getSwiftBaseType(context: context)
             let valueField = m.field[1]
@@ -183,8 +183,8 @@ extension Google_Protobuf_FieldDescriptorProto {
         case .group, .message:
             return context.getMessageNameForPath(path: typeName)! + "()"
         case .enum:
-            let e = context.enumByProtoName[typeName]!
-            if e.value.count == 0 {
+            let e = context.enumDescriptor(forTypeName: typeName)
+            if e.value.isEmpty {
                 return "nil"
             } else {
                 let defaultCase = e.value[0].name
@@ -196,7 +196,7 @@ extension Google_Protobuf_FieldDescriptorProto {
 
     func getTraitsType(context: Context) -> String {
         if getIsMap(context: context) {
-            let m = context.getMessageForPath(path: typeName)!
+            let m = context.messageDescriptor(forTypeName: typeName)
             let keyField = m.field[0]
             let keyTraits = keyField.getTraitsType(context: context)
             let valueField = m.field[1]
@@ -297,7 +297,7 @@ struct MessageFieldGenerator {
         self.descriptor = descriptor
         self.jsonName = descriptor.jsonName
         if descriptor.type == .group {
-            let g = context.getMessageForPath(path: descriptor.typeName)!
+            let g = context.messageDescriptor(forTypeName: descriptor.typeName)
             let lowerName = toLowerCamelCase(g.name)
             self.swiftName = sanitizeFieldName(lowerName)
             let sanitizedUpper = sanitizeFieldName(toUpperCamelCase(g.name), basedOn: lowerName)
@@ -374,7 +374,7 @@ struct MessageFieldGenerator {
             let type = descriptor.type
             if type == .group { return true }
             if type == .message {
-                let m = context.getMessageForPath(path: descriptor.typeName)!
+                let m = context.messageDescriptor(forTypeName: descriptor.typeName)
                 if m.options.mapEntry {
                     let valueField = m.field[1]
                     return valueField.type == .message

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -38,7 +38,6 @@ class MessageGenerator {
   private let messages: [MessageGenerator]
   private let isProto3: Bool
   private let isExtensible: Bool
-  private let isGroup: Bool
   private let isAnyMessage: Bool
 
   private let path: [Int32]
@@ -59,7 +58,6 @@ class MessageGenerator {
     self.protoFullName = (parentProtoPath == nil ? "" : (parentProtoPath! + ".")) + self.protoMessageName
     self.descriptor = descriptor
     self.isProto3 = file.isProto3
-    self.isGroup = context.protoNameIsGroup.contains(protoFullName)
     self.isExtensible = descriptor.extensionRange.count > 0
     self.protoPackageName = file.protoPackageName
     if let parentSwiftName = parentSwiftName {
@@ -760,7 +758,7 @@ fileprivate func hasMessageField(
   let hasMessageField = descriptor.field.contains {
     ($0.type == .message || $0.type == .group)
     && $0.label != .repeated
-    && (context.getMessageForPath(path: $0.typeName)?.options.mapEntry != true)
+    && (context.messageDescriptor(forTypeName: $0.typeName).options.mapEntry != true)
   }
   return hasMessageField
 }
@@ -795,8 +793,8 @@ fileprivate func messageHasRequiredFields(
       if f.label == .required {
         return true
       }
-      if (f.isMessage || f.isGroup) &&
-        hasRequiredFieldsInner(context.getMessageForPath(path: f.typeName)!) {
+      if (f.isMessage) &&
+        hasRequiredFieldsInner(context.messageDescriptor(forTypeName: f.typeName)) {
         return true
       }
     }
@@ -811,6 +809,6 @@ fileprivate func messageHasRequiredFields(
   msgTypeName: String,
   context: Context
 ) -> Bool {
-  let msgDesc = context.getMessageForPath(path: msgTypeName)!
+  let msgDesc = context.messageDescriptor(forTypeName: msgTypeName)
   return messageHasRequiredFields(descriptor: msgDesc, context: context)
 }


### PR DESCRIPTION
- Remove unused swiftNameForProtoName on Context.
- Rename getMessageForPath(path:) to messageDescriptor(forTypeName:) and have
  it use the already built catch so it isn't always linear.
- Remove the linear lookup of Message types.
- Add helper for enum descriptor lookup off Context.
- Drop Context's fileByProtoName, isn't used.
- Stop tracking the parents, wasn't used.
- Stop tracking what type names were groups at the Context level. Groups are
  still messages and the knowledge they are a group is inspected on the field
  when generating, so this was just wasted work.