### PR TITLE
Update conformance and plugin documentation

### DIFF
--- a/Documentation/CONFORMANCE_TESTS.md
+++ b/Documentation/CONFORMANCE_TESTS.md
@@ -8,37 +8,61 @@ SwiftProtobuf currently passes Google's entire conformance test suite.
 We have integrated the conformance test with the SwiftProtobuf test
 suite to help ensure that we remain conformant in the future as well.
 
+If you have Google's protobuf source code on your system, then a
+simple environment variable setting will run the conformance test
+as part of every `make test.`
+We strongly recommend anyone making changes to SwiftProtobuf run
+these tests regularly.
+
 ## Preparation
 
-The conformance test suite requires Swift 3.0, standard command-line tools such as make and awk, and a full source checkout of [Google's protobuf project](https://github.com/google/protobuf).
+The conformance test suite requires Swift 3.0, standard command-line
+tools such as make and awk, and a full source checkout of
+[Google's protobuf project](https://github.com/google/protobuf).
 
-## Building the Tests
+The Makefile assumes by default that the protobuf project
+is checked out in an adjacent directory.
+If this is not true, you should set the `GOOGLE_PROTOBUF_CHECKOUT`
+environment variable to the full path of the protobuf checkout.
 
-The `Makefile` at the root of the SwiftProtobuf project has the following lines, which
-specify how to run the installed `protoc` program on your system, and where to find
-the Google protobuf source tree:
-```Makefile
-PROTOC=protoc
-GOOGLE_PROTOBUF_CHECKOUT=../protobuf
+## Running the Tests
+
+If the Makefile can find the protobuf project sources, then
+the following should suffice:
+```console
+$ make test
 ```
+This will build and run the SwiftProtobuf test suite,
+verify the code generator, and finally run the conformance tests.
 
-If these do not match your system, you can run `make PROTOC=[path] GOOGLE_PROTOBUF_CHECKOUT=[path] [target]`,
-or edit the `Makefile` directly if you prefer.
-
-After setting these variables, you can type:
+You can also run the conformance tests by themselves:
 ```console
 $ make test-conformance
 ```
 
-which will build Google's conformance host program (which manages the
-conformance test process) and the Swift Protobuf conformance checker
-(which executes the individual test cases).
+## Test Environment
 
-It will then run the test suite and print out any discrepancies found by the tool.
+The `Makefile` at the root of the SwiftProtobuf project has the
+following lines, which specify how to run the installed `protoc`
+program on your system, and where to find the Google protobuf source
+tree:
+```Makefile
+PROTOC=protoc
+GOOGLE_PROTOBUF_CHECKOUT?=../protobuf
+```
+
+If these do not match your system, you can specify one or both
+on the command line
+```
+$ make PROTOC=[path] GOOGLE_PROTOBUF_CHECKOUT=[path] test
+```
 
 ## If you have problems
 
-The most common problem area is building Google's conformance host program.  You may find it easier to switch to the directory where you have checked out Google's protobuf sources and build the host program manually:
+The most common problem area is building Google's conformance host
+program.  You may find it easier to switch to the directory where you
+have checked out Google's protobuf sources and build the host program
+manually:
 ```console
 $ cd protobuf
 $ ./configure
@@ -58,7 +82,10 @@ At this writing, all of the conformance tests succeed.
 
 ## Report any issues
 
-If the conformance test prints out any "unexpected failures", please look in the Github Issues to see if the problem you're seeing was already reported.  If not, please send us a detailed report, including:
+If the conformance test prints out any "unexpected failures", please
+look in the Github Issues to see if the problem you're seeing was
+already reported.  If not, please send us a detailed report,
+including:
 * The specific operating system and version (for example, "macOS 10.12.1" or "Ubuntu 15.10")
 * The version of Swift you have installed (from `swift --version`)
 * The version of the protobuf source code you are working with (look at the AC_INIT line near the top of configure.ac)

--- a/Documentation/PLUGIN.md
+++ b/Documentation/PLUGIN.md
@@ -8,24 +8,24 @@ Swift code.
 
 ## Getting Started
 
-If you've worked with Protocol Buffers before, adding Swift support is very
-simple:  you just need to build the `protoc-gen-swift` program and copy it into
-any directory in your PATH.  The protoc program will find and use it automatically, allowing you
-to build Swift sources for your proto files.  You will also, of course, need to
-add the corresponding Swift runtime library to your project.
+If you've worked with Protocol Buffers before, adding Swift support is
+very simple: you just need to build the `protoc-gen-swift` program and
+copy it into any directory in your PATH.  The protoc program will find
+and use it automatically, allowing you to build Swift sources for your
+proto files.  You will also, of course, need to add the corresponding
+Swift runtime library to your project.
 
 ### System Requirements
 
 To use Swift with Protocol buffers, you'll need:
 
-* A recent Swift 3 compiler that includes the Swift Package Manager.  The Swift
-protobuf project is being developed and tested against the Swift 3.0 developer
-preview available from [Swift.org](https://swift.org)
+* A recent Swift 3 compiler that includes the Swift Package Manager.
+  We recommend using the latest release build from
+  [Swift.org](https://swift.org) or the command-line tools included
+  with the latest version of Xcode.
 
-* Google's protoc compiler.  The Swift protoc plugin is being actively
-developed and tested against the protobuf 3.0 release.  It may work with earlier
-versions of protoc.  You can get recent versions from
-[Google's github repository](https://github.com/google/protobuf).
+* Google's protoc compiler.  You can get recent versions from
+  [Google's github repository](https://github.com/google/protobuf).
 
 ### Build and Install
 
@@ -37,13 +37,14 @@ $ cd swift-protobuf
 $ swift build
 ```
 
-This will create a binary called `protoc-gen-swift` in the `.build/debug`
-directory.  To install, just copy this one executable anywhere in your PATH.
+This will create a binary called `protoc-gen-swift` in the
+`.build/debug` directory.  To install, just copy this one executable
+anywhere in your PATH.
 
 ### Converting .proto files into Swift
 
-To generate Swift output for your .proto files, you run the `protoc` command as
-usual, using the `--swift_out=<directory>` option:
+To generate Swift output for your .proto files, you run the `protoc`
+command as usual, using the `--swift_out=<directory>` option:
 
 ```
 $ protoc --swift_out=. my.proto
@@ -55,22 +56,20 @@ The `protoc` program will automatically look for `protoc-gen-swift` in your
 Each `.proto` input file will get translated to a corresponding `.pb.swift` file
 in the output directory.
 
-#### Changing how Source is Generated
+#### How to Specify Code-Generation Options
 
-The plugin tries to use reasonable default behaviors for the code it generates,
-but there are a few things that can be configured to specific needs.
+The plugin tries to use reasonable default behaviors for the code it
+generates, but there are a few things that can be configured to
+specific needs.
 
-`protoc` supports passing generator options to the plugins, and the Swift plugin
-uses these to communicate changes from the default behaviors.
-
-The options are given with a `--swift_opt` argument like this:
-
+You can use the `--swift_opt` argument to `protoc` to pass options to the
+Swift code generator as follows:
 ```
 $ protoc --swift_opt=[NAME]=[VALUE] --swift_out:. foo/bar/*.proto mumble/*.proto
 ```
 
-And more than one _NAME/VALUE_ pair can be passed by using the argument multiple times:
-
+If you need to specify multiple options, you can use more than one
+`--swift_opt` argument:
 ```
 $ protoc \
     --swift_opt=[NAME1]=[VALUE1] \
@@ -86,10 +85,11 @@ using protoc 3.2.1 or later, then this workaround is _not_ needed.
 
 ##### Generation Option: `FileNaming` - Naming of Generated Sources
 
-By default, the paths to the proto files are maintained on the generated files.
-So if you pass `foo/bar/my.proto`, you will get `foo/bar/my.pb.swift` in the
-output directory. The Swift plugin supports an option to control the generated
-file names, the option is given as part of the `--swift_out` argument like this:
+By default, the paths to the proto files are maintained on the
+generated files.  So if you pass `foo/bar/my.proto`, you will get
+`foo/bar/my.pb.swift` in the output directory. The Swift plugin
+supports an option to control the generated file names, the option is
+given as part of the `--swift_out` argument like this:
 
 ```
 $ protoc --swift_opt=FileNaming=[value]: --swift_out=. foo/bar/*.proto mumble/*.proto
@@ -97,19 +97,20 @@ $ protoc --swift_opt=FileNaming=[value]: --swift_out=. foo/bar/*.proto mumble/*.
 
 The possible values for `FileNaming` are:
 
- * `FullPath` (default): Like all other languages, "foo/bar/baz.proto" makes
-   "foo/bar/baz.pb.swift.
- * `PathToUnderscores`: To help with things like the Swift Package Manager
-   where someone might want all the files in one directory; "foo/bar/baz.proto"
-   makes "foo_bar_baz.pb.swift".
- * `DropPath`: Drop the path from the input and just write all files into the
-   output directory; "foo/bar/baz.proto" makes "baz.pb.swift".
+* `FullPath` (default): Like all other languages, "foo/bar/baz.proto" makes
+  "foo/bar/baz.pb.swift.
+* `PathToUnderscores`: To help with things like the Swift Package
+  Manager where someone might want all the files in one directory;
+  "foo/bar/baz.proto" makes "foo_bar_baz.pb.swift".
+* `DropPath`: Drop the path from the input and just write all files
+  into the output directory; "foo/bar/baz.proto" makes "baz.pb.swift".
 
 ##### Generation Option: `Visibility` - Visibility of Generated Types
 
-By default, the types created in the generated source will end up as internal
-because no visibility is set on them.  If you want the types to be made public
-the option can be given as:
+By default, SwiftProtobuf does not specify a visibility for the
+generated types, methods, and properties.  As a result, these will end
+up with the default (`internal`) access.  You can change this with the
+`Visibility` option:
 
 ```
 $ protoc --swift_opt=Visibility=[value] --swift_out=. foo/bar/*.proto mumble/*.proto
@@ -117,29 +118,32 @@ $ protoc --swift_opt=Visibility=[value] --swift_out=. foo/bar/*.proto mumble/*.p
 
 The possible values for `Visibility` are:
 
- * `Internal` (default): No visibility is set for the types, so they get the
-   default internal visibility.
- * `Public`: The visibility on the types is set to `public` so the types will
-   be exposed outside the module they are compiled into.
+* `Internal` (default): No visibility is set for the types, so they get the
+  default internal visibility.
+* `Public`: The visibility on the types is set to `public` so the types will
+  be exposed outside the module they are compiled into.
 
 ### Building your project
 
-After copying the `.pb.swift` files into your project, you will need to add the
-[SwiftProtobuf library](https://github.com/apple/swift-protobuf) to your project
-to support the generated code.  If you are using the Swift Package Manager, you
-should first check what version of `protoc-gen-swift` you are currently using:
+After copying the `.pb.swift` files into your project, you will need
+to add the
+[SwiftProtobuf library](https://github.com/apple/swift-protobuf) to
+your project to support the generated code.  If you are using the
+Swift Package Manager, you should first check what version of
+`protoc-gen-swift` you are currently using:
 
 ```
 $ protoc-gen-swift --version
-protoc-gen-swift 0.9.12
+protoc-gen-swift 1.0.1
 ```
 
-And then add a dependency to your Package.swift file.  Adjust the `Version()`
-here to match the `protoc-gen-swift` version you checked above:
+And then add a dependency to your Package.swift file.  Adjust the
+`Version()` here to match the `protoc-gen-swift` version you checked
+above:
 
 ```swift
 dependencies: [
-        .Package(url: "https://github.com/apple/swift-protobuf.git", Version(0,9,12))
+        .Package(url: "https://github.com/apple/swift-protobuf.git", Version(1,0,1))
 ]
 ```
 


### PR DESCRIPTION
Another pass over the Conformance check and Plugin documents.

This is mostly just wordsmithing and reformatting.

The only substantial change is to restructure the Conformance testing discussion to encourage people to just use the `make test` target (which now runs conformance).
