### PR TITLE
Inline oneof traverse

### DIFF
--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -168,7 +168,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
       try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
     case .jsonPayload(let v)?:
       try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    default: break
+    case nil: break
     }
     if self.requestedOutputFormat != .unspecified {
       try visitor.visitSingularEnumField(value: self.requestedOutputFormat, fieldNumber: 3)
@@ -325,7 +325,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
       try visitor.visitSingularStringField(value: v, fieldNumber: 5)
     case .serializeError(let v)?:
       try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-    default: break
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }

--- a/Reference/conformance/conformance.pb.swift
+++ b/Reference/conformance/conformance.pb.swift
@@ -163,7 +163,13 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   /// other serializer methods are defined in the SwiftProtobuf library. See the
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try self.payload?.traverse(visitor: &visitor)
+    switch self.payload {
+    case .protobufPayload(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
+    case .jsonPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    default: break
+    }
     if self.requestedOutputFormat != .unspecified {
       try visitor.visitSingularEnumField(value: self.requestedOutputFormat, fieldNumber: 3)
     }
@@ -306,7 +312,21 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// other serializer methods are defined in the SwiftProtobuf library. See the
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try self.result?.traverse(visitor: &visitor)
+    switch self.result {
+    case .parseError(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    case .runtimeError(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    case .protobufPayload(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
+    case .jsonPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+    case .skipped(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+    case .serializeError(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+    default: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 }
@@ -359,15 +379,6 @@ extension Conformance_ConformanceRequest.OneOf_Payload {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .protobufPayload(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
-    case .jsonPayload(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    }
   }
 }
 
@@ -437,22 +448,5 @@ extension Conformance_ConformanceResponse.OneOf_Result {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .parseError(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-    case .runtimeError(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .protobufPayload(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
-    case .jsonPayload(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-    case .skipped(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-    case .serializeError(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-    }
   }
 }

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -249,7 +249,21 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._kind?.traverse(visitor: &visitor)
+      switch _storage._kind {
+      case .nullValue(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
+      case .numberValue(let v)?:
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
+      case .stringValue(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      case .boolValue(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
+      case .structValue(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      case .listValue(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -406,23 +420,6 @@ extension Google_Protobuf_Value.OneOf_Kind {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .nullValue(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
-    case .numberValue(let v):
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
-    case .stringValue(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-    case .boolValue(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
-    case .structValue(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    case .listValue(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
   }
 }
 

--- a/Reference/google/protobuf/struct.pb.swift
+++ b/Reference/google/protobuf/struct.pb.swift
@@ -262,7 +262,7 @@ struct Google_Protobuf_Value: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
       case .listValue(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -1247,7 +1247,27 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       if !_storage._mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: _storage._mapStringForeignEnum, fieldNumber: 74)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      case .oneofBool(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
+      case .oneofUint64(let v)?:
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
+      case .oneofFloat(let v)?:
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
+      case .oneofDouble(let v)?:
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
+      case .oneofEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
+      default: break
+      }
       if let v = _storage._optionalBoolWrapper {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 201)
       }
@@ -1998,29 +2018,6 @@ extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    case .oneofBool(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
-    case .oneofUint64(let v):
-      try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
-    case .oneofFloat(let v):
-      try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
-    case .oneofDouble(let v):
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
-    case .oneofEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
-    }
   }
 }
 

--- a/Reference/google/protobuf/test_messages_proto3.pb.swift
+++ b/Reference/google/protobuf/test_messages_proto3.pb.swift
@@ -1266,7 +1266,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
       case .oneofEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
-      default: break
+      case nil: break
       }
       if let v = _storage._optionalBoolWrapper {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 201)

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -1242,7 +1242,17 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
       if let v = _storage._defaultCord {
         try visitor.visitSingularStringField(value: v, fieldNumber: 85)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -4196,7 +4206,17 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._foo?.traverse(visitor: &visitor)
+      switch _storage._foo {
+      case .fooInt(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      case .fooString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      case .fooMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      case .fooGroup(let v)?:
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -4719,8 +4739,42 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._foo?.traverse(visitor: &visitor)
-      try _storage._bar?.traverse(visitor: &visitor)
+      switch _storage._foo {
+      case .fooInt(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      case .fooString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      case .fooCord(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      case .fooStringPiece(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+      case .fooBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
+      case .fooEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+      case .fooMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      case .fooGroup(let v)?:
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
+      case .fooLazyMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      default: break
+      }
+      switch _storage._bar {
+      case .barInt(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
+      case .barString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 13)
+      case .barCord(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 14)
+      case .barStringPiece(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 15)
+      case .barBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
+      case .barEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
+      default: break
+      }
       if let v = _storage._bazInt {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 18)
       }
@@ -4866,7 +4920,15 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._foo?.traverse(visitor: &visitor)
+      switch _storage._foo {
+      case .fooInt(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      case .fooString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      case .fooMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -6372,7 +6434,17 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       if !_storage._stringStringMap.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _storage._stringStringMap, fieldNumber: 536870010)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+      case .oneofTestAllTypes(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -9496,19 +9568,6 @@ extension ProtobufUnittest_TestAllTypes.OneOf_OneofField {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    }
-  }
 }
 
 extension ProtobufUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
@@ -10743,19 +10802,6 @@ extension ProtobufUnittest_TestOneof.OneOf_Foo {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .fooInt(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-    case .fooString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .fooMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    case .fooGroup(let v):
-      try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
-    }
-  }
 }
 
 extension ProtobufUnittest_TestOneof.FooGroup: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -10964,29 +11010,6 @@ extension ProtobufUnittest_TestOneof2.OneOf_Foo {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .fooInt(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-    case .fooString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .fooCord(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-    case .fooStringPiece(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-    case .fooBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
-    case .fooEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    case .fooMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    case .fooGroup(let v):
-      try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
-    case .fooLazyMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-    }
-  }
 }
 
 extension ProtobufUnittest_TestOneof2.OneOf_Bar {
@@ -11038,23 +11061,6 @@ extension ProtobufUnittest_TestOneof2.OneOf_Bar {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .barInt(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
-    case .barString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 13)
-    case .barCord(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 14)
-    case .barStringPiece(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 15)
-    case .barBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
-    case .barEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
-    }
   }
 }
 
@@ -11159,17 +11165,6 @@ extension ProtobufUnittest_TestRequiredOneof.OneOf_Foo {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .fooInt(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-    case .fooString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .fooMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
   }
 }
 
@@ -11800,19 +11795,6 @@ extension ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-    case .oneofTestAllTypes(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-    }
   }
 }
 

--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -1251,7 +1251,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -4215,7 +4215,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
       case .fooGroup(let v)?:
         try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -4758,7 +4758,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
         try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
       case .fooLazyMessage(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      default: break
+      case nil: break
       }
       switch _storage._bar {
       case .barInt(let v)?:
@@ -4773,7 +4773,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
         try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
       case .barEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
-      default: break
+      case nil: break
       }
       if let v = _storage._bazInt {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 18)
@@ -4927,7 +4927,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 2)
       case .fooMessage(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -6443,7 +6443,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
         try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -194,7 +194,9 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
     if let v = self._field1 {
       try visitor.visitSingularStringField(value: v, fieldNumber: 1)
     }
-    try self.anOneof?.traverse(visitor: &visitor)
+    if case .oneofField(let v)? = self.anOneof {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2580,12 +2582,6 @@ extension ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .oneofField(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -1241,7 +1241,19 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
       if let v = _storage._defaultCord {
         try visitor.visitSingularStringField(value: v, fieldNumber: 85)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      case .oneofLazyNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
+      default: break
+      }
       if let v = _storage._deceptivelyNamedList {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 116)
       }
@@ -2446,7 +2458,17 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       if !_storage._stringStringMap.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _storage._stringStringMap, fieldNumber: 536870010)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+      case .oneofTestAllTypes(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -5107,21 +5129,6 @@ extension ProtobufUnittest_TestAllTypesLite.OneOf_OneofField {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    case .oneofLazyNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-    }
-  }
 }
 
 extension ProtobufUnittest_TestAllTypesLite.NestedEnum: SwiftProtobuf._ProtoNameProviding {
@@ -5662,19 +5669,6 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-    case .oneofTestAllTypes(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -1252,7 +1252,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
       case .oneofLazyNestedMessage(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-      default: break
+      case nil: break
       }
       if let v = _storage._deceptivelyNamedList {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 116)
@@ -2467,7 +2467,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
         try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -1180,7 +1180,19 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
       if let v = _storage._defaultCord {
         try visitor.visitSingularStringField(value: v, fieldNumber: 85)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      case .lazyOneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1658,21 +1670,6 @@ extension ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    case .lazyOneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_no_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_no_arena.pb.swift
@@ -1191,7 +1191,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
       case .lazyOneofNestedMessage(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -673,7 +673,17 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
       if !_storage._repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _storage._repeatedLazyMessage, fieldNumber: 57)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1041,19 +1051,6 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
-    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_no_field_presence.pb.swift
+++ b/Reference/google/protobuf/unittest_no_field_presence.pb.swift
@@ -682,7 +682,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -157,7 +157,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
       case .stringField(let v)?:
         try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      default: break
+      case nil: break
       }
       if let v = _storage._msg {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 19)

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -152,7 +152,13 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
       if let v = _storage._i {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
       }
-      try _storage._foo?.traverse(visitor: &visitor)
+      switch _storage._foo {
+      case .integerField(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+      case .stringField(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      default: break
+      }
       if let v = _storage._msg {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 19)
       }
@@ -399,15 +405,6 @@ extension ProtobufUnittest_TestOptimizedForSize.OneOf_Foo {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .integerField(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-    case .stringField(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -199,7 +199,13 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
     if !self.repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitPackedEnumField(value: self.repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try self.o?.traverse(visitor: &visitor)
+    switch self.o {
+    case .oneofE1(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+    case .oneofE2(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+    default: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 }
@@ -288,7 +294,13 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     if !self.repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitPackedEnumField(value: self.repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try self.o?.traverse(visitor: &visitor)
+    switch self.o {
+    case .oneofE1(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+    case .oneofE2(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+    default: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 }
@@ -357,15 +369,6 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofE1(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-    case .oneofE2(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    }
-  }
 }
 
 extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -410,14 +413,5 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofE1(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-    case .oneofE2(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    }
   }
 }

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum.pb.swift
@@ -204,7 +204,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
       try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
     case .oneofE2(let v)?:
       try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    default: break
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -299,7 +299,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
       try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
     case .oneofE2(let v)?:
       try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    default: break
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -170,7 +170,13 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
     if !self.repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitRepeatedEnumField(value: self.repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try self.o?.traverse(visitor: &visitor)
+    switch self.o {
+    case .oneofE1(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+    case .oneofE2(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+    default: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -231,14 +237,5 @@ extension Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofE1(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-    case .oneofE2(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    }
   }
 }

--- a/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
+++ b/Reference/google/protobuf/unittest_preserve_unknown_enum2.pb.swift
@@ -175,7 +175,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
       try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
     case .oneofE2(let v)?:
       try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    default: break
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -765,7 +765,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -1889,7 +1889,7 @@ struct Proto3TestOneof: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 2)
       case .fooMessage(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/google/protobuf/unittest_proto3.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3.pb.swift
@@ -756,7 +756,17 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
       if !_storage._repeatedPublicImportMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _storage._repeatedPublicImportMessage, fieldNumber: 54)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1872,7 +1882,15 @@ struct Proto3TestOneof: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._foo?.traverse(visitor: &visitor)
+      switch _storage._foo {
+      case .fooInt(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      case .fooString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      case .fooMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -2646,19 +2664,6 @@ extension Proto3TestAllTypes.OneOf_OneofField {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    }
-  }
 }
 
 extension Proto3TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
@@ -3242,17 +3247,6 @@ extension Proto3TestOneof.OneOf_Foo {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .fooInt(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-    case .fooString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .fooMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -694,7 +694,17 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
       if !_storage._repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _storage._repeatedLazyMessage, fieldNumber: 57)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1325,19 +1335,6 @@ extension Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_proto3_arena.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena.pb.swift
@@ -703,7 +703,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -694,7 +694,17 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
       if !_storage._repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _storage._repeatedLazyMessage, fieldNumber: 57)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1325,19 +1335,6 @@ extension Proto3ArenaLiteUnittest_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_arena_lite.pb.swift
@@ -703,7 +703,7 @@ struct Proto3ArenaLiteUnittest_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -694,7 +694,17 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
       if !_storage._repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _storage._repeatedLazyMessage, fieldNumber: 57)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1325,19 +1335,6 @@ extension Proto3LiteUnittest_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    }
   }
 }
 

--- a/Reference/google/protobuf/unittest_proto3_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_proto3_lite.pb.swift
@@ -703,7 +703,7 @@ struct Proto3LiteUnittest_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -768,7 +768,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
       case .bytesField(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/google/protobuf/unittest_well_known_types.pb.swift
+++ b/Reference/google/protobuf/unittest_well_known_types.pb.swift
@@ -731,7 +731,45 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .anyField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      case .apiField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      case .durationField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      case .emptyField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      case .fieldMaskField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      case .sourceContextField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      case .structField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      case .timestampField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+      case .typeField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+      case .doubleField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+      case .floatField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      case .int64Field(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+      case .uint64Field(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+      case .int32Field(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
+      case .uint32Field(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+      case .boolField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
+      case .stringField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
+      case .bytesField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1338,47 +1376,6 @@ extension ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .anyField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    case .apiField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    case .durationField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    case .emptyField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-    case .fieldMaskField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    case .sourceContextField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    case .structField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    case .timestampField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-    case .typeField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-    case .doubleField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-    case .floatField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-    case .int64Field(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-    case .uint64Field(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-    case .int32Field(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
-    case .uint32Field(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
-    case .boolField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
-    case .stringField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
-    case .bytesField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
-    }
   }
 }
 

--- a/Reference/pluginlib_descriptor_test.pb.swift
+++ b/Reference/pluginlib_descriptor_test.pb.swift
@@ -280,7 +280,17 @@ struct SDTTopLevelMessage: SwiftProtobuf.Message {
       if let v = _storage._field2 {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
       }
-      try _storage._o?.traverse(visitor: &visitor)
+      switch _storage._o {
+      case .field3(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 3)
+      case .field4(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 4)
+      case .field5(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      case .field6(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -620,19 +630,6 @@ extension SDTTopLevelMessage.OneOf_O {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .field3(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 3)
-    case .field4(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 4)
-    case .field5(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    case .field6(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
   }
 }
 

--- a/Reference/pluginlib_descriptor_test.pb.swift
+++ b/Reference/pluginlib_descriptor_test.pb.swift
@@ -289,7 +289,7 @@ struct SDTTopLevelMessage: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
       case .field6(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -930,7 +930,17 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
       if let v = _storage._defaultCord {
         try visitor.visitSingularStringField(value: v, fieldNumber: 85)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1346,19 +1356,6 @@ extension ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    }
   }
 }
 

--- a/Reference/unittest_swift_all_required_types.pb.swift
+++ b/Reference/unittest_swift_all_required_types.pb.swift
@@ -939,7 +939,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -235,6 +235,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
         try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
       case .oneofInt32(let v)?:
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
+      case nil: break
       default: break
       }
       if let v = _storage._myString {
@@ -462,7 +463,7 @@ struct Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftProt
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
     case .b(let v)?:
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 26)
-    default: break
+    case nil: break
     }
     if case .a2(let v)? = self.oConflictField {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 101)

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -230,16 +230,26 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
         try visitor.visitSingularInt64Field(value: v, fieldNumber: 1)
       }
       try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 2, end: 9)
-      try _storage._options?.traverse_9_10(visitor: &visitor)
+      switch _storage._options {
+      case .oneofBool(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
+      case .oneofInt32(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
+      default: break
+      }
       if let v = _storage._myString {
         try visitor.visitSingularStringField(value: v, fieldNumber: 11)
       }
       try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 12, end: 56)
-      try _storage._options?.traverse_60(visitor: &visitor)
+      if case .oneofInt64(let v)? = _storage._options {
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
+      }
       if let v = _storage._myFloat {
         try visitor.visitSingularFloatField(value: v, fieldNumber: 101)
       }
-      try _storage._options?.traverse_150(visitor: &visitor)
+      if case .oneofString(let v)? = _storage._options {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 150)
+      }
       if let v = _storage._optionalNestedMessage {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
       }
@@ -447,18 +457,36 @@ struct Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftProt
   /// other serializer methods are defined in the SwiftProtobuf library. See the
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try self.oGood?.traverse(visitor: &visitor)
-    try self.oConflictField?.traverse_101(visitor: &visitor)
+    switch self.oGood {
+    case .a(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    case .b(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 26)
+    default: break
+    }
+    if case .a2(let v)? = self.oConflictField {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 101)
+    }
     if let v = self._m {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 113)
     }
-    try self.oConflictField?.traverse_126(visitor: &visitor)
-    try self.oConflictExtensionsStart?.traverse_201(visitor: &visitor)
+    if case .b2(let v)? = self.oConflictField {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 126)
+    }
+    if case .a3(let v)? = self.oConflictExtensionsStart {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 201)
+    }
     try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 202, end: 203)
-    try self.oConflictExtensionsStart?.traverse_226(visitor: &visitor)
-    try self.oConflictExtensionsEnd?.traverse_301(visitor: &visitor)
+    if case .b3(let v)? = self.oConflictExtensionsStart {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 226)
+    }
+    if case .a4(let v)? = self.oConflictExtensionsEnd {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 301)
+    }
     try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 325, end: 326)
-    try self.oConflictExtensionsEnd?.traverse_326(visitor: &visitor)
+    if case .b4(let v)? = self.oConflictExtensionsEnd {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 326)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -618,29 +646,6 @@ extension Swift_Protobuf_TestFieldOrderings.OneOf_Options {
     }
     return nil
   }
-
-  fileprivate func traverse_9_10<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofBool(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
-    case .oneofInt32(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
-    default:
-      break
-    }
-  }
-
-  fileprivate func traverse_60<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .oneofInt64(let v) = self {
-      try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
-    }
-  }
-
-  fileprivate func traverse_150<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .oneofString(let v) = self {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 150)
-    }
-  }
 }
 
 extension Swift_Protobuf_TestFieldOrderings.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -704,15 +709,6 @@ extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OGood {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .a(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-    case .b(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 26)
-    }
-  }
 }
 
 extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictField {
@@ -736,18 +732,6 @@ extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse_101<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .a2(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 101)
-    }
-  }
-
-  fileprivate func traverse_126<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .b2(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 126)
-    }
   }
 }
 
@@ -773,18 +757,6 @@ extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsStart
     }
     return nil
   }
-
-  fileprivate func traverse_201<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .a3(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 201)
-    }
-  }
-
-  fileprivate func traverse_226<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .b3(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 226)
-    }
-  }
 }
 
 extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsEnd {
@@ -808,17 +780,5 @@ extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsEnd {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse_301<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .a4(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 301)
-    }
-  }
-
-  fileprivate func traverse_326<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .b4(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 326)
-    }
   }
 }

--- a/Reference/unittest_swift_oneof_all_required.pb.swift
+++ b/Reference/unittest_swift_oneof_all_required.pb.swift
@@ -315,7 +315,7 @@ struct ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message {
         try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
       case .option4(let v)?:
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 6)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Reference/unittest_swift_oneof_all_required.pb.swift
+++ b/Reference/unittest_swift_oneof_all_required.pb.swift
@@ -306,7 +306,17 @@ struct ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._option?.traverse(visitor: &visitor)
+      switch _storage._option {
+      case .option1(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      case .option2(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      case .option3(let v)?:
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
+      case .option4(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 6)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -415,19 +425,6 @@ extension ProtobufUnittest_OneOfContainer.OneOf_Option {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .option1(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    case .option2(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    case .option3(let v):
-      try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
-    case .option4(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 6)
-    }
   }
 }
 

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -961,7 +961,45 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
       if !_storage._repeatedEnum.isEmpty {
         try visitor.visitRepeatedEnumField(value: _storage._repeatedEnum, fieldNumber: 49)
       }
-      try _storage._o?.traverse(visitor: &visitor)
+      switch _storage._o {
+      case .oneofInt32(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
+      case .oneofInt64(let v)?:
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
+      case .oneofUint64(let v)?:
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
+      case .oneofSint32(let v)?:
+        try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
+      case .oneofSint64(let v)?:
+        try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
+      case .oneofFixed32(let v)?:
+        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
+      case .oneofFixed64(let v)?:
+        try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
+      case .oneofSfixed32(let v)?:
+        try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
+      case .oneofSfixed64(let v)?:
+        try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
+      case .oneofFloat(let v)?:
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
+      case .oneofDouble(let v)?:
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
+      case .oneofBool(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 64)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
+      case .oneofGroup(let v)?:
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 66)
+      case .oneofMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
+      case .oneofEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
+      default: break
+      }
       if !_storage._mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _storage._mapInt32Int32, fieldNumber: 70)
       }
@@ -1509,47 +1547,6 @@ extension ProtobufUnittest_Message2.OneOf_O {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofInt32(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
-    case .oneofInt64(let v):
-      try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
-    case .oneofUint64(let v):
-      try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
-    case .oneofSint32(let v):
-      try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
-    case .oneofSint64(let v):
-      try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
-    case .oneofFixed32(let v):
-      try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
-    case .oneofFixed64(let v):
-      try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
-    case .oneofSfixed32(let v):
-      try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
-    case .oneofSfixed64(let v):
-      try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
-    case .oneofFloat(let v):
-      try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
-    case .oneofDouble(let v):
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
-    case .oneofBool(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 64)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
-    case .oneofGroup(let v):
-      try visitor.visitSingularGroupField(value: v, fieldNumber: 66)
-    case .oneofMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
-    case .oneofEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-    }
   }
 }
 

--- a/Reference/unittest_swift_runtime_proto2.pb.swift
+++ b/Reference/unittest_swift_runtime_proto2.pb.swift
@@ -998,7 +998,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
       case .oneofEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-      default: break
+      case nil: break
       }
       if !_storage._mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _storage._mapInt32Int32, fieldNumber: 70)

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -763,7 +763,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
       case .oneofEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-      default: break
+      case nil: break
       }
       if !_storage._mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _storage._mapInt32Int32, fieldNumber: 70)

--- a/Reference/unittest_swift_runtime_proto3.pb.swift
+++ b/Reference/unittest_swift_runtime_proto3.pb.swift
@@ -728,7 +728,43 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
       if !_storage._repeatedEnum.isEmpty {
         try visitor.visitPackedEnumField(value: _storage._repeatedEnum, fieldNumber: 49)
       }
-      try _storage._o?.traverse(visitor: &visitor)
+      switch _storage._o {
+      case .oneofInt32(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
+      case .oneofInt64(let v)?:
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
+      case .oneofUint64(let v)?:
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
+      case .oneofSint32(let v)?:
+        try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
+      case .oneofSint64(let v)?:
+        try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
+      case .oneofFixed32(let v)?:
+        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
+      case .oneofFixed64(let v)?:
+        try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
+      case .oneofSfixed32(let v)?:
+        try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
+      case .oneofSfixed64(let v)?:
+        try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
+      case .oneofFloat(let v)?:
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
+      case .oneofDouble(let v)?:
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
+      case .oneofBool(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 64)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
+      case .oneofMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
+      case .oneofEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
+      default: break
+      }
       if !_storage._mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _storage._mapInt32Int32, fieldNumber: 70)
       }
@@ -1260,45 +1296,6 @@ extension ProtobufUnittest_Message3.OneOf_O {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofInt32(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
-    case .oneofInt64(let v):
-      try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
-    case .oneofUint64(let v):
-      try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
-    case .oneofSint32(let v):
-      try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
-    case .oneofSint64(let v):
-      try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
-    case .oneofFixed32(let v):
-      try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
-    case .oneofFixed64(let v):
-      try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
-    case .oneofSfixed32(let v):
-      try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
-    case .oneofSfixed64(let v):
-      try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
-    case .oneofFloat(let v):
-      try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
-    case .oneofDouble(let v):
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
-    case .oneofBool(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 64)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
-    case .oneofMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
-    case .oneofEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-    }
   }
 }
 

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -168,7 +168,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
       try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
     case .jsonPayload(let v)?:
       try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    default: break
+    case nil: break
     }
     if self.requestedOutputFormat != .unspecified {
       try visitor.visitSingularEnumField(value: self.requestedOutputFormat, fieldNumber: 3)
@@ -325,7 +325,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
       try visitor.visitSingularStringField(value: v, fieldNumber: 5)
     case .serializeError(let v)?:
       try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-    default: break
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }

--- a/Sources/Conformance/conformance.pb.swift
+++ b/Sources/Conformance/conformance.pb.swift
@@ -163,7 +163,13 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   /// other serializer methods are defined in the SwiftProtobuf library. See the
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try self.payload?.traverse(visitor: &visitor)
+    switch self.payload {
+    case .protobufPayload(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
+    case .jsonPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    default: break
+    }
     if self.requestedOutputFormat != .unspecified {
       try visitor.visitSingularEnumField(value: self.requestedOutputFormat, fieldNumber: 3)
     }
@@ -306,7 +312,21 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// other serializer methods are defined in the SwiftProtobuf library. See the
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try self.result?.traverse(visitor: &visitor)
+    switch self.result {
+    case .parseError(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    case .runtimeError(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    case .protobufPayload(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
+    case .jsonPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+    case .skipped(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+    case .serializeError(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+    default: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 }
@@ -359,15 +379,6 @@ extension Conformance_ConformanceRequest.OneOf_Payload {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .protobufPayload(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
-    case .jsonPayload(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    }
   }
 }
 
@@ -437,22 +448,5 @@ extension Conformance_ConformanceResponse.OneOf_Result {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .parseError(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-    case .runtimeError(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .protobufPayload(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
-    case .jsonPayload(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-    case .skipped(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-    case .serializeError(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-    }
   }
 }

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -1247,7 +1247,27 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       if !_storage._mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: _storage._mapStringForeignEnum, fieldNumber: 74)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      case .oneofBool(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
+      case .oneofUint64(let v)?:
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
+      case .oneofFloat(let v)?:
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
+      case .oneofDouble(let v)?:
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
+      case .oneofEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
+      default: break
+      }
       if let v = _storage._optionalBoolWrapper {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 201)
       }
@@ -1998,29 +2018,6 @@ extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    case .oneofBool(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
-    case .oneofUint64(let v):
-      try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
-    case .oneofFloat(let v):
-      try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
-    case .oneofDouble(let v):
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
-    case .oneofEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
-    }
   }
 }
 

--- a/Sources/Conformance/test_messages_proto3.pb.swift
+++ b/Sources/Conformance/test_messages_proto3.pb.swift
@@ -1266,7 +1266,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
       case .oneofEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
-      default: break
+      case nil: break
       }
       if let v = _storage._optionalBoolWrapper {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 201)

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -262,7 +262,7 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
       case .listValue(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Sources/SwiftProtobuf/struct.pb.swift
+++ b/Sources/SwiftProtobuf/struct.pb.swift
@@ -249,7 +249,21 @@ public struct Google_Protobuf_Value: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._kind?.traverse(visitor: &visitor)
+      switch _storage._kind {
+      case .nullValue(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
+      case .numberValue(let v)?:
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
+      case .stringValue(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      case .boolValue(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
+      case .structValue(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      case .listValue(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -406,23 +420,6 @@ extension Google_Protobuf_Value.OneOf_Kind {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .nullValue(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 1)
-    case .numberValue(let v):
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 2)
-    case .stringValue(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-    case .boolValue(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 4)
-    case .structValue(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    case .listValue(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    }
   }
 }
 

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -404,8 +404,10 @@ class OneofGenerator {
                 p.print("try visitor.visitSingular\(f.protoGenericType)Field(value: v, fieldNumber: \(f.number))\n")
                 p.outdent()
             }
-            // Covers any cases not in this group as well as nil (no oneof field being set).
-            p.print("default: break\n")
+            p.print("case nil: break\n")  // Cover not being set.
+            if fieldSortedGrouped.count > 1 {
+                p.print("default: break\n")  // Multiple groups, cover other cases.
+            }
         }
         p.print("}\n")
     }

--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -290,39 +290,6 @@ class OneofGenerator {
         p.outdent()
         p.print("}\n")
 
-        // A Traverse for each group.
-        let hasMultipleGroups = fieldSortedGrouped.count > 1
-        for g in 0..<fieldSortedGrouped.count {
-            p.print("\n")
-            p.print("fileprivate func traverse\(groupName(g))<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {\n")
-            p.indent()
-            let group = fieldSortedGrouped[g]
-            if group.count == 1 {
-                let f = group.first!
-                p.print("if case .\(f.swiftName)(let v) = self {\n")
-                p.indent()
-                p.print("try visitor.visitSingular\(f.protoGenericType)Field(value: v, fieldNumber: \(f.number))\n")
-                p.outdent()
-            } else {
-                p.print("switch self {\n")
-                for f in group {
-                    p.print("case .\(f.swiftName)(let v):\n")
-                    p.indent()
-                    p.print("try visitor.visitSingular\(f.protoGenericType)Field(value: v, fieldNumber: \(f.number))\n")
-                    p.outdent()
-                }
-                if hasMultipleGroups {
-                    p.print("default:\n")
-                    p.indent()
-                    p.print("break\n")
-                    p.outdent()
-                }
-            }
-            p.print("}\n")
-            p.outdent()
-            p.print("}\n")
-        }
-
         p.outdent()
         p.print("}\n")
     }
@@ -333,23 +300,6 @@ class OneofGenerator {
         }
         let prefix = variable.isEmpty ? "self." : "\(variable)."
         return "\(prefix)\(swiftFieldName)"
-    }
-
-    private func groupName(_ group: Int) -> String {
-        precondition(group < fieldSortedGrouped.count)
-
-        if fieldSortedGrouped.count == 1 {
-            // One group for the oneof, no names needed.
-            return ""
-        }
-
-        // Name it based on the field number(s).
-        let fieldGroup = fieldSortedGrouped[group]
-        if fieldGroup.count == 1 {
-            return "_\(fieldGroup.first!.number)"
-        } else {
-            return "_\(fieldGroup.first!.number)_\(fieldGroup.last!.number)"
-        }
     }
 
     private func gerenateOneofEnumProperty(printer p: inout CodePrinter) {
@@ -441,7 +391,23 @@ class OneofGenerator {
         let group = fieldSortedGrouped[field.group]
         guard field === group.first else { return }
 
-        p.print("try \(storedProperty())?.traverse\(groupName(field.group))(visitor: &visitor)\n")
+        if group.count == 1 {
+            p.print("if case .\(field.swiftName)(let v)? = \(storedProperty()) {\n")
+            p.indent()
+            p.print("try visitor.visitSingular\(field.protoGenericType)Field(value: v, fieldNumber: \(field.number))\n")
+            p.outdent()
+        } else {
+            p.print("switch \(storedProperty()) {\n")
+            for f in group {
+                p.print("case .\(f.swiftName)(let v)?:\n")
+                p.indent()
+                p.print("try visitor.visitSingular\(f.protoGenericType)Field(value: v, fieldNumber: \(f.number))\n")
+                p.outdent()
+            }
+            // Covers any cases not in this group as well as nil (no oneof field being set).
+            p.print("default: break\n")
+        }
+        p.print("}\n")
     }
 
     func generateFieldComparison(printer p: inout CodePrinter, field: MemberFieldGenerator) {

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -168,7 +168,7 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
       try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
     case .jsonPayload(let v)?:
       try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    default: break
+    case nil: break
     }
     if self.requestedOutputFormat != .unspecified {
       try visitor.visitSingularEnumField(value: self.requestedOutputFormat, fieldNumber: 3)
@@ -325,7 +325,7 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
       try visitor.visitSingularStringField(value: v, fieldNumber: 5)
     case .serializeError(let v)?:
       try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-    default: break
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }

--- a/Tests/SwiftProtobufTests/conformance.pb.swift
+++ b/Tests/SwiftProtobufTests/conformance.pb.swift
@@ -163,7 +163,13 @@ struct Conformance_ConformanceRequest: SwiftProtobuf.Message {
   /// other serializer methods are defined in the SwiftProtobuf library. See the
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try self.payload?.traverse(visitor: &visitor)
+    switch self.payload {
+    case .protobufPayload(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
+    case .jsonPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    default: break
+    }
     if self.requestedOutputFormat != .unspecified {
       try visitor.visitSingularEnumField(value: self.requestedOutputFormat, fieldNumber: 3)
     }
@@ -306,7 +312,21 @@ struct Conformance_ConformanceResponse: SwiftProtobuf.Message {
   /// other serializer methods are defined in the SwiftProtobuf library. See the
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try self.result?.traverse(visitor: &visitor)
+    switch self.result {
+    case .parseError(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
+    case .runtimeError(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+    case .protobufPayload(let v)?:
+      try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
+    case .jsonPayload(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+    case .skipped(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
+    case .serializeError(let v)?:
+      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
+    default: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 }
@@ -359,15 +379,6 @@ extension Conformance_ConformanceRequest.OneOf_Payload {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .protobufPayload(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 1)
-    case .jsonPayload(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    }
   }
 }
 
@@ -437,22 +448,5 @@ extension Conformance_ConformanceResponse.OneOf_Result {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .parseError(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 1)
-    case .runtimeError(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .protobufPayload(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 3)
-    case .jsonPayload(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-    case .skipped(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 5)
-    case .serializeError(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 6)
-    }
   }
 }

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -1247,7 +1247,27 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
       if !_storage._mapStringForeignEnum.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufEnumMap<SwiftProtobuf.ProtobufString,ProtobufTestMessages_Proto3_ForeignEnum>.self, value: _storage._mapStringForeignEnum, fieldNumber: 74)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      case .oneofBool(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
+      case .oneofUint64(let v)?:
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
+      case .oneofFloat(let v)?:
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
+      case .oneofDouble(let v)?:
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
+      case .oneofEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
+      default: break
+      }
       if let v = _storage._optionalBoolWrapper {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 201)
       }
@@ -1998,29 +2018,6 @@ extension ProtobufTestMessages_Proto3_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    case .oneofBool(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 115)
-    case .oneofUint64(let v):
-      try visitor.visitSingularUInt64Field(value: v, fieldNumber: 116)
-    case .oneofFloat(let v):
-      try visitor.visitSingularFloatField(value: v, fieldNumber: 117)
-    case .oneofDouble(let v):
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
-    case .oneofEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/test_messages_proto3.pb.swift
@@ -1266,7 +1266,7 @@ struct ProtobufTestMessages_Proto3_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularDoubleField(value: v, fieldNumber: 118)
       case .oneofEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 119)
-      default: break
+      case nil: break
       }
       if let v = _storage._optionalBoolWrapper {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 201)

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -1242,7 +1242,17 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
       if let v = _storage._defaultCord {
         try visitor.visitSingularStringField(value: v, fieldNumber: 85)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -4196,7 +4206,17 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._foo?.traverse(visitor: &visitor)
+      switch _storage._foo {
+      case .fooInt(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      case .fooString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      case .fooMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      case .fooGroup(let v)?:
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -4719,8 +4739,42 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._foo?.traverse(visitor: &visitor)
-      try _storage._bar?.traverse(visitor: &visitor)
+      switch _storage._foo {
+      case .fooInt(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      case .fooString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      case .fooCord(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      case .fooStringPiece(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+      case .fooBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
+      case .fooEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+      case .fooMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      case .fooGroup(let v)?:
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
+      case .fooLazyMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      default: break
+      }
+      switch _storage._bar {
+      case .barInt(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
+      case .barString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 13)
+      case .barCord(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 14)
+      case .barStringPiece(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 15)
+      case .barBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
+      case .barEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
+      default: break
+      }
       if let v = _storage._bazInt {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 18)
       }
@@ -4866,7 +4920,15 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._foo?.traverse(visitor: &visitor)
+      switch _storage._foo {
+      case .fooInt(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      case .fooString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      case .fooMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -6372,7 +6434,17 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
       if !_storage._stringStringMap.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _storage._stringStringMap, fieldNumber: 536870010)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+      case .oneofTestAllTypes(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -9496,19 +9568,6 @@ extension ProtobufUnittest_TestAllTypes.OneOf_OneofField {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    }
-  }
 }
 
 extension ProtobufUnittest_TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
@@ -10743,19 +10802,6 @@ extension ProtobufUnittest_TestOneof.OneOf_Foo {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .fooInt(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-    case .fooString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .fooMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    case .fooGroup(let v):
-      try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
-    }
-  }
 }
 
 extension ProtobufUnittest_TestOneof.FooGroup: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -10964,29 +11010,6 @@ extension ProtobufUnittest_TestOneof2.OneOf_Foo {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .fooInt(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-    case .fooString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .fooCord(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-    case .fooStringPiece(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-    case .fooBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 5)
-    case .fooEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    case .fooMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    case .fooGroup(let v):
-      try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
-    case .fooLazyMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-    }
-  }
 }
 
 extension ProtobufUnittest_TestOneof2.OneOf_Bar {
@@ -11038,23 +11061,6 @@ extension ProtobufUnittest_TestOneof2.OneOf_Bar {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .barInt(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 12)
-    case .barString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 13)
-    case .barCord(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 14)
-    case .barStringPiece(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 15)
-    case .barBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
-    case .barEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
-    }
   }
 }
 
@@ -11159,17 +11165,6 @@ extension ProtobufUnittest_TestRequiredOneof.OneOf_Foo {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .fooInt(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-    case .fooString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .fooMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
   }
 }
 
@@ -11800,19 +11795,6 @@ extension ProtobufUnittest_TestHugeFieldNumbers.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-    case .oneofTestAllTypes(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -1251,7 +1251,7 @@ struct ProtobufUnittest_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -4215,7 +4215,7 @@ struct ProtobufUnittest_TestOneof: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
       case .fooGroup(let v)?:
         try visitor.visitSingularGroupField(value: v, fieldNumber: 4)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -4758,7 +4758,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
         try visitor.visitSingularGroupField(value: v, fieldNumber: 8)
       case .fooLazyMessage(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-      default: break
+      case nil: break
       }
       switch _storage._bar {
       case .barInt(let v)?:
@@ -4773,7 +4773,7 @@ struct ProtobufUnittest_TestOneof2: SwiftProtobuf.Message {
         try visitor.visitSingularBytesField(value: v, fieldNumber: 16)
       case .barEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 17)
-      default: break
+      case nil: break
       }
       if let v = _storage._bazInt {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 18)
@@ -4927,7 +4927,7 @@ struct ProtobufUnittest_TestRequiredOneof: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 2)
       case .fooMessage(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -6443,7 +6443,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
         try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -194,7 +194,9 @@ struct ProtobufUnittest_TestMessageWithCustomOptions: SwiftProtobuf.Message {
     if let v = self._field1 {
       try visitor.visitSingularStringField(value: v, fieldNumber: 1)
     }
-    try self.anOneof?.traverse(visitor: &visitor)
+    if case .oneofField(let v)? = self.anOneof {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -2580,12 +2582,6 @@ extension ProtobufUnittest_TestMessageWithCustomOptions.OneOf_AnOneof {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .oneofField(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -1241,7 +1241,19 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
       if let v = _storage._defaultCord {
         try visitor.visitSingularStringField(value: v, fieldNumber: 85)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      case .oneofLazyNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
+      default: break
+      }
       if let v = _storage._deceptivelyNamedList {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 116)
       }
@@ -2446,7 +2458,17 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
       if !_storage._stringStringMap.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: _storage._stringStringMap, fieldNumber: 536870010)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
+      case .oneofTestAllTypes(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -5107,21 +5129,6 @@ extension ProtobufUnittest_TestAllTypesLite.OneOf_OneofField {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    case .oneofLazyNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-    }
-  }
 }
 
 extension ProtobufUnittest_TestAllTypesLite.NestedEnum: SwiftProtobuf._ProtoNameProviding {
@@ -5662,19 +5669,6 @@ extension ProtobufUnittest_TestHugeFieldNumbersLite.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 536870011)
-    case .oneofTestAllTypes(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 536870012)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -1252,7 +1252,7 @@ struct ProtobufUnittest_TestAllTypesLite: SwiftProtobuf.Message {
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
       case .oneofLazyNestedMessage(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-      default: break
+      case nil: break
       }
       if let v = _storage._deceptivelyNamedList {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 116)
@@ -2467,7 +2467,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
         try visitor.visitSingularStringField(value: v, fieldNumber: 536870013)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 536870014)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -1180,7 +1180,19 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
       if let v = _storage._defaultCord {
         try visitor.visitSingularStringField(value: v, fieldNumber: 85)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      case .lazyOneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1658,21 +1670,6 @@ extension ProtobufUnittestNoArena_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    case .lazyOneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_arena.pb.swift
@@ -1191,7 +1191,7 @@ struct ProtobufUnittestNoArena_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
       case .lazyOneofNestedMessage(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 115)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -673,7 +673,17 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
       if !_storage._repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _storage._repeatedLazyMessage, fieldNumber: 57)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1041,19 +1051,6 @@ extension Proto2NofieldpresenceUnittest_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_field_presence.pb.swift
@@ -682,7 +682,7 @@ struct Proto2NofieldpresenceUnittest_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -157,7 +157,7 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
       case .stringField(let v)?:
         try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-      default: break
+      case nil: break
       }
       if let v = _storage._msg {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 19)

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -152,7 +152,13 @@ struct ProtobufUnittest_TestOptimizedForSize: SwiftProtobuf.Message, SwiftProtob
       if let v = _storage._i {
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
       }
-      try _storage._foo?.traverse(visitor: &visitor)
+      switch _storage._foo {
+      case .integerField(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
+      case .stringField(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 3)
+      default: break
+      }
       if let v = _storage._msg {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 19)
       }
@@ -399,15 +405,6 @@ extension ProtobufUnittest_TestOptimizedForSize.OneOf_Foo {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .integerField(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 2)
-    case .stringField(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 3)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -199,7 +199,13 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
     if !self.repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitPackedEnumField(value: self.repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try self.o?.traverse(visitor: &visitor)
+    switch self.o {
+    case .oneofE1(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+    case .oneofE2(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+    default: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 }
@@ -288,7 +294,13 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
     if !self.repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitPackedEnumField(value: self.repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try self.o?.traverse(visitor: &visitor)
+    switch self.o {
+    case .oneofE1(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+    case .oneofE2(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+    default: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 }
@@ -357,15 +369,6 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessage.OneOf_O {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofE1(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-    case .oneofE2(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    }
-  }
 }
 
 extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -410,14 +413,5 @@ extension Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra.OneOf_O {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofE1(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-    case .oneofE2(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    }
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum.pb.swift
@@ -204,7 +204,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
       try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
     case .oneofE2(let v)?:
       try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    default: break
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -299,7 +299,7 @@ struct Proto3PreserveUnknownEnumUnittest_MyMessagePlusExtra: SwiftProtobuf.Messa
       try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
     case .oneofE2(let v)?:
       try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    default: break
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -170,7 +170,13 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
     if !self.repeatedPackedUnexpectedE.isEmpty {
       try visitor.visitRepeatedEnumField(value: self.repeatedPackedUnexpectedE, fieldNumber: 4)
     }
-    try self.o?.traverse(visitor: &visitor)
+    switch self.o {
+    case .oneofE1(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
+    case .oneofE2(let v)?:
+      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
+    default: break
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -231,14 +237,5 @@ extension Proto2PreserveUnknownEnumUnittest_MyMessage.OneOf_O {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofE1(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
-    case .oneofE2(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    }
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_preserve_unknown_enum2.pb.swift
@@ -175,7 +175,7 @@ struct Proto2PreserveUnknownEnumUnittest_MyMessage: SwiftProtobuf.Message {
       try visitor.visitSingularEnumField(value: v, fieldNumber: 5)
     case .oneofE2(let v)?:
       try visitor.visitSingularEnumField(value: v, fieldNumber: 6)
-    default: break
+    case nil: break
     }
     try unknownFields.traverse(visitor: &visitor)
   }

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -765,7 +765,7 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -1889,7 +1889,7 @@ struct Proto3TestOneof: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 2)
       case .fooMessage(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3.pb.swift
@@ -756,7 +756,17 @@ struct Proto3TestAllTypes: SwiftProtobuf.Message {
       if !_storage._repeatedPublicImportMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _storage._repeatedPublicImportMessage, fieldNumber: 54)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1872,7 +1882,15 @@ struct Proto3TestOneof: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._foo?.traverse(visitor: &visitor)
+      switch _storage._foo {
+      case .fooInt(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+      case .fooString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 2)
+      case .fooMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -2646,19 +2664,6 @@ extension Proto3TestAllTypes.OneOf_OneofField {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    }
-  }
 }
 
 extension Proto3TestAllTypes.NestedEnum: SwiftProtobuf._ProtoNameProviding {
@@ -3242,17 +3247,6 @@ extension Proto3TestOneof.OneOf_Foo {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .fooInt(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-    case .fooString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 2)
-    case .fooMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -694,7 +694,17 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
       if !_storage._repeatedLazyMessage.isEmpty {
         try visitor.visitRepeatedMessageField(value: _storage._repeatedLazyMessage, fieldNumber: 57)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1325,19 +1335,6 @@ extension Proto3ArenaUnittest_TestAllTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_proto3_arena.pb.swift
@@ -703,7 +703,7 @@ struct Proto3ArenaUnittest_TestAllTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -930,7 +930,17 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
       if let v = _storage._defaultCord {
         try visitor.visitSingularStringField(value: v, fieldNumber: 85)
       }
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
+      case .oneofNestedMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 113)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1346,19 +1356,6 @@ extension ProtobufUnittest_TestAllRequiredTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 111)
-    case .oneofNestedMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 112)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 113)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_all_required_types.pb.swift
@@ -939,7 +939,7 @@ struct ProtobufUnittest_TestAllRequiredTypes: SwiftProtobuf.Message {
         try visitor.visitSingularStringField(value: v, fieldNumber: 113)
       case .oneofBytes(let v)?:
         try visitor.visitSingularBytesField(value: v, fieldNumber: 114)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -235,6 +235,7 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
         try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
       case .oneofInt32(let v)?:
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
+      case nil: break
       default: break
       }
       if let v = _storage._myString {
@@ -462,7 +463,7 @@ struct Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftProt
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
     case .b(let v)?:
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 26)
-    default: break
+    case nil: break
     }
     if case .a2(let v)? = self.oConflictField {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 101)

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -230,16 +230,26 @@ struct Swift_Protobuf_TestFieldOrderings: SwiftProtobuf.Message, SwiftProtobuf.E
         try visitor.visitSingularInt64Field(value: v, fieldNumber: 1)
       }
       try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 2, end: 9)
-      try _storage._options?.traverse_9_10(visitor: &visitor)
+      switch _storage._options {
+      case .oneofBool(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
+      case .oneofInt32(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
+      default: break
+      }
       if let v = _storage._myString {
         try visitor.visitSingularStringField(value: v, fieldNumber: 11)
       }
       try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 12, end: 56)
-      try _storage._options?.traverse_60(visitor: &visitor)
+      if case .oneofInt64(let v)? = _storage._options {
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
+      }
       if let v = _storage._myFloat {
         try visitor.visitSingularFloatField(value: v, fieldNumber: 101)
       }
-      try _storage._options?.traverse_150(visitor: &visitor)
+      if case .oneofString(let v)? = _storage._options {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 150)
+      }
       if let v = _storage._optionalNestedMessage {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 200)
       }
@@ -447,18 +457,36 @@ struct Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftProt
   /// other serializer methods are defined in the SwiftProtobuf library. See the
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    try self.oGood?.traverse(visitor: &visitor)
-    try self.oConflictField?.traverse_101(visitor: &visitor)
+    switch self.oGood {
+    case .a(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
+    case .b(let v)?:
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 26)
+    default: break
+    }
+    if case .a2(let v)? = self.oConflictField {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 101)
+    }
     if let v = self._m {
       try visitor.visitSingularInt32Field(value: v, fieldNumber: 113)
     }
-    try self.oConflictField?.traverse_126(visitor: &visitor)
-    try self.oConflictExtensionsStart?.traverse_201(visitor: &visitor)
+    if case .b2(let v)? = self.oConflictField {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 126)
+    }
+    if case .a3(let v)? = self.oConflictExtensionsStart {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 201)
+    }
     try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 202, end: 203)
-    try self.oConflictExtensionsStart?.traverse_226(visitor: &visitor)
-    try self.oConflictExtensionsEnd?.traverse_301(visitor: &visitor)
+    if case .b3(let v)? = self.oConflictExtensionsStart {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 226)
+    }
+    if case .a4(let v)? = self.oConflictExtensionsEnd {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 301)
+    }
     try visitor.visitExtensionFields(fields: _protobuf_extensionFieldValues, start: 325, end: 326)
-    try self.oConflictExtensionsEnd?.traverse_326(visitor: &visitor)
+    if case .b4(let v)? = self.oConflictExtensionsEnd {
+      try visitor.visitSingularInt32Field(value: v, fieldNumber: 326)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -618,29 +646,6 @@ extension Swift_Protobuf_TestFieldOrderings.OneOf_Options {
     }
     return nil
   }
-
-  fileprivate func traverse_9_10<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofBool(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 9)
-    case .oneofInt32(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 10)
-    default:
-      break
-    }
-  }
-
-  fileprivate func traverse_60<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .oneofInt64(let v) = self {
-      try visitor.visitSingularInt64Field(value: v, fieldNumber: 60)
-    }
-  }
-
-  fileprivate func traverse_150<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .oneofString(let v) = self {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 150)
-    }
-  }
 }
 
 extension Swift_Protobuf_TestFieldOrderings.NestedMessage: SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
@@ -704,15 +709,6 @@ extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OGood {
     }
     return nil
   }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .a(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 1)
-    case .b(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 26)
-    }
-  }
 }
 
 extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictField {
@@ -736,18 +732,6 @@ extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse_101<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .a2(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 101)
-    }
-  }
-
-  fileprivate func traverse_126<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .b2(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 126)
-    }
   }
 }
 
@@ -773,18 +757,6 @@ extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsStart
     }
     return nil
   }
-
-  fileprivate func traverse_201<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .a3(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 201)
-    }
-  }
-
-  fileprivate func traverse_226<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .b3(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 226)
-    }
-  }
 }
 
 extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsEnd {
@@ -808,17 +780,5 @@ extension Swift_Protobuf_OneofTraversalGeneration.OneOf_OConflictExtensionsEnd {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse_301<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .a4(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 301)
-    }
-  }
-
-  fileprivate func traverse_326<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if case .b4(let v) = self {
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 326)
-    }
   }
 }

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
@@ -315,7 +315,7 @@ struct ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message {
         try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
       case .option4(let v)?:
         try visitor.visitSingularInt32Field(value: v, fieldNumber: 6)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_oneof_all_required.pb.swift
@@ -306,7 +306,17 @@ struct ProtobufUnittest_OneOfContainer: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._option?.traverse(visitor: &visitor)
+      switch _storage._option {
+      case .option1(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      case .option2(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      case .option3(let v)?:
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
+      case .option4(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 6)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -415,19 +425,6 @@ extension ProtobufUnittest_OneOfContainer.OneOf_Option {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .option1(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    case .option2(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    case .option3(let v):
-      try visitor.visitSingularGroupField(value: v, fieldNumber: 3)
-    case .option4(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 6)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -961,7 +961,45 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
       if !_storage._repeatedEnum.isEmpty {
         try visitor.visitRepeatedEnumField(value: _storage._repeatedEnum, fieldNumber: 49)
       }
-      try _storage._o?.traverse(visitor: &visitor)
+      switch _storage._o {
+      case .oneofInt32(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
+      case .oneofInt64(let v)?:
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
+      case .oneofUint64(let v)?:
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
+      case .oneofSint32(let v)?:
+        try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
+      case .oneofSint64(let v)?:
+        try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
+      case .oneofFixed32(let v)?:
+        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
+      case .oneofFixed64(let v)?:
+        try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
+      case .oneofSfixed32(let v)?:
+        try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
+      case .oneofSfixed64(let v)?:
+        try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
+      case .oneofFloat(let v)?:
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
+      case .oneofDouble(let v)?:
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
+      case .oneofBool(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 64)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
+      case .oneofGroup(let v)?:
+        try visitor.visitSingularGroupField(value: v, fieldNumber: 66)
+      case .oneofMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
+      case .oneofEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
+      default: break
+      }
       if !_storage._mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _storage._mapInt32Int32, fieldNumber: 70)
       }
@@ -1509,47 +1547,6 @@ extension ProtobufUnittest_Message2.OneOf_O {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofInt32(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
-    case .oneofInt64(let v):
-      try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
-    case .oneofUint64(let v):
-      try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
-    case .oneofSint32(let v):
-      try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
-    case .oneofSint64(let v):
-      try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
-    case .oneofFixed32(let v):
-      try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
-    case .oneofFixed64(let v):
-      try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
-    case .oneofSfixed32(let v):
-      try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
-    case .oneofSfixed64(let v):
-      try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
-    case .oneofFloat(let v):
-      try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
-    case .oneofDouble(let v):
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
-    case .oneofBool(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 64)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
-    case .oneofGroup(let v):
-      try visitor.visitSingularGroupField(value: v, fieldNumber: 66)
-    case .oneofMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
-    case .oneofEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto2.pb.swift
@@ -998,7 +998,7 @@ struct ProtobufUnittest_Message2: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
       case .oneofEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-      default: break
+      case nil: break
       }
       if !_storage._mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _storage._mapInt32Int32, fieldNumber: 70)

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -763,7 +763,7 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
       case .oneofEnum(let v)?:
         try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-      default: break
+      case nil: break
       }
       if !_storage._mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _storage._mapInt32Int32, fieldNumber: 70)

--- a/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_runtime_proto3.pb.swift
@@ -728,7 +728,43 @@ struct ProtobufUnittest_Message3: SwiftProtobuf.Message {
       if !_storage._repeatedEnum.isEmpty {
         try visitor.visitPackedEnumField(value: _storage._repeatedEnum, fieldNumber: 49)
       }
-      try _storage._o?.traverse(visitor: &visitor)
+      switch _storage._o {
+      case .oneofInt32(let v)?:
+        try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
+      case .oneofInt64(let v)?:
+        try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
+      case .oneofUint32(let v)?:
+        try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
+      case .oneofUint64(let v)?:
+        try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
+      case .oneofSint32(let v)?:
+        try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
+      case .oneofSint64(let v)?:
+        try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
+      case .oneofFixed32(let v)?:
+        try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
+      case .oneofFixed64(let v)?:
+        try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
+      case .oneofSfixed32(let v)?:
+        try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
+      case .oneofSfixed64(let v)?:
+        try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
+      case .oneofFloat(let v)?:
+        try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
+      case .oneofDouble(let v)?:
+        try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
+      case .oneofBool(let v)?:
+        try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
+      case .oneofString(let v)?:
+        try visitor.visitSingularStringField(value: v, fieldNumber: 64)
+      case .oneofBytes(let v)?:
+        try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
+      case .oneofMessage(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
+      case .oneofEnum(let v)?:
+        try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
+      default: break
+      }
       if !_storage._mapInt32Int32.isEmpty {
         try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufInt32,SwiftProtobuf.ProtobufInt32>.self, value: _storage._mapInt32Int32, fieldNumber: 70)
       }
@@ -1260,45 +1296,6 @@ extension ProtobufUnittest_Message3.OneOf_O {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .oneofInt32(let v):
-      try visitor.visitSingularInt32Field(value: v, fieldNumber: 51)
-    case .oneofInt64(let v):
-      try visitor.visitSingularInt64Field(value: v, fieldNumber: 52)
-    case .oneofUint32(let v):
-      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 53)
-    case .oneofUint64(let v):
-      try visitor.visitSingularUInt64Field(value: v, fieldNumber: 54)
-    case .oneofSint32(let v):
-      try visitor.visitSingularSInt32Field(value: v, fieldNumber: 55)
-    case .oneofSint64(let v):
-      try visitor.visitSingularSInt64Field(value: v, fieldNumber: 56)
-    case .oneofFixed32(let v):
-      try visitor.visitSingularFixed32Field(value: v, fieldNumber: 57)
-    case .oneofFixed64(let v):
-      try visitor.visitSingularFixed64Field(value: v, fieldNumber: 58)
-    case .oneofSfixed32(let v):
-      try visitor.visitSingularSFixed32Field(value: v, fieldNumber: 59)
-    case .oneofSfixed64(let v):
-      try visitor.visitSingularSFixed64Field(value: v, fieldNumber: 60)
-    case .oneofFloat(let v):
-      try visitor.visitSingularFloatField(value: v, fieldNumber: 61)
-    case .oneofDouble(let v):
-      try visitor.visitSingularDoubleField(value: v, fieldNumber: 62)
-    case .oneofBool(let v):
-      try visitor.visitSingularBoolField(value: v, fieldNumber: 63)
-    case .oneofString(let v):
-      try visitor.visitSingularStringField(value: v, fieldNumber: 64)
-    case .oneofBytes(let v):
-      try visitor.visitSingularBytesField(value: v, fieldNumber: 65)
-    case .oneofMessage(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 68)
-    case .oneofEnum(let v):
-      try visitor.visitSingularEnumField(value: v, fieldNumber: 69)
-    }
   }
 }
 

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -768,7 +768,7 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
       case .bytesField(let v)?:
         try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
-      default: break
+      case nil: break
       }
     }
     try unknownFields.traverse(visitor: &visitor)

--- a/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_well_known_types.pb.swift
@@ -731,7 +731,45 @@ struct ProtobufUnittest_OneofWellKnownTypes: SwiftProtobuf.Message {
   /// `Message` and `Message+*Additions` files.
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
-      try _storage._oneofField?.traverse(visitor: &visitor)
+      switch _storage._oneofField {
+      case .anyField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+      case .apiField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      case .durationField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+      case .emptyField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      case .fieldMaskField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      case .sourceContextField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      case .structField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      case .timestampField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+      case .typeField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+      case .doubleField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+      case .floatField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      case .int64Field(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+      case .uint64Field(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+      case .int32Field(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
+      case .uint32Field(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+      case .boolField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
+      case .stringField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
+      case .bytesField(let v)?:
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
+      default: break
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -1338,47 +1376,6 @@ extension ProtobufUnittest_OneofWellKnownTypes.OneOf_OneofField {
       break
     }
     return nil
-  }
-
-  fileprivate func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    switch self {
-    case .anyField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    case .apiField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    case .durationField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    case .emptyField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-    case .fieldMaskField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    case .sourceContextField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    case .structField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    case .timestampField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-    case .typeField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-    case .doubleField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-    case .floatField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-    case .int64Field(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-    case .uint64Field(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-    case .int32Field(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
-    case .uint32Field(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
-    case .boolField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
-    case .stringField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
-    case .bytesField(let v):
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
-    }
   }
 }
 


### PR DESCRIPTION
In working on the oneof parsing, it dawned on me, the helpers we have on the oneof likely are more a result of the old generator code vs. actually being needed from a behavior pov.  So this takes the helpers out of the `traverse` code paths, and instead inlines the groups directly within the message's traverse.  Thoughts?

@tbkka @allevato 
