### PR TITLE
Use fatalError to enforce the function can't hit this state in a release build

### DIFF
--- a/Sources/protoc-gen-swift/OneofGenerator.swift
+++ b/Sources/protoc-gen-swift/OneofGenerator.swift
@@ -174,7 +174,7 @@ class OneofGenerator {
                 return f
             }
         }
-        assert(false)
+        fatalError("Can't happen")
     }
 
     func generateMainEnum(printer p: inout CodePrinter) {


### PR DESCRIPTION
Fixes: https://github.com/apple/swift-protobuf/issues/539