### PR TITLE
Update isInitialized checks to use descriptors.

### DIFF
--- a/Sources/PluginLibrary/Descriptor.swift
+++ b/Sources/PluginLibrary/Descriptor.swift
@@ -405,7 +405,7 @@ public final class FieldDescriptor {
     }
 
     switch type {
-    case .message, .group:
+    case .group, .message:
       messageType = registry.descriptor(name: proto.typeName)
     case .enum:
       enumType = registry.enumDescriptor(name: proto.typeName)


### PR DESCRIPTION
- Move helper to see if a message has required fields over to the descriptor.
- Use the fullName in the set for what was tracked to simplify things.
- Be more consistent to use .group then .message in checking both in a switch case.