### PR TITLE
Fix parsing of oneofs to not set the field on decode failures.

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -326,15 +326,19 @@ extension Conformance_ConformanceRequest.OneOf_Payload {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .protobufPayload(value)
-      return
+      if let value = value {
+        self = .protobufPayload(value)
+        return
+      }
     case 2:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .jsonPayload(value)
-      return
+      if let value = value {
+        self = .jsonPayload(value)
+        return
+      }
     default:
       break
     }
@@ -372,35 +376,47 @@ extension Conformance_ConformanceResponse.OneOf_Result {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .parseError(value)
-      return
+      if let value = value {
+        self = .parseError(value)
+        return
+      }
     case 2:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .runtimeError(value)
-      return
+      if let value = value {
+        self = .runtimeError(value)
+        return
+      }
     case 3:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .protobufPayload(value)
-      return
+      if let value = value {
+        self = .protobufPayload(value)
+        return
+      }
     case 4:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .jsonPayload(value)
-      return
+      if let value = value {
+        self = .jsonPayload(value)
+        return
+      }
     case 5:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .skipped(value)
-      return
+      if let value = value {
+        self = .skipped(value)
+        return
+      }
     case 6:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .serializeError(value)
-      return
+      if let value = value {
+        self = .serializeError(value)
+        return
+      }
     default:
       break
     }

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -337,25 +337,33 @@ extension Google_Protobuf_Value.OneOf_Kind {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1:
-      var value = Google_Protobuf_NullValue()
+      var value: Google_Protobuf_NullValue?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .nullValue(value)
-      return
+      if let value = value {
+        self = .nullValue(value)
+        return
+      }
     case 2:
-      var value = Double()
+      var value: Double?
       try decoder.decodeSingularDoubleField(value: &value)
-      self = .numberValue(value)
-      return
+      if let value = value {
+        self = .numberValue(value)
+        return
+      }
     case 3:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .stringValue(value)
-      return
+      if let value = value {
+        self = .stringValue(value)
+        return
+      }
     case 4:
-      var value = Bool()
+      var value: Bool?
       try decoder.decodeSingularBoolField(value: &value)
-      self = .boolValue(value)
-      return
+      if let value = value {
+        self = .boolValue(value)
+        return
+      }
     case 5:
       var value: Google_Protobuf_Struct?
       try decoder.decodeSingularMessageField(value: &value)

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -1908,10 +1908,12 @@ extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -1920,40 +1922,54 @@ extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     case 115:
-      var value = Bool()
+      var value: Bool?
       try decoder.decodeSingularBoolField(value: &value)
-      self = .oneofBool(value)
-      return
+      if let value = value {
+        self = .oneofBool(value)
+        return
+      }
     case 116:
-      var value = UInt64()
+      var value: UInt64?
       try decoder.decodeSingularUInt64Field(value: &value)
-      self = .oneofUint64(value)
-      return
+      if let value = value {
+        self = .oneofUint64(value)
+        return
+      }
     case 117:
-      var value = Float()
+      var value: Float?
       try decoder.decodeSingularFloatField(value: &value)
-      self = .oneofFloat(value)
-      return
+      if let value = value {
+        self = .oneofFloat(value)
+        return
+      }
     case 118:
-      var value = Double()
+      var value: Double?
       try decoder.decodeSingularDoubleField(value: &value)
-      self = .oneofDouble(value)
-      return
+      if let value = value {
+        self = .oneofDouble(value)
+        return
+      }
     case 119:
-      var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
+      var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofEnum(value)
-      return
+      if let value = value {
+        self = .oneofEnum(value)
+        return
+      }
     default:
       break
     }

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -978,10 +978,12 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -990,15 +992,19 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum()
+      var value: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofEnum(value)
-      return
+      if let value = value {
+        self = .oneofEnum(value)
+        return
+      }
     default:
       break
     }

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -323,15 +323,19 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 5:
-      var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
+      var value: Proto3PreserveUnknownEnumUnittest_MyEnum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofE1(value)
-      return
+      if let value = value {
+        self = .oneofE1(value)
+        return
+      }
     case 6:
-      var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
+      var value: Proto3PreserveUnknownEnumUnittest_MyEnum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofE2(value)
-      return
+      if let value = value {
+        self = .oneofE2(value)
+        return
+      }
     default:
       break
     }
@@ -373,15 +377,19 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 5:
-      var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
+      var value: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofE1(value)
-      return
+      if let value = value {
+        self = .oneofE1(value)
+        return
+      }
     case 6:
-      var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
+      var value: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofE2(value)
-      return
+      if let value = value {
+        self = .oneofE2(value)
+        return
+      }
     default:
       break
     }

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -2326,10 +2326,12 @@ extension Proto3TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: Proto3TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -2338,15 +2340,19 @@ extension Proto3TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     default:
       break
     }
@@ -2924,15 +2930,19 @@ extension Proto3TestOneof.OneOf_Foo {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1:
-      var value = Int32()
+      var value: Int32?
       try decoder.decodeSingularInt32Field(value: &value)
-      self = .fooInt(value)
-      return
+      if let value = value {
+        self = .fooInt(value)
+        return
+      }
     case 2:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .fooString(value)
-      return
+      if let value = value {
+        self = .fooString(value)
+        return
+      }
     case 3:
       var value: Proto3TestAllTypes?
       try decoder.decodeSingularMessageField(value: &value)

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -1238,10 +1238,12 @@ extension Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: Proto3ArenaUnittest_TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -1250,15 +1252,19 @@ extension Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     default:
       break
     }

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -1238,10 +1238,12 @@ extension Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: Proto3ArenaLiteUnittest_TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -1250,15 +1252,19 @@ extension Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     default:
       break
     }

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -1238,10 +1238,12 @@ extension Proto3LiteUnittest_TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: Proto3LiteUnittest_TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -1250,15 +1252,19 @@ extension Proto3LiteUnittest_TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     default:
       break
     }

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -1114,80 +1114,110 @@ extension ProtobufUnittest_Message3.OneOf_O {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 51:
-      var value = Int32()
+      var value: Int32?
       try decoder.decodeSingularInt32Field(value: &value)
-      self = .oneofInt32(value)
-      return
+      if let value = value {
+        self = .oneofInt32(value)
+        return
+      }
     case 52:
-      var value = Int64()
+      var value: Int64?
       try decoder.decodeSingularInt64Field(value: &value)
-      self = .oneofInt64(value)
-      return
+      if let value = value {
+        self = .oneofInt64(value)
+        return
+      }
     case 53:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 54:
-      var value = UInt64()
+      var value: UInt64?
       try decoder.decodeSingularUInt64Field(value: &value)
-      self = .oneofUint64(value)
-      return
+      if let value = value {
+        self = .oneofUint64(value)
+        return
+      }
     case 55:
-      var value = Int32()
+      var value: Int32?
       try decoder.decodeSingularSInt32Field(value: &value)
-      self = .oneofSint32(value)
-      return
+      if let value = value {
+        self = .oneofSint32(value)
+        return
+      }
     case 56:
-      var value = Int64()
+      var value: Int64?
       try decoder.decodeSingularSInt64Field(value: &value)
-      self = .oneofSint64(value)
-      return
+      if let value = value {
+        self = .oneofSint64(value)
+        return
+      }
     case 57:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularFixed32Field(value: &value)
-      self = .oneofFixed32(value)
-      return
+      if let value = value {
+        self = .oneofFixed32(value)
+        return
+      }
     case 58:
-      var value = UInt64()
+      var value: UInt64?
       try decoder.decodeSingularFixed64Field(value: &value)
-      self = .oneofFixed64(value)
-      return
+      if let value = value {
+        self = .oneofFixed64(value)
+        return
+      }
     case 59:
-      var value = Int32()
+      var value: Int32?
       try decoder.decodeSingularSFixed32Field(value: &value)
-      self = .oneofSfixed32(value)
-      return
+      if let value = value {
+        self = .oneofSfixed32(value)
+        return
+      }
     case 60:
-      var value = Int64()
+      var value: Int64?
       try decoder.decodeSingularSFixed64Field(value: &value)
-      self = .oneofSfixed64(value)
-      return
+      if let value = value {
+        self = .oneofSfixed64(value)
+        return
+      }
     case 61:
-      var value = Float()
+      var value: Float?
       try decoder.decodeSingularFloatField(value: &value)
-      self = .oneofFloat(value)
-      return
+      if let value = value {
+        self = .oneofFloat(value)
+        return
+      }
     case 62:
-      var value = Double()
+      var value: Double?
       try decoder.decodeSingularDoubleField(value: &value)
-      self = .oneofDouble(value)
-      return
+      if let value = value {
+        self = .oneofDouble(value)
+        return
+      }
     case 63:
-      var value = Bool()
+      var value: Bool?
       try decoder.decodeSingularBoolField(value: &value)
-      self = .oneofBool(value)
-      return
+      if let value = value {
+        self = .oneofBool(value)
+        return
+      }
     case 64:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 65:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     case 68:
       var value: ProtobufUnittest_Message3?
       try decoder.decodeSingularMessageField(value: &value)
@@ -1196,10 +1226,12 @@ extension ProtobufUnittest_Message3.OneOf_O {
         return
       }
     case 69:
-      var value = ProtobufUnittest_Message3.Enum()
+      var value: ProtobufUnittest_Message3.Enum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofEnum(value)
-      return
+      if let value = value {
+        self = .oneofEnum(value)
+        return
+      }
     default:
       break
     }

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -326,15 +326,19 @@ extension Conformance_ConformanceRequest.OneOf_Payload {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .protobufPayload(value)
-      return
+      if let value = value {
+        self = .protobufPayload(value)
+        return
+      }
     case 2:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .jsonPayload(value)
-      return
+      if let value = value {
+        self = .jsonPayload(value)
+        return
+      }
     default:
       break
     }
@@ -372,35 +376,47 @@ extension Conformance_ConformanceResponse.OneOf_Result {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .parseError(value)
-      return
+      if let value = value {
+        self = .parseError(value)
+        return
+      }
     case 2:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .runtimeError(value)
-      return
+      if let value = value {
+        self = .runtimeError(value)
+        return
+      }
     case 3:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .protobufPayload(value)
-      return
+      if let value = value {
+        self = .protobufPayload(value)
+        return
+      }
     case 4:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .jsonPayload(value)
-      return
+      if let value = value {
+        self = .jsonPayload(value)
+        return
+      }
     case 5:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .skipped(value)
-      return
+      if let value = value {
+        self = .skipped(value)
+        return
+      }
     case 6:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .serializeError(value)
-      return
+      if let value = value {
+        self = .serializeError(value)
+        return
+      }
     default:
       break
     }

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -1908,10 +1908,12 @@ extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -1920,40 +1922,54 @@ extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     case 115:
-      var value = Bool()
+      var value: Bool?
       try decoder.decodeSingularBoolField(value: &value)
-      self = .oneofBool(value)
-      return
+      if let value = value {
+        self = .oneofBool(value)
+        return
+      }
     case 116:
-      var value = UInt64()
+      var value: UInt64?
       try decoder.decodeSingularUInt64Field(value: &value)
-      self = .oneofUint64(value)
-      return
+      if let value = value {
+        self = .oneofUint64(value)
+        return
+      }
     case 117:
-      var value = Float()
+      var value: Float?
       try decoder.decodeSingularFloatField(value: &value)
-      self = .oneofFloat(value)
-      return
+      if let value = value {
+        self = .oneofFloat(value)
+        return
+      }
     case 118:
-      var value = Double()
+      var value: Double?
       try decoder.decodeSingularDoubleField(value: &value)
-      self = .oneofDouble(value)
-      return
+      if let value = value {
+        self = .oneofDouble(value)
+        return
+      }
     case 119:
-      var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
+      var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofEnum(value)
-      return
+      if let value = value {
+        self = .oneofEnum(value)
+        return
+      }
     default:
       break
     }

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -337,25 +337,33 @@ extension Google_Protobuf_Value.OneOf_Kind {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1:
-      var value = Google_Protobuf_NullValue()
+      var value: Google_Protobuf_NullValue?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .nullValue(value)
-      return
+      if let value = value {
+        self = .nullValue(value)
+        return
+      }
     case 2:
-      var value = Double()
+      var value: Double?
       try decoder.decodeSingularDoubleField(value: &value)
-      self = .numberValue(value)
-      return
+      if let value = value {
+        self = .numberValue(value)
+        return
+      }
     case 3:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .stringValue(value)
-      return
+      if let value = value {
+        self = .stringValue(value)
+        return
+      }
     case 4:
-      var value = Bool()
+      var value: Bool?
       try decoder.decodeSingularBoolField(value: &value)
-      self = .boolValue(value)
-      return
+      if let value = value {
+        self = .boolValue(value)
+        return
+      }
     case 5:
       var value: Google_Protobuf_Struct?
       try decoder.decodeSingularMessageField(value: &value)

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -247,8 +247,6 @@ class OneofGenerator {
     }
 
     func generateRuntimeSupport(printer p: inout CodePrinter) {
-        let isProto3 = oneofDescriptor.containingType.file.syntax == .proto3
-
         p.print(
             "\n",
             "extension \(swiftFullName) {\n")
@@ -263,29 +261,16 @@ class OneofGenerator {
 
             p.print("case \(f.number):\n")
             p.indent()
-
-            // TODO(thomasvl): Revisit this, in all cases, I think we need success/failure
-            // from decode otherwise we assign to zero for wronge write type. None oneof
-            // is likely also wrong.
-            if isProto3 && !f.isMessage {
-                // Proto3 has non-optional fields, so this is simpler
-                p.print(
-                    "var value = \(f.swiftType)()\n",
-                    "try decoder.\(decoderMethod)(value: &value)\n",
-                    "self = .\(f.swiftName)(value)\n",
-                    "return\n")
-            } else {
-                p.print(
-                    "var value: \(f.swiftType)?\n",
-                    "try decoder.\(decoderMethod)(value: &value)\n",
-                    "if let value = value {\n")
-                p.indent()
-                p.print(
-                    "self = .\(f.swiftName)(value)\n",
-                    "return\n")
-                p.outdent()
-                p.print("}\n")
-            }
+            p.print(
+                "var value: \(f.swiftType)?\n",
+                "try decoder.\(decoderMethod)(value: &value)\n",
+                "if let value = value {\n")
+            p.indent()
+            p.print(
+                "self = .\(f.swiftName)(value)\n",
+                "return\n")
+            p.outdent()
+            p.print("}\n")
             p.outdent()
         }
         p.print("default:\n")

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -73,9 +73,17 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
         baseAssertDecodeSucceeds(bytes, file: file, line: line, check: check)
     }
 
-    func assertDecodesAsUnknownFields(_ bytes: [UInt8], file: XCTestFileArgType = #file, line: UInt = #line) {
+    // Helper to check that decode succeeds by the data ended up in unknown fields.
+    // Supports an optional `check` to do additional validation.
+    func assertDecodesAsUnknownFields(_ bytes: [UInt8], file: XCTestFileArgType = #file, line: UInt = #line, check: ((MessageTestType) -> Bool)? = nil) {
         assertDecodeSucceeds(bytes, file: file, line: line) {
-            $0.unknownFields.data == Data(bytes: bytes)
+            if $0.unknownFields.data != Data(bytes: bytes) {
+                return false
+            }
+            if let check = check {
+                return check($0)
+            }
+            return true
         }
     }
 

--- a/Tests/SwiftProtobufTests/Test_AllTypes.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes.swift
@@ -1953,7 +1953,9 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
         assertDecodeFails([249, 6])
         assertDecodeFails([249, 6, 0])
         assertDecodeFails([250, 6])
-        assertDecodesAsUnknownFields([250, 6, 0])  // Wrong wire type (length delimited), valid as an unknown field
+        assertDecodesAsUnknownFields([250, 6, 0]) {  // Wrong wire type (length delimited), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
         assertDecodeFails([251, 6])
         assertDecodeFails([251, 6, 0])
         assertDecodeFails([252, 6])
@@ -2026,7 +2028,9 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
 
     func testEncoding_oneofNestedMessage9() {
         assertDecodeFails([128, 7])
-        assertDecodesAsUnknownFields([128, 7, 0])  // Wrong wire type (varint), valid as an unknown field
+        assertDecodesAsUnknownFields([128, 7, 0]) {  // Wrong wire type (varint), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
         assertDecodeFails([129, 7])
         assertDecodeFails([129, 7, 0])
         assertDecodeFails([131, 7])
@@ -2054,13 +2058,21 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
         assertDecodeFails([138, 7, 1]) // Truncated body
         assertDecodeFails([138, 7, 1, 192]) // Malformed UTF-8
         // Bad wire types:
-        assertDecodesAsUnknownFields([136, 7, 0])  // Wrong wire type (varint), valid as an unknown field
-        assertDecodesAsUnknownFields([136, 7, 1])  // Wrong wire type (varint), valid as an unknown field
-        assertDecodesAsUnknownFields([137, 7, 1, 1, 1, 1, 1, 1, 1, 1])  // Wrong wire type (fixed64), valid as an unknown field
+        assertDecodesAsUnknownFields([136, 7, 0]) {  // Wrong wire type (varint), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
+        assertDecodesAsUnknownFields([136, 7, 1]) {  // Wrong wire type (varint), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
+        assertDecodesAsUnknownFields([137, 7, 1, 1, 1, 1, 1, 1, 1, 1]) {  // Wrong wire type (fixed64), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
         assertDecodeFails([139, 7]) // Wire type 3
         assertDecodeFails([140, 7]) // Wire type 4
         assertDecodeFails([141, 7, 0])  // Wire type 5
-        assertDecodesAsUnknownFields([141, 7, 0, 0, 0, 0])  // Wrong wire type (fixed32), valid as an unknown field
+        assertDecodesAsUnknownFields([141, 7, 0, 0, 0, 0]) {  // Wrong wire type (fixed32), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
         assertDecodeFails([142, 7]) // Wire type 6
         assertDecodeFails([142, 7, 0]) // Wire type 6
         assertDecodeFails([143, 7]) // Wire type 7
@@ -2117,7 +2129,9 @@ class Test_AllTypes: XCTestCase, PBTestHelpers {
         assertDecodeFails([146, 7, 1])
         // Bad wire types:
         assertDecodeFails([144, 7])
-        assertDecodesAsUnknownFields([144, 7, 0])  // Wrong wire type (varint), valid as an unknown field
+        assertDecodesAsUnknownFields([144, 7, 0]) {  // Wrong wire type (varint), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
         assertDecodeFails([145, 7])
         assertDecodeFails([145, 7, 0])
         assertDecodeFails([147, 7])

--- a/Tests/SwiftProtobufTests/Test_AllTypes_Proto3.swift
+++ b/Tests/SwiftProtobufTests/Test_AllTypes_Proto3.swift
@@ -1195,7 +1195,9 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
         assertDecodeFails([249, 6])
         assertDecodeFails([249, 6, 0])
         assertDecodeFails([250, 6])
-        assertDecodesAsUnknownFields([250, 6, 0])  // Wrong wire type (length delimited), valid as an unknown field
+        assertDecodesAsUnknownFields([250, 6, 0]) {  // Wrong wire type (length delimited), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
         assertDecodeFails([251, 6])
         assertDecodeFails([251, 6, 0])
         assertDecodeFails([252, 6])
@@ -1265,7 +1267,9 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
 
     func testEncoding_oneofNestedMessage9() {
         assertDecodeFails([128, 7])
-        assertDecodesAsUnknownFields([128, 7, 0])  // Wrong wire type (varint), valid as an unknown field
+        assertDecodesAsUnknownFields([128, 7, 0]) { // Wrong wire type (varint), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
         assertDecodeFails([129, 7])
         assertDecodeFails([129, 7, 0])
         assertDecodeFails([131, 7])
@@ -1293,13 +1297,21 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
         assertDecodeFails([138, 7, 1]) // Truncated body
         assertDecodeFails([138, 7, 1, 192]) // Malformed UTF-8
         // Bad wire types:
-        assertDecodesAsUnknownFields([136, 7, 0])  // Wrong wire type (varint), valid as an unknown field
-        assertDecodesAsUnknownFields([136, 7, 1])  // Wrong wire type (varint), valid as an unknown field
-        assertDecodesAsUnknownFields([137, 7, 1, 1, 1, 1, 1, 1, 1, 1])  // Wrong wire type (fixed64), valid as an unknown field
+        assertDecodesAsUnknownFields([136, 7, 0]) {  // Wrong wire type (varint), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
+        assertDecodesAsUnknownFields([136, 7, 1]) {  // Wrong wire type (varint), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
+        assertDecodesAsUnknownFields([137, 7, 1, 1, 1, 1, 1, 1, 1, 1]) {  // Wrong wire type (fixed64), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
         assertDecodeFails([139, 7]) // Wire type 3
         assertDecodeFails([140, 7]) // Wire type 4
         assertDecodeFails([141, 7, 0])  // Wire type 5
-        assertDecodesAsUnknownFields([141, 7, 0, 0, 0, 0])  // Wrong wire type (fixed32), valid as an unknown field
+        assertDecodesAsUnknownFields([141, 7, 0, 0, 0, 0]) {  // Wrong wire type (fixed32), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
         assertDecodeFails([142, 7]) // Wire type 6
         assertDecodeFails([142, 7, 0]) // Wire type 6
         assertDecodeFails([143, 7]) // Wire type 7
@@ -1356,7 +1368,9 @@ class Test_AllTypes_Proto3: XCTestCase, PBTestHelpers {
         assertDecodeFails([146, 7, 1])
         // Bad wire types:
         assertDecodeFails([144, 7])
-        assertDecodesAsUnknownFields([144, 7, 0])  // Wrong wire type (varint), valid as an unknown field
+        assertDecodesAsUnknownFields([144, 7, 0]) {  // Wrong wire type (varint), valid as an unknown field
+            $0.oneofField == nil  // oneof doesn't get set.
+        }
         assertDecodeFails([145, 7])
         assertDecodeFails([145, 7, 0])
         assertDecodeFails([147, 7])

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -326,15 +326,19 @@ extension Conformance_ConformanceRequest.OneOf_Payload {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .protobufPayload(value)
-      return
+      if let value = value {
+        self = .protobufPayload(value)
+        return
+      }
     case 2:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .jsonPayload(value)
-      return
+      if let value = value {
+        self = .jsonPayload(value)
+        return
+      }
     default:
       break
     }
@@ -372,35 +376,47 @@ extension Conformance_ConformanceResponse.OneOf_Result {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .parseError(value)
-      return
+      if let value = value {
+        self = .parseError(value)
+        return
+      }
     case 2:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .runtimeError(value)
-      return
+      if let value = value {
+        self = .runtimeError(value)
+        return
+      }
     case 3:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .protobufPayload(value)
-      return
+      if let value = value {
+        self = .protobufPayload(value)
+        return
+      }
     case 4:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .jsonPayload(value)
-      return
+      if let value = value {
+        self = .jsonPayload(value)
+        return
+      }
     case 5:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .skipped(value)
-      return
+      if let value = value {
+        self = .skipped(value)
+        return
+      }
     case 6:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .serializeError(value)
-      return
+      if let value = value {
+        self = .serializeError(value)
+        return
+      }
     default:
       break
     }

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -1908,10 +1908,12 @@ extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -1920,40 +1922,54 @@ extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     case 115:
-      var value = Bool()
+      var value: Bool?
       try decoder.decodeSingularBoolField(value: &value)
-      self = .oneofBool(value)
-      return
+      if let value = value {
+        self = .oneofBool(value)
+        return
+      }
     case 116:
-      var value = UInt64()
+      var value: UInt64?
       try decoder.decodeSingularUInt64Field(value: &value)
-      self = .oneofUint64(value)
-      return
+      if let value = value {
+        self = .oneofUint64(value)
+        return
+      }
     case 117:
-      var value = Float()
+      var value: Float?
       try decoder.decodeSingularFloatField(value: &value)
-      self = .oneofFloat(value)
-      return
+      if let value = value {
+        self = .oneofFloat(value)
+        return
+      }
     case 118:
-      var value = Double()
+      var value: Double?
       try decoder.decodeSingularDoubleField(value: &value)
-      self = .oneofDouble(value)
-      return
+      if let value = value {
+        self = .oneofDouble(value)
+        return
+      }
     case 119:
-      var value = ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum()
+      var value: ProtobufTestMessages_Proto3_TestAllTypes.NestedEnum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofEnum(value)
-      return
+      if let value = value {
+        self = .oneofEnum(value)
+        return
+      }
     default:
       break
     }

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -978,10 +978,12 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: Proto2NofieldpresenceUnittest_TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -990,15 +992,19 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum()
+      var value: Proto2NofieldpresenceUnittest_TestAllTypes.NestedEnum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofEnum(value)
-      return
+      if let value = value {
+        self = .oneofEnum(value)
+        return
+      }
     default:
       break
     }

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -323,15 +323,19 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 5:
-      var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
+      var value: Proto3PreserveUnknownEnumUnittest_MyEnum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofE1(value)
-      return
+      if let value = value {
+        self = .oneofE1(value)
+        return
+      }
     case 6:
-      var value = Proto3PreserveUnknownEnumUnittest_MyEnum()
+      var value: Proto3PreserveUnknownEnumUnittest_MyEnum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofE2(value)
-      return
+      if let value = value {
+        self = .oneofE2(value)
+        return
+      }
     default:
       break
     }
@@ -373,15 +377,19 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 5:
-      var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
+      var value: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofE1(value)
-      return
+      if let value = value {
+        self = .oneofE1(value)
+        return
+      }
     case 6:
-      var value = Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra()
+      var value: Proto3PreserveUnknownEnumUnittest_MyEnumPlusExtra?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofE2(value)
-      return
+      if let value = value {
+        self = .oneofE2(value)
+        return
+      }
     default:
       break
     }

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -2326,10 +2326,12 @@ extension Proto3TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: Proto3TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -2338,15 +2340,19 @@ extension Proto3TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     default:
       break
     }
@@ -2924,15 +2930,19 @@ extension Proto3TestOneof.OneOf_Foo {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 1:
-      var value = Int32()
+      var value: Int32?
       try decoder.decodeSingularInt32Field(value: &value)
-      self = .fooInt(value)
-      return
+      if let value = value {
+        self = .fooInt(value)
+        return
+      }
     case 2:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .fooString(value)
-      return
+      if let value = value {
+        self = .fooString(value)
+        return
+      }
     case 3:
       var value: Proto3TestAllTypes?
       try decoder.decodeSingularMessageField(value: &value)

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -1238,10 +1238,12 @@ extension Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 111:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 112:
       var value: Proto3ArenaUnittest_TestAllTypes.NestedMessage?
       try decoder.decodeSingularMessageField(value: &value)
@@ -1250,15 +1252,19 @@ extension Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField {
         return
       }
     case 113:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 114:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     default:
       break
     }

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -1114,80 +1114,110 @@ extension ProtobufUnittest_Message3.OneOf_O {
   fileprivate init?<T: SwiftProtobuf.Decoder>(byDecodingFrom decoder: inout T, fieldNumber: Int) throws {
     switch fieldNumber {
     case 51:
-      var value = Int32()
+      var value: Int32?
       try decoder.decodeSingularInt32Field(value: &value)
-      self = .oneofInt32(value)
-      return
+      if let value = value {
+        self = .oneofInt32(value)
+        return
+      }
     case 52:
-      var value = Int64()
+      var value: Int64?
       try decoder.decodeSingularInt64Field(value: &value)
-      self = .oneofInt64(value)
-      return
+      if let value = value {
+        self = .oneofInt64(value)
+        return
+      }
     case 53:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularUInt32Field(value: &value)
-      self = .oneofUint32(value)
-      return
+      if let value = value {
+        self = .oneofUint32(value)
+        return
+      }
     case 54:
-      var value = UInt64()
+      var value: UInt64?
       try decoder.decodeSingularUInt64Field(value: &value)
-      self = .oneofUint64(value)
-      return
+      if let value = value {
+        self = .oneofUint64(value)
+        return
+      }
     case 55:
-      var value = Int32()
+      var value: Int32?
       try decoder.decodeSingularSInt32Field(value: &value)
-      self = .oneofSint32(value)
-      return
+      if let value = value {
+        self = .oneofSint32(value)
+        return
+      }
     case 56:
-      var value = Int64()
+      var value: Int64?
       try decoder.decodeSingularSInt64Field(value: &value)
-      self = .oneofSint64(value)
-      return
+      if let value = value {
+        self = .oneofSint64(value)
+        return
+      }
     case 57:
-      var value = UInt32()
+      var value: UInt32?
       try decoder.decodeSingularFixed32Field(value: &value)
-      self = .oneofFixed32(value)
-      return
+      if let value = value {
+        self = .oneofFixed32(value)
+        return
+      }
     case 58:
-      var value = UInt64()
+      var value: UInt64?
       try decoder.decodeSingularFixed64Field(value: &value)
-      self = .oneofFixed64(value)
-      return
+      if let value = value {
+        self = .oneofFixed64(value)
+        return
+      }
     case 59:
-      var value = Int32()
+      var value: Int32?
       try decoder.decodeSingularSFixed32Field(value: &value)
-      self = .oneofSfixed32(value)
-      return
+      if let value = value {
+        self = .oneofSfixed32(value)
+        return
+      }
     case 60:
-      var value = Int64()
+      var value: Int64?
       try decoder.decodeSingularSFixed64Field(value: &value)
-      self = .oneofSfixed64(value)
-      return
+      if let value = value {
+        self = .oneofSfixed64(value)
+        return
+      }
     case 61:
-      var value = Float()
+      var value: Float?
       try decoder.decodeSingularFloatField(value: &value)
-      self = .oneofFloat(value)
-      return
+      if let value = value {
+        self = .oneofFloat(value)
+        return
+      }
     case 62:
-      var value = Double()
+      var value: Double?
       try decoder.decodeSingularDoubleField(value: &value)
-      self = .oneofDouble(value)
-      return
+      if let value = value {
+        self = .oneofDouble(value)
+        return
+      }
     case 63:
-      var value = Bool()
+      var value: Bool?
       try decoder.decodeSingularBoolField(value: &value)
-      self = .oneofBool(value)
-      return
+      if let value = value {
+        self = .oneofBool(value)
+        return
+      }
     case 64:
-      var value = String()
+      var value: String?
       try decoder.decodeSingularStringField(value: &value)
-      self = .oneofString(value)
-      return
+      if let value = value {
+        self = .oneofString(value)
+        return
+      }
     case 65:
-      var value = Data()
+      var value: Data?
       try decoder.decodeSingularBytesField(value: &value)
-      self = .oneofBytes(value)
-      return
+      if let value = value {
+        self = .oneofBytes(value)
+        return
+      }
     case 68:
       var value: ProtobufUnittest_Message3?
       try decoder.decodeSingularMessageField(value: &value)
@@ -1196,10 +1226,12 @@ extension ProtobufUnittest_Message3.OneOf_O {
         return
       }
     case 69:
-      var value = ProtobufUnittest_Message3.Enum()
+      var value: ProtobufUnittest_Message3.Enum?
       try decoder.decodeSingularEnumField(value: &value)
-      self = .oneofEnum(value)
-      return
+      if let value = value {
+        self = .oneofEnum(value)
+        return
+      }
     default:
       break
     }


### PR DESCRIPTION
- Always use the optional based decode so the generated code can confirm
  something was decoded before returning a new enum value.
- Expand one of the test helpers to take an optional check block.
- Add test to ensure the oneof doesn't get set if the decode went
  to unknown fields.

Fixes https://github.com/apple/swift-protobuf/issues/525