### PR TITLE
Correct TextFormat for Group Extension Fields.

### DIFF
--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -7899,7 +7899,7 @@ let ProtobufUnittest_Extensions_optional_bytes_extension = SwiftProtobuf.Message
 
 let ProtobufUnittest_Extensions_OptionalGroup_extension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 16,
-  fieldName: "protobuf_unittest.OptionalGroup_extension",
+  fieldName: "protobuf_unittest.optionalgroup_extension",
   defaultValue: ProtobufUnittest_OptionalGroup_extension()
 )
 
@@ -8056,7 +8056,7 @@ let ProtobufUnittest_Extensions_repeated_bytes_extension = SwiftProtobuf.Message
 
 let ProtobufUnittest_Extensions_RepeatedGroup_extension = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 46,
-  fieldName: "protobuf_unittest.RepeatedGroup_extension",
+  fieldName: "protobuf_unittest.repeatedgroup_extension",
   defaultValue: []
 )
 

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -2219,7 +2219,7 @@ let ProtobufUnittest_Extensions_complex_opt3 = SwiftProtobuf.MessageExtension<Op
 
 let ProtobufUnittest_Extensions_ComplexOpt6 = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_ComplexOpt6>, Google_Protobuf_MessageOptions>(
   _protobuf_fieldNumber: 7595468,
-  fieldName: "protobuf_unittest.ComplexOpt6",
+  fieldName: "protobuf_unittest.complexopt6",
   defaultValue: ProtobufUnittest_ComplexOpt6()
 )
 

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -4043,7 +4043,7 @@ let ProtobufUnittest_Extensions_optional_bytes_extension_lite = SwiftProtobuf.Me
 
 let ProtobufUnittest_Extensions_OptionalGroup_extension_lite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 16,
-  fieldName: "protobuf_unittest.OptionalGroup_extension_lite",
+  fieldName: "protobuf_unittest.optionalgroup_extension_lite",
   defaultValue: ProtobufUnittest_OptionalGroup_extension_lite()
 )
 
@@ -4200,7 +4200,7 @@ let ProtobufUnittest_Extensions_repeated_bytes_extension_lite = SwiftProtobuf.Me
 
 let ProtobufUnittest_Extensions_RepeatedGroup_extension_lite = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 46,
-  fieldName: "protobuf_unittest.RepeatedGroup_extension_lite",
+  fieldName: "protobuf_unittest.repeatedgroup_extension_lite",
   defaultValue: []
 )
 

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -476,7 +476,7 @@ let ProtobufUnittest_Extend_Extensions_b = SwiftProtobuf.MessageExtension<Option
 
 let ProtobufUnittest_Extend_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.extend.C",
+  fieldName: "protobuf_unittest.extend.c",
   defaultValue: ProtobufUnittest_Extend_C()
 )
 

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -213,7 +213,7 @@ let ProtobufUnittest_Extend2_Extensions_b = SwiftProtobuf.MessageExtension<Optio
 
 let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 221,
-  fieldName: "protobuf_unittest.extend2.C",
+  fieldName: "protobuf_unittest.extend2.c",
   defaultValue: ProtobufUnittest_Extend2_C()
 )
 
@@ -227,7 +227,7 @@ extension ProtobufUnittest_Extend2_MyMessage {
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 211,
-      fieldName: "protobuf_unittest.extend2.MyMessage.C",
+      fieldName: "protobuf_unittest.extend2.MyMessage.c",
       defaultValue: ProtobufUnittest_Extend2_MyMessage.C()
     )
   }

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -213,7 +213,7 @@ let ProtobufUnittest_Extend3_Extensions_b = SwiftProtobuf.MessageExtension<Optio
 
 let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 321,
-  fieldName: "protobuf_unittest.extend3.C",
+  fieldName: "protobuf_unittest.extend3.c",
   defaultValue: ProtobufUnittest_Extend3_C()
 )
 
@@ -227,7 +227,7 @@ extension ProtobufUnittest_Extend3_MyMessage {
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 311,
-      fieldName: "protobuf_unittest.extend3.MyMessage.C",
+      fieldName: "protobuf_unittest.extend3.MyMessage.c",
       defaultValue: ProtobufUnittest_Extend3_MyMessage.C()
     )
   }

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -213,7 +213,7 @@ let Ext4Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<Swi
 
 let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 421,
-  fieldName: "protobuf_unittest.extend4.C",
+  fieldName: "protobuf_unittest.extend4.c",
   defaultValue: Ext4C()
 )
 
@@ -227,7 +227,7 @@ extension Ext4MyMessage {
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 411,
-      fieldName: "protobuf_unittest.extend4.MyMessage.C",
+      fieldName: "protobuf_unittest.extend4.MyMessage.c",
       defaultValue: Ext4MyMessage.C()
     )
   }

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -472,13 +472,13 @@ let UnittestSwiftGroups_Extensions: SwiftProtobuf.SimpleExtensionMap = [
 
 let Extensions_ExtensionGroup = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ExtensionGroup>, SwiftTestGroupExtensions>(
   _protobuf_fieldNumber: 2,
-  fieldName: "ExtensionGroup",
+  fieldName: "extensiongroup",
   defaultValue: ExtensionGroup()
 )
 
 let Extensions_RepeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(
   _protobuf_fieldNumber: 3,
-  fieldName: "RepeatedExtensionGroup",
+  fieldName: "repeatedextensiongroup",
   defaultValue: []
 )
 

--- a/Sources/protoc-gen-swift/ExtensionGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionGenerator.swift
@@ -78,7 +78,7 @@ struct ExtensionGenerator {
         self.context = context
         self.apiType = proto.getSwiftApiType(context: context, isProto3: false)
         self.comments = descriptor.protoSourceComments()
-        self.fieldName = proto.isGroup ? proto.bareTypeName : proto.name
+        self.fieldName = proto.name
         if let parentProtoPath = parentProtoPath, !parentProtoPath.isEmpty {
             var p = parentProtoPath
             assert(p.hasPrefix("."))

--- a/Tests/SwiftProtobufTests/Test_TextFormat_proto2_extensions.swift
+++ b/Tests/SwiftProtobufTests/Test_TextFormat_proto2_extensions.swift
@@ -28,13 +28,13 @@ class Test_TextFormat_proto2_extensions: XCTestCase, PBTestHelpers {
         // Fails if we don't provide the extensions to the decoder:
         assertTextFormatDecodeFails("[protobuf_unittest.optional_int32_extension]: 789\n")
 
-        assertTextFormatEncode("[protobuf_unittest.OptionalGroup_extension] {\n  a: 789\n}\n",
+        assertTextFormatEncode("[protobuf_unittest.optionalgroup_extension] {\n  a: 789\n}\n",
                          extensions: ProtobufUnittest_Unittest_Extensions) {
             (o: inout MessageTestType) in
             o.ProtobufUnittest_optionalGroupExtension.a = 789
         }
         // Fails if we don't provide the extensions to the decoder:
-        assertTextFormatDecodeFails("[protobuf_unittest.OptionalGroup_extension] {\n  a: 789\n}\n")
+        assertTextFormatDecodeFails("[protobuf_unittest.optionalgroup_extension] {\n  a: 789\n}\n")
     }
 
     func test_nested_extension() {

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -7899,7 +7899,7 @@ let ProtobufUnittest_Extensions_optional_bytes_extension = SwiftProtobuf.Message
 
 let ProtobufUnittest_Extensions_OptionalGroup_extension = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 16,
-  fieldName: "protobuf_unittest.OptionalGroup_extension",
+  fieldName: "protobuf_unittest.optionalgroup_extension",
   defaultValue: ProtobufUnittest_OptionalGroup_extension()
 )
 
@@ -8056,7 +8056,7 @@ let ProtobufUnittest_Extensions_repeated_bytes_extension = SwiftProtobuf.Message
 
 let ProtobufUnittest_Extensions_RepeatedGroup_extension = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension>, ProtobufUnittest_TestAllExtensions>(
   _protobuf_fieldNumber: 46,
-  fieldName: "protobuf_unittest.RepeatedGroup_extension",
+  fieldName: "protobuf_unittest.repeatedgroup_extension",
   defaultValue: []
 )
 

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -2219,7 +2219,7 @@ let ProtobufUnittest_Extensions_complex_opt3 = SwiftProtobuf.MessageExtension<Op
 
 let ProtobufUnittest_Extensions_ComplexOpt6 = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_ComplexOpt6>, Google_Protobuf_MessageOptions>(
   _protobuf_fieldNumber: 7595468,
-  fieldName: "protobuf_unittest.ComplexOpt6",
+  fieldName: "protobuf_unittest.complexopt6",
   defaultValue: ProtobufUnittest_ComplexOpt6()
 )
 

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -4043,7 +4043,7 @@ let ProtobufUnittest_Extensions_optional_bytes_extension_lite = SwiftProtobuf.Me
 
 let ProtobufUnittest_Extensions_OptionalGroup_extension_lite = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_OptionalGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 16,
-  fieldName: "protobuf_unittest.OptionalGroup_extension_lite",
+  fieldName: "protobuf_unittest.optionalgroup_extension_lite",
   defaultValue: ProtobufUnittest_OptionalGroup_extension_lite()
 )
 
@@ -4200,7 +4200,7 @@ let ProtobufUnittest_Extensions_repeated_bytes_extension_lite = SwiftProtobuf.Me
 
 let ProtobufUnittest_Extensions_RepeatedGroup_extension_lite = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<ProtobufUnittest_RepeatedGroup_extension_lite>, ProtobufUnittest_TestAllExtensionsLite>(
   _protobuf_fieldNumber: 46,
-  fieldName: "protobuf_unittest.RepeatedGroup_extension_lite",
+  fieldName: "protobuf_unittest.repeatedgroup_extension_lite",
   defaultValue: []
 )
 

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -476,7 +476,7 @@ let ProtobufUnittest_Extend_Extensions_b = SwiftProtobuf.MessageExtension<Option
 
 let ProtobufUnittest_Extend_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 101,
-  fieldName: "protobuf_unittest.extend.C",
+  fieldName: "protobuf_unittest.extend.c",
   defaultValue: ProtobufUnittest_Extend_C()
 )
 

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -213,7 +213,7 @@ let ProtobufUnittest_Extend2_Extensions_b = SwiftProtobuf.MessageExtension<Optio
 
 let ProtobufUnittest_Extend2_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 221,
-  fieldName: "protobuf_unittest.extend2.C",
+  fieldName: "protobuf_unittest.extend2.c",
   defaultValue: ProtobufUnittest_Extend2_C()
 )
 
@@ -227,7 +227,7 @@ extension ProtobufUnittest_Extend2_MyMessage {
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend2_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 211,
-      fieldName: "protobuf_unittest.extend2.MyMessage.C",
+      fieldName: "protobuf_unittest.extend2.MyMessage.c",
       defaultValue: ProtobufUnittest_Extend2_MyMessage.C()
     )
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -213,7 +213,7 @@ let ProtobufUnittest_Extend3_Extensions_b = SwiftProtobuf.MessageExtension<Optio
 
 let ProtobufUnittest_Extend3_Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 321,
-  fieldName: "protobuf_unittest.extend3.C",
+  fieldName: "protobuf_unittest.extend3.c",
   defaultValue: ProtobufUnittest_Extend3_C()
 )
 
@@ -227,7 +227,7 @@ extension ProtobufUnittest_Extend3_MyMessage {
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ProtobufUnittest_Extend3_MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 311,
-      fieldName: "protobuf_unittest.extend3.MyMessage.C",
+      fieldName: "protobuf_unittest.extend3.MyMessage.c",
       defaultValue: ProtobufUnittest_Extend3_MyMessage.C()
     )
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -213,7 +213,7 @@ let Ext4Extensions_b = SwiftProtobuf.MessageExtension<OptionalExtensionField<Swi
 
 let Ext4Extensions_C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
   _protobuf_fieldNumber: 421,
-  fieldName: "protobuf_unittest.extend4.C",
+  fieldName: "protobuf_unittest.extend4.c",
   defaultValue: Ext4C()
 )
 
@@ -227,7 +227,7 @@ extension Ext4MyMessage {
 
     static let C = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<Ext4MyMessage.C>, ProtobufUnittest_Extend_Foo.Bar.Baz>(
       _protobuf_fieldNumber: 411,
-      fieldName: "protobuf_unittest.extend4.MyMessage.C",
+      fieldName: "protobuf_unittest.extend4.MyMessage.c",
       defaultValue: Ext4MyMessage.C()
     )
   }

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -472,13 +472,13 @@ let UnittestSwiftGroups_Extensions: SwiftProtobuf.SimpleExtensionMap = [
 
 let Extensions_ExtensionGroup = SwiftProtobuf.MessageExtension<OptionalGroupExtensionField<ExtensionGroup>, SwiftTestGroupExtensions>(
   _protobuf_fieldNumber: 2,
-  fieldName: "ExtensionGroup",
+  fieldName: "extensiongroup",
   defaultValue: ExtensionGroup()
 )
 
 let Extensions_RepeatedExtensionGroup = SwiftProtobuf.MessageExtension<RepeatedGroupExtensionField<RepeatedExtensionGroup>, SwiftTestGroupExtensions>(
   _protobuf_fieldNumber: 3,
-  fieldName: "RepeatedExtensionGroup",
+  fieldName: "repeatedextensiongroup",
   defaultValue: []
 )
 


### PR DESCRIPTION
When used as extension fields, the format of the group name is the
lowercase form.

You can find some examples in google/protobuf's
src/google/protobuf/testdata/text_format_unittest_extensions_data_pointy.txt -

```
[protobuf_unittest.optionalgroup_extension] {
  a: 117
}
```
