### PR TITLE
Add namer and update extensions

### DIFF
--- a/Sources/PluginLibrary/Descriptor+Extensions.swift
+++ b/Sources/PluginLibrary/Descriptor+Extensions.swift
@@ -73,6 +73,15 @@ extension FieldDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
     }
     path.append(index)
   }
+
+  /// Helper to return the name to as the "base" for naming of generated fields.
+  ///
+  /// Groups use the underlying message's name. The way groups are declared in
+  /// proto files, the filed names is derived by lowercasing the Group's name,
+  /// so there are no underscores, etc. to rebuild a camel case name from.
+  var namingBase: String {
+    return type == .group ? messageType.name : name
+  }
 }
 
 extension ServiceDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {

--- a/Sources/PluginLibrary/Descriptor+Extensions.swift
+++ b/Sources/PluginLibrary/Descriptor+Extensions.swift
@@ -12,11 +12,6 @@ import Foundation
 import SwiftProtobuf
 
 extension FileDescriptor: ProvidesSourceCodeLocation {
-  // True if this file should perserve unknown enums within the enum.
-  public var hasUnknownEnumPreservingSemantics: Bool {
-    return syntax == .proto3
-  }
-
   public var sourceCodeInfoLocation: Google_Protobuf_SourceCodeInfo.Location? {
     // google/protobuf's descriptor.cc says it should be an empty path.
     return sourceCodeInfoLocation(path: IndexPath())
@@ -36,11 +31,6 @@ extension Descriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
 }
 
 extension EnumDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  // True if this enum should perserve unknown enums within the enum.
-  public var hasUnknownEnumPreservingSemantics: Bool {
-    return file.hasUnknownEnumPreservingSemantics
-  }
-
   public func getLocationPath(path: inout IndexPath) {
     if let containingType = containingType {
       containingType.getLocationPath(path: &path)
@@ -53,8 +43,6 @@ extension EnumDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
 }
 
 extension EnumValueDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  public weak var file: FileDescriptor! { return enumType.file }
-
   public func getLocationPath(path: inout IndexPath) {
     enumType.getLocationPath(path: &path)
     path.append(Google_Protobuf_EnumDescriptorProto.FieldNumbers.value)
@@ -63,8 +51,6 @@ extension EnumValueDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation 
 }
 
 extension OneofDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  public weak var file: FileDescriptor! { return containingType.file }
-
   public func getLocationPath(path: inout IndexPath) {
     containingType.getLocationPath(path: &path)
     path.append(Google_Protobuf_DescriptorProto.FieldNumbers.oneofDecl)
@@ -97,8 +83,6 @@ extension ServiceDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
 }
 
 extension MethodDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  public weak var file: FileDescriptor! { return service.file }
-
   public func getLocationPath(path: inout IndexPath) {
     service.getLocationPath(path: &path)
     path.append(Google_Protobuf_ServiceDescriptorProto.FieldNumbers.method)

--- a/Sources/PluginLibrary/Descriptor.swift
+++ b/Sources/PluginLibrary/Descriptor.swift
@@ -162,6 +162,10 @@ public final class Descriptor {
   public let oneofs: [OneofDescriptor]
   public let extensions: [FieldDescriptor]
 
+  public var extensionRanges: [Google_Protobuf_DescriptorProto.ExtensionRange] {
+    return proto.extensionRange
+  }
+
   fileprivate init(proto: Google_Protobuf_DescriptorProto,
                    index: Int,
                    registry: Registry,

--- a/Sources/PluginLibrary/NamingUtils.swift
+++ b/Sources/PluginLibrary/NamingUtils.swift
@@ -484,4 +484,8 @@ enum NamingUtils {
     return s.trimmingCharacters(in: backtickCharacterSet)
   }
 
+  static func periodsToUnderscores(_ s: String) -> String {
+    return s.replacingOccurrences(of: ".", with: "_")
+  }
+
 }

--- a/Sources/PluginLibrary/SwiftProtobufNamer.swift
+++ b/Sources/PluginLibrary/SwiftProtobufNamer.swift
@@ -1,0 +1,114 @@
+// Sources/PluginLibrary/SwiftProtobufNamer - A helper that generates SwiftProtobuf names.
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// A helper that can generate SwiftProtobuf names from types.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+
+public final class SwiftProtobufNamer {
+  var filePrefixCache = [String:String]()
+  var enumCanStripPrefixCache = [String:Bool]()
+
+  public init() {
+    // TODO(thomasvl): Eventually support taking a mapping of files to modules.
+  }
+
+  /// Calculate the relative name for the given message.
+  public func relativeName(message: Descriptor) -> String {
+    if message.containingType != nil {
+      return NamingUtils.sanitize(messageName: message.name)
+    } else {
+      let prefix = typePrefix(forFile: message.file)
+      return NamingUtils.sanitize(messageName: prefix + message.name)
+    }
+  }
+
+  /// Calculate the full name for the given message.
+  public func fullName(message: Descriptor) -> String {
+    let relativeName = self.relativeName(message: message)
+    guard let containingType = message.containingType else {
+      return relativeName
+    }
+    return fullName(message:containingType) + "." + relativeName
+  }
+
+  /// Calculate the relative name for the given enum.
+  public func relativeName(enum e: EnumDescriptor) -> String {
+    if e.containingType != nil {
+      return NamingUtils.sanitize(enumName: e.name)
+    } else {
+      let prefix = typePrefix(forFile: e.file)
+      return NamingUtils.sanitize(enumName: prefix + e.name)
+    }
+  }
+
+  /// Calculate the full name for the given enum.
+  public func fullName(enum e: EnumDescriptor) -> String {
+    let relativeName = self.relativeName(enum: e)
+    guard  let containingType = e.containingType else {
+      return relativeName
+    }
+    return fullName(message: containingType) + "." + relativeName
+  }
+
+  /// Calculate the relative name for the given enum value.
+  public func relativeName(enumValue: EnumValueDescriptor) -> String {
+    let baseName: String
+    if canStripPrefix(enum: enumValue.enumType) {
+      baseName = NamingUtils.strip(protoPrefix: enumValue.enumType.name, from: enumValue.name)!
+    } else {
+      baseName = enumValue.name
+    }
+
+    let camelCased = NamingUtils.toLowerCamelCase(baseName)
+    return NamingUtils.sanitize(enumCaseName: camelCased)
+  }
+
+  /// Calculate the full name for the given enum value.
+  public func fullName(enumValue: EnumValueDescriptor) -> String {
+    return fullName(enum: enumValue.enumType) + "." + relativeName(enumValue: enumValue)
+  }
+
+  /// The relative name with a leading dot so it can be used where
+  /// the type is known.
+  public func dottedRelativeName(enumValue: EnumValueDescriptor) -> String {
+    let relativeName = self.relativeName(enumValue: enumValue)
+    return "." + NamingUtils.trimBackticks(relativeName)
+  }
+
+  /// Calculate the prefix to use for this file, it is derived from the
+  /// proto package or swift_prefix file option.
+  public func typePrefix(forFile file: FileDescriptor) -> String {
+    if let result = filePrefixCache[file.name] {
+      return result
+    }
+
+    let result = NamingUtils.typePrefix(protoPackage: file.package,
+                                        fileOptions: file.fileOptions)
+    filePrefixCache[file.name] = result
+    return result
+  }
+  
+  // MARK: - Internal helpers
+
+  /// Calculate if the given enum's value can use prefix stripping.
+  func canStripPrefix(enum e: EnumDescriptor) -> Bool {
+    if let result = enumCanStripPrefixCache[e.fullName] {
+      return result
+    }
+
+    let result = NamingUtils.canStripPrefix(enumProto: e.proto)
+    enumCanStripPrefixCache[e.fullName] = result
+    return result
+  }
+
+}

--- a/Sources/PluginLibrary/SwiftProtobufNamer.swift
+++ b/Sources/PluginLibrary/SwiftProtobufNamer.swift
@@ -85,6 +85,17 @@ public final class SwiftProtobufNamer {
     return "." + NamingUtils.trimBackticks(relativeName)
   }
 
+  /// Calculate the relative name for the given oneof.
+  public func relativeName(oneof: OneofDescriptor) -> String {
+    let camelCase = NamingUtils.toUpperCamelCase(oneof.name)
+    return NamingUtils.sanitize(oneofName: "OneOf_\(camelCase)")
+  }
+
+  /// Calculate the full name for the given oneof.
+  public func fullName(oneof: OneofDescriptor) -> String {
+    return fullName(message: oneof.containingType) + "." + relativeName(oneof: oneof)
+  }
+
   /// Calculate the prefix to use for this file, it is derived from the
   /// proto package or swift_prefix file option.
   public func typePrefix(forFile file: FileDescriptor) -> String {

--- a/Sources/PluginLibrary/SwiftProtobufNamer.swift
+++ b/Sources/PluginLibrary/SwiftProtobufNamer.swift
@@ -54,7 +54,7 @@ public final class SwiftProtobufNamer {
   /// Calculate the full name for the given enum.
   public func fullName(enum e: EnumDescriptor) -> String {
     let relativeName = self.relativeName(enum: e)
-    guard  let containingType = e.containingType else {
+    guard let containingType = e.containingType else {
       return relativeName
     }
     return fullName(message: containingType) + "." + relativeName
@@ -127,7 +127,7 @@ public final class SwiftProtobufNamer {
 
   public typealias MessageExtensionNames = (value: String, has: String, clear: String)
 
-  /// Calculate the names to use for the Swfit Extension on the extended
+  /// Calculate the names to use for the Swift Extension on the extended
   /// message..
   ///
   /// - Precondition: `extensionField` must be FieldDescriptor for an extension.
@@ -142,7 +142,7 @@ public final class SwiftProtobufNamer {
 
     if let extensionScope = field.extensionScope {
       let extensionScopeSwiftFullName = fullName(message: extensionScope)
-      // Don't worry about any sanitize api on this names; since there is a
+      // Don't worry about any sanitize api on these names; since there is a
       // Message name on the front, it should never hit a reserved word.
       //
       // fieldBaseName is the lowerCase name even though we put more on the

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -17,9 +17,149 @@ extension FileDescriptor {
   }
 }
 
+extension FieldDescriptor {
+
+  func swiftType(namer: SwiftProtobufNamer) -> String {
+    if isMap {
+      let mapDescriptor: Descriptor = messageType
+      let keyField = mapDescriptor.fields[0]
+      let keyType = keyField.swiftType(namer: namer)
+      let valueField = mapDescriptor.fields[1]
+      let valueType = valueField.swiftType(namer: namer)
+      return "Dictionary<" + keyType + "," + valueType + ">"
+    }
+
+    let result: String
+    switch type {
+    case .double: result = "Double"
+    case .float: result = "Float"
+    case .int64: result = "Int64"
+    case .uint64: result = "UInt64"
+    case .int32: result = "Int32"
+    case .fixed64: result = "UInt64"
+    case .fixed32: result = "UInt32"
+    case .bool: result = "Bool"
+    case .string: result = "String"
+    case .group: result = namer.fullName(message: messageType)
+    case .message: result = namer.fullName(message: messageType)
+    case .bytes: result = "Data"
+    case .uint32: result = "UInt32"
+    case .enum: result = namer.fullName(enum: enumType)
+    case .sfixed32: result = "Int32"
+    case .sfixed64: result = "Int64"
+    case .sint32: result = "Int32"
+    case .sint64: result = "Int64"
+    }
+
+    if label == .repeated {
+      return "[\(result)]"
+    }
+    return result
+  }
+
+  func swiftDefaultValue(namer: SwiftProtobufNamer) -> String {
+    if isMap {
+      return "[:]"
+    }
+    if label == .repeated {
+      return "[]"
+    }
+
+    if let defaultValue = explicitDefaultValue {
+      switch type {
+      case .double:
+        switch defaultValue {
+        case "inf": return "Double.infinity"
+        case "-inf": return "-Double.infinity"
+        case "nan": return "Double.nan"
+        default: return defaultValue
+        }
+      case .float:
+        switch defaultValue {
+        case "inf": return "Float.infinity"
+        case "-inf": return "-Float.infinity"
+        case "nan": return "Float.nan"
+        default: return defaultValue
+        }
+      case .string:
+        return stringToEscapedStringLiteral(defaultValue)
+      case .bytes:
+        return escapedToDataLiteral(defaultValue)
+      case .enum:
+        let enumValue = enumType.value(named: defaultValue)!
+        // TODO(thomasvl): Can't this be short name?
+        return namer.fullName(enumValue: enumValue)
+      default:
+        return defaultValue
+      }
+    }
+
+    switch type {
+    case .bool: return "false"
+    case .string: return "String()"
+    case .bytes: return "SwiftProtobuf.Internal.emptyData"
+    case .group, .message:
+      return namer.fullName(message: messageType) + "()"
+    case .enum:
+      // TODO(thomasvl): Can't this be short name?
+      return namer.fullName(enumValue: enumType.defaultValue)
+    default:
+      return "0"
+    }
+  }
+
+  /// Calculates the traits type used for maps and extensions, they
+  /// are used in decoding and visiting.
+  func traitsType(namer: SwiftProtobufNamer) -> String {
+    if isMap {
+      let mapDescriptor: Descriptor = messageType
+      let keyField = mapDescriptor.fields[0]
+      let keyTraits = keyField.traitsType(namer: namer)
+      let valueField = mapDescriptor.fields[1]
+      let valueTraits = valueField.traitsType(namer: namer)
+      switch valueField.type {
+      case .message:  // Map's can't have a group as the value
+        return "SwiftProtobuf._ProtobufMessageMap<\(keyTraits),\(valueTraits)>"
+      case .enum:
+        return "SwiftProtobuf._ProtobufEnumMap<\(keyTraits),\(valueTraits)>"
+      default:
+        return "SwiftProtobuf._ProtobufMap<\(keyTraits),\(valueTraits)>"
+      }
+    }
+    switch type {
+    case .double: return "SwiftProtobuf.ProtobufDouble"
+    case .float: return "SwiftProtobuf.ProtobufFloat"
+    case .int64: return "SwiftProtobuf.ProtobufInt64"
+    case .uint64: return "SwiftProtobuf.ProtobufUInt64"
+    case .int32: return "SwiftProtobuf.ProtobufInt32"
+    case .fixed64: return "SwiftProtobuf.ProtobufFixed64"
+    case .fixed32: return "SwiftProtobuf.ProtobufFixed32"
+    case .bool: return "SwiftProtobuf.ProtobufBool"
+    case .string: return "SwiftProtobuf.ProtobufString"
+    case .group, .message: return namer.fullName(message: messageType)
+    case .bytes: return "SwiftProtobuf.ProtobufBytes"
+    case .uint32: return "SwiftProtobuf.ProtobufUInt32"
+    case .enum: return namer.fullName(enum: enumType)
+    case .sfixed32: return "SwiftProtobuf.ProtobufSFixed32"
+    case .sfixed64: return "SwiftProtobuf.ProtobufSFixed64"
+    case .sint32: return "SwiftProtobuf.ProtobufSInt32"
+    case .sint64: return "SwiftProtobuf.ProtobufSInt64"
+    }
+  }
+}
+
 extension EnumDescriptor {
   // True if this enum should perserve unknown enums within the enum.
   var hasUnknownPreservingSemantics: Bool {
     return file.hasUnknownEnumPreservingSemantics
+  }
+
+  func value(named: String) -> EnumValueDescriptor? {
+    for v in values {
+      if v.name == named {
+        return v
+      }
+    }
+    return nil
   }
 }

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -1,0 +1,25 @@
+// Sources/protoc-gen-swift/Descriptor+Extensions.swift - Additions to Descriptors
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+
+import PluginLibrary
+
+extension FileDescriptor {
+  // True if this file should perserve unknown enums within the enum.
+  var hasUnknownEnumPreservingSemantics: Bool {
+    return syntax == .proto3
+  }
+}
+
+extension EnumDescriptor {
+  // True if this enum should perserve unknown enums within the enum.
+  var hasUnknownPreservingSemantics: Bool {
+    return file.hasUnknownEnumPreservingSemantics
+  }
+}

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -242,7 +242,7 @@ class FileGenerator {
 
         var extensions = [ExtensionGenerator]()
         for e in fileDescriptor.extensions {
-            extensions.append(ExtensionGenerator(descriptor: e, generatorOptions: generatorOptions, namer: namer, parentProtoPath: fileDescriptor.proto.protoPath, file: self, context: context))
+            extensions.append(ExtensionGenerator(descriptor: e, generatorOptions: generatorOptions, namer: namer))
         }
 
         for e in enums {

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -160,6 +160,7 @@ extension Google_Protobuf_FileDescriptorProto {
 class FileGenerator {
     private let fileDescriptor: FileDescriptor
     private let generatorOptions: GeneratorOptions
+    private let namer = SwiftProtobufNamer()
 
     var outputFilename: String {
         let ext = ".pb.swift"
@@ -183,7 +184,7 @@ class FileGenerator {
     }
 
     var protoPackageName: String {return fileDescriptor.package}
-    var swiftPrefix: String {return fileDescriptor.swiftTypePrefix}
+    var swiftPrefix: String {return namer.typePrefix(forFile: fileDescriptor)}
     var isProto3: Bool {return fileDescriptor.syntax == .proto3}
     private var isWellKnownType: Bool {return fileDescriptor.proto.isWellKnownType}
     private var baseFilename: String {return fileDescriptor.proto.baseFilename}
@@ -231,12 +232,12 @@ class FileGenerator {
         generateVersionCheck(printer: &p)
 
         let enums = fileDescriptor.enums.map {
-            return EnumGenerator(descriptor: $0, generatorOptions: generatorOptions)
+            return EnumGenerator(descriptor: $0, generatorOptions: generatorOptions, namer: namer)
         }
 
         var messages = [MessageGenerator]()
         for m in fileDescriptor.messages {
-            messages.append(MessageGenerator(descriptor: m, generatorOptions: generatorOptions, parentSwiftName: nil, parentProtoPath: fileDescriptor.proto.protoPath, file: self, context: context))
+          messages.append(MessageGenerator(descriptor: m, generatorOptions: generatorOptions, namer: namer, parentSwiftName: nil, parentProtoPath: fileDescriptor.proto.protoPath, file: self, context: context))
         }
 
         var extensions = [ExtensionGenerator]()

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -242,7 +242,7 @@ class FileGenerator {
 
         var extensions = [ExtensionGenerator]()
         for e in fileDescriptor.extensions {
-            extensions.append(ExtensionGenerator(descriptor: e, generatorOptions: generatorOptions, parentProtoPath: fileDescriptor.proto.protoPath, swiftDeclaringMessageName: nil, file: self, context: context))
+            extensions.append(ExtensionGenerator(descriptor: e, generatorOptions: generatorOptions, namer: namer, parentProtoPath: fileDescriptor.proto.protoPath, file: self, context: context))
         }
 
         for e in enums {

--- a/Sources/protoc-gen-swift/GeneratorOptions.swift
+++ b/Sources/protoc-gen-swift/GeneratorOptions.swift
@@ -24,14 +24,7 @@ class GeneratorOptions {
   let visibility: Visibility
 
   /// A string snippet to insert for the visibility
-  private(set) lazy var visibilitySourceSnippet: String = {
-    switch self.visibility {
-    case .Internal:
-      return ""
-    case .Public:
-      return "public "
-    }
-  }()
+  let visibilitySourceSnippet: String
 
   init(parameter: String?) throws {
     var outputNaming: OutputNaming = .FullPath
@@ -60,5 +53,13 @@ class GeneratorOptions {
 
     self.outputNaming = outputNaming
     self.visibility = visibility
+
+    switch visibility {
+    case .Internal:
+      visibilitySourceSnippet = ""
+    case .Public:
+      visibilitySourceSnippet = "public "
+    }
+
   }
 }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -84,7 +84,6 @@ class MessageGenerator {
     }
     self.fields = fields
     fieldsSortedByNumber = fields.sorted {$0.number < $1.number}
-    let sortedFieldNumbers = fieldsSortedByNumber.map { $0.number }
 
     var extensions = [ExtensionGenerator]()
     for e in descriptor.extensions {
@@ -99,7 +98,7 @@ class MessageGenerator {
         $0.descriptor.hasOneofIndex && $0.descriptor.oneofIndex == Int32(i)
       }
       i += 1
-      let oneof = OneofGenerator(descriptor: o, generatorOptions: generatorOptions, file: file, fields: oneofFields, swiftMessageFullName: swiftFullName, parentFieldNumbersSorted: sortedFieldNumbers, parentExtensionRanges: proto.extensionRange)
+      let oneof = OneofGenerator(descriptor: o, generatorOptions: generatorOptions, namer: namer, fields: oneofFields)
       oneofs.append(oneof)
     }
     self.oneofs = oneofs

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -88,7 +88,7 @@ class MessageGenerator {
 
     var extensions = [ExtensionGenerator]()
     for e in descriptor.extensions {
-      extensions.append(ExtensionGenerator(descriptor: e, generatorOptions: generatorOptions, parentProtoPath: protoFullName, swiftDeclaringMessageName: swiftFullName, file: file, context: context))
+      extensions.append(ExtensionGenerator(descriptor: e, generatorOptions: generatorOptions, namer: namer, parentProtoPath: protoFullName, file: file, context: context))
     }
     self.extensions = extensions
 

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -78,18 +78,14 @@ class MessageGenerator {
     }
     self.swiftMessageConformance = conformance.joined(separator: ", ")
 
-    var fields = [MessageFieldGenerator]()
-    for f in descriptor.fields {
-      fields.append(MessageFieldGenerator(descriptor: f, generatorOptions: generatorOptions, messageDescriptor: proto, file: file, context: context))
+    fields = descriptor.fields.map {
+      return MessageFieldGenerator(descriptor: $0, generatorOptions: generatorOptions, messageDescriptor: proto, file: file, context: context)
     }
-    self.fields = fields
     fieldsSortedByNumber = fields.sorted {$0.number < $1.number}
 
-    var extensions = [ExtensionGenerator]()
-    for e in descriptor.extensions {
-      extensions.append(ExtensionGenerator(descriptor: e, generatorOptions: generatorOptions, namer: namer, parentProtoPath: protoFullName, file: file, context: context))
+    extensions = descriptor.extensions.map {
+      return ExtensionGenerator(descriptor: $0, generatorOptions: generatorOptions, namer: namer)
     }
-    self.extensions = extensions
 
     var i: Int32 = 0
     var oneofs = [OneofGenerator]()

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -121,20 +121,14 @@ class MessageGenerator {
       hasMessageField(descriptor: descriptor.proto, context: context)
     if isAnyMessage {
       self.storage = AnyMessageStorageClassGenerator(
-        descriptor: proto,
+        descriptor: descriptor,
         fields: fields,
-        oneofs: oneofs,
-        file: file,
-        messageSwiftName: swiftFullName,
-        context: context)
+        oneofs: oneofs)
     } else if useHeapStorage {
       self.storage = MessageStorageClassGenerator(
-        descriptor: proto,
+        descriptor: descriptor,
         fields: fields,
-        oneofs: oneofs,
-        file: file,
-        messageSwiftName: swiftFullName,
-        context: context)
+        oneofs: oneofs)
     } else {
         self.storage = nil
     }

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -21,6 +21,7 @@ import SwiftProtobuf
 class MessageGenerator {
   private let descriptor: Descriptor
   private let generatorOptions: GeneratorOptions
+  private let namer: SwiftProtobufNamer
   private let context: Context
   private let visibility: String
   private let protoFullName: String
@@ -43,6 +44,7 @@ class MessageGenerator {
   init(
     descriptor: Descriptor,
     generatorOptions: GeneratorOptions,
+    namer: SwiftProtobufNamer,
     parentSwiftName: String?,
     parentProtoPath: String?,
     file: FileGenerator,
@@ -50,6 +52,7 @@ class MessageGenerator {
   ) {
     self.descriptor = descriptor
     self.generatorOptions = generatorOptions
+    self.namer = namer
 
     let proto = descriptor.proto
     self.protoMessageName = proto.name
@@ -102,12 +105,12 @@ class MessageGenerator {
     self.oneofs = oneofs
 
     self.enums = descriptor.enums.map {
-      return EnumGenerator(descriptor: $0, generatorOptions: generatorOptions)
+      return EnumGenerator(descriptor: $0, generatorOptions: generatorOptions, namer: namer)
     }
 
     var messages = [MessageGenerator]()
     for m in descriptor.messages where !m.isMapEntry {
-      messages.append(MessageGenerator(descriptor: m, generatorOptions: generatorOptions, parentSwiftName: swiftFullName, parentProtoPath: protoFullName, file: file, context: context))
+      messages.append(MessageGenerator(descriptor: m, generatorOptions: generatorOptions, namer: namer, parentSwiftName: swiftFullName, parentProtoPath: protoFullName, file: file, context: context))
     }
     self.messages = messages
 

--- a/Sources/protoc-gen-swift/MessageStorageClassGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageStorageClassGenerator.swift
@@ -20,25 +20,18 @@ import SwiftProtobuf
 /// Generates the `_StorageClass` used for messages that employ copy-on-write
 /// logic for some of their fields.
 class MessageStorageClassGenerator {
+  private let descriptor: Descriptor
   private let fields: [MessageFieldGenerator]
   private let oneofs: [OneofGenerator]
-  private let descriptor: Google_Protobuf_DescriptorProto
-  private let messageSwiftName: String
-  private let context: Context
 
   /// Creates a new `MessageStorageClassGenerator`.
-  init(descriptor: Google_Protobuf_DescriptorProto,
+  init(descriptor: Descriptor,
        fields: [MessageFieldGenerator],
-       oneofs: [OneofGenerator],
-       file: FileGenerator,
-       messageSwiftName: String,
-       context: Context
-  ) {
+       oneofs: [OneofGenerator]
+    ) {
     self.descriptor = descriptor
     self.fields = fields
     self.oneofs = oneofs
-    self.messageSwiftName = messageSwiftName
-    self.context = context
   }
 
   /// Visibility of the storage within the Message.
@@ -84,8 +77,8 @@ class MessageStorageClassGenerator {
       if f.descriptor.hasOneofIndex {
         let oneofIndex = f.descriptor.oneofIndex
         if !oneofsHandled.contains(oneofIndex) {
-          let oneof = f.oneof!
-          p.print("var \(oneof.swiftStorageFieldName): \(messageSwiftName).\(oneof.swiftRelativeType)?\n")
+          let oneofFullName = oneofs[Int(oneofIndex)].swiftFullName
+          p.print("var \(f.oneof!.swiftStorageFieldName): \(oneofFullName)?\n")
           oneofsHandled.insert(oneofIndex)
         }
       } else {

--- a/Sources/protoc-gen-swift/StringUtils.swift
+++ b/Sources/protoc-gen-swift/StringUtils.swift
@@ -196,6 +196,9 @@ func trimWhitespace(_ s: String) -> String {
 /// Fortunately, it uses only a limited subset of the C escapse:
 ///  \n\r\t\\\'\" and three-digit octal escapes but nothing else.
 func escapedToDataLiteral(_ s: String) -> String {
+  if s.isEmpty {
+    return "SwiftProtobuf.Internal.emptyData"
+  }
   var out = "Data(bytes: ["
   var separator = ""
   var escape = false


### PR DESCRIPTION
Revisit the idea of exposing Swift specific info in the Descriptors and instead put it in a Namer helper.  This will simplify support for generated protos coming from modules and depending on each other (#294).

Fully migrate the ExtensionGenerator off of the protos and onto the Descriptors.
