### PR TITLE
Swap the use of IndexPath for a custom Hashable array.

### DIFF
--- a/Sources/PluginLibrary/Descriptor+Extensions.swift
+++ b/Sources/PluginLibrary/Descriptor+Extensions.swift
@@ -14,52 +14,52 @@ import SwiftProtobuf
 extension FileDescriptor: ProvidesSourceCodeLocation {
   public var sourceCodeInfoLocation: Google_Protobuf_SourceCodeInfo.Location? {
     // google/protobuf's descriptor.cc says it should be an empty path.
-    return sourceCodeInfoLocation(path: IndexPath())
+    return sourceCodeInfoLocation(path: [])
   }
 }
 
 extension Descriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  public func getLocationPath(path: inout IndexPath) {
+  public func getLocationPath(path: inout [Int32]) {
     if let containingType = containingType {
       containingType.getLocationPath(path: &path)
       path.append(Google_Protobuf_DescriptorProto.FieldNumbers.nestedType)
     } else {
       path.append(Google_Protobuf_FileDescriptorProto.FieldNumbers.messageType)
     }
-    path.append(index)
+    path.append(Int32(index))
   }
 }
 
 extension EnumDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  public func getLocationPath(path: inout IndexPath) {
+  public func getLocationPath(path: inout [Int32]) {
     if let containingType = containingType {
       containingType.getLocationPath(path: &path)
       path.append(Google_Protobuf_DescriptorProto.FieldNumbers.enumType)
     } else {
       path.append(Google_Protobuf_FileDescriptorProto.FieldNumbers.enumType)
     }
-    path.append(index)
+    path.append(Int32(index))
   }
 }
 
 extension EnumValueDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  public func getLocationPath(path: inout IndexPath) {
+  public func getLocationPath(path: inout [Int32]) {
     enumType.getLocationPath(path: &path)
     path.append(Google_Protobuf_EnumDescriptorProto.FieldNumbers.value)
-    path.append(index)
+    path.append(Int32(index))
   }
 }
 
 extension OneofDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  public func getLocationPath(path: inout IndexPath) {
+  public func getLocationPath(path: inout [Int32]) {
     containingType.getLocationPath(path: &path)
     path.append(Google_Protobuf_DescriptorProto.FieldNumbers.oneofDecl)
-    path.append(index)
+    path.append(Int32(index))
   }
 }
 
 extension FieldDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  public func getLocationPath(path: inout IndexPath) {
+  public func getLocationPath(path: inout [Int32]) {
     if isExtension {
       if let extensionScope = extensionScope {
         extensionScope.getLocationPath(path: &path)
@@ -71,7 +71,7 @@ extension FieldDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
       containingType.getLocationPath(path: &path)
       path.append(Google_Protobuf_DescriptorProto.FieldNumbers.field)
     }
-    path.append(index)
+    path.append(Int32(index))
   }
 
   /// Helper to return the name to as the "base" for naming of generated fields.
@@ -85,16 +85,16 @@ extension FieldDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
 }
 
 extension ServiceDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  public func getLocationPath(path: inout IndexPath) {
+  public func getLocationPath(path: inout [Int32]) {
     path.append(Google_Protobuf_FileDescriptorProto.FieldNumbers.service)
-    path.append(index)
+    path.append(Int32(index))
   }
 }
 
 extension MethodDescriptor: ProvidesLocationPath, ProvidesSourceCodeLocation {
-  public func getLocationPath(path: inout IndexPath) {
+  public func getLocationPath(path: inout [Int32]) {
     service.getLocationPath(path: &path)
     path.append(Google_Protobuf_ServiceDescriptorProto.FieldNumbers.method)
-    path.append(index)
+    path.append(Int32(index))
   }
 }

--- a/Sources/PluginLibrary/Descriptor.swift
+++ b/Sources/PluginLibrary/Descriptor.swift
@@ -127,8 +127,8 @@ public final class FileDescriptor {
     self.services.forEach { $0.bind(file: self, registry: registry) }
   }
 
-  public func sourceCodeInfoLocation(path: IndexPath) -> Google_Protobuf_SourceCodeInfo.Location? {
-    guard let location = locationMap[path] else {
+  public func sourceCodeInfoLocation(path: [Int32]) -> Google_Protobuf_SourceCodeInfo.Location? {
+    guard let location = locationMap[HashableArray(path)] else {
       return nil
     }
     return location
@@ -136,11 +136,13 @@ public final class FileDescriptor {
 
   // Lazy so this can be computed on demand, as the imported files won't need
   // comments during generation.
-  private lazy var locationMap: [IndexPath:Google_Protobuf_SourceCodeInfo.Location] = {
-    var result: [IndexPath:Google_Protobuf_SourceCodeInfo.Location] = [:]
+  private lazy var locationMap: [HashableArray<Int32>:Google_Protobuf_SourceCodeInfo.Location] = {
+    // IndexPath should work as the key here instead of our custom class; but as of May 2017,
+    // the build on linux was failing to find source comment, and it seem trace back
+    // problems in that implementation of IndexSet.
+    var result: [HashableArray<Int32>:Google_Protobuf_SourceCodeInfo.Location] = [:]
     for loc in self.proto.sourceCodeInfo.location {
-      let intList = loc.path.map { return Int($0) }
-      result[IndexPath(indexes: intList)] = loc
+      result[HashableArray(loc.path)] = loc
     }
     return result
   }()

--- a/Sources/PluginLibrary/FieldNumbers.swift
+++ b/Sources/PluginLibrary/FieldNumbers.swift
@@ -16,31 +16,31 @@ import Foundation
 
 extension Google_Protobuf_FileDescriptorProto {
   struct FieldNumbers {
-    static let messageType: Int = 4
-    static let enumType: Int = 5
-    static let service: Int = 6
-    static let `extension`: Int = 7
+    static let messageType: Int32 = 4
+    static let enumType: Int32 = 5
+    static let service: Int32 = 6
+    static let `extension`: Int32 = 7
   }
 }
 
 extension Google_Protobuf_DescriptorProto {
   struct FieldNumbers {
-    static let field: Int = 2
-    static let nestedType: Int = 3
-    static let enumType: Int = 4
-    static let `extension`: Int = 6
-    static let oneofDecl: Int = 8
+    static let field: Int32 = 2
+    static let nestedType: Int32 = 3
+    static let enumType: Int32 = 4
+    static let `extension`: Int32 = 6
+    static let oneofDecl: Int32 = 8
   }
 }
 
 extension Google_Protobuf_EnumDescriptorProto {
   struct FieldNumbers {
-    static let value: Int = 2
+    static let value: Int32 = 2
   }
 }
 
 extension Google_Protobuf_ServiceDescriptorProto {
   struct FieldNumbers {
-    static let method: Int = 2
+    static let method: Int32 = 2
   }
 }

--- a/Sources/PluginLibrary/HashableArray.swift
+++ b/Sources/PluginLibrary/HashableArray.swift
@@ -1,0 +1,27 @@
+// Sources/PluginLibrary/HashableArray.swift - Wrapper array to support hashing
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+
+/// Helper type to use an array as a dictionary key.
+struct HashableArray<T: Hashable>: Hashable {
+  let array: [T]
+  let hashValue: Int
+
+  init(_ array: [T]) {
+    self.array = array
+    var hash = Int(bitPattern: 2166136261)
+    for i in array {
+      hash = (hash &* Int(16777619)) ^ i.hashValue
+    }
+    hashValue = hash
+  }
+  static func ==(lhs: HashableArray<T>, rhs: HashableArray<T>) -> Bool {
+    return lhs.hashValue == rhs.hashValue && lhs.array == rhs.array
+  }
+}

--- a/Sources/PluginLibrary/ProvidesLocationPath.swift
+++ b/Sources/PluginLibrary/ProvidesLocationPath.swift
@@ -11,6 +11,6 @@
 import Foundation
 
 public protocol ProvidesLocationPath {
-  func getLocationPath(path: inout IndexPath)
+  func getLocationPath(path: inout [Int32])
   weak var file: FileDescriptor! { get }
 }

--- a/Sources/PluginLibrary/ProvidesSourceCodeLocation.swift
+++ b/Sources/PluginLibrary/ProvidesSourceCodeLocation.swift
@@ -17,7 +17,7 @@ public protocol ProvidesSourceCodeLocation {
 // Default implementation for things that support ProvidesLocationPath.
 extension ProvidesSourceCodeLocation where Self: ProvidesLocationPath {
   public var sourceCodeInfoLocation: Google_Protobuf_SourceCodeInfo.Location? {
-    var path = IndexPath()
+    var path = [Int32]()
     getLocationPath(path: &path)
     return file.sourceCodeInfoLocation(path: path)
   }

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -195,7 +195,7 @@ class FileGenerator {
         // the file is an empty path. That never seems to have comments on it.
         // https://github.com/google/protobuf/issues/2249 opened to figure out
         // the right way to do this since the syntax entry is optional.
-        let syntaxPath = IndexPath(index: Google_Protobuf_FileDescriptorProto.FieldNumbers.syntax)
+        let syntaxPath = [Google_Protobuf_FileDescriptorProto.FieldNumbers.syntax]
         if let syntaxLocation = fileDescriptor.sourceCodeInfoLocation(path: syntaxPath) {
           let comments = syntaxLocation.asSourceComment(commentPrefix: "///",
                                                         leadingDetachedPrefix: "//")

--- a/Sources/protoc-gen-swift/Google_Protobuf_FileDescriptorProto+Extensions.swift
+++ b/Sources/protoc-gen-swift/Google_Protobuf_FileDescriptorProto+Extensions.swift
@@ -19,6 +19,6 @@ import SwiftProtobuf
 extension Google_Protobuf_FileDescriptorProto {
   // Field numbers used to collect .proto file comments.
   struct FieldNumbers {
-    static let syntax: Int = 12
+    static let syntax: Int32 = 12
   }
 }


### PR DESCRIPTION
Using IndexPath as the Dictionary key seems to result no comments being
found for when generating on Linux. Use a custom class with out own hash
to avoid that.

Basically a revert of commit eaafacea5ab521f1f27bbe852d37fbe6f5f7de4d.

Fixes https://github.com/apple/swift-protobuf/issues/513