### PR TITLE
Revisit enum name stemming.

### DIFF
--- a/Reference/google/protobuf/unittest_import_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_import_proto3.pb.swift
@@ -57,19 +57,19 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 enum Proto3ImportEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
-  case importEnumUnspecified // = 0
+  case unspecified // = 0
   case importFoo // = 7
   case importBar // = 8
   case importBaz // = 9
   case UNRECOGNIZED(Int)
 
   init() {
-    self = .importEnumUnspecified
+    self = .unspecified
   }
 
   init?(rawValue: Int) {
     switch rawValue {
-    case 0: self = .importEnumUnspecified
+    case 0: self = .unspecified
     case 7: self = .importFoo
     case 8: self = .importBar
     case 9: self = .importBaz
@@ -79,7 +79,7 @@ enum Proto3ImportEnum: SwiftProtobuf.Enum {
 
   var rawValue: Int {
     switch self {
-    case .importEnumUnspecified: return 0
+    case .unspecified: return 0
     case .importFoo: return 7
     case .importBar: return 8
     case .importBaz: return 9

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -92,7 +92,7 @@ enum Proto3ForeignEnum: SwiftProtobuf.Enum {
 /// Test an enum that has multiple values with the same number.
 enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum {
   typealias RawValue = Int
-  case testEnumWithDupValueUnspecified // = 0
+  case unspecified // = 0
   case foo1 // = 1
   case bar1 // = 2
   case baz // = 3
@@ -101,12 +101,12 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum {
   case UNRECOGNIZED(Int)
 
   init() {
-    self = .testEnumWithDupValueUnspecified
+    self = .unspecified
   }
 
   init?(rawValue: Int) {
     switch rawValue {
-    case 0: self = .testEnumWithDupValueUnspecified
+    case 0: self = .unspecified
     case 1: self = .foo1
     case 2: self = .bar1
     case 3: self = .baz
@@ -116,7 +116,7 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum {
 
   var rawValue: Int {
     switch self {
-    case .testEnumWithDupValueUnspecified: return 0
+    case .unspecified: return 0
     case .foo1: return 1
     case .bar1: return 2
     case .baz: return 3
@@ -129,7 +129,7 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum {
 /// Test an enum with large, unordered values.
 enum Proto3TestSparseEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
-  case testSparseEnumUnspecified // = 0
+  case unspecified // = 0
   case sparseA // = 123
   case sparseB // = 62374
   case sparseC // = 12589234
@@ -142,14 +142,14 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum {
   case UNRECOGNIZED(Int)
 
   init() {
-    self = .testSparseEnumUnspecified
+    self = .unspecified
   }
 
   init?(rawValue: Int) {
     switch rawValue {
     case -53452: self = .sparseE
     case -15: self = .sparseD
-    case 0: self = .testSparseEnumUnspecified
+    case 0: self = .unspecified
     case 2: self = .sparseG
     case 123: self = .sparseA
     case 62374: self = .sparseB
@@ -162,7 +162,7 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum {
     switch self {
     case .sparseE: return -53452
     case .sparseD: return -15
-    case .testSparseEnumUnspecified: return 0
+    case .unspecified: return 0
     case .sparseG: return 2
     case .sparseA: return 123
     case .sparseB: return 62374
@@ -478,7 +478,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
 
   enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
-    case nestedEnumUnspecified // = 0
+    case unspecified // = 0
     case foo // = 1
     case bar // = 2
     case baz // = 3
@@ -488,13 +488,13 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     case UNRECOGNIZED(Int)
 
     init() {
-      self = .nestedEnumUnspecified
+      self = .unspecified
     }
 
     init?(rawValue: Int) {
       switch rawValue {
       case -1: self = .neg
-      case 0: self = .nestedEnumUnspecified
+      case 0: self = .unspecified
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
@@ -505,7 +505,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     var rawValue: Int {
       switch self {
       case .neg: return -1
-      case .nestedEnumUnspecified: return 0
+      case .unspecified: return 0
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
@@ -662,13 +662,13 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
       if let v = _storage._singleImportMessage {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 20)
       }
-      if _storage._singleNestedEnum != Proto3TestAllTypes.NestedEnum.nestedEnumUnspecified {
+      if _storage._singleNestedEnum != Proto3TestAllTypes.NestedEnum.unspecified {
         try visitor.visitSingularEnumField(value: _storage._singleNestedEnum, fieldNumber: 21)
       }
       if _storage._singleForeignEnum != Proto3ForeignEnum.foreignUnspecified {
         try visitor.visitSingularEnumField(value: _storage._singleForeignEnum, fieldNumber: 22)
       }
-      if _storage._singleImportEnum != Proto3ImportEnum.importEnumUnspecified {
+      if _storage._singleImportEnum != Proto3ImportEnum.unspecified {
         try visitor.visitSingularEnumField(value: _storage._singleImportEnum, fieldNumber: 23)
       }
       if let v = _storage._singlePublicImportMessage {
@@ -1100,7 +1100,7 @@ struct Proto3TestMutualRecursionB: SwiftProtobuf.Message {
 struct Proto3TestEnumAllowAlias: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEnumAllowAlias"
 
-  var value: Proto3TestEnumWithDupValue = Proto3TestEnumWithDupValue.testEnumWithDupValueUnspecified
+  var value: Proto3TestEnumWithDupValue = Proto3TestEnumWithDupValue.unspecified
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1116,7 +1116,7 @@ struct Proto3TestEnumAllowAlias: SwiftProtobuf.Message {
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.value != Proto3TestEnumWithDupValue.testEnumWithDupValueUnspecified {
+    if self.value != Proto3TestEnumWithDupValue.unspecified {
       try visitor.visitSingularEnumField(value: self.value, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -1335,7 +1335,7 @@ struct Proto3TestFieldOrderings: SwiftProtobuf.Message {
 struct Proto3SparseEnumMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SparseEnumMessage"
 
-  var sparseEnum: Proto3TestSparseEnum = Proto3TestSparseEnum.testSparseEnumUnspecified
+  var sparseEnum: Proto3TestSparseEnum = Proto3TestSparseEnum.unspecified
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1351,7 +1351,7 @@ struct Proto3SparseEnumMessage: SwiftProtobuf.Message {
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.sparseEnum != Proto3TestSparseEnum.testSparseEnumUnspecified {
+    if self.sparseEnum != Proto3TestSparseEnum.unspecified {
       try visitor.visitSingularEnumField(value: self.sparseEnum, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -2179,9 +2179,9 @@ extension Proto3TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftPro
     var _singleNestedMessage: Proto3TestAllTypes.NestedMessage? = nil
     var _singleForeignMessage: Proto3ForeignMessage? = nil
     var _singleImportMessage: Proto3ImportMessage? = nil
-    var _singleNestedEnum: Proto3TestAllTypes.NestedEnum = Proto3TestAllTypes.NestedEnum.nestedEnumUnspecified
+    var _singleNestedEnum: Proto3TestAllTypes.NestedEnum = Proto3TestAllTypes.NestedEnum.unspecified
     var _singleForeignEnum: Proto3ForeignEnum = Proto3ForeignEnum.foreignUnspecified
-    var _singleImportEnum: Proto3ImportEnum = Proto3ImportEnum.importEnumUnspecified
+    var _singleImportEnum: Proto3ImportEnum = Proto3ImportEnum.unspecified
     var _singlePublicImportMessage: Proto3PublicImportMessage? = nil
     var _repeatedInt32: [Int32] = []
     var _repeatedInt64: [Int64] = []

--- a/Reference/unittest_swift_enum.pb.swift
+++ b/Reference/unittest_swift_enum.pb.swift
@@ -82,16 +82,16 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
   enum EnumTest2: SwiftProtobuf.Enum {
     typealias RawValue = Int
-    case enumTest2FirstValue // = 1
+    case firstValue // = 1
     case secondValue // = 2
 
     init() {
-      self = .enumTest2FirstValue
+      self = .firstValue
     }
 
     init?(rawValue: Int) {
       switch rawValue {
-      case 1: self = .enumTest2FirstValue
+      case 1: self = .firstValue
       case 2: self = .secondValue
       default: return nil
       }
@@ -99,7 +99,7 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
     var rawValue: Int {
       switch self {
-      case .enumTest2FirstValue: return 1
+      case .firstValue: return 1
       case .secondValue: return 2
       }
     }

--- a/Sources/PluginLibrary/NamingUtils.swift
+++ b/Sources/PluginLibrary/NamingUtils.swift
@@ -371,20 +371,6 @@ enum NamingUtils {
     return from[idx..<from.endIndex]
   }
 
-  static func canStripPrefix(enumProto: Google_Protobuf_EnumDescriptorProto) -> Bool {
-    let enumName = enumProto.name
-    for value in enumProto.value {
-      guard let strippedName = strip(protoPrefix: enumName, from: value.name) else {
-        return false
-      }
-      let camelCased = toLowerCamelCase(strippedName)
-      if !isValidSwiftIdentifier(camelCased) {
-        return false
-      }
-    }
-    return true
-  }
-
   static func sanitize(messageName s: String) -> String {
     return sanitizeTypeName(s, disambiguator: "Message")
   }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -34,7 +34,6 @@ extension Test_NamingUtils {
         return [
             ("testTypePrefix", {try run_test(test:($0 as! Test_NamingUtils).testTypePrefix)}),
             ("testStrip_protoPrefix", {try run_test(test:($0 as! Test_NamingUtils).testStrip_protoPrefix)}),
-            ("testCanStripPrefix", {try run_test(test:($0 as! Test_NamingUtils).testCanStripPrefix)}),
             ("testSanitize_messageName", {try run_test(test:($0 as! Test_NamingUtils).testSanitize_messageName)}),
             ("testSanitize_enumName", {try run_test(test:($0 as! Test_NamingUtils).testSanitize_enumName)}),
             ("testSanitize_oneofName", {try run_test(test:($0 as! Test_NamingUtils).testSanitize_oneofName)}),

--- a/Tests/PluginLibraryTests/Test_NamingUtils.swift
+++ b/Tests/PluginLibraryTests/Test_NamingUtils.swift
@@ -93,34 +93,6 @@ class Test_NamingUtils: XCTestCase {
     }
   }
 
-  func testCanStripPrefix() {
-    // enumName, value1, value2, expected
-    let tests: [(String, String, String, Bool)] = [
-      ( "FOO", "foo_bar", "foo_baz", true),
-      ( "FOO", "foo_bar", "foo_baz2", true),
-
-      ( "FOO", "foo_bar", "baz", false),
-      ( "FOO", "bar", "foo_baz", false),
-      ( "FOO", "bar", "baz", false),
-
-      ( "FOO", "foo", "bar", false),
-
-      // Identifier can't start with a number after stripping.
-      ( "FOO", "foo_1bar", "foo_baz", false),
-    ]
-    for (name, value1, value2, expected) in tests {
-      let proto = Google_Protobuf_EnumDescriptorProto.with {
-        $0.name = name
-        $0.value = [
-          Google_Protobuf_EnumValueDescriptorProto(name: value1, number: 0),
-          Google_Protobuf_EnumValueDescriptorProto(name: value2, number: 1),
-        ]
-      }
-      XCTAssertEqual(NamingUtils.canStripPrefix(enumProto: proto), expected,
-                     "Name: \(name), Value1: \(value1), Value2: \(value2)")
-    }
-  }
-
   func testSanitize_messageName() {
     // input, expected
     let tests: [(String, String)] = [

--- a/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_BasicFields_Access_Proto3.swift
@@ -161,7 +161,7 @@ class Test_BasicFields_Access_Proto3: XCTestCase {
 
   func testOptionalNestedEnum() {
     var msg = Proto3TestAllTypes()
-    XCTAssertEqual(msg.singleNestedEnum, .nestedEnumUnspecified)
+    XCTAssertEqual(msg.singleNestedEnum, .unspecified)
     msg.singleNestedEnum = .bar
     XCTAssertEqual(msg.singleNestedEnum, .bar)
   }
@@ -175,7 +175,7 @@ class Test_BasicFields_Access_Proto3: XCTestCase {
 
   func testOptionalImportEnum() {
     var msg = Proto3TestAllTypes()
-    XCTAssertEqual(msg.singleImportEnum, .importEnumUnspecified)
+    XCTAssertEqual(msg.singleImportEnum, .unspecified)
     msg.singleImportEnum = .importBar
     XCTAssertEqual(msg.singleImportEnum, .importBar)
   }

--- a/Tests/SwiftProtobufTests/Test_Enum.swift
+++ b/Tests/SwiftProtobufTests/Test_Enum.swift
@@ -44,7 +44,7 @@ class Test_Enum: XCTestCase, PBTestHelpers {
     func testEnumPrefix() {
         XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest1.firstValue.rawValue, 1)
         XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest1.secondValue.rawValue, 2)
-        XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest2.enumTest2FirstValue.rawValue, 1)
+        XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest2.firstValue.rawValue, 1)
         XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest2.secondValue.rawValue, 2)
     }
 

--- a/Tests/SwiftProtobufTests/Test_Enum_Proto2.swift
+++ b/Tests/SwiftProtobufTests/Test_Enum_Proto2.swift
@@ -56,7 +56,7 @@ class Test_Enum_Proto2: XCTestCase, PBTestHelpers {
     func testEnumPrefix() {
         XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest1.firstValue.rawValue, 1)
         XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest1.secondValue.rawValue, 2)
-        XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest2.enumTest2FirstValue.rawValue, 1)
+        XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest2.firstValue.rawValue, 1)
         XCTAssertEqual(ProtobufUnittest_SwiftEnumTest.EnumTest2.secondValue.rawValue, 2)
     }
 

--- a/Tests/SwiftProtobufTests/unittest_import_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_import_proto3.pb.swift
@@ -57,19 +57,19 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 
 enum Proto3ImportEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
-  case importEnumUnspecified // = 0
+  case unspecified // = 0
   case importFoo // = 7
   case importBar // = 8
   case importBaz // = 9
   case UNRECOGNIZED(Int)
 
   init() {
-    self = .importEnumUnspecified
+    self = .unspecified
   }
 
   init?(rawValue: Int) {
     switch rawValue {
-    case 0: self = .importEnumUnspecified
+    case 0: self = .unspecified
     case 7: self = .importFoo
     case 8: self = .importBar
     case 9: self = .importBaz
@@ -79,7 +79,7 @@ enum Proto3ImportEnum: SwiftProtobuf.Enum {
 
   var rawValue: Int {
     switch self {
-    case .importEnumUnspecified: return 0
+    case .unspecified: return 0
     case .importFoo: return 7
     case .importBar: return 8
     case .importBaz: return 9

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -92,7 +92,7 @@ enum Proto3ForeignEnum: SwiftProtobuf.Enum {
 /// Test an enum that has multiple values with the same number.
 enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum {
   typealias RawValue = Int
-  case testEnumWithDupValueUnspecified // = 0
+  case unspecified // = 0
   case foo1 // = 1
   case bar1 // = 2
   case baz // = 3
@@ -101,12 +101,12 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum {
   case UNRECOGNIZED(Int)
 
   init() {
-    self = .testEnumWithDupValueUnspecified
+    self = .unspecified
   }
 
   init?(rawValue: Int) {
     switch rawValue {
-    case 0: self = .testEnumWithDupValueUnspecified
+    case 0: self = .unspecified
     case 1: self = .foo1
     case 2: self = .bar1
     case 3: self = .baz
@@ -116,7 +116,7 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum {
 
   var rawValue: Int {
     switch self {
-    case .testEnumWithDupValueUnspecified: return 0
+    case .unspecified: return 0
     case .foo1: return 1
     case .bar1: return 2
     case .baz: return 3
@@ -129,7 +129,7 @@ enum Proto3TestEnumWithDupValue: SwiftProtobuf.Enum {
 /// Test an enum with large, unordered values.
 enum Proto3TestSparseEnum: SwiftProtobuf.Enum {
   typealias RawValue = Int
-  case testSparseEnumUnspecified // = 0
+  case unspecified // = 0
   case sparseA // = 123
   case sparseB // = 62374
   case sparseC // = 12589234
@@ -142,14 +142,14 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum {
   case UNRECOGNIZED(Int)
 
   init() {
-    self = .testSparseEnumUnspecified
+    self = .unspecified
   }
 
   init?(rawValue: Int) {
     switch rawValue {
     case -53452: self = .sparseE
     case -15: self = .sparseD
-    case 0: self = .testSparseEnumUnspecified
+    case 0: self = .unspecified
     case 2: self = .sparseG
     case 123: self = .sparseA
     case 62374: self = .sparseB
@@ -162,7 +162,7 @@ enum Proto3TestSparseEnum: SwiftProtobuf.Enum {
     switch self {
     case .sparseE: return -53452
     case .sparseD: return -15
-    case .testSparseEnumUnspecified: return 0
+    case .unspecified: return 0
     case .sparseG: return 2
     case .sparseA: return 123
     case .sparseB: return 62374
@@ -478,7 +478,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
 
   enum NestedEnum: SwiftProtobuf.Enum {
     typealias RawValue = Int
-    case nestedEnumUnspecified // = 0
+    case unspecified // = 0
     case foo // = 1
     case bar // = 2
     case baz // = 3
@@ -488,13 +488,13 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     case UNRECOGNIZED(Int)
 
     init() {
-      self = .nestedEnumUnspecified
+      self = .unspecified
     }
 
     init?(rawValue: Int) {
       switch rawValue {
       case -1: self = .neg
-      case 0: self = .nestedEnumUnspecified
+      case 0: self = .unspecified
       case 1: self = .foo
       case 2: self = .bar
       case 3: self = .baz
@@ -505,7 +505,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
     var rawValue: Int {
       switch self {
       case .neg: return -1
-      case .nestedEnumUnspecified: return 0
+      case .unspecified: return 0
       case .foo: return 1
       case .bar: return 2
       case .baz: return 3
@@ -662,13 +662,13 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
       if let v = _storage._singleImportMessage {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 20)
       }
-      if _storage._singleNestedEnum != Proto3TestAllTypes.NestedEnum.nestedEnumUnspecified {
+      if _storage._singleNestedEnum != Proto3TestAllTypes.NestedEnum.unspecified {
         try visitor.visitSingularEnumField(value: _storage._singleNestedEnum, fieldNumber: 21)
       }
       if _storage._singleForeignEnum != Proto3ForeignEnum.foreignUnspecified {
         try visitor.visitSingularEnumField(value: _storage._singleForeignEnum, fieldNumber: 22)
       }
-      if _storage._singleImportEnum != Proto3ImportEnum.importEnumUnspecified {
+      if _storage._singleImportEnum != Proto3ImportEnum.unspecified {
         try visitor.visitSingularEnumField(value: _storage._singleImportEnum, fieldNumber: 23)
       }
       if let v = _storage._singlePublicImportMessage {
@@ -1100,7 +1100,7 @@ struct Proto3TestMutualRecursionB: SwiftProtobuf.Message {
 struct Proto3TestEnumAllowAlias: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".TestEnumAllowAlias"
 
-  var value: Proto3TestEnumWithDupValue = Proto3TestEnumWithDupValue.testEnumWithDupValueUnspecified
+  var value: Proto3TestEnumWithDupValue = Proto3TestEnumWithDupValue.unspecified
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1116,7 +1116,7 @@ struct Proto3TestEnumAllowAlias: SwiftProtobuf.Message {
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.value != Proto3TestEnumWithDupValue.testEnumWithDupValueUnspecified {
+    if self.value != Proto3TestEnumWithDupValue.unspecified {
       try visitor.visitSingularEnumField(value: self.value, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -1335,7 +1335,7 @@ struct Proto3TestFieldOrderings: SwiftProtobuf.Message {
 struct Proto3SparseEnumMessage: SwiftProtobuf.Message {
   static let protoMessageName: String = _protobuf_package + ".SparseEnumMessage"
 
-  var sparseEnum: Proto3TestSparseEnum = Proto3TestSparseEnum.testSparseEnumUnspecified
+  var sparseEnum: Proto3TestSparseEnum = Proto3TestSparseEnum.unspecified
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -1351,7 +1351,7 @@ struct Proto3SparseEnumMessage: SwiftProtobuf.Message {
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if self.sparseEnum != Proto3TestSparseEnum.testSparseEnumUnspecified {
+    if self.sparseEnum != Proto3TestSparseEnum.unspecified {
       try visitor.visitSingularEnumField(value: self.sparseEnum, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -2179,9 +2179,9 @@ extension Proto3TestAllTypes: SwiftProtobuf._MessageImplementationBase, SwiftPro
     var _singleNestedMessage: Proto3TestAllTypes.NestedMessage? = nil
     var _singleForeignMessage: Proto3ForeignMessage? = nil
     var _singleImportMessage: Proto3ImportMessage? = nil
-    var _singleNestedEnum: Proto3TestAllTypes.NestedEnum = Proto3TestAllTypes.NestedEnum.nestedEnumUnspecified
+    var _singleNestedEnum: Proto3TestAllTypes.NestedEnum = Proto3TestAllTypes.NestedEnum.unspecified
     var _singleForeignEnum: Proto3ForeignEnum = Proto3ForeignEnum.foreignUnspecified
-    var _singleImportEnum: Proto3ImportEnum = Proto3ImportEnum.importEnumUnspecified
+    var _singleImportEnum: Proto3ImportEnum = Proto3ImportEnum.unspecified
     var _singlePublicImportMessage: Proto3PublicImportMessage? = nil
     var _repeatedInt32: [Int32] = []
     var _repeatedInt64: [Int64] = []

--- a/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_enum.pb.swift
@@ -82,16 +82,16 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
   enum EnumTest2: SwiftProtobuf.Enum {
     typealias RawValue = Int
-    case enumTest2FirstValue // = 1
+    case firstValue // = 1
     case secondValue // = 2
 
     init() {
-      self = .enumTest2FirstValue
+      self = .firstValue
     }
 
     init?(rawValue: Int) {
       switch rawValue {
-      case 1: self = .enumTest2FirstValue
+      case 1: self = .firstValue
       case 2: self = .secondValue
       default: return nil
       }
@@ -99,7 +99,7 @@ struct ProtobufUnittest_SwiftEnumTest: SwiftProtobuf.Message {
 
     var rawValue: Int {
       switch self {
-      case .enumTest2FirstValue: return 1
+      case .firstValue: return 1
       case .secondValue: return 2
       }
     }


### PR DESCRIPTION
Remove the requirement that all enum values having to be prefixed
with the enum name to do any stemming. This should help in two ways:

- If a new enum value is added that doesn't share the prefix, it won't
  suddenly change all the existing names breaking existing code.
- If there is an alias (that could be deprecated) for a old name that
  didn't have the prefix, the existence of it doesn't prevent the newer
  names from getting the stemming and being more "swifty".

Note: The CSharp generator does this, it prefix strips any value it can,
without requiring all of the value to have the enum type as the prefix.

Reminder - This has never been generic common prefix stripping, it is
only about stripping the enum name off the front of the value.  That
specific case is because most protobuf enum follow that pattern since
global C++ enum values are global scope, so a common prefix is needed
on them.