### PR TITLE
Add a generic FieldGenerator interface and move Oneof items to it.

### DIFF
--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -429,10 +429,12 @@ struct Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftProt
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 113)
     }
     try self.oConflictField?.traverse(visitor: &visitor, start: 126, end: 127)
+    try self.oConflictExtensionsStart?.traverse(visitor: &visitor, start: 201, end: 202)
     try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 202, end: 203)
-    try self.oConflictExtensionsStart?.traverse(visitor: &visitor, start: 201, end: 227)
+    try self.oConflictExtensionsStart?.traverse(visitor: &visitor, start: 226, end: 227)
+    try self.oConflictExtensionsEnd?.traverse(visitor: &visitor, start: 301, end: 302)
     try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 325, end: 326)
-    try self.oConflictExtensionsEnd?.traverse(visitor: &visitor, start: 301, end: 327)
+    try self.oConflictExtensionsEnd?.traverse(visitor: &visitor, start: 326, end: 327)
     try unknownFields.traverse(visitor: &visitor)
   }
 

--- a/Sources/PluginLibrary/Descriptor.swift
+++ b/Sources/PluginLibrary/Descriptor.swift
@@ -344,6 +344,11 @@ public final class FieldDescriptor {
     return "\(prefix).\(proto.name)"
   }
 
+  public var jsonName: String? {
+    guard proto.hasJsonName else { return nil }
+    return proto.jsonName
+  }
+
   /// The default value (string) set in the proto file.
   public var explicitDefaultValue: String? {
     if !proto.hasDefaultValue {

--- a/Sources/protoc-gen-swift/Descriptor+Extensions.swift
+++ b/Sources/protoc-gen-swift/Descriptor+Extensions.swift
@@ -157,6 +157,31 @@ extension FieldDescriptor {
     return result
   }
 
+  var protoGenericType: String {
+    precondition(!isMap)
+
+    switch type {
+    case .double: return "Double"
+    case .float: return "Float"
+    case .int64: return "Int64"
+    case .uint64: return "UInt64"
+    case .int32: return "Int32"
+    case .fixed64: return "Fixed64"
+    case .fixed32: return "Fixed32"
+    case .bool: return "Bool"
+    case .string: return "String"
+    case .group: return "Group"
+    case .message: return "Message"
+    case .bytes: return "Bytes"
+    case .uint32: return "UInt32"
+    case .enum: return "Enum"
+    case .sfixed32: return "SFixed32"
+    case .sfixed64: return "SFixed64"
+    case .sint32: return "SInt32"
+    case .sint64: return "SInt64"
+    }
+  }
+
   func swiftDefaultValue(namer: SwiftProtobufNamer) -> String {
     if isMap {
       return "[:]"

--- a/Sources/protoc-gen-swift/ExtensionGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionGenerator.swift
@@ -18,7 +18,7 @@ import Foundation
 import PluginLibrary
 import SwiftProtobuf
 
-struct ExtensionGenerator {
+class ExtensionGenerator {
     private let fieldDescriptor: FieldDescriptor
     private let generatorOptions: GeneratorOptions
     private let namer: SwiftProtobufNamer

--- a/Sources/protoc-gen-swift/FieldGenerator.swift
+++ b/Sources/protoc-gen-swift/FieldGenerator.swift
@@ -1,0 +1,117 @@
+// Sources/protoc-gen-swift/FieldGenerator.swift - Base class for Field Generators
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See LICENSE.txt for license information:
+// https://github.com/apple/swift-protobuf/blob/master/LICENSE.txt
+//
+// -----------------------------------------------------------------------------
+///
+/// Code generation for the private storage class used inside copy-on-write
+/// messages.
+///
+// -----------------------------------------------------------------------------
+
+import Foundation
+import PluginLibrary
+import SwiftProtobuf
+
+
+/// Interface for field generators.
+protocol FieldGenerator {
+  var number: Int { get }
+
+  /// Name mapping entry for the field.
+  var fieldMapNames: String { get }
+
+  /// Generate the interface for this field, this is includes any extra methods (has/clear).
+  func generateInterface(printer: inout CodePrinter)
+
+  /// Generate any additional storage needed for this field.
+  func generateStorage(printer: inout CodePrinter)
+
+  /// Generate the line to copy this field during a _StorageClass clone.
+  func generateStorageClassClone(printer: inout CodePrinter)
+
+  /// Generate the case and decoder invoke needed for this field.
+  func generateDecodeFieldCase(printer: inout CodePrinter)
+
+  /// Generate the support for traversing this field.
+  func generateTraverse(printer: inout CodePrinter)
+
+  /// Generate support for comparing this field's value.
+  /// The generated code should return false in the current scope if the field's don't match.
+  func generateFieldComparison(printer: inout CodePrinter)
+
+  /// Generate any support needed to ensure required fields are set.
+  /// The generated code should return false the field isn't set.
+  func generateRequiredFieldCheck(printer: inout CodePrinter)
+
+  /// Generate any support needed to this field's value is initialized.
+  /// The generated code should return false if it isn't set.
+  func generateIsInitializedCheck(printer: inout CodePrinter)
+}
+
+/// Simple base class for FieldGenerators that also provides fieldMapNames.
+class FieldGeneratorBase {
+  let number: Int
+  let fieldDescriptor: FieldDescriptor
+
+  var fieldMapNames: String {
+    // Protobuf Text uses the unqualified group name for the field
+    // name instead of the field name provided by protoc.  As far
+    // as I can tell, no one uses the fieldname provided by protoc,
+    // so let's just put the field name that Protobuf Text
+    // actually uses here.
+    let protoName: String
+    if fieldDescriptor.type == .group {
+      protoName = fieldDescriptor.messageType.name
+    } else {
+      protoName = fieldDescriptor.name
+    }
+
+    let jsonName = fieldDescriptor.jsonName ?? protoName
+    if jsonName == protoName {
+      /// The proto and JSON names are identical:
+      return ".same(proto: \"\(protoName)\")"
+    } else {
+      let libraryGeneratedJsonName = toJsonFieldName(protoName)
+      if jsonName == libraryGeneratedJsonName {
+        /// The library will generate the same thing protoc gave, so
+        /// we can let the library recompute this:
+        return ".standard(proto: \"\(protoName)\")"
+      } else {
+        /// The library's generation didn't match, so specify this explicitly.
+        return ".unique(proto: \"\(protoName)\", json: \"\(jsonName)\")"
+      }
+    }
+  }
+
+  init(descriptor: FieldDescriptor) {
+    precondition(!descriptor.isExtension)
+    number = Int(descriptor.number)
+    fieldDescriptor = descriptor
+  }
+}
+
+/// This must be exactly the same as the corresponding code in the
+/// SwiftProtobuf library.  Changing it will break compatibility of
+/// the generated code with old library version.
+///
+private func toJsonFieldName(_ s: String) -> String {
+  var result = ""
+  var capitalizeNext = false
+
+  for c in s.characters {
+    if c == "_" {
+      capitalizeNext = true
+    } else if capitalizeNext {
+      result.append(String(c).uppercased())
+      capitalizeNext = false
+    } else {
+      result.append(String(c))
+    }
+  }
+  return result;
+}

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -429,10 +429,12 @@ struct Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftProt
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 113)
     }
     try self.oConflictField?.traverse(visitor: &visitor, start: 126, end: 127)
+    try self.oConflictExtensionsStart?.traverse(visitor: &visitor, start: 201, end: 202)
     try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 202, end: 203)
-    try self.oConflictExtensionsStart?.traverse(visitor: &visitor, start: 201, end: 227)
+    try self.oConflictExtensionsStart?.traverse(visitor: &visitor, start: 226, end: 227)
+    try self.oConflictExtensionsEnd?.traverse(visitor: &visitor, start: 301, end: 302)
     try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 325, end: 326)
-    try self.oConflictExtensionsEnd?.traverse(visitor: &visitor, start: 301, end: 327)
+    try self.oConflictExtensionsEnd?.traverse(visitor: &visitor, start: 326, end: 327)
     try unknownFields.traverse(visitor: &visitor)
   }
 


### PR DESCRIPTION
- Add FieldGenerator for a interface for field generation.
- Add FieldGeneratorBase for some common things.
- Move MessageGenerator and MessageStorageClassGenerator over to using
  the FieldGenerator protocol.
- Add a custom impl of FieldGenerator within OneofGenerator so it can
  forward all work to the OneofGenerator and provide basic caching of
  computed values.
- Overhaul Oneof generation in terms of the new classes.
- Remove the oneof field support from MessageFieldGenerator.