### PR TITLE
Fix bytes hash with Swift 3.0.x

### DIFF
--- a/Sources/SwiftProtobuf/HashVisitor.swift
+++ b/Sources/SwiftProtobuf/HashVisitor.swift
@@ -79,7 +79,15 @@ internal struct HashVisitor: Visitor {
 
   mutating func visitSingularBytesField(value: Data, fieldNumber: Int) throws {
     mix(fieldNumber)
+#if swift(>=3.1)
     mix(value.hashValue)
+#else
+    value.enumerateBytes { (block, index, stop) in
+        for b in block {
+            mix(Int(b))
+        }
+    }
+#endif
   }
 
   mutating func visitSingularEnumField<E: Enum>(value: E,


### PR DESCRIPTION
Apparently, Data.hashValue was broken at one time.

Note:  This still uses the native Data.hashValue with Swift 3.1 and later.
