### PR TITLE
Another attempt to explain why optional != Optional

### DIFF
--- a/Documentation/INTERNALS.md
+++ b/Documentation/INTERNALS.md
@@ -120,16 +120,15 @@ the absence of a value.
 Proto2 optional fields are not nullable; they always have a value.
 This is a subtle but important difference between the two.
 
-In my own code, I've found that I use proto2 optionals
-in two different ways:
-Most of the time, I just use whatever value is there,
+Usually, the current form seems to noticeably simplify the usage:
+Most of the time, you just want to use whatever value is there,
 relying on the default when no value was set explicitly.
-But sometimes, I do need to verify that the other side
-explicitly provided the values I expect.
-In these cases, it is far easier for me to assert
+Sometimes, you may need to verify that the other side
+explicitly provided the values you expect.
+In these cases, it is generally easier to assert
 that the received object `has` the expected fields
 in just one place, then use the current values throughout,
-than to unwrap Swift Optionals at every access.
+than to test and unwrap Swift Optionals at every access.
 
 **Proto2 required fields:**
 

--- a/Documentation/INTERNALS.md
+++ b/Documentation/INTERNALS.md
@@ -153,6 +153,16 @@ Since extensions may be compiled separately, the `isInitialized`
 check must always visit any extensible messages in case one of
 their extensions has required fields.)
 
+The generated `isInitialized` property is used in the following cases:
+
+* When initializing an `Any` field
+* Just before serializing to binary format
+* Just after decoding from binary format
+
+Each of these APIs supports a `partial` parameter; setting this
+parameter to `true` will suppress the check, allowing you to encode or
+decode a partial object that may be lacking required fields.
+
 **Proto2 and proto3 repeated and map fields:**
 
 Repeated and map fields work the same way in proto2 and proto3.


### PR DESCRIPTION
It occurred to me recently that part of the confusion rests in the fact that protobuf binary encoding does omit "unset" fields, which naturally leads to comparisons with nullable Optionals.  So here's another way to explain this distinction by first clarifying that fields omitted from the serialized form are not actually unset, it's just that their value is not transferred.