### PR TITLE
Add encoding/decoding for top-level Arrays of Message types from JSON

### DIFF
--- a/Sources/SwiftProtobuf/Array+JSONAdditions.swift
+++ b/Sources/SwiftProtobuf/Array+JSONAdditions.swift
@@ -1,0 +1,85 @@
+// Sources/SwiftProtobuf/Array+JSONAdditions.swift - JSON format primitive types
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Extensions to `Array` to support JSON encoding/decoding.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+
+/// JSON encoding and decoding methods for arrays of messages.
+public extension Array where Iterator.Element: Message {
+  /// Returns a string containing the JSON serialization of the messages.
+  ///
+  /// Unlike binary encoding, presence of required fields is not enforced when
+  /// serializing to JSON.
+  ///
+  /// - Returns: A string containing the JSON serialization of the messages.
+  /// - Throws: `JSONEncodingError` if encoding fails.
+  func jsonString() throws -> String {
+    let data = try jsonUTF8Data()
+    return String(data: data, encoding: String.Encoding.utf8)!
+  }
+
+  /// Returns a Data containing the UTF-8 JSON serialization of the messages.
+  ///
+  /// Unlike binary encoding, presence of required fields is not enforced when
+  /// serializing to JSON.
+  ///
+  /// - Returns: A Data containing the JSON serialization of the messages.
+  /// - Throws: `JSONEncodingError` if encoding fails.
+  func jsonUTF8Data() throws -> Data {
+    var visitor = try JSONEncodingVisitor(type: Iterator.Element.self)
+    visitor.startArray()
+    for v in self {
+        visitor.startObject()
+        try v.traverse(visitor: &visitor)
+        visitor.endObject()
+    }
+    visitor.endArray()
+    return visitor.dataResult
+  }
+
+  /// Creates a new array of messages by decoding the given string containing a
+  /// serialized array of messages in JSON format.
+  ///
+  /// - Parameter jsonString: The JSON-formatted string to decode.
+  /// - Throws: `JSONDecodingError` if decoding fails.
+  public init(jsonString: String) throws {
+    if jsonString.isEmpty {
+      throw JSONDecodingError.truncated
+    }
+    if let data = jsonString.data(using: String.Encoding.utf8) {
+      try self.init(jsonUTF8Data: data)
+    } else {
+      throw JSONDecodingError.truncated
+    }
+  }
+
+  /// Creates a new array of messages by decoding the given `Data` containing a
+  /// serialized array of messages in JSON format, interpreting the data as
+  /// UTF-8 encoded text.
+  ///
+  /// - Parameter jsonUTF8Data: The JSON-formatted data to decode, represented
+  ///   as UTF-8 encoded text.
+  /// - Throws: `JSONDecodingError` if decoding fails.
+  public init(jsonUTF8Data: Data) throws {
+    self.init()
+    try jsonUTF8Data.withUnsafeBytes { (bytes:UnsafePointer<UInt8>) in
+      let buffer = UnsafeBufferPointer(start: bytes, count: jsonUTF8Data.count)
+      var decoder = JSONDecoder(source: buffer)
+      try decoder.decodeRepeatedMessageField(value: &self)
+      if !decoder.scanner.complete {
+        throw JSONDecodingError.trailingGarbage
+      }
+    }
+  }
+
+}

--- a/Sources/SwiftProtobuf/JSONEncoder.swift
+++ b/Sources/SwiftProtobuf/JSONEncoder.swift
@@ -32,6 +32,8 @@ private let asciiComma = UInt8(ascii: ",")
 private let asciiDoubleQuote = UInt8(ascii: "\"")
 private let asciiBackslash = UInt8(ascii: "\\")
 private let asciiForwardSlash = UInt8(ascii: "/")
+private let asciiOpenSquareBracket = UInt8(ascii: "[")
+private let asciiCloseSquareBracket = UInt8(ascii: "]")
 private let asciiOpenCurlyBracket = UInt8(ascii: "{")
 private let asciiCloseCurlyBracket = UInt8(ascii: "}")
 private let asciiUpperA = UInt8(ascii: "A")
@@ -127,8 +129,23 @@ internal struct JSONEncoder {
         separator = asciiComma
     }
 
+    /// Append an open square bracket `[` to the JSON.
+    internal mutating func startArray() {
+        data.append(asciiOpenSquareBracket)
+        separator = nil
+    }
+
+    /// Append a close square bracket `]` to the JSON.
+    internal mutating func endArray() {
+        data.append(asciiCloseSquareBracket)
+        separator = asciiComma
+    }
+
     /// Append an open curly brace `{` to the JSON.
     internal mutating func startObject() {
+        if let s = separator {
+            data.append(s)
+        }
         data.append(asciiOpenCurlyBracket)
         separator = nil
     }

--- a/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/JSONEncodingVisitor.swift
@@ -30,6 +30,16 @@ internal struct JSONEncodingVisitor: Visitor {
       return encoder.stringResult
   }
 
+  /// Creates a new visitor for serializing a message of the given type to JSON
+  /// format.
+  init(type: Message.Type) throws {
+    if let nameProviding = type as? _ProtoNameProviding.Type {
+      self.nameMap = nameProviding._protobuf_nameMap
+    } else {
+      throw JSONEncodingError.missingFieldNames
+    }
+  }
+
   /// Creates a new visitor that serializes the given message to JSON format.
   init(message: Message) throws {
     if let nameProviding = message as? _ProtoNameProviding {
@@ -37,6 +47,14 @@ internal struct JSONEncodingVisitor: Visitor {
     } else {
       throw JSONEncodingError.missingFieldNames
     }
+  }
+
+  mutating func startArray() {
+    encoder.startArray()
+  }
+
+  mutating func endArray() {
+    encoder.endArray()
   }
 
   mutating func startObject() {

--- a/Sources/SwiftProtobuf/Message+JSONArrayAdditions.swift
+++ b/Sources/SwiftProtobuf/Message+JSONArrayAdditions.swift
@@ -22,10 +22,10 @@ public extension Message {
   /// serializing to JSON.
   ///
   /// - Returns: A string containing the JSON serialization of the messages.
-  /// - Parameter array: The array of messages to encode.
+  /// - Parameter collection: The list of messages to encode.
   /// - Throws: `JSONEncodingError` if encoding fails.
-  public static func jsonString(from array: [Self]) throws -> String {
-    let data = try jsonUTF8Data(from: array)
+  public static func jsonString<C: Collection>(from collection: C) throws -> String where C.Iterator.Element == Self {
+    let data = try jsonUTF8Data(from: collection)
     return String(data: data, encoding: String.Encoding.utf8)!
   }
 
@@ -35,14 +35,14 @@ public extension Message {
   /// serializing to JSON.
   ///
   /// - Returns: A Data containing the JSON serialization of the messages.
-  /// - Parameter array: The array of messages to encode.
+  /// - Parameter collection: The list of messages to encode.
   /// - Throws: `JSONEncodingError` if encoding fails.
-  public static func jsonUTF8Data(from array: [Self]) throws -> Data {
+  public static func jsonUTF8Data<C: Collection>(from collection: C) throws -> Data where C.Iterator.Element == Self {
     var visitor = try JSONEncodingVisitor(type: Self.self)
     visitor.startArray()
-    for v in array {
+    for message in collection {
         visitor.startObject()
-        try v.traverse(visitor: &visitor)
+        try message.traverse(visitor: &visitor)
         visitor.endObject()
     }
     visitor.endArray()

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -279,10 +279,10 @@
 		DB2E0AFA1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */; };
 		DB2E0AFB1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */; };
 		DB2E0AFC1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */; };
-		DB2E0AFE1EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */; };
-		DB2E0AFF1EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */; };
-		DB2E0B001EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */; };
-		DB2E0B011EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */; };
+		DB2E0AFE1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
+		DB2E0AFF1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
+		DB2E0B001EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
+		DB2E0B011EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */; };
 		ECBC5C491DF6ABC500F658E8 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */; };
 		ECBC5C4A1DF6ABC500F658E8 /* Google_Protobuf_Struct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift */; };
 		ECBC5C4B1DF6ABC500F658E8 /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */; };
@@ -687,7 +687,7 @@
 		BCCA0E681DB1210E00957D74 /* Message+TextFormatAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Message+TextFormatAdditions.swift"; sourceTree = "<group>"; };
 		BCCA0E751DB123F800957D74 /* Test_TextFormat_proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_proto3.swift; sourceTree = "<group>"; };
 		DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_JSON_Array.swift; sourceTree = "<group>"; };
-		DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+JSONAdditions.swift"; sourceTree = "<group>"; };
+		DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "Message+JSONArrayAdditions.swift"; sourceTree = "<group>"; tabWidth = 2; };
 		F41BA3FB1E76F635004F6E95 /* Google_Protobuf_Any+Registry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Any+Registry.swift"; sourceTree = "<group>"; };
 		F41BA4121E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Any+Extensions.swift"; sourceTree = "<group>"; };
 		F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyUnpackError.swift; sourceTree = "<group>"; };
@@ -900,7 +900,6 @@
 				F41BA4411E7AE53C004F6E95 /* AnyMessageStorage.swift */,
 				F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */,
 				__PBXFileRef_Sources/Protobuf/api.pb.swift /* api.pb.swift */,
-				DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift */,
 				9C667A8F1E4C203D008B974F /* BinaryDecodingError.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */,
@@ -944,6 +943,7 @@
 				AA78AD351E84C5B4001C43F9 /* Message+AnyAdditions.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryTypes.swift /* Message+BinaryAdditions.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufJSONTypes.swift /* Message+JSONAdditions.swift */,
+				DB2E0AFD1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift */,
 				BCCA0E681DB1210E00957D74 /* Message+TextFormatAdditions.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufExtensions.swift /* MessageExtension.swift */,
 				AAF2ED391DEF3FBC007B510F /* NameMap.swift */,
@@ -1387,7 +1387,7 @@
 				AA28A4AD1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift in Sources */,
 				9C2F23821D7780D1008524F2 /* Google_Protobuf_Struct+Extensions.swift in Sources */,
 				9CA424431E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
-				DB2E0AFF1EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */,
+				DB2E0AFF1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */,
 				AA78AD371E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
 				9C2F23831D7780D1008524F2 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */,
 				9C2F23851D7780D1008524F2 /* BinaryDecoder.swift in Sources */,
@@ -1467,7 +1467,7 @@
 				F47138961E4E56AC00C8492C /* Internal.swift in Sources */,
 				9C75F8851DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift in Sources */,
-				DB2E0AFE1EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */,
+				DB2E0AFE1EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */,
 				AA78AD361E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
 				AAF2ED3A1DEF3FBC007B510F /* NameMap.swift in Sources */,
 				9CA424421E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
@@ -1656,7 +1656,7 @@
 				AAF2EE011DFB1450007B510F /* JSONIntegerConverting.swift in Sources */,
 				F44F93801DAEA76700BC5B85 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
 				9CA424441E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
-				DB2E0B001EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */,
+				DB2E0B001EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */,
 				AA78AD381E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
 				F44F938F1DAEA76700BC5B85 /* Message.swift in Sources */,
 				F44F93861DAEA76700BC5B85 /* Enum.swift in Sources */,
@@ -1845,7 +1845,7 @@
 				F44F94191DAEB23500BC5B85 /* Decoder.swift in Sources */,
 				AAF2ED3D1DEF3FBC007B510F /* NameMap.swift in Sources */,
 				9CA424451E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
-				DB2E0B011EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */,
+				DB2E0B011EB25D1D00F59319 /* Message+JSONArrayAdditions.swift in Sources */,
 				AA78AD391E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
 				AA05BF521DAEB7E800619042 /* FieldTag.swift in Sources */,
 				F44F94221DAEB23500BC5B85 /* FieldTypes.swift in Sources */,

--- a/SwiftProtobuf.xcodeproj/project.pbxproj
+++ b/SwiftProtobuf.xcodeproj/project.pbxproj
@@ -276,6 +276,13 @@
 		BCCA0E6A1DB1210E00957D74 /* TextFormatEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */; };
 		BCCA0E6B1DB1210E00957D74 /* Message+TextFormatAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E681DB1210E00957D74 /* Message+TextFormatAdditions.swift */; };
 		BCCA0E7A1DB124B800957D74 /* Test_TextFormat_proto3.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCCA0E751DB123F800957D74 /* Test_TextFormat_proto3.swift */; };
+		DB2E0AFA1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */; };
+		DB2E0AFB1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */; };
+		DB2E0AFC1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */; };
+		DB2E0AFE1EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */; };
+		DB2E0AFF1EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */; };
+		DB2E0B001EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */; };
+		DB2E0B011EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */; };
 		ECBC5C491DF6ABC500F658E8 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAEA52711DA80DD4003F318F /* Google_Protobuf_Wrappers+Extensions.swift */; };
 		ECBC5C4A1DF6ABC500F658E8 /* Google_Protobuf_Struct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/Google_Protobuf_Struct.swift /* Google_Protobuf_Struct+Extensions.swift */; };
 		ECBC5C4B1DF6ABC500F658E8 /* timestamp.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Protobuf/timestamp.pb.swift /* timestamp.pb.swift */; };
@@ -679,6 +686,8 @@
 		BCCA0E671DB1210E00957D74 /* TextFormatEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFormatEncoder.swift; sourceTree = "<group>"; };
 		BCCA0E681DB1210E00957D74 /* Message+TextFormatAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Message+TextFormatAdditions.swift"; sourceTree = "<group>"; };
 		BCCA0E751DB123F800957D74 /* Test_TextFormat_proto3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_TextFormat_proto3.swift; sourceTree = "<group>"; };
+		DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Test_JSON_Array.swift; sourceTree = "<group>"; };
+		DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+JSONAdditions.swift"; sourceTree = "<group>"; };
 		F41BA3FB1E76F635004F6E95 /* Google_Protobuf_Any+Registry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Any+Registry.swift"; sourceTree = "<group>"; };
 		F41BA4121E79BDCA004F6E95 /* Google_Protobuf_Any+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Google_Protobuf_Any+Extensions.swift"; sourceTree = "<group>"; };
 		F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyUnpackError.swift; sourceTree = "<group>"; };
@@ -891,6 +900,7 @@
 				F41BA4411E7AE53C004F6E95 /* AnyMessageStorage.swift */,
 				F41BA4171E79C568004F6E95 /* AnyUnpackError.swift */,
 				__PBXFileRef_Sources/Protobuf/api.pb.swift /* api.pb.swift */,
+				DB2E0AFD1EB25D1D00F59319 /* Array+JSONAdditions.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryDecoding.swift /* BinaryDecoder.swift */,
 				9C667A8F1E4C203D008B974F /* BinaryDecodingError.swift */,
 				__PBXFileRef_Sources/Protobuf/ProtobufBinaryEncoding.swift /* BinaryEncoder.swift */,
@@ -990,6 +1000,7 @@
 				__PBXFileRef_Tests/ProtobufTests/Test_FieldMask.swift /* Test_FieldMask.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_FieldOrdering.swift /* Test_FieldOrdering.swift */,
 				F4539D241E688B000076251F /* Test_GroupWithGroups.swift */,
+				DB2E0AF91EB24C7600F59319 /* Test_JSON_Array.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_JSON_Conformance.swift /* Test_JSON_Conformance.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_JSON_Group.swift /* Test_JSON_Group.swift */,
 				__PBXFileRef_Tests/ProtobufTests/Test_JSON.swift /* Test_JSON.swift */,
@@ -1302,6 +1313,7 @@
 				9C8CDA3D1D7A28F600E207CA /* Test_Struct.swift in Sources */,
 				9C8CDA3E1D7A28F600E207CA /* Test_Timestamp.swift in Sources */,
 				9C8CDA3F1D7A28F600E207CA /* Test_Type.swift in Sources */,
+				DB2E0AFB1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */,
 				F48FDD281E4D18060061D5C1 /* Test_TextFormat_proto3.swift in Sources */,
 				9C8CDA401D7A28F600E207CA /* Test_Unknown_proto2.swift in Sources */,
 				9C8CDA411D7A28F600E207CA /* Test_Unknown_proto3.swift in Sources */,
@@ -1375,6 +1387,7 @@
 				AA28A4AD1DA454DA00C866D9 /* BinaryEncodingSizeVisitor.swift in Sources */,
 				9C2F23821D7780D1008524F2 /* Google_Protobuf_Struct+Extensions.swift in Sources */,
 				9CA424431E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
+				DB2E0AFF1EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */,
 				AA78AD371E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
 				9C2F23831D7780D1008524F2 /* Google_Protobuf_Timestamp+Extensions.swift in Sources */,
 				9C2F23851D7780D1008524F2 /* BinaryDecoder.swift in Sources */,
@@ -1454,6 +1467,7 @@
 				F47138961E4E56AC00C8492C /* Internal.swift in Sources */,
 				9C75F8851DDD3045005CCFF2 /* SimpleExtensionMap.swift in Sources */,
 				__src_cc_ref_Sources/Protobuf/ProtobufFieldDecoder.swift /* Decoder.swift in Sources */,
+				DB2E0AFE1EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */,
 				AA78AD361E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
 				AAF2ED3A1DEF3FBC007B510F /* NameMap.swift in Sources */,
 				9CA424421E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
@@ -1568,6 +1582,7 @@
 				F44F943A1DBFBB7400BC5B85 /* Test_BasicFields_Access_Proto3.swift in Sources */,
 				F44F94351DBF9AEA00BC5B85 /* Test_BasicFields_Access_Proto2.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Timestamp.swift /* Test_Timestamp.swift in Sources */,
+				DB2E0AFA1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Type.swift /* Test_Type.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Unknown_proto2.swift /* Test_Unknown_proto2.swift in Sources */,
 				__src_cc_ref_Tests/ProtobufTests/Test_Unknown_proto3.swift /* Test_Unknown_proto3.swift in Sources */,
@@ -1641,6 +1656,7 @@
 				AAF2EE011DFB1450007B510F /* JSONIntegerConverting.swift in Sources */,
 				F44F93801DAEA76700BC5B85 /* Google_Protobuf_Wrappers+Extensions.swift in Sources */,
 				9CA424441E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
+				DB2E0B001EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */,
 				AA78AD381E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
 				F44F938F1DAEA76700BC5B85 /* Message.swift in Sources */,
 				F44F93861DAEA76700BC5B85 /* Enum.swift in Sources */,
@@ -1755,6 +1771,7 @@
 				F44F93B41DAEA8C900BC5B85 /* Test_Api.swift in Sources */,
 				F44F93E41DAEA8C900BC5B85 /* unittest_no_generic_services.pb.swift in Sources */,
 				F44F944A1DBFF18100BC5B85 /* Test_MapFields_Access_Proto2.swift in Sources */,
+				DB2E0AFC1EB24C7600F59319 /* Test_JSON_Array.swift in Sources */,
 				F44F93CF1DAEA8C900BC5B85 /* Test_Unknown_proto3.swift in Sources */,
 				F48FDD2A1E4D18080061D5C1 /* Test_TextFormat_proto3.swift in Sources */,
 				F44F93AC1DAEA8C900BC5B85 /* descriptor.pb.swift in Sources */,
@@ -1828,6 +1845,7 @@
 				F44F94191DAEB23500BC5B85 /* Decoder.swift in Sources */,
 				AAF2ED3D1DEF3FBC007B510F /* NameMap.swift in Sources */,
 				9CA424451E286D4E00C0E5B4 /* StringUtils.swift in Sources */,
+				DB2E0B011EB25D1D00F59319 /* Array+JSONAdditions.swift in Sources */,
 				AA78AD391E84C5B4001C43F9 /* Message+AnyAdditions.swift in Sources */,
 				AA05BF521DAEB7E800619042 /* FieldTag.swift in Sources */,
 				F44F94221DAEB23500BC5B85 /* FieldTypes.swift in Sources */,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -571,6 +571,15 @@ extension Test_JSONUnpacked {
     }
 }
 
+extension Test_JSON_Array {
+    static var allTests: [(String, (XCTestCase) throws -> ())] {
+        return [
+            ("testTwoObjectsWithMultipleFields", {try run_test(test:($0 as! Test_JSON_Array).testTwoObjectsWithMultipleFields)}),
+            ("testRepeatedNestedMessage", {try run_test(test:($0 as! Test_JSON_Array).testRepeatedNestedMessage)})
+        ]
+    }
+}
+
 extension Test_JSON_Conformance {
     static var allTests: [(String, (XCTestCase) throws -> ())] {
         return [
@@ -1133,6 +1142,7 @@ XCTMain(
         (testCaseClass: Test_JSON.self, allTests: Test_JSON.allTests),
         (testCaseClass: Test_JSONPacked.self, allTests: Test_JSONPacked.allTests),
         (testCaseClass: Test_JSONUnpacked.self, allTests: Test_JSONUnpacked.allTests),
+        (testCaseClass: Test_JSON_Array.self, allTests: Test_JSON_Array.allTests),
         (testCaseClass: Test_JSON_Conformance.self, allTests: Test_JSON_Conformance.allTests),
         (testCaseClass: Test_JSON_Group.self, allTests: Test_JSON_Group.allTests),
         (testCaseClass: Test_Map.self, allTests: Test_Map.allTests),

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -152,6 +152,25 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
         }
     }
 
+    func assertJSONArrayEncode(_ expected: String, file: XCTestFileArgType = #file, line: UInt = #line, configure: (inout [MessageTestType]) -> Void) {
+        let empty = [MessageTestType]()
+        var configured = empty
+        configure(&configured)
+        XCTAssert(configured != empty, "Object should not be equal to empty object", file: file, line: line)
+        do {
+            let encoded = try configured.jsonString()
+            XCTAssert(expected == encoded, "Did not encode correctly: got \(encoded)", file: file, line: line)
+            do {
+                let decoded = try [MessageTestType](jsonString: encoded)
+                XCTAssert(decoded == configured, "Encode/decode cycle should generate equal object: \(decoded) != \(configured)", file: file, line: line)
+            } catch {
+                XCTFail("Encode/decode cycle should not throw error decoding: \(encoded), but it threw \(error)", file: file, line: line)
+            }
+        } catch let e {
+            XCTFail("Failed to serialize JSON: \(e)\n    \(configured)", file: file, line: line)
+        }
+    }
+
     func assertJSONDecodeSucceeds(_ json: String, file: XCTestFileArgType = #file, line: UInt = #line, check: (MessageTestType) -> Bool) {
         do {
             let decoded: MessageTestType = try MessageTestType(jsonString: json)
@@ -203,6 +222,29 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
         }
     }
 
+    func assertJSONArrayDecodeSucceeds(_ json: String, file: XCTestFileArgType = #file, line: UInt = #line, check: ([MessageTestType]) -> Bool) {
+        do {
+            let decoded: [MessageTestType] = try [MessageTestType](jsonString: json)
+            XCTAssert(check(decoded), "Condition failed for \(decoded)", file: file, line: line)
+
+            do {
+                let encoded = try decoded.jsonString()
+                do {
+                    let redecoded = try [MessageTestType](jsonString: json)
+                    XCTAssert(check(redecoded), "Condition failed for redecoded \(redecoded)", file: file, line: line)
+                    XCTAssertEqual(decoded, redecoded, file: file, line: line)
+                } catch {
+                    XCTFail("Swift should have recoded/redecoded without error: \(encoded)", file: file, line: line)
+                }
+            } catch let e {
+                XCTFail("Swift should have recoded without error but got \(e)\n    \(decoded)", file: file, line: line)
+            }
+        } catch let e {
+            XCTFail("Swift should have decoded without error but got \(e): \(json)", file: file, line: line)
+            return
+        }
+    }
+
     func assertJSONDecodeFails(_ json: String, file: XCTestFileArgType = #file, line: UInt = #line) {
         do {
             let _ = try MessageTestType(jsonString: json)
@@ -216,6 +258,15 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
         do {
             let _ = try MessageTestType(textFormatString: text)
             XCTFail("Swift decode should have failed: \(text)", file: file, line: line)
+        } catch {
+            // Yay! It failed!
+        }
+    }
+
+    func assertJSONArrayDecodeFails(_ json: String, file: XCTestFileArgType = #file, line: UInt = #line) {
+        do {
+            let _ = try [MessageTestType](jsonString: json)
+            XCTFail("Swift decode should have failed: \(json)", file: file, line: line)
         } catch {
             // Yay! It failed!
         }

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -158,10 +158,10 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
         configure(&configured)
         XCTAssert(configured != empty, "Object should not be equal to empty object", file: file, line: line)
         do {
-            let encoded = try configured.jsonString()
+            let encoded = try MessageTestType.jsonString(from: configured)
             XCTAssert(expected == encoded, "Did not encode correctly: got \(encoded)", file: file, line: line)
             do {
-                let decoded = try [MessageTestType](jsonString: encoded)
+                let decoded = try MessageTestType.array(fromJSONString: encoded)
                 XCTAssert(decoded == configured, "Encode/decode cycle should generate equal object: \(decoded) != \(configured)", file: file, line: line)
             } catch {
                 XCTFail("Encode/decode cycle should not throw error decoding: \(encoded), but it threw \(error)", file: file, line: line)
@@ -224,13 +224,13 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
 
     func assertJSONArrayDecodeSucceeds(_ json: String, file: XCTestFileArgType = #file, line: UInt = #line, check: ([MessageTestType]) -> Bool) {
         do {
-            let decoded: [MessageTestType] = try [MessageTestType](jsonString: json)
+            let decoded: [MessageTestType] = try MessageTestType.array(fromJSONString: json)
             XCTAssert(check(decoded), "Condition failed for \(decoded)", file: file, line: line)
 
             do {
-                let encoded = try decoded.jsonString()
+                let encoded = try MessageTestType.jsonString(from: decoded)
                 do {
-                    let redecoded = try [MessageTestType](jsonString: json)
+                    let redecoded = try MessageTestType.array(fromJSONString: json)
                     XCTAssert(check(redecoded), "Condition failed for redecoded \(redecoded)", file: file, line: line)
                     XCTAssertEqual(decoded, redecoded, file: file, line: line)
                 } catch {
@@ -265,7 +265,7 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
 
     func assertJSONArrayDecodeFails(_ json: String, file: XCTestFileArgType = #file, line: UInt = #line) {
         do {
-            let _ = try [MessageTestType](jsonString: json)
+            let _ = try MessageTestType.array(fromJSONString: json)
             XCTFail("Swift decode should have failed: \(json)", file: file, line: line)
         } catch {
             // Yay! It failed!

--- a/Tests/SwiftProtobufTests/Test_JSON_Array.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON_Array.swift
@@ -1,0 +1,167 @@
+// Tests/SwiftProtobufTests/Test_JSON_Array.swift - Exercise JSON flat array coding
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// JSON is a major new feature for Proto3.  This test suite exercises
+/// the JSON coding for all primitive types, including boundary and error
+/// cases.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+import XCTest
+import SwiftProtobuf
+
+class Test_JSON_Array: XCTestCase, PBTestHelpers {
+    typealias MessageTestType = Proto3TestAllTypes
+
+    private func configureTwoObjects(_ o: inout [MessageTestType]) {
+        var o1 = MessageTestType()
+        o1.singleInt32 = 1
+        o1.singleInt64 = 2
+        o1.singleUint32 = 3
+        o1.singleUint64 = 4
+        o1.singleSint32 = 5
+        o1.singleSint64 = 6
+        o1.singleFixed32 = 7
+        o1.singleFixed64 = 8
+        o1.singleSfixed32 = 9
+        o1.singleSfixed64 = 10
+        o1.singleFloat = 11
+        o1.singleDouble = 12
+        o1.singleBool = true
+        o1.singleString = "abc"
+        o1.singleBytes = Data(bytes: [65, 66])
+        var nested = MessageTestType.NestedMessage()
+        nested.bb = 7
+        o1.singleNestedMessage = nested
+        var foreign = Proto3ForeignMessage()
+        foreign.c = 88
+        o1.singleForeignMessage = foreign
+        var importMessage = Proto3ImportMessage()
+        importMessage.d = -9
+        o1.singleImportMessage = importMessage
+        o1.singleNestedEnum = .baz
+        o1.singleForeignEnum = .foreignBaz
+        o1.singleImportEnum = .importBaz
+        var publicImportMessage = Proto3PublicImportMessage()
+        publicImportMessage.e = -999999
+        o1.singlePublicImportMessage = publicImportMessage
+        o1.repeatedInt32 = [1, 2]
+        o1.repeatedInt64 = [3, 4]
+        o1.repeatedUint32 = [5, 6]
+        o1.repeatedUint64 = [7, 8]
+        o1.repeatedSint32 = [9, 10]
+        o1.repeatedSint64 = [11, 12]
+        o1.repeatedFixed32 = [13, 14]
+        o1.repeatedFixed64 = [15, 16]
+        o1.repeatedSfixed32 = [17, 18]
+        o1.repeatedSfixed64 = [19, 20]
+        o1.repeatedFloat = [21, 22]
+        o1.repeatedDouble = [23, 24]
+        o1.repeatedBool = [true, false]
+        o1.repeatedString = ["abc", "def"]
+        o1.repeatedBytes = [Data(), Data(bytes: [65, 66])]
+        var nested2 = nested
+        nested2.bb = -7
+        o1.repeatedNestedMessage = [nested, nested2]
+        var foreign2 = foreign
+        foreign2.c = -88
+        o1.repeatedForeignMessage = [foreign, foreign2]
+        var importMessage2 = importMessage
+        importMessage2.d = 999999
+        o1.repeatedImportMessage = [importMessage, importMessage2]
+        o1.repeatedNestedEnum = [.bar, .baz]
+        o1.repeatedForeignEnum = [.foreignBar, .foreignBaz]
+        o1.repeatedImportEnum = [.importBar, .importBaz]
+        var publicImportMessage2 = publicImportMessage
+        publicImportMessage2.e = 999999
+        o1.repeatedPublicImportMessage = [publicImportMessage, publicImportMessage2]
+        o1.oneofUint32 = 99
+        o.append(o1)
+
+        let o2 = MessageTestType()
+        o.append(o2)
+    }
+
+    func testTwoObjectsWithMultipleFields() {
+        let expected: String = ("[{"
+            + "\"singleInt32\":1,"
+            + "\"singleInt64\":\"2\","
+            + "\"singleUint32\":3,"
+            + "\"singleUint64\":\"4\","
+            + "\"singleSint32\":5,"
+            + "\"singleSint64\":\"6\","
+            + "\"singleFixed32\":7,"
+            + "\"singleFixed64\":\"8\","
+            + "\"singleSfixed32\":9,"
+            + "\"singleSfixed64\":\"10\","
+            + "\"singleFloat\":11,"
+            + "\"singleDouble\":12,"
+            + "\"singleBool\":true,"
+            + "\"singleString\":\"abc\","
+            + "\"singleBytes\":\"QUI=\","
+            + "\"singleNestedMessage\":{\"bb\":7},"
+            + "\"singleForeignMessage\":{\"c\":88},"
+            + "\"singleImportMessage\":{\"d\":-9},"
+            + "\"singleNestedEnum\":\"BAZ\","
+            + "\"singleForeignEnum\":\"FOREIGN_BAZ\","
+            + "\"singleImportEnum\":\"IMPORT_BAZ\","
+            + "\"singlePublicImportMessage\":{\"e\":-999999},"
+            + "\"repeatedInt32\":[1,2],"
+            + "\"repeatedInt64\":[\"3\",\"4\"],"
+            + "\"repeatedUint32\":[5,6],"
+            + "\"repeatedUint64\":[\"7\",\"8\"],"
+            + "\"repeatedSint32\":[9,10],"
+            + "\"repeatedSint64\":[\"11\",\"12\"],"
+            + "\"repeatedFixed32\":[13,14],"
+            + "\"repeatedFixed64\":[\"15\",\"16\"],"
+            + "\"repeatedSfixed32\":[17,18],"
+            + "\"repeatedSfixed64\":[\"19\",\"20\"],"
+            + "\"repeatedFloat\":[21,22],"
+            + "\"repeatedDouble\":[23,24],"
+            + "\"repeatedBool\":[true,false],"
+            + "\"repeatedString\":[\"abc\",\"def\"],"
+            + "\"repeatedBytes\":[\"\",\"QUI=\"],"
+            + "\"repeatedNestedMessage\":[{\"bb\":7},{\"bb\":-7}],"
+            + "\"repeatedForeignMessage\":[{\"c\":88},{\"c\":-88}],"
+            + "\"repeatedImportMessage\":[{\"d\":-9},{\"d\":999999}],"
+            + "\"repeatedNestedEnum\":[\"BAR\",\"BAZ\"],"
+            + "\"repeatedForeignEnum\":[\"FOREIGN_BAR\",\"FOREIGN_BAZ\"],"
+            + "\"repeatedImportEnum\":[\"IMPORT_BAR\",\"IMPORT_BAZ\"],"
+            + "\"repeatedPublicImportMessage\":[{\"e\":-999999},{\"e\":999999}],"
+            + "\"oneofUint32\":99"
+            + "},{}]")
+        assertJSONArrayEncode(expected, configure: configureTwoObjects)
+    }
+
+    func testRepeatedNestedMessage() {
+        assertJSONArrayEncode("[{\"repeatedNestedMessage\":[{\"bb\":1}]},{\"repeatedNestedMessage\":[{\"bb\":1},{\"bb\":2}]}]") {(o: inout [MessageTestType]) in
+            var o1 = MessageTestType()
+            var sub1 = Proto3TestAllTypes.NestedMessage()
+            sub1.bb = 1
+            o1.repeatedNestedMessage = [sub1]
+            o.append(o1)
+
+            var o2 = MessageTestType()
+            var sub2 = Proto3TestAllTypes.NestedMessage()
+            sub2.bb = 1
+            var sub3 = Proto3TestAllTypes.NestedMessage()
+            sub3.bb = 2
+            o2.repeatedNestedMessage = [sub2, sub3]
+            o.append(o2)
+        }
+
+        assertJSONArrayDecodeSucceeds("[{\"repeatedNestedMessage\": []}]") {
+            $0[0].repeatedNestedMessage == []
+        }
+
+        assertJSONArrayDecodeFails("{\"repeatedNestedMessage\": []}")
+    }
+}


### PR DESCRIPTION
JSON supports putting both objects and arrays at the top-level. For developers using Protobuf JSON as a bridge to an existing service, it may be necessary to ingest one of these top-level arrays directly as an array of messages.