### PR TITLE
Group the Swift Extensions for Proto Extensions

### DIFF
--- a/Reference/google/protobuf/unittest.pb.swift
+++ b/Reference/google/protobuf/unittest.pb.swift
@@ -6600,6 +6600,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 // MARK: - Extension support defined in unittest.proto.
 
 extension ProtobufUnittest_TestAllExtensions {
+
   /// Singular
   var ProtobufUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension) ?? 0}
@@ -6615,9 +6616,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalInt64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension, value: newValue)}
@@ -6632,9 +6631,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension, value: newValue)}
@@ -6649,9 +6646,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalUint64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension, value: newValue)}
@@ -6666,9 +6661,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSint32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension, value: newValue)}
@@ -6683,9 +6676,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSint64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension, value: newValue)}
@@ -6700,9 +6691,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFixed32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension, value: newValue)}
@@ -6717,9 +6706,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFixed64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension, value: newValue)}
@@ -6734,9 +6721,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSfixed32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension, value: newValue)}
@@ -6751,9 +6736,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSfixed64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension, value: newValue)}
@@ -6768,9 +6751,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFloatExtension: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension, value: newValue)}
@@ -6785,9 +6766,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalDoubleExtension: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension, value: newValue)}
@@ -6802,9 +6781,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalBoolExtension: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension, value: newValue)}
@@ -6819,9 +6796,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension, value: newValue)}
@@ -6836,9 +6811,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension, value: newValue)}
@@ -6853,9 +6826,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalGroupExtension: ProtobufUnittest_OptionalGroup_extension {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension) ?? ProtobufUnittest_OptionalGroup_extension()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension, value: newValue)}
@@ -6870,9 +6841,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalGroupExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension, value: newValue)}
@@ -6887,9 +6856,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalForeignMessageExtension: ProtobufUnittest_ForeignMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension) ?? ProtobufUnittest_ForeignMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension, value: newValue)}
@@ -6904,9 +6871,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalForeignMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalImportMessageExtension: ProtobufUnittestImport_ImportMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension) ?? ProtobufUnittestImport_ImportMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension, value: newValue)}
@@ -6921,9 +6886,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension) ?? .foo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension, value: newValue)}
@@ -6938,9 +6901,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalForeignEnumExtension: ProtobufUnittest_ForeignEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension) ?? .foreignFoo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension, value: newValue)}
@@ -6955,9 +6916,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalImportEnumExtension: ProtobufUnittestImport_ImportEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension) ?? .importFoo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension, value: newValue)}
@@ -6972,9 +6931,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringPieceExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension, value: newValue)}
@@ -6989,9 +6946,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalCordExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension, value: newValue)}
@@ -7006,9 +6961,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalPublicImportMessageExtension: ProtobufUnittestImport_PublicImportMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension) ?? ProtobufUnittestImport_PublicImportMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension, value: newValue)}
@@ -7023,9 +6976,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalPublicImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalLazyMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension, value: newValue)}
@@ -7040,9 +6991,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalLazyMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   /// Repeated
   var ProtobufUnittest_repeatedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension) ?? []}
@@ -7058,9 +7007,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedInt64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension, value: newValue)}
@@ -7075,9 +7022,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedUint32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension, value: newValue)}
@@ -7092,9 +7037,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedUint64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension, value: newValue)}
@@ -7109,9 +7052,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSint32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension, value: newValue)}
@@ -7126,9 +7067,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSint64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension, value: newValue)}
@@ -7143,9 +7082,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFixed32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension, value: newValue)}
@@ -7160,9 +7097,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFixed64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension, value: newValue)}
@@ -7177,9 +7112,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSfixed32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension, value: newValue)}
@@ -7194,9 +7127,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSfixed64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension, value: newValue)}
@@ -7211,9 +7142,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFloatExtension: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension, value: newValue)}
@@ -7228,9 +7157,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedDoubleExtension: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension, value: newValue)}
@@ -7245,9 +7172,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedBoolExtension: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension, value: newValue)}
@@ -7262,9 +7187,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedStringExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension, value: newValue)}
@@ -7279,9 +7202,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedBytesExtension: [Data] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension, value: newValue)}
@@ -7296,9 +7217,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedGroupExtension: [ProtobufUnittest_RepeatedGroup_extension] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension, value: newValue)}
@@ -7313,9 +7232,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedGroupExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedNestedMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension, value: newValue)}
@@ -7330,9 +7247,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedForeignMessageExtension: [ProtobufUnittest_ForeignMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension, value: newValue)}
@@ -7347,9 +7262,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedForeignMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedImportMessageExtension: [ProtobufUnittestImport_ImportMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension, value: newValue)}
@@ -7364,9 +7277,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedNestedEnumExtension: [ProtobufUnittest_TestAllTypes.NestedEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension, value: newValue)}
@@ -7381,9 +7292,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedForeignEnumExtension: [ProtobufUnittest_ForeignEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension, value: newValue)}
@@ -7398,9 +7307,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedImportEnumExtension: [ProtobufUnittestImport_ImportEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension, value: newValue)}
@@ -7415,9 +7322,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedStringPieceExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension, value: newValue)}
@@ -7432,9 +7337,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedCordExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension, value: newValue)}
@@ -7449,9 +7352,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedLazyMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension, value: newValue)}
@@ -7466,9 +7367,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedLazyMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   /// Singular with defaults
   var ProtobufUnittest_defaultInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension) ?? 41}
@@ -7484,9 +7383,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultInt64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension) ?? 42}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension, value: newValue)}
@@ -7501,9 +7398,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension) ?? 43}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension, value: newValue)}
@@ -7518,9 +7413,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultUint64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension) ?? 44}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension, value: newValue)}
@@ -7535,9 +7428,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSint32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension) ?? -45}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension, value: newValue)}
@@ -7552,9 +7443,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSint64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension) ?? 46}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension, value: newValue)}
@@ -7569,9 +7458,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFixed32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension) ?? 47}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension, value: newValue)}
@@ -7586,9 +7473,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFixed64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension) ?? 48}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension, value: newValue)}
@@ -7603,9 +7488,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSfixed32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension) ?? 49}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension, value: newValue)}
@@ -7620,9 +7503,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSfixed64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension) ?? -50}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension, value: newValue)}
@@ -7637,9 +7518,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFloatExtension: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension) ?? 51.5}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension, value: newValue)}
@@ -7654,9 +7533,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultDoubleExtension: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension) ?? 52000}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension, value: newValue)}
@@ -7671,9 +7548,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultBoolExtension: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension) ?? true}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension, value: newValue)}
@@ -7688,9 +7563,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension) ?? "hello"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension, value: newValue)}
@@ -7705,9 +7578,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension) ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension, value: newValue)}
@@ -7722,9 +7593,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension) ?? .bar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension, value: newValue)}
@@ -7739,9 +7608,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultForeignEnumExtension: ProtobufUnittest_ForeignEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension) ?? .foreignBar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension, value: newValue)}
@@ -7756,9 +7623,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultImportEnumExtension: ProtobufUnittestImport_ImportEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension) ?? .importBar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension, value: newValue)}
@@ -7773,9 +7638,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultStringPieceExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension) ?? "abc"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension, value: newValue)}
@@ -7790,9 +7653,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultCordExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension) ?? "123"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension, value: newValue)}
@@ -7807,9 +7668,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   /// For oneof test
   var ProtobufUnittest_oneofUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension) ?? 0}
@@ -7825,9 +7684,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_oneofUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension, value: newValue)}
@@ -7842,9 +7699,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_oneofNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension, value: newValue)}
@@ -7859,9 +7714,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_oneofStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension, value: newValue)}
@@ -7876,536 +7729,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_oneofBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension)
   }
-}
 
-extension ProtobufUnittest_TestFieldOrderings {
-  var ProtobufUnittest_myExtensionString: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string) ?? String()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_my_extension_string`
-  /// has been explicitly set.
-  var hasProtobufUnittest_myExtensionString: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_my_extension_string`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_myExtensionString() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
-  }
-}
-
-extension ProtobufUnittest_TestFieldOrderings {
-  var ProtobufUnittest_myExtensionInt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_my_extension_int`
-  /// has been explicitly set.
-  var hasProtobufUnittest_myExtensionInt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_my_extension_int`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_myExtensionInt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedInt64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedUint32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedUint64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedSint32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedSint64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedFixed32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedFixed64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedSfixed32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedSfixed64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedFloatExtension: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_float_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_float_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedDoubleExtension: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_double_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_double_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedBoolExtension: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_bool_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_bool_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedEnumExtension: [ProtobufUnittest_ForeignEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_enum_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_enum_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_int32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_int32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedInt64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_int64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_int64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedUint32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_uint32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_uint32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedUint64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_uint64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_uint64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedSint32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sint32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sint32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedSint64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sint64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sint64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedFixed32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_fixed32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_fixed32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedFixed64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_fixed64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_fixed64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedSfixed32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sfixed32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sfixed32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedSfixed64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sfixed64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sfixed64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedFloatExtension: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_float_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_float_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedDoubleExtension: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_double_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_double_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedBoolExtension: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_bool_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_bool_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedEnumExtension: [ProtobufUnittest_ForeignEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_enum_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_enum_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
-  }
-}
-
-extension ProtobufUnittest_TestHugeFieldNumbers {
-  var ProtobufUnittest_testAllTypes: ProtobufUnittest_TestAllTypes {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types) ?? ProtobufUnittest_TestAllTypes()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_test_all_types`
-  /// has been explicitly set.
-  var hasProtobufUnittest_testAllTypes: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_test_all_types`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_testAllTypes() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensions {
   /// Check for bug where string extensions declared in tested scope did not
   /// compile.
   var ProtobufUnittest_TestNestedExtension_test: String {
@@ -8422,9 +7746,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_TestNestedExtension_test() {
     clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   /// Used to test if generated extension name is correct when there are
   /// underscores.
   var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
@@ -8441,9 +7763,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_TestRequired_single: ProtobufUnittest_TestRequired {
     get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single) ?? ProtobufUnittest_TestRequired()}
     set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single, value: newValue)}
@@ -8458,9 +7778,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_TestRequired_single() {
     clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_TestRequired_multi: [ProtobufUnittest_TestRequired] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi, value: newValue)}
@@ -8477,7 +7795,272 @@ extension ProtobufUnittest_TestAllExtensions {
   }
 }
 
+extension ProtobufUnittest_TestFieldOrderings {
+
+  var ProtobufUnittest_myExtensionString: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string) ?? String()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_my_extension_string`
+  /// has been explicitly set.
+  var hasProtobufUnittest_myExtensionString: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_my_extension_string`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_myExtensionString() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
+  }
+
+  var ProtobufUnittest_myExtensionInt: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_my_extension_int`
+  /// has been explicitly set.
+  var hasProtobufUnittest_myExtensionInt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_my_extension_int`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_myExtensionInt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
+  }
+}
+
+extension ProtobufUnittest_TestHugeFieldNumbers {
+
+  var ProtobufUnittest_testAllTypes: ProtobufUnittest_TestAllTypes {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types) ?? ProtobufUnittest_TestAllTypes()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_test_all_types`
+  /// has been explicitly set.
+  var hasProtobufUnittest_testAllTypes: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_test_all_types`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_testAllTypes() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
+  }
+}
+
+extension ProtobufUnittest_TestPackedExtensions {
+
+  var ProtobufUnittest_packedInt32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedInt32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedInt32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
+  }
+
+  var ProtobufUnittest_packedInt64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedInt64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedInt64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
+  }
+
+  var ProtobufUnittest_packedUint32Extension: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedUint32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedUint32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
+  }
+
+  var ProtobufUnittest_packedUint64Extension: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedUint64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedUint64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
+  }
+
+  var ProtobufUnittest_packedSint32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSint32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSint32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
+  }
+
+  var ProtobufUnittest_packedSint64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSint64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSint64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
+  }
+
+  var ProtobufUnittest_packedFixed32Extension: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFixed32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFixed32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
+  }
+
+  var ProtobufUnittest_packedFixed64Extension: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFixed64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFixed64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
+  }
+
+  var ProtobufUnittest_packedSfixed32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSfixed32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSfixed32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
+  }
+
+  var ProtobufUnittest_packedSfixed64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSfixed64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSfixed64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
+  }
+
+  var ProtobufUnittest_packedFloatExtension: [Float] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_float_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFloatExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_float_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFloatExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
+  }
+
+  var ProtobufUnittest_packedDoubleExtension: [Double] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_double_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedDoubleExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_double_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedDoubleExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
+  }
+
+  var ProtobufUnittest_packedBoolExtension: [Bool] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_bool_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedBoolExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_bool_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedBoolExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
+  }
+
+  var ProtobufUnittest_packedEnumExtension: [ProtobufUnittest_ForeignEnum] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_enum_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedEnumExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_enum_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedEnumExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
+  }
+}
+
 extension ProtobufUnittest_TestParsingMerge {
+
   var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypes()}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext, value: newValue)}
@@ -8492,9 +8075,7 @@ extension ProtobufUnittest_TestParsingMerge {
   mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
   }
-}
 
-extension ProtobufUnittest_TestParsingMerge {
   var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext, value: newValue)}
@@ -8509,6 +8090,220 @@ extension ProtobufUnittest_TestParsingMerge {
   mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
   }
+}
+
+extension ProtobufUnittest_TestUnpackedExtensions {
+
+  var ProtobufUnittest_unpackedInt32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_int32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedInt32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_int32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedInt32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
+  }
+
+  var ProtobufUnittest_unpackedInt64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_int64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedInt64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_int64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedInt64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
+  }
+
+  var ProtobufUnittest_unpackedUint32Extension: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_uint32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedUint32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_uint32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedUint32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
+  }
+
+  var ProtobufUnittest_unpackedUint64Extension: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_uint64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedUint64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_uint64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedUint64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
+  }
+
+  var ProtobufUnittest_unpackedSint32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sint32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedSint32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sint32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedSint32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
+  }
+
+  var ProtobufUnittest_unpackedSint64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sint64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedSint64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sint64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedSint64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
+  }
+
+  var ProtobufUnittest_unpackedFixed32Extension: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_fixed32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedFixed32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_fixed32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedFixed32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
+  }
+
+  var ProtobufUnittest_unpackedFixed64Extension: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_fixed64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedFixed64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_fixed64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedFixed64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
+  }
+
+  var ProtobufUnittest_unpackedSfixed32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sfixed32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedSfixed32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sfixed32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedSfixed32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
+  }
+
+  var ProtobufUnittest_unpackedSfixed64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sfixed64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedSfixed64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sfixed64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedSfixed64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
+  }
+
+  var ProtobufUnittest_unpackedFloatExtension: [Float] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_float_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedFloatExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_float_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedFloatExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
+  }
+
+  var ProtobufUnittest_unpackedDoubleExtension: [Double] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_double_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedDoubleExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_double_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedDoubleExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
+  }
+
+  var ProtobufUnittest_unpackedBoolExtension: [Bool] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_bool_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedBoolExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_bool_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedBoolExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
+  }
+
+  var ProtobufUnittest_unpackedEnumExtension: [ProtobufUnittest_ForeignEnum] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_enum_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedEnumExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_enum_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedEnumExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
+  }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/google/protobuf/unittest_custom_options.pb.swift
+++ b/Reference/google/protobuf/unittest_custom_options.pb.swift
@@ -1406,94 +1406,8 @@ struct ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf.Message
 
 // MARK: - Extension support defined in unittest_custom_options.proto.
 
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_fileOpt1: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_file_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fileOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_file_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fileOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_messageOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_message_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_messageOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_message_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_messageOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
-  }
-}
-
-extension Google_Protobuf_FieldOptions {
-  var ProtobufUnittest_fieldOpt1: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_field_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fieldOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_field_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fieldOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
-  }
-}
-
-extension Google_Protobuf_FieldOptions {
-  /// This is useful for testing that we correctly register default values for
-  /// extension options.
-  var ProtobufUnittest_fieldOpt2: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2) ?? 42}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_field_opt2`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fieldOpt2: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_field_opt2`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fieldOpt2() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
-  }
-}
-
-extension Google_Protobuf_OneofOptions {
-  var ProtobufUnittest_oneofOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_oneof_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_oneofOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_oneof_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_oneofOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
-  }
-}
-
 extension Google_Protobuf_EnumOptions {
+
   var ProtobufUnittest_enumOpt1: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1, value: newValue)}
@@ -1508,536 +1422,7 @@ extension Google_Protobuf_EnumOptions {
   mutating func clearProtobufUnittest_enumOpt1() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1)
   }
-}
 
-extension Google_Protobuf_EnumValueOptions {
-  var ProtobufUnittest_enumValueOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_enum_value_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_enumValueOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_enum_value_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_enumValueOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
-  }
-}
-
-extension Google_Protobuf_ServiceOptions {
-  var ProtobufUnittest_serviceOpt1: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_service_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_serviceOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_service_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_serviceOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
-  }
-}
-
-extension Google_Protobuf_MethodOptions {
-  var ProtobufUnittest_methodOpt1: ProtobufUnittest_MethodOpt1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1) ?? .val1}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_method_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_methodOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_method_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_methodOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_boolOpt: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_bool_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_boolOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_bool_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_boolOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_int32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_int32_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_int32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_int32_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_int32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_int64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_int64_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_int64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_int64_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_int64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_uint32Opt: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_uint32_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_uint32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_uint32_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_uint32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_uint64Opt: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_uint64_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_uint64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_uint64_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_uint64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_sint32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_sint32_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_sint32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_sint32_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_sint32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_sint64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_sint64_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_sint64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_sint64_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_sint64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_fixed32Opt: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_fixed32_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fixed32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_fixed32_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fixed32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_fixed64Opt: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_fixed64_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fixed64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_fixed64_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fixed64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_sfixed32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_sfixed32_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_sfixed32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_sfixed32_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_sfixed32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_sfixed64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_sfixed64_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_sfixed64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_sfixed64_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_sfixed64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_floatOpt: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_float_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_float_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_float_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_floatOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_float_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_floatOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_doubleOpt: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_double_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_double_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_double_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_doubleOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_double_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_doubleOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_stringOpt: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_string_opt) ?? String()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_string_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_string_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_stringOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_string_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_stringOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_bytesOpt: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt) ?? SwiftProtobuf.Internal.emptyData}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_bytes_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_bytesOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_bytes_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_bytesOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_enumOpt: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt) ?? .testOptionEnumType1}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_enum_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_enumOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_enum_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_enumOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_messageTypeOpt: ProtobufUnittest_DummyMessageInvalidAsOptionType {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt) ?? ProtobufUnittest_DummyMessageInvalidAsOptionType()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_message_type_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_messageTypeOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_message_type_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_messageTypeOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
-  }
-}
-
-extension ProtobufUnittest_ComplexOptionType1 {
-  var ProtobufUnittest_quux: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_quux) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_quux, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_quux`
-  /// has been explicitly set.
-  var hasProtobufUnittest_quux: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_quux)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_quux`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_quux() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_quux)
-  }
-}
-
-extension ProtobufUnittest_ComplexOptionType1 {
-  var ProtobufUnittest_corge: ProtobufUnittest_ComplexOptionType3 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_corge) ?? ProtobufUnittest_ComplexOptionType3()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_corge, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_corge`
-  /// has been explicitly set.
-  var hasProtobufUnittest_corge: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_corge)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_corge`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_corge() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_corge)
-  }
-}
-
-extension ProtobufUnittest_ComplexOptionType2 {
-  var ProtobufUnittest_grault: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_grault) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_grault, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_grault`
-  /// has been explicitly set.
-  var hasProtobufUnittest_grault: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_grault)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_grault`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_grault() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_grault)
-  }
-}
-
-extension ProtobufUnittest_ComplexOptionType2 {
-  var ProtobufUnittest_garply: ProtobufUnittest_ComplexOptionType1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_garply) ?? ProtobufUnittest_ComplexOptionType1()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_garply, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_garply`
-  /// has been explicitly set.
-  var hasProtobufUnittest_garply: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_garply)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_garply`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_garply() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_garply)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_complexOpt1: ProtobufUnittest_ComplexOptionType1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1) ?? ProtobufUnittest_ComplexOptionType1()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_complexOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_complexOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_complexOpt2: ProtobufUnittest_ComplexOptionType2 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2) ?? ProtobufUnittest_ComplexOptionType2()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt2`
-  /// has been explicitly set.
-  var hasProtobufUnittest_complexOpt2: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt2`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_complexOpt2() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_complexOpt3: ProtobufUnittest_ComplexOptionType3 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3) ?? ProtobufUnittest_ComplexOptionType3()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt3`
-  /// has been explicitly set.
-  var hasProtobufUnittest_complexOpt3: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt3`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_complexOpt3() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_complexOpt6: ProtobufUnittest_ComplexOpt6 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6) ?? ProtobufUnittest_ComplexOpt6()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_ComplexOpt6`
-  /// has been explicitly set.
-  var hasProtobufUnittest_complexOpt6: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_ComplexOpt6`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_complexOpt6() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
-  }
-}
-
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_fileopt: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fileopt) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fileopt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_fileopt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fileopt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fileopt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_fileopt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fileopt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fileopt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_msgopt: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_msgopt) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_msgopt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_msgopt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_msgopt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_msgopt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_msgopt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_msgopt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_msgopt)
-  }
-}
-
-extension Google_Protobuf_FieldOptions {
-  var ProtobufUnittest_fieldopt: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_fieldopt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fieldopt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_fieldopt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fieldopt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt)
-  }
-}
-
-extension Google_Protobuf_EnumOptions {
   var ProtobufUnittest_enumopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enumopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_enumopt, value: newValue)}
@@ -2055,6 +1440,22 @@ extension Google_Protobuf_EnumOptions {
 }
 
 extension Google_Protobuf_EnumValueOptions {
+
+  var ProtobufUnittest_enumValueOpt1: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_enum_value_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_enumValueOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_enum_value_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_enumValueOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
+  }
+
   var ProtobufUnittest_enumvalopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enumvalopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_enumvalopt, value: newValue)}
@@ -2071,41 +1472,466 @@ extension Google_Protobuf_EnumValueOptions {
   }
 }
 
-extension Google_Protobuf_ServiceOptions {
-  var ProtobufUnittest_serviceopt: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt, value: newValue)}
+extension Google_Protobuf_FieldOptions {
+
+  var ProtobufUnittest_fieldOpt1: UInt64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1, value: newValue)}
   }
-  /// Returns true if extension `ProtobufUnittest_Extensions_serviceopt`
+  /// Returns true if extension `ProtobufUnittest_Extensions_field_opt1`
   /// has been explicitly set.
-  var hasProtobufUnittest_serviceopt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt)
+  var hasProtobufUnittest_fieldOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
   }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_serviceopt`.
+  /// Clears the value of extension `ProtobufUnittest_Extensions_field_opt1`.
   /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_serviceopt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt)
+  mutating func clearProtobufUnittest_fieldOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
+  }
+
+  /// This is useful for testing that we correctly register default values for
+  /// extension options.
+  var ProtobufUnittest_fieldOpt2: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2) ?? 42}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_field_opt2`
+  /// has been explicitly set.
+  var hasProtobufUnittest_fieldOpt2: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_field_opt2`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_fieldOpt2() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
+  }
+
+  var ProtobufUnittest_fieldopt: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_fieldopt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_fieldopt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_fieldopt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_fieldopt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt)
   }
 }
 
-extension Google_Protobuf_MethodOptions {
-  var ProtobufUnittest_methodopt: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_methodopt) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_methodopt, value: newValue)}
+extension Google_Protobuf_FileOptions {
+
+  var ProtobufUnittest_fileOpt1: UInt64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1, value: newValue)}
   }
-  /// Returns true if extension `ProtobufUnittest_Extensions_methodopt`
+  /// Returns true if extension `ProtobufUnittest_Extensions_file_opt1`
   /// has been explicitly set.
-  var hasProtobufUnittest_methodopt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_methodopt)
+  var hasProtobufUnittest_fileOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
   }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_methodopt`.
+  /// Clears the value of extension `ProtobufUnittest_Extensions_file_opt1`.
   /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_methodopt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_methodopt)
+  mutating func clearProtobufUnittest_fileOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
+  }
+
+  var ProtobufUnittest_fileopt: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fileopt) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fileopt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_fileopt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_fileopt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fileopt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_fileopt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_fileopt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fileopt)
+  }
+
+  var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Aggregate.Extensions.nested`
+  /// has been explicitly set.
+  var hasProtobufUnittest_Aggregate_nested: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Aggregate.Extensions.nested`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_Aggregate_nested() {
+    clearExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  }
+
+  var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_NestedOptionType.Extensions.nested_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_NestedOptionType.Extensions.nested_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
+
+  var ProtobufUnittest_messageOpt1: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_message_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_messageOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_message_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_messageOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
+  }
+
+  var ProtobufUnittest_boolOpt: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_bool_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_boolOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_bool_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_boolOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
+  }
+
+  var ProtobufUnittest_int32Opt: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_int32_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_int32Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_int32_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_int32Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
+  }
+
+  var ProtobufUnittest_int64Opt: Int64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_int64_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_int64Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_int64_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_int64Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
+  }
+
+  var ProtobufUnittest_uint32Opt: UInt32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_uint32_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_uint32Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_uint32_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_uint32Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
+  }
+
+  var ProtobufUnittest_uint64Opt: UInt64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_uint64_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_uint64Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_uint64_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_uint64Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
+  }
+
+  var ProtobufUnittest_sint32Opt: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_sint32_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_sint32Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_sint32_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_sint32Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
+  }
+
+  var ProtobufUnittest_sint64Opt: Int64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_sint64_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_sint64Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_sint64_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_sint64Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
+  }
+
+  var ProtobufUnittest_fixed32Opt: UInt32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_fixed32_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_fixed32Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_fixed32_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_fixed32Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
+  }
+
+  var ProtobufUnittest_fixed64Opt: UInt64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_fixed64_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_fixed64Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_fixed64_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_fixed64Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
+  }
+
+  var ProtobufUnittest_sfixed32Opt: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_sfixed32_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_sfixed32Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_sfixed32_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_sfixed32Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
+  }
+
+  var ProtobufUnittest_sfixed64Opt: Int64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_sfixed64_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_sfixed64Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_sfixed64_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_sfixed64Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
+  }
+
+  var ProtobufUnittest_floatOpt: Float {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_float_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_float_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_float_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_floatOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_float_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_floatOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
+  }
+
+  var ProtobufUnittest_doubleOpt: Double {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_double_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_double_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_double_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_doubleOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_double_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_doubleOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
+  }
+
+  var ProtobufUnittest_stringOpt: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_string_opt) ?? String()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_string_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_string_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_stringOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_string_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_stringOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
+  }
+
+  var ProtobufUnittest_bytesOpt: Data {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt) ?? SwiftProtobuf.Internal.emptyData}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_bytes_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_bytesOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_bytes_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_bytesOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
+  }
+
+  var ProtobufUnittest_enumOpt: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt) ?? .testOptionEnumType1}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_enum_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_enumOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_enum_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_enumOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
+  }
+
+  var ProtobufUnittest_messageTypeOpt: ProtobufUnittest_DummyMessageInvalidAsOptionType {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt) ?? ProtobufUnittest_DummyMessageInvalidAsOptionType()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_message_type_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_messageTypeOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_message_type_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_messageTypeOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
+  }
+
+  var ProtobufUnittest_complexOpt1: ProtobufUnittest_ComplexOptionType1 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1) ?? ProtobufUnittest_ComplexOptionType1()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_complexOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_complexOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
+  }
+
+  var ProtobufUnittest_complexOpt2: ProtobufUnittest_ComplexOptionType2 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2) ?? ProtobufUnittest_ComplexOptionType2()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt2`
+  /// has been explicitly set.
+  var hasProtobufUnittest_complexOpt2: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt2`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_complexOpt2() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
+  }
+
+  var ProtobufUnittest_complexOpt3: ProtobufUnittest_ComplexOptionType3 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3) ?? ProtobufUnittest_ComplexOptionType3()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt3`
+  /// has been explicitly set.
+  var hasProtobufUnittest_complexOpt3: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt3`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_complexOpt3() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
+  }
+
+  var ProtobufUnittest_complexOpt6: ProtobufUnittest_ComplexOpt6 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6) ?? ProtobufUnittest_ComplexOpt6()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_ComplexOpt6`
+  /// has been explicitly set.
+  var hasProtobufUnittest_complexOpt6: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_ComplexOpt6`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_complexOpt6() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
+  }
+
+  var ProtobufUnittest_msgopt: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_msgopt) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_msgopt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_msgopt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_msgopt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_msgopt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_msgopt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_msgopt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_msgopt)
+  }
+
   var ProtobufUnittest_requiredEnumOpt: ProtobufUnittest_OldOptionType {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt) ?? ProtobufUnittest_OldOptionType()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt, value: newValue)}
@@ -2120,9 +1946,7 @@ extension Google_Protobuf_MessageOptions {
   mutating func clearProtobufUnittest_requiredEnumOpt() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt)
   }
-}
 
-extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4, value: newValue)}
@@ -2139,7 +1963,92 @@ extension Google_Protobuf_MessageOptions {
   }
 }
 
+extension Google_Protobuf_MethodOptions {
+
+  var ProtobufUnittest_methodOpt1: ProtobufUnittest_MethodOpt1 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1) ?? .val1}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_method_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_methodOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_method_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_methodOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
+  }
+
+  var ProtobufUnittest_methodopt: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_methodopt) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_methodopt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_methodopt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_methodopt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_methodopt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_methodopt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_methodopt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_methodopt)
+  }
+}
+
+extension Google_Protobuf_OneofOptions {
+
+  var ProtobufUnittest_oneofOpt1: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_oneof_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_oneofOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_oneof_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_oneofOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
+  }
+}
+
+extension Google_Protobuf_ServiceOptions {
+
+  var ProtobufUnittest_serviceOpt1: Int64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_service_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_serviceOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_service_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_serviceOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
+  }
+
+  var ProtobufUnittest_serviceopt: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_serviceopt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_serviceopt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_serviceopt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_serviceopt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt)
+  }
+}
+
 extension ProtobufUnittest_AggregateMessageSet {
+
   var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
     get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension) ?? ProtobufUnittest_AggregateMessageSetElement()}
     set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension, value: newValue)}
@@ -2156,38 +2065,71 @@ extension ProtobufUnittest_AggregateMessageSet {
   }
 }
 
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested, value: newValue)}
+extension ProtobufUnittest_ComplexOptionType1 {
+
+  var ProtobufUnittest_quux: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_quux) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_quux, value: newValue)}
   }
-  /// Returns true if extension `ProtobufUnittest_Aggregate.Extensions.nested`
+  /// Returns true if extension `ProtobufUnittest_Extensions_quux`
   /// has been explicitly set.
-  var hasProtobufUnittest_Aggregate_nested: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  var hasProtobufUnittest_quux: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_quux)
   }
-  /// Clears the value of extension `ProtobufUnittest_Aggregate.Extensions.nested`.
+  /// Clears the value of extension `ProtobufUnittest_Extensions_quux`.
   /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_Aggregate_nested() {
-    clearExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  mutating func clearProtobufUnittest_quux() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_quux)
+  }
+
+  var ProtobufUnittest_corge: ProtobufUnittest_ComplexOptionType3 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_corge) ?? ProtobufUnittest_ComplexOptionType3()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_corge, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_corge`
+  /// has been explicitly set.
+  var hasProtobufUnittest_corge: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_corge)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_corge`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_corge() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_corge)
   }
 }
 
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension, value: newValue)}
+extension ProtobufUnittest_ComplexOptionType2 {
+
+  var ProtobufUnittest_grault: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_grault) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_grault, value: newValue)}
   }
-  /// Returns true if extension `ProtobufUnittest_NestedOptionType.Extensions.nested_extension`
+  /// Returns true if extension `ProtobufUnittest_Extensions_grault`
   /// has been explicitly set.
-  var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
+  var hasProtobufUnittest_grault: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_grault)
   }
-  /// Clears the value of extension `ProtobufUnittest_NestedOptionType.Extensions.nested_extension`.
+  /// Clears the value of extension `ProtobufUnittest_Extensions_grault`.
   /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
+  mutating func clearProtobufUnittest_grault() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_grault)
   }
+
+  var ProtobufUnittest_garply: ProtobufUnittest_ComplexOptionType1 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_garply) ?? ProtobufUnittest_ComplexOptionType1()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_garply, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_garply`
+  /// has been explicitly set.
+  var hasProtobufUnittest_garply: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_garply)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_garply`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_garply() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_garply)
+  }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/google/protobuf/unittest_lite.pb.swift
+++ b/Reference/google/protobuf/unittest_lite.pb.swift
@@ -2524,6 +2524,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 // MARK: - Extension support defined in unittest_lite.proto.
 
 extension ProtobufUnittest_TestAllExtensionsLite {
+
   /// Singular
   var ProtobufUnittest_optionalInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite) ?? 0}
@@ -2539,9 +2540,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalInt64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite, value: newValue)}
@@ -2556,9 +2555,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite, value: newValue)}
@@ -2573,9 +2570,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalUint64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite, value: newValue)}
@@ -2590,9 +2585,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSint32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite, value: newValue)}
@@ -2607,9 +2600,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSint64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite, value: newValue)}
@@ -2624,9 +2615,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFixed32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite, value: newValue)}
@@ -2641,9 +2630,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFixed64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite, value: newValue)}
@@ -2658,9 +2645,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSfixed32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite, value: newValue)}
@@ -2675,9 +2660,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSfixed64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite, value: newValue)}
@@ -2692,9 +2675,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFloatExtensionLite: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite, value: newValue)}
@@ -2709,9 +2690,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalDoubleExtensionLite: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite, value: newValue)}
@@ -2726,9 +2705,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalBoolExtensionLite: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite, value: newValue)}
@@ -2743,9 +2720,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite, value: newValue)}
@@ -2760,9 +2735,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite, value: newValue)}
@@ -2777,9 +2750,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalGroupExtensionLite: ProtobufUnittest_OptionalGroup_extension_lite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite) ?? ProtobufUnittest_OptionalGroup_extension_lite()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite, value: newValue)}
@@ -2794,9 +2765,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalGroupExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite, value: newValue)}
@@ -2811,9 +2780,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalForeignMessageExtensionLite: ProtobufUnittest_ForeignMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite) ?? ProtobufUnittest_ForeignMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite, value: newValue)}
@@ -2828,9 +2795,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalForeignMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalImportMessageExtensionLite: ProtobufUnittestImport_ImportMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite) ?? ProtobufUnittestImport_ImportMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite, value: newValue)}
@@ -2845,9 +2810,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite) ?? .foo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite, value: newValue)}
@@ -2862,9 +2825,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite) ?? .foreignLiteFoo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite, value: newValue)}
@@ -2879,9 +2840,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite) ?? .importLiteFoo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite, value: newValue)}
@@ -2896,9 +2855,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringPieceExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite, value: newValue)}
@@ -2913,9 +2870,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalCordExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite, value: newValue)}
@@ -2930,9 +2885,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalPublicImportMessageExtensionLite: ProtobufUnittestImport_PublicImportMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite) ?? ProtobufUnittestImport_PublicImportMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite, value: newValue)}
@@ -2947,9 +2900,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalPublicImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalLazyMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite, value: newValue)}
@@ -2964,9 +2915,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalLazyMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   /// Repeated
   var ProtobufUnittest_repeatedInt32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite) ?? []}
@@ -2982,9 +2931,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedInt64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite, value: newValue)}
@@ -2999,9 +2946,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedUint32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite, value: newValue)}
@@ -3016,9 +2961,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedUint64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite, value: newValue)}
@@ -3033,9 +2976,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSint32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite, value: newValue)}
@@ -3050,9 +2991,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSint64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite, value: newValue)}
@@ -3067,9 +3006,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFixed32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite, value: newValue)}
@@ -3084,9 +3021,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFixed64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite, value: newValue)}
@@ -3101,9 +3036,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSfixed32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite, value: newValue)}
@@ -3118,9 +3051,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSfixed64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite, value: newValue)}
@@ -3135,9 +3066,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFloatExtensionLite: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite, value: newValue)}
@@ -3152,9 +3081,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedDoubleExtensionLite: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite, value: newValue)}
@@ -3169,9 +3096,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedBoolExtensionLite: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite, value: newValue)}
@@ -3186,9 +3111,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedStringExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite, value: newValue)}
@@ -3203,9 +3126,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedBytesExtensionLite: [Data] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite, value: newValue)}
@@ -3220,9 +3141,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedGroupExtensionLite: [ProtobufUnittest_RepeatedGroup_extension_lite] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite, value: newValue)}
@@ -3237,9 +3156,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedGroupExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedNestedMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite, value: newValue)}
@@ -3254,9 +3171,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedForeignMessageExtensionLite: [ProtobufUnittest_ForeignMessageLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite, value: newValue)}
@@ -3271,9 +3186,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedForeignMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedImportMessageExtensionLite: [ProtobufUnittestImport_ImportMessageLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite, value: newValue)}
@@ -3288,9 +3201,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedNestedEnumExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite, value: newValue)}
@@ -3305,9 +3216,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedForeignEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite, value: newValue)}
@@ -3322,9 +3231,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedImportEnumExtensionLite: [ProtobufUnittestImport_ImportEnumLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite, value: newValue)}
@@ -3339,9 +3246,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedStringPieceExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite, value: newValue)}
@@ -3356,9 +3261,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedCordExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite, value: newValue)}
@@ -3373,9 +3276,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedLazyMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite, value: newValue)}
@@ -3390,9 +3291,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedLazyMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   /// Singular with defaults
   var ProtobufUnittest_defaultInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite) ?? 41}
@@ -3408,9 +3307,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultInt64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite) ?? 42}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite, value: newValue)}
@@ -3425,9 +3322,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite) ?? 43}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite, value: newValue)}
@@ -3442,9 +3337,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultUint64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite) ?? 44}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite, value: newValue)}
@@ -3459,9 +3352,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSint32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite) ?? -45}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite, value: newValue)}
@@ -3476,9 +3367,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSint64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite) ?? 46}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite, value: newValue)}
@@ -3493,9 +3382,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFixed32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite) ?? 47}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite, value: newValue)}
@@ -3510,9 +3397,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFixed64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite) ?? 48}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite, value: newValue)}
@@ -3527,9 +3412,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSfixed32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite) ?? 49}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite, value: newValue)}
@@ -3544,9 +3427,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSfixed64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite) ?? -50}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite, value: newValue)}
@@ -3561,9 +3442,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFloatExtensionLite: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite) ?? 51.5}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite, value: newValue)}
@@ -3578,9 +3457,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultDoubleExtensionLite: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite) ?? 52000}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite, value: newValue)}
@@ -3595,9 +3472,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultBoolExtensionLite: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite) ?? true}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite, value: newValue)}
@@ -3612,9 +3487,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite) ?? "hello"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite, value: newValue)}
@@ -3629,9 +3502,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite) ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite, value: newValue)}
@@ -3646,9 +3517,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite) ?? .bar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite, value: newValue)}
@@ -3663,9 +3532,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite) ?? .foreignLiteBar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite, value: newValue)}
@@ -3680,9 +3547,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite) ?? .importLiteBar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite, value: newValue)}
@@ -3697,9 +3562,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultStringPieceExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite) ?? "abc"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite, value: newValue)}
@@ -3714,9 +3577,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultCordExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite) ?? "123"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite, value: newValue)}
@@ -3731,9 +3592,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   /// For oneof test
   var ProtobufUnittest_oneofUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite) ?? 0}
@@ -3749,9 +3608,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_oneofUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite, value: newValue)}
@@ -3766,9 +3623,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_oneofNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite, value: newValue)}
@@ -3783,9 +3638,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_oneofStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite, value: newValue)}
@@ -3800,264 +3653,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_oneofBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedInt32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int32_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedInt32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int32_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedInt32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedInt64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int64_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedInt64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int64_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedInt64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedUint32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint32_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint32_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedUint64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint64_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedUint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint64_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedUint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedSint32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint32_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint32_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedSint64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint64_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint64_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedFixed32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed32_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed32_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedFixed64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed64_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed64_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedSfixed32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed32_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSfixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed32_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSfixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedSfixed64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed64_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSfixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed64_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSfixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedFloatExtensionLite: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_float_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFloatExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_float_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFloatExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedDoubleExtensionLite: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_double_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedDoubleExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_double_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedDoubleExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedBoolExtensionLite: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_bool_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedBoolExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_bool_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedBoolExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_enum_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_enum_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestHugeFieldNumbersLite {
-  var ProtobufUnittest_testAllTypesLite: ProtobufUnittest_TestAllTypesLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite) ?? ProtobufUnittest_TestAllTypesLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_test_all_types_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_testAllTypesLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_test_all_types_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_testAllTypesLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension, value: newValue)}
@@ -4074,7 +3670,239 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   }
 }
 
+extension ProtobufUnittest_TestHugeFieldNumbersLite {
+
+  var ProtobufUnittest_testAllTypesLite: ProtobufUnittest_TestAllTypesLite {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite) ?? ProtobufUnittest_TestAllTypesLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_test_all_types_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_testAllTypesLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_test_all_types_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_testAllTypesLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
+  }
+}
+
+extension ProtobufUnittest_TestPackedExtensionsLite {
+
+  var ProtobufUnittest_packedInt32ExtensionLite: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int32_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedInt32ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int32_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedInt32ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
+  }
+
+  var ProtobufUnittest_packedInt64ExtensionLite: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int64_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedInt64ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int64_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedInt64ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
+  }
+
+  var ProtobufUnittest_packedUint32ExtensionLite: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint32_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedUint32ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint32_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedUint32ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
+  }
+
+  var ProtobufUnittest_packedUint64ExtensionLite: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint64_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedUint64ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint64_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedUint64ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
+  }
+
+  var ProtobufUnittest_packedSint32ExtensionLite: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint32_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSint32ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint32_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSint32ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
+  }
+
+  var ProtobufUnittest_packedSint64ExtensionLite: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint64_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSint64ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint64_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSint64ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
+  }
+
+  var ProtobufUnittest_packedFixed32ExtensionLite: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed32_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFixed32ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed32_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFixed32ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
+  }
+
+  var ProtobufUnittest_packedFixed64ExtensionLite: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed64_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFixed64ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed64_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFixed64ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
+  }
+
+  var ProtobufUnittest_packedSfixed32ExtensionLite: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed32_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSfixed32ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed32_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSfixed32ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
+  }
+
+  var ProtobufUnittest_packedSfixed64ExtensionLite: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed64_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSfixed64ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed64_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSfixed64ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
+  }
+
+  var ProtobufUnittest_packedFloatExtensionLite: [Float] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_float_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFloatExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_float_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFloatExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
+  }
+
+  var ProtobufUnittest_packedDoubleExtensionLite: [Double] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_double_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedDoubleExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_double_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedDoubleExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
+  }
+
+  var ProtobufUnittest_packedBoolExtensionLite: [Bool] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_bool_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedBoolExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_bool_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedBoolExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
+  }
+
+  var ProtobufUnittest_packedEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_enum_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedEnumExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_enum_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedEnumExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
+  }
+}
+
 extension ProtobufUnittest_TestParsingMergeLite {
+
   var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypesLite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext, value: newValue)}
@@ -4089,9 +3917,7 @@ extension ProtobufUnittest_TestParsingMergeLite {
   mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
   }
-}
 
-extension ProtobufUnittest_TestParsingMergeLite {
   var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext, value: newValue)}
@@ -4106,6 +3932,7 @@ extension ProtobufUnittest_TestParsingMergeLite {
   mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/google/protobuf/unittest_mset.pb.swift
+++ b/Reference/google/protobuf/unittest_mset.pb.swift
@@ -303,6 +303,7 @@ struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_mset.proto.
 
 extension Proto2WireformatUnittest_TestMessageSet {
+
   var ProtobufUnittest_TestMessageSetExtension1_messageSetExtension: ProtobufUnittest_TestMessageSetExtension1 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension) ?? ProtobufUnittest_TestMessageSetExtension1()}
     set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension, value: newValue)}
@@ -317,9 +318,7 @@ extension Proto2WireformatUnittest_TestMessageSet {
   mutating func clearProtobufUnittest_TestMessageSetExtension1_messageSetExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension)
   }
-}
 
-extension Proto2WireformatUnittest_TestMessageSet {
   var ProtobufUnittest_TestMessageSetExtension2_messageSetExtension: ProtobufUnittest_TestMessageSetExtension2 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension) ?? ProtobufUnittest_TestMessageSetExtension2()}
     set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension, value: newValue)}
@@ -334,6 +333,7 @@ extension Proto2WireformatUnittest_TestMessageSet {
   mutating func clearProtobufUnittest_TestMessageSetExtension2_messageSetExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/google/protobuf/unittest_no_generic_services.pb.swift
+++ b/Reference/google/protobuf/unittest_no_generic_services.pb.swift
@@ -129,6 +129,7 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf.Message,
 // MARK: - Extension support defined in unittest_no_generic_services.proto.
 
 extension Google_Protobuf_NoGenericServicesTest_TestMessage {
+
   var Google_Protobuf_NoGenericServicesTest_testExtension: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension, value: newValue)}
@@ -143,6 +144,7 @@ extension Google_Protobuf_NoGenericServicesTest_TestMessage {
   mutating func clearGoogle_Protobuf_NoGenericServicesTest_testExtension() {
     clearExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/google/protobuf/unittest_optimize_for.pb.swift
+++ b/Reference/google/protobuf/unittest_optimize_for.pb.swift
@@ -282,6 +282,7 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_optimize_for.proto.
 
 extension ProtobufUnittest_TestOptimizedForSize {
+
   var ProtobufUnittest_TestOptimizedForSize_testExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension, value: newValue)}
@@ -296,9 +297,7 @@ extension ProtobufUnittest_TestOptimizedForSize {
   mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension)
   }
-}
 
-extension ProtobufUnittest_TestOptimizedForSize {
   var ProtobufUnittest_TestOptimizedForSize_testExtension2: ProtobufUnittest_TestRequiredOptimizedForSize {
     get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2) ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
     set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2, value: newValue)}
@@ -313,6 +312,7 @@ extension ProtobufUnittest_TestOptimizedForSize {
   mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension2() {
     clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/pluginlib_descriptor_test.pb.swift
+++ b/Reference/pluginlib_descriptor_test.pb.swift
@@ -476,6 +476,7 @@ struct SDTScoperForExt: SwiftProtobuf.Message {
 // MARK: - Extension support defined in pluginlib_descriptor_test.proto.
 
 extension Google_Protobuf_FieldOptions {
+
   var SDTextStr: String {
     get {return getExtensionValue(ext: SDTExtensions_ext_str) ?? String()}
     set {setExtensionValue(ext: SDTExtensions_ext_str, value: newValue)}
@@ -493,6 +494,7 @@ extension Google_Protobuf_FieldOptions {
 }
 
 extension Google_Protobuf_MessageOptions {
+
   var SDTScoperForExt_extEnum: SDTTopLevelEnum {
     get {return getExtensionValue(ext: SDTScoperForExt.Extensions.ext_enum) ?? .valueZero}
     set {setExtensionValue(ext: SDTScoperForExt.Extensions.ext_enum, value: newValue)}
@@ -507,9 +509,7 @@ extension Google_Protobuf_MessageOptions {
   mutating func clearSDTScoperForExt_extEnum() {
     clearExtensionValue(ext: SDTScoperForExt.Extensions.ext_enum)
   }
-}
 
-extension Google_Protobuf_MessageOptions {
   var SDTScoperForExt_extMsg: SDTTopLevelMessage2 {
     get {return getExtensionValue(ext: SDTScoperForExt.Extensions.ext_msg) ?? SDTTopLevelMessage2()}
     set {setExtensionValue(ext: SDTScoperForExt.Extensions.ext_msg, value: newValue)}
@@ -524,6 +524,7 @@ extension Google_Protobuf_MessageOptions {
   mutating func clearSDTScoperForExt_extMsg() {
     clearExtensionValue(ext: SDTScoperForExt.Extensions.ext_msg)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_extension.pb.swift
+++ b/Reference/unittest_swift_extension.pb.swift
@@ -382,6 +382,7 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
 // MARK: - Extension support defined in unittest_swift_extension.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+
   var ProtobufUnittest_Extend_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b, value: newValue)}
@@ -396,9 +397,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend_b() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend_c: ProtobufUnittest_Extend_C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C) ?? ProtobufUnittest_Extend_C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C, value: newValue)}
@@ -416,6 +415,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 }
 
 extension ProtobufUnittest_Extend_Msg1 {
+
   var ProtobufUnittest_Extend_aB: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b, value: newValue)}
@@ -433,6 +433,7 @@ extension ProtobufUnittest_Extend_Msg1 {
 }
 
 extension ProtobufUnittest_Extend_Msg2 {
+
   var ProtobufUnittest_Extend_aB: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB, value: newValue)}
@@ -450,6 +451,7 @@ extension ProtobufUnittest_Extend_Msg2 {
 }
 
 extension ProtobufUnittest_Extend_MsgNoStorage {
+
   var ProtobufUnittest_Extend_extA: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_a) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_a, value: newValue)}
@@ -464,9 +466,7 @@ extension ProtobufUnittest_Extend_MsgNoStorage {
   mutating func clearProtobufUnittest_Extend_extA() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_a)
   }
-}
 
-extension ProtobufUnittest_Extend_MsgNoStorage {
   var ProtobufUnittest_Extend_extB: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_b) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_b, value: newValue)}
@@ -484,6 +484,7 @@ extension ProtobufUnittest_Extend_MsgNoStorage {
 }
 
 extension ProtobufUnittest_Extend_MsgUsesStorage {
+
   var ProtobufUnittest_Extend_extC: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_c) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_c, value: newValue)}
@@ -498,9 +499,7 @@ extension ProtobufUnittest_Extend_MsgUsesStorage {
   mutating func clearProtobufUnittest_Extend_extC() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_c)
   }
-}
 
-extension ProtobufUnittest_Extend_MsgUsesStorage {
   var ProtobufUnittest_Extend_extD: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_d) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_d, value: newValue)}
@@ -515,6 +514,7 @@ extension ProtobufUnittest_Extend_MsgUsesStorage {
   mutating func clearProtobufUnittest_Extend_extD() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_d)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_extension2.pb.swift
+++ b/Reference/unittest_swift_extension2.pb.swift
@@ -151,6 +151,7 @@ struct ProtobufUnittest_Extend2_C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension2.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+
   var ProtobufUnittest_Extend2_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b, value: newValue)}
@@ -165,9 +166,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend2_b() {
     clearExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_c: ProtobufUnittest_Extend2_C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C) ?? ProtobufUnittest_Extend2_C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C, value: newValue)}
@@ -182,9 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend2_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_MyMessage_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b, value: newValue)}
@@ -199,9 +196,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend2_MyMessage_b() {
     clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_MyMessage_c: ProtobufUnittest_Extend2_MyMessage.C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend2_MyMessage.C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C, value: newValue)}
@@ -216,6 +211,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend2_MyMessage_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_extension3.pb.swift
+++ b/Reference/unittest_swift_extension3.pb.swift
@@ -151,6 +151,7 @@ struct ProtobufUnittest_Extend3_C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension3.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+
   var ProtobufUnittest_Extend3_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b, value: newValue)}
@@ -165,9 +166,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend3_b() {
     clearExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_c: ProtobufUnittest_Extend3_C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C) ?? ProtobufUnittest_Extend3_C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C, value: newValue)}
@@ -182,9 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend3_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_MyMessage_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b, value: newValue)}
@@ -199,9 +196,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend3_MyMessage_b() {
     clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_MyMessage_c: ProtobufUnittest_Extend3_MyMessage.C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend3_MyMessage.C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C, value: newValue)}
@@ -216,6 +211,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend3_MyMessage_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_extension4.pb.swift
+++ b/Reference/unittest_swift_extension4.pb.swift
@@ -151,6 +151,7 @@ struct Ext4C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension4.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+
   var Ext4b: String {
     get {return getExtensionValue(ext: Ext4Extensions_b) ?? String()}
     set {setExtensionValue(ext: Ext4Extensions_b, value: newValue)}
@@ -165,9 +166,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearExt4b() {
     clearExtensionValue(ext: Ext4Extensions_b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4c: Ext4C {
     get {return getExtensionValue(ext: Ext4Extensions_C) ?? Ext4C()}
     set {setExtensionValue(ext: Ext4Extensions_C, value: newValue)}
@@ -182,9 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearExt4c() {
     clearExtensionValue(ext: Ext4Extensions_C)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4MyMessage_b: String {
     get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: Ext4MyMessage.Extensions.b, value: newValue)}
@@ -199,9 +196,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearExt4MyMessage_b() {
     clearExtensionValue(ext: Ext4MyMessage.Extensions.b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4MyMessage_c: Ext4MyMessage.C {
     get {return getExtensionValue(ext: Ext4MyMessage.Extensions.C) ?? Ext4MyMessage.C()}
     set {setExtensionValue(ext: Ext4MyMessage.Extensions.C, value: newValue)}
@@ -216,6 +211,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearExt4MyMessage_c() {
     clearExtensionValue(ext: Ext4MyMessage.Extensions.C)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_fieldorder.pb.swift
+++ b/Reference/unittest_swift_fieldorder.pb.swift
@@ -533,6 +533,7 @@ struct Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftProt
 // MARK: - Extension support defined in unittest_swift_fieldorder.proto.
 
 extension Swift_Protobuf_TestFieldOrderings {
+
   var Swift_Protobuf_myExtensionString: String {
     get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string) ?? String()}
     set {setExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string, value: newValue)}
@@ -547,9 +548,7 @@ extension Swift_Protobuf_TestFieldOrderings {
   mutating func clearSwift_Protobuf_myExtensionString() {
     clearExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string)
   }
-}
 
-extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionInt: Int32 {
     get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int) ?? 0}
     set {setExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int, value: newValue)}
@@ -564,6 +563,7 @@ extension Swift_Protobuf_TestFieldOrderings {
   mutating func clearSwift_Protobuf_myExtensionInt() {
     clearExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_groups.pb.swift
+++ b/Reference/unittest_swift_groups.pb.swift
@@ -500,6 +500,7 @@ struct SwiftTestNestingGroupsMessage: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_groups.proto.
 
 extension SwiftTestGroupExtensions {
+
   var extensionGroup: ExtensionGroup {
     get {return getExtensionValue(ext: Extensions_ExtensionGroup) ?? ExtensionGroup()}
     set {setExtensionValue(ext: Extensions_ExtensionGroup, value: newValue)}
@@ -514,9 +515,7 @@ extension SwiftTestGroupExtensions {
   mutating func clearExtensionGroup() {
     clearExtensionValue(ext: Extensions_ExtensionGroup)
   }
-}
 
-extension SwiftTestGroupExtensions {
   var repeatedExtensionGroup: [RepeatedExtensionGroup] {
     get {return getExtensionValue(ext: Extensions_RepeatedExtensionGroup) ?? []}
     set {setExtensionValue(ext: Extensions_RepeatedExtensionGroup, value: newValue)}
@@ -531,6 +530,7 @@ extension SwiftTestGroupExtensions {
   mutating func clearRepeatedExtensionGroup() {
     clearExtensionValue(ext: Extensions_RepeatedExtensionGroup)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_naming.pb.swift
+++ b/Reference/unittest_swift_naming.pb.swift
@@ -18787,7 +18787,746 @@ struct SwiftUnittest_Names_ExtensionNamingInitialsWordCase: SwiftProtobuf.Messag
 
 // MARK: - Extension support defined in unittest_swift_naming.proto.
 
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+
+  var SwiftUnittest_Names_Lowers_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.http`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.http`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
+  }
+
+  var SwiftUnittest_Names_Lowers_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.http_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.http_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
+  }
+
+  var SwiftUnittest_Names_Lowers_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_http_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_http_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
+  }
+
+  var SwiftUnittest_Names_Lowers_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_http`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_http`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
+  }
+
+  var SwiftUnittest_Names_Lowers_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.https`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.https`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
+  }
+
+  var SwiftUnittest_Names_Lowers_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.https_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.https_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
+  }
+
+  var SwiftUnittest_Names_Lowers_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_https_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_https_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
+  }
+
+  var SwiftUnittest_Names_Lowers_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_https`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_https`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
+  }
+
+  var SwiftUnittest_Names_Lowers_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.url`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.url`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
+  }
+
+  var SwiftUnittest_Names_Lowers_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.url_value`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.url_value`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
+  }
+
+  var SwiftUnittest_Names_Lowers_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_url_value`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_url_value`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
+  }
+
+  var SwiftUnittest_Names_Lowers_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_url`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_url`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
+  }
+
+  var SwiftUnittest_Names_Lowers_aBC: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.a_b_c`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_aBC: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.a_b_c`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_aBC() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
+  }
+
+  var SwiftUnittest_Names_Lowers_id: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.id`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_id: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.id`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_id() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id)
+  }
+
+  var SwiftUnittest_Names_Lowers_idNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.id_number`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_idNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.id_number`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_idNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number)
+  }
+
+  var SwiftUnittest_Names_Lowers_theIDNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_id_number`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theIDNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_id_number`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theIDNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number)
+  }
+
+  var SwiftUnittest_Names_Lowers_requestID: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.request_id`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_requestID: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.request_id`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_requestID() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id)
+  }
+
+  var SwiftUnittest_Names_Uppers_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTP`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTP`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
+  }
+
+  var SwiftUnittest_Names_Uppers_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTP_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTP_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
+  }
+
+  var SwiftUnittest_Names_Uppers_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
+  }
+
+  var SwiftUnittest_Names_Uppers_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
+  }
+
+  var SwiftUnittest_Names_Uppers_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
+  }
+
+  var SwiftUnittest_Names_Uppers_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
+  }
+
+  var SwiftUnittest_Names_Uppers_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
+  }
+
+  var SwiftUnittest_Names_Uppers_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
+  }
+
+  var SwiftUnittest_Names_Uppers_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.URL`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.URL`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
+  }
+
+  var SwiftUnittest_Names_Uppers_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.URL_value`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.URL_value`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
+  }
+
+  var SwiftUnittest_Names_Uppers_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_URL_value`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_URL_value`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
+  }
+
+  var SwiftUnittest_Names_Uppers_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_URL`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_URL`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
+  }
+
+  var SwiftUnittest_Names_Uppers_id: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.ID`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_id: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.ID`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_id() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID)
+  }
+
+  var SwiftUnittest_Names_Uppers_idNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.ID_number`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_idNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.ID_number`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_idNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number)
+  }
+
+  var SwiftUnittest_Names_Uppers_theIDNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_ID_number`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theIDNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_ID_number`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theIDNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number)
+  }
+
+  var SwiftUnittest_Names_Uppers_requestID: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.request_ID`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_requestID: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.request_ID`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_requestID() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID)
+  }
+
+  var SwiftUnittest_Names_WordCase_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Http`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Http`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
+  }
+
+  var SwiftUnittest_Names_WordCase_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.HttpRequest`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.HttpRequest`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
+  }
+
+  var SwiftUnittest_Names_WordCase_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
+  }
+
+  var SwiftUnittest_Names_WordCase_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttp`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttp`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
+  }
+
+  var SwiftUnittest_Names_WordCase_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Https`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Https`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
+  }
+
+  var SwiftUnittest_Names_WordCase_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.HttpsRequest`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.HttpsRequest`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
+  }
+
+  var SwiftUnittest_Names_WordCase_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
+  }
+
+  var SwiftUnittest_Names_WordCase_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttps`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttps`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
+  }
+
+  var SwiftUnittest_Names_WordCase_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Url`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Url`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
+  }
+
+  var SwiftUnittest_Names_WordCase_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.UrlValue`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.UrlValue`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
+  }
+
+  var SwiftUnittest_Names_WordCase_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheUrlValue`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheUrlValue`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
+  }
+
+  var SwiftUnittest_Names_WordCase_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheUrl`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheUrl`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
+  }
+
+  var SwiftUnittest_Names_WordCase_id: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Id`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_id: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Id`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_id() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id)
+  }
+
+  var SwiftUnittest_Names_WordCase_idNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.IdNumber`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_idNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.IdNumber`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_idNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber)
+  }
+
+  var SwiftUnittest_Names_WordCase_theIDNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheIdNumber`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theIDNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheIdNumber`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theIDNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber)
+  }
+
+  var SwiftUnittest_Names_WordCase_requestID: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.RequestId`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_requestID: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.RequestId`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_requestID() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId)
+  }
+}
+
 extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
+
   var SwiftUnittest_Names_http: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_http) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_http, value: newValue)}
@@ -18802,9 +19541,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_http() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_httpRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_http_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_http_request, value: newValue)}
@@ -18819,9 +19556,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_httpRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_http_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http_request, value: newValue)}
@@ -18836,9 +19571,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theHTTPRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theHTTP: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http, value: newValue)}
@@ -18853,9 +19586,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theHTTP() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_https: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_https) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_https, value: newValue)}
@@ -18870,9 +19601,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_https() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_httpsRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_https_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_https_request, value: newValue)}
@@ -18887,9 +19616,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_httpsRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_https_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https_request, value: newValue)}
@@ -18904,9 +19631,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theHTTPSRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theHTTPS: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https, value: newValue)}
@@ -18921,9 +19646,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theHTTPS() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_url: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_url) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_url, value: newValue)}
@@ -18938,9 +19661,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_url() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_urlValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_url_value) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_url_value, value: newValue)}
@@ -18955,9 +19676,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_urlValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_url_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theURLValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url_value) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url_value, value: newValue)}
@@ -18972,9 +19691,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theURLValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theURL: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url, value: newValue)}
@@ -18989,9 +19706,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theURL() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_aBC: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_a_b_c) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_a_b_c, value: newValue)}
@@ -19006,9 +19721,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_aBC() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_a_b_c)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_id: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_id) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_id, value: newValue)}
@@ -19023,9 +19736,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_id() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_id)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_idNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_id_number) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_id_number, value: newValue)}
@@ -19040,9 +19751,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_idNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_id_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theIDNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_id_number) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_id_number, value: newValue)}
@@ -19057,9 +19766,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theIDNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_id_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_requestID: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_request_id) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_request_id, value: newValue)}
@@ -19077,6 +19784,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
+
   var SwiftUnittest_Names_http: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP, value: newValue)}
@@ -19091,9 +19799,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_http() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_httpRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP_request, value: newValue)}
@@ -19108,9 +19814,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_httpRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP_request, value: newValue)}
@@ -19125,9 +19829,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theHTTPRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theHTTP: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP, value: newValue)}
@@ -19142,9 +19844,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theHTTP() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_https: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS, value: newValue)}
@@ -19159,9 +19859,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_https() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_httpsRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS_request, value: newValue)}
@@ -19176,9 +19874,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_httpsRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS_request, value: newValue)}
@@ -19193,9 +19889,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theHTTPSRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theHTTPS: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS, value: newValue)}
@@ -19210,9 +19904,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theHTTPS() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_url: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_URL) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_URL, value: newValue)}
@@ -19227,9 +19919,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_url() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_URL)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_urlValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_URL_value) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_URL_value, value: newValue)}
@@ -19244,9 +19934,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_urlValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_URL_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theURLValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL_value) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL_value, value: newValue)}
@@ -19261,9 +19949,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theURLValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theURL: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL, value: newValue)}
@@ -19278,9 +19964,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theURL() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_id: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_ID) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_ID, value: newValue)}
@@ -19295,9 +19979,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_id() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_ID)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_idNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_ID_number) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_ID_number, value: newValue)}
@@ -19312,9 +19994,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_idNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_ID_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theIDNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_ID_number) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_ID_number, value: newValue)}
@@ -19329,9 +20009,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theIDNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_ID_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_requestID: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_request_ID) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_request_ID, value: newValue)}
@@ -19349,6 +20027,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
+
   var SwiftUnittest_Names_http: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_Http) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_Http, value: newValue)}
@@ -19363,9 +20042,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_http() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_Http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_httpRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpRequest) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpRequest, value: newValue)}
@@ -19380,9 +20057,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_httpRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpRequest) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpRequest, value: newValue)}
@@ -19397,9 +20072,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theHTTPRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theHTTP: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttp) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttp, value: newValue)}
@@ -19414,9 +20087,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theHTTP() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttp)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_https: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_Https) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_Https, value: newValue)}
@@ -19431,9 +20102,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_https() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_Https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_httpsRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpsRequest) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpsRequest, value: newValue)}
@@ -19448,9 +20117,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_httpsRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpsRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpsRequest) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpsRequest, value: newValue)}
@@ -19465,9 +20132,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theHTTPSRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpsRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theHTTPS: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttps) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttps, value: newValue)}
@@ -19482,9 +20147,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theHTTPS() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttps)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_url: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_Url) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_Url, value: newValue)}
@@ -19499,9 +20162,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_url() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_Url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_urlValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_UrlValue) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_UrlValue, value: newValue)}
@@ -19516,9 +20177,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_urlValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_UrlValue)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theURLValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrlValue) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrlValue, value: newValue)}
@@ -19533,9 +20192,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theURLValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrlValue)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theURL: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrl) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrl, value: newValue)}
@@ -19550,9 +20207,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theURL() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrl)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_id: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_Id) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_Id, value: newValue)}
@@ -19567,9 +20222,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_id() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_Id)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_idNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_IdNumber) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_IdNumber, value: newValue)}
@@ -19584,9 +20237,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_idNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_IdNumber)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theIDNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheIdNumber) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheIdNumber, value: newValue)}
@@ -19601,9 +20252,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theIDNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheIdNumber)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_requestID: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_RequestId) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_RequestId, value: newValue)}
@@ -19621,6 +20270,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
 }
 
 extension SwiftUnittest_Names_Foo {
+
   var SwiftUnittest_Names_FieldNames_foo1: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_FieldNames.Extensions.foo1) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_FieldNames.Extensions.foo1, value: newValue)}
@@ -19635,9 +20285,7 @@ extension SwiftUnittest_Names_Foo {
   mutating func clearSwiftUnittest_Names_FieldNames_foo1() {
     clearExtensionValue(ext: SwiftUnittest_Names_FieldNames.Extensions.foo1)
   }
-}
 
-extension SwiftUnittest_Names_Foo {
   var SwiftUnittest_Names_MessageNames_foo2: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo2) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo2, value: newValue)}
@@ -19652,9 +20300,7 @@ extension SwiftUnittest_Names_Foo {
   mutating func clearSwiftUnittest_Names_MessageNames_foo2() {
     clearExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo2)
   }
-}
 
-extension SwiftUnittest_Names_Foo {
   var SwiftUnittest_Names_MessageNames_foo4: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo4) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo4, value: newValue)}
@@ -19669,9 +20315,7 @@ extension SwiftUnittest_Names_Foo {
   mutating func clearSwiftUnittest_Names_MessageNames_foo4() {
     clearExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo4)
   }
-}
 
-extension SwiftUnittest_Names_Foo {
   var SwiftUnittest_Names_MessageNames_StringMessage_foo3: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_MessageNames.StringMessage.Extensions.foo3) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_MessageNames.StringMessage.Extensions.foo3, value: newValue)}
@@ -19686,839 +20330,7 @@ extension SwiftUnittest_Names_Foo {
   mutating func clearSwiftUnittest_Names_MessageNames_StringMessage_foo3() {
     clearExtensionValue(ext: SwiftUnittest_Names_MessageNames.StringMessage.Extensions.foo3)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.http`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.http`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.http_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.http_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_http_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_http_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_http`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_http`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.https`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.https`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.https_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.https_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_https_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_https_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_https`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_https`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.url`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.url`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.url_value`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.url_value`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_url_value`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_url_value`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_url`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_url`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_aBC: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.a_b_c`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_aBC: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.a_b_c`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_aBC() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_id: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.id`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_id: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.id`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_id() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_idNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.id_number`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_idNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.id_number`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_idNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theIDNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_id_number`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theIDNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_id_number`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theIDNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_requestID: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.request_id`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_requestID: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.request_id`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_requestID() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTP`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTP`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTP_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTP_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.URL`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.URL`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.URL_value`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.URL_value`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_URL_value`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_URL_value`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_URL`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_URL`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_id: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.ID`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_id: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.ID`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_id() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_idNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.ID_number`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_idNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.ID_number`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_idNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theIDNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_ID_number`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theIDNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_ID_number`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theIDNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_requestID: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.request_ID`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_requestID: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.request_ID`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_requestID() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Http`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Http`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.HttpRequest`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.HttpRequest`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttp`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttp`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Https`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Https`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.HttpsRequest`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.HttpsRequest`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttps`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttps`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Url`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Url`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.UrlValue`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.UrlValue`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheUrlValue`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheUrlValue`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheUrl`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheUrl`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_id: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Id`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_id: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Id`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_id() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_idNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.IdNumber`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_idNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.IdNumber`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_idNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theIDNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheIdNumber`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theIDNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheIdNumber`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theIDNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_requestID: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.RequestId`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_requestID: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.RequestId`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_requestID() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId)
-  }
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_naming_no_prefix.pb.swift
+++ b/Reference/unittest_swift_naming_no_prefix.pb.swift
@@ -38,6 +38,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 // MARK: - Extension support defined in unittest_swift_naming_no_prefix.proto.
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
+
   var http: Int32 {
     get {return getExtensionValue(ext: Extensions_http) ?? 0}
     set {setExtensionValue(ext: Extensions_http, value: newValue)}
@@ -52,9 +53,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearHTTP() {
     clearExtensionValue(ext: Extensions_http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var httpRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_http_request) ?? 0}
     set {setExtensionValue(ext: Extensions_http_request, value: newValue)}
@@ -69,9 +68,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearHTTPRequest() {
     clearExtensionValue(ext: Extensions_http_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_the_http_request) ?? 0}
     set {setExtensionValue(ext: Extensions_the_http_request, value: newValue)}
@@ -86,9 +83,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheHTTPRequest() {
     clearExtensionValue(ext: Extensions_the_http_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theHTTP: Int32 {
     get {return getExtensionValue(ext: Extensions_the_http) ?? 0}
     set {setExtensionValue(ext: Extensions_the_http, value: newValue)}
@@ -103,9 +98,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheHTTP() {
     clearExtensionValue(ext: Extensions_the_http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var https: Int32 {
     get {return getExtensionValue(ext: Extensions_https) ?? 0}
     set {setExtensionValue(ext: Extensions_https, value: newValue)}
@@ -120,9 +113,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearHTTPS() {
     clearExtensionValue(ext: Extensions_https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var httpsRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_https_request) ?? 0}
     set {setExtensionValue(ext: Extensions_https_request, value: newValue)}
@@ -137,9 +128,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearHTTPSRequest() {
     clearExtensionValue(ext: Extensions_https_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_the_https_request) ?? 0}
     set {setExtensionValue(ext: Extensions_the_https_request, value: newValue)}
@@ -154,9 +143,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheHTTPSRequest() {
     clearExtensionValue(ext: Extensions_the_https_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theHTTPS: Int32 {
     get {return getExtensionValue(ext: Extensions_the_https) ?? 0}
     set {setExtensionValue(ext: Extensions_the_https, value: newValue)}
@@ -171,9 +158,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheHTTPS() {
     clearExtensionValue(ext: Extensions_the_https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var url: Int32 {
     get {return getExtensionValue(ext: Extensions_url) ?? 0}
     set {setExtensionValue(ext: Extensions_url, value: newValue)}
@@ -188,9 +173,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearURL() {
     clearExtensionValue(ext: Extensions_url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var urlValue: Int32 {
     get {return getExtensionValue(ext: Extensions_url_value) ?? 0}
     set {setExtensionValue(ext: Extensions_url_value, value: newValue)}
@@ -205,9 +188,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearURLValue() {
     clearExtensionValue(ext: Extensions_url_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theURLValue: Int32 {
     get {return getExtensionValue(ext: Extensions_the_url_value) ?? 0}
     set {setExtensionValue(ext: Extensions_the_url_value, value: newValue)}
@@ -222,9 +203,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheURLValue() {
     clearExtensionValue(ext: Extensions_the_url_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theURL: Int32 {
     get {return getExtensionValue(ext: Extensions_the_url) ?? 0}
     set {setExtensionValue(ext: Extensions_the_url, value: newValue)}
@@ -239,9 +218,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheURL() {
     clearExtensionValue(ext: Extensions_the_url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var aBC: Int32 {
     get {return getExtensionValue(ext: Extensions_a_b_c) ?? 0}
     set {setExtensionValue(ext: Extensions_a_b_c, value: newValue)}
@@ -256,9 +233,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearABC() {
     clearExtensionValue(ext: Extensions_a_b_c)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var id: Int32 {
     get {return getExtensionValue(ext: Extensions_id) ?? 0}
     set {setExtensionValue(ext: Extensions_id, value: newValue)}
@@ -273,9 +248,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearID() {
     clearExtensionValue(ext: Extensions_id)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var idNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_id_number) ?? 0}
     set {setExtensionValue(ext: Extensions_id_number, value: newValue)}
@@ -290,9 +263,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearIDNumber() {
     clearExtensionValue(ext: Extensions_id_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theIDNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_the_id_number) ?? 0}
     set {setExtensionValue(ext: Extensions_the_id_number, value: newValue)}
@@ -307,9 +278,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheIDNumber() {
     clearExtensionValue(ext: Extensions_the_id_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var requestID: Int32 {
     get {return getExtensionValue(ext: Extensions_request_id) ?? 0}
     set {setExtensionValue(ext: Extensions_request_id, value: newValue)}
@@ -327,6 +296,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
+
   var http: Int32 {
     get {return getExtensionValue(ext: Extensions_HTTP) ?? 0}
     set {setExtensionValue(ext: Extensions_HTTP, value: newValue)}
@@ -341,9 +311,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearHTTP() {
     clearExtensionValue(ext: Extensions_HTTP)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var httpRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_HTTP_request) ?? 0}
     set {setExtensionValue(ext: Extensions_HTTP_request, value: newValue)}
@@ -358,9 +326,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearHTTPRequest() {
     clearExtensionValue(ext: Extensions_HTTP_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_the_HTTP_request) ?? 0}
     set {setExtensionValue(ext: Extensions_the_HTTP_request, value: newValue)}
@@ -375,9 +341,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheHTTPRequest() {
     clearExtensionValue(ext: Extensions_the_HTTP_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theHTTP: Int32 {
     get {return getExtensionValue(ext: Extensions_the_HTTP) ?? 0}
     set {setExtensionValue(ext: Extensions_the_HTTP, value: newValue)}
@@ -392,9 +356,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheHTTP() {
     clearExtensionValue(ext: Extensions_the_HTTP)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var https: Int32 {
     get {return getExtensionValue(ext: Extensions_HTTPS) ?? 0}
     set {setExtensionValue(ext: Extensions_HTTPS, value: newValue)}
@@ -409,9 +371,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearHTTPS() {
     clearExtensionValue(ext: Extensions_HTTPS)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var httpsRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_HTTPS_request) ?? 0}
     set {setExtensionValue(ext: Extensions_HTTPS_request, value: newValue)}
@@ -426,9 +386,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearHTTPSRequest() {
     clearExtensionValue(ext: Extensions_HTTPS_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_the_HTTPS_request) ?? 0}
     set {setExtensionValue(ext: Extensions_the_HTTPS_request, value: newValue)}
@@ -443,9 +401,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheHTTPSRequest() {
     clearExtensionValue(ext: Extensions_the_HTTPS_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theHTTPS: Int32 {
     get {return getExtensionValue(ext: Extensions_the_HTTPS) ?? 0}
     set {setExtensionValue(ext: Extensions_the_HTTPS, value: newValue)}
@@ -460,9 +416,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheHTTPS() {
     clearExtensionValue(ext: Extensions_the_HTTPS)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var url: Int32 {
     get {return getExtensionValue(ext: Extensions_URL) ?? 0}
     set {setExtensionValue(ext: Extensions_URL, value: newValue)}
@@ -477,9 +431,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearURL() {
     clearExtensionValue(ext: Extensions_URL)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var urlValue: Int32 {
     get {return getExtensionValue(ext: Extensions_URL_value) ?? 0}
     set {setExtensionValue(ext: Extensions_URL_value, value: newValue)}
@@ -494,9 +446,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearURLValue() {
     clearExtensionValue(ext: Extensions_URL_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theURLValue: Int32 {
     get {return getExtensionValue(ext: Extensions_the_URL_value) ?? 0}
     set {setExtensionValue(ext: Extensions_the_URL_value, value: newValue)}
@@ -511,9 +461,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheURLValue() {
     clearExtensionValue(ext: Extensions_the_URL_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theURL: Int32 {
     get {return getExtensionValue(ext: Extensions_the_URL) ?? 0}
     set {setExtensionValue(ext: Extensions_the_URL, value: newValue)}
@@ -528,9 +476,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheURL() {
     clearExtensionValue(ext: Extensions_the_URL)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var id: Int32 {
     get {return getExtensionValue(ext: Extensions_ID) ?? 0}
     set {setExtensionValue(ext: Extensions_ID, value: newValue)}
@@ -545,9 +491,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearID() {
     clearExtensionValue(ext: Extensions_ID)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var idNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_ID_number) ?? 0}
     set {setExtensionValue(ext: Extensions_ID_number, value: newValue)}
@@ -562,9 +506,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearIDNumber() {
     clearExtensionValue(ext: Extensions_ID_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theIDNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_the_ID_number) ?? 0}
     set {setExtensionValue(ext: Extensions_the_ID_number, value: newValue)}
@@ -579,9 +521,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheIDNumber() {
     clearExtensionValue(ext: Extensions_the_ID_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var requestID: Int32 {
     get {return getExtensionValue(ext: Extensions_request_ID) ?? 0}
     set {setExtensionValue(ext: Extensions_request_ID, value: newValue)}
@@ -599,6 +539,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
+
   var http: Int32 {
     get {return getExtensionValue(ext: Extensions_Http) ?? 0}
     set {setExtensionValue(ext: Extensions_Http, value: newValue)}
@@ -613,9 +554,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearHTTP() {
     clearExtensionValue(ext: Extensions_Http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var httpRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_HttpRequest) ?? 0}
     set {setExtensionValue(ext: Extensions_HttpRequest, value: newValue)}
@@ -630,9 +569,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearHTTPRequest() {
     clearExtensionValue(ext: Extensions_HttpRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_TheHttpRequest) ?? 0}
     set {setExtensionValue(ext: Extensions_TheHttpRequest, value: newValue)}
@@ -647,9 +584,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheHTTPRequest() {
     clearExtensionValue(ext: Extensions_TheHttpRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theHTTP: Int32 {
     get {return getExtensionValue(ext: Extensions_TheHttp) ?? 0}
     set {setExtensionValue(ext: Extensions_TheHttp, value: newValue)}
@@ -664,9 +599,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheHTTP() {
     clearExtensionValue(ext: Extensions_TheHttp)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var https: Int32 {
     get {return getExtensionValue(ext: Extensions_Https) ?? 0}
     set {setExtensionValue(ext: Extensions_Https, value: newValue)}
@@ -681,9 +614,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearHTTPS() {
     clearExtensionValue(ext: Extensions_Https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var httpsRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_HttpsRequest) ?? 0}
     set {setExtensionValue(ext: Extensions_HttpsRequest, value: newValue)}
@@ -698,9 +629,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearHTTPSRequest() {
     clearExtensionValue(ext: Extensions_HttpsRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_TheHttpsRequest) ?? 0}
     set {setExtensionValue(ext: Extensions_TheHttpsRequest, value: newValue)}
@@ -715,9 +644,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheHTTPSRequest() {
     clearExtensionValue(ext: Extensions_TheHttpsRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theHTTPS: Int32 {
     get {return getExtensionValue(ext: Extensions_TheHttps) ?? 0}
     set {setExtensionValue(ext: Extensions_TheHttps, value: newValue)}
@@ -732,9 +659,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheHTTPS() {
     clearExtensionValue(ext: Extensions_TheHttps)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var url: Int32 {
     get {return getExtensionValue(ext: Extensions_Url) ?? 0}
     set {setExtensionValue(ext: Extensions_Url, value: newValue)}
@@ -749,9 +674,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearURL() {
     clearExtensionValue(ext: Extensions_Url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var urlValue: Int32 {
     get {return getExtensionValue(ext: Extensions_UrlValue) ?? 0}
     set {setExtensionValue(ext: Extensions_UrlValue, value: newValue)}
@@ -766,9 +689,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearURLValue() {
     clearExtensionValue(ext: Extensions_UrlValue)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theURLValue: Int32 {
     get {return getExtensionValue(ext: Extensions_TheUrlValue) ?? 0}
     set {setExtensionValue(ext: Extensions_TheUrlValue, value: newValue)}
@@ -783,9 +704,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheURLValue() {
     clearExtensionValue(ext: Extensions_TheUrlValue)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theURL: Int32 {
     get {return getExtensionValue(ext: Extensions_TheUrl) ?? 0}
     set {setExtensionValue(ext: Extensions_TheUrl, value: newValue)}
@@ -800,9 +719,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheURL() {
     clearExtensionValue(ext: Extensions_TheUrl)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var id: Int32 {
     get {return getExtensionValue(ext: Extensions_Id) ?? 0}
     set {setExtensionValue(ext: Extensions_Id, value: newValue)}
@@ -817,9 +734,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearID() {
     clearExtensionValue(ext: Extensions_Id)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var idNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_IdNumber) ?? 0}
     set {setExtensionValue(ext: Extensions_IdNumber, value: newValue)}
@@ -834,9 +749,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearIDNumber() {
     clearExtensionValue(ext: Extensions_IdNumber)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theIDNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_TheIdNumber) ?? 0}
     set {setExtensionValue(ext: Extensions_TheIdNumber, value: newValue)}
@@ -851,9 +764,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheIDNumber() {
     clearExtensionValue(ext: Extensions_TheIdNumber)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var requestID: Int32 {
     get {return getExtensionValue(ext: Extensions_RequestId) ?? 0}
     set {setExtensionValue(ext: Extensions_RequestId, value: newValue)}
@@ -868,6 +779,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearRequestID() {
     clearExtensionValue(ext: Extensions_RequestId)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_reserved.pb.swift
+++ b/Reference/unittest_swift_reserved.pb.swift
@@ -370,6 +370,7 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_reserved.proto.
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
+
   /// Won't get _p added because it is fully qualified.
   var ProtobufUnittest_debugDescription: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debug_description) ?? false}
@@ -385,9 +386,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_debugDescription() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   /// These are scoped to the file, so the package prefix (or a Swift prefix)
   /// will get added to them to they aren't going to get renamed.
   var ProtobufUnittest_as: Bool {
@@ -404,9 +403,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_as() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_as)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_var: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_var) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_var, value: newValue)}
@@ -421,9 +418,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_var() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_var)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_try: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_try) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_try, value: newValue)}
@@ -438,9 +433,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_try() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_try)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_do: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_do) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_do, value: newValue)}
@@ -455,9 +448,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_do() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_do)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_nil: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_nil) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_nil, value: newValue)}
@@ -472,9 +463,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_nil() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_nil)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   /// This will end up in the "enum Extensions" to scope it, but there
   /// the raw form is used ("hash_value", not the Swift one "hashValue"),
   /// so there is no conflict, and no renaming happens.
@@ -492,9 +481,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_hashValue() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   /// Reserved words, since these end up in the "struct Extensions", they
   /// can't just be get their names, and sanitation kicks.
   var ProtobufUnittest_SwiftReservedTestExt_as: Bool {
@@ -511,9 +498,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_as() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.as)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_SwiftReservedTestExt_var: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.var) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.var, value: newValue)}
@@ -528,9 +513,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_var() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.var)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_SwiftReservedTestExt_try: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.try) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.try, value: newValue)}
@@ -545,9 +528,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_try() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.try)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_SwiftReservedTestExt_do: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.do) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.do, value: newValue)}
@@ -562,9 +543,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_do() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.do)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_SwiftReservedTestExt_nil: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.nil) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.nil, value: newValue)}
@@ -579,6 +558,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_nil() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.nil)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_reserved_ext.pb.swift
+++ b/Reference/unittest_swift_reserved_ext.pb.swift
@@ -63,6 +63,7 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_reserved_ext.proto.
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+
   /// Will get _p added because it has no package/swift prefix to scope and
   /// would otherwise be a problem when added to the message.
   var debugDescription_p: Bool {
@@ -79,9 +80,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearDebugDescription_p() {
     clearExtensionValue(ext: Extensions_debugDescription)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   /// These will get _p added for the same reasoning.
   var `as`: Bool {
     get {return getExtensionValue(ext: Extensions_as) ?? false}
@@ -97,9 +96,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearAs() {
     clearExtensionValue(ext: Extensions_as)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var `var`: Bool {
     get {return getExtensionValue(ext: Extensions_var) ?? false}
     set {setExtensionValue(ext: Extensions_var, value: newValue)}
@@ -114,9 +111,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearVar() {
     clearExtensionValue(ext: Extensions_var)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var `try`: Bool {
     get {return getExtensionValue(ext: Extensions_try) ?? false}
     set {setExtensionValue(ext: Extensions_try, value: newValue)}
@@ -131,9 +126,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearTry() {
     clearExtensionValue(ext: Extensions_try)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var `do`: Bool {
     get {return getExtensionValue(ext: Extensions_do) ?? false}
     set {setExtensionValue(ext: Extensions_do, value: newValue)}
@@ -148,9 +141,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearDo() {
     clearExtensionValue(ext: Extensions_do)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var `nil`: Bool {
     get {return getExtensionValue(ext: Extensions_nil) ?? false}
     set {setExtensionValue(ext: Extensions_nil, value: newValue)}
@@ -165,9 +156,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearNil() {
     clearExtensionValue(ext: Extensions_nil)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_hashValue: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue_) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue_, value: newValue)}
@@ -182,9 +171,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_hashValue() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue_)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   /// Reserved words, since these end up in the "enum Extensions", they
   /// can't just be get their names, and sanitation kicks.
   var SwiftReservedTestExt2_as: Bool {
@@ -201,9 +188,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_as() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.as)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_var: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.var) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.var, value: newValue)}
@@ -218,9 +203,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_var() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.var)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_try: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.try) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.try, value: newValue)}
@@ -235,9 +218,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_try() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.try)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_do: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.do) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.do, value: newValue)}
@@ -252,9 +233,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_do() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.do)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_nil: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil, value: newValue)}
@@ -269,6 +248,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_nil() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Reference/unittest_swift_startup.pb.swift
+++ b/Reference/unittest_swift_startup.pb.swift
@@ -113,6 +113,7 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_startup.proto.
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
+
   /// Singular
   var ProtobufObjcUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension) ?? 0}
@@ -128,9 +129,7 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   mutating func clearProtobufObjcUnittest_optionalInt32Extension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension)
   }
-}
 
-extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_repeatedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension) ?? []}
     set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension, value: newValue)}
@@ -145,9 +144,7 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   mutating func clearProtobufObjcUnittest_repeatedInt32Extension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension)
   }
-}
 
-extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension, value: newValue)}
@@ -162,6 +159,7 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Sources/protoc-gen-swift/ExtensionGenerator.swift
+++ b/Sources/protoc-gen-swift/ExtensionGenerator.swift
@@ -22,7 +22,7 @@ class ExtensionGenerator {
 
     // Helper to hold all the extensions when generating things across all
     // the extensions within a given file.
-    class Set {
+    class ExtensionSet {
         private let fileDescriptor: FileDescriptor
         private let generatorOptions: GeneratorOptions
         private let namer: SwiftProtobufNamer

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -117,14 +117,14 @@ class FileGenerator {
             m.generateMainStruct(printer: &p, parent: nil)
         }
 
-        var registry = [String]()
-        for e in extensions {
-            e.register(&registry)
-        }
+        let extensionSet = ExtensionGenerator.Set(fileDescriptor: fileDescriptor,
+                                                  generatorOptions: generatorOptions,
+                                                  namer: namer)
+        extensionSet.register(extensions: extensions)
         for m in messages {
-            m.registerExtensions(registry: &registry)
+            m.registerExtensions(set: extensionSet)
         }
-        if !registry.isEmpty {
+        if !extensionSet.isEmpty {
             let pathParts = splitPath(pathname: fileDescriptor.name)
             let filename = pathParts.base + pathParts.suffix
             p.print(
@@ -133,37 +133,20 @@ class FileGenerator {
 
             // Generate the Swift Extensions on the Messages that provide the api
             // for using the protobuf extension.
-            for e in extensions {
-                e.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
-            }
-            for m in messages {
-                m.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
-            }
+            extensionSet.generateMessageSwiftExtensions(printer: &p)
 
             // Generate a registry for the file.
-            let filenameAsIdentifer = NamingUtils.toUpperCamelCase(pathParts.base)
-            let filePrefix = namer.typePrefix(forFile: fileDescriptor)
-            p.print(
-                "\n",
-                "/// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by\n",
-                "/// this .proto file. It can be used any place an `SwiftProtobuf.ExtensionMap` is needed\n",
-                "/// in parsing, or it can be combined with other `SwiftProtobuf.SimpleExtensionMap`s to create\n",
-                "/// a larger `SwiftProtobuf.SimpleExtensionMap`.\n",
-                "\(generatorOptions.visibilitySourceSnippet)let \(filePrefix)\(filenameAsIdentifer)_Extensions: SwiftProtobuf.SimpleExtensionMap = [\n")
-            p.indent()
-            var separator = ""
-            for e in registry {
-                p.print(separator, e)
-                separator = ",\n"
-            }
-            p.print("\n")
-            p.outdent()
-            p.print("]\n")
+            extensionSet.generateFileProtobufExtensionRegistry(printer: &p)
 
             // Generate the Extension's declarations (used by the two above things).
+            //
             // This is done after the other two as the only time developers will need
             // these symbols is if they are manually building their own ExtensionMap;
             // so the others are assumed more interesting.
+            //
+            // This is not done via the ExtensionSet because for Message scoped
+            // extensions, they are done in a Swift Extension on the Message's
+            // type.
             for e in extensions {
                 p.print("\n")
                 e.generateProtobufExtensionDeclarations(printer: &p)

--- a/Sources/protoc-gen-swift/FileGenerator.swift
+++ b/Sources/protoc-gen-swift/FileGenerator.swift
@@ -117,9 +117,10 @@ class FileGenerator {
             m.generateMainStruct(printer: &p, parent: nil)
         }
 
-        let extensionSet = ExtensionGenerator.Set(fileDescriptor: fileDescriptor,
-                                                  generatorOptions: generatorOptions,
-                                                  namer: namer)
+        let extensionSet = ExtensionGenerator.ExtensionSet(
+          fileDescriptor: fileDescriptor,
+          generatorOptions: generatorOptions,
+          namer: namer)
         extensionSet.register(extensions: extensions)
         for m in messages {
             m.registerExtensions(set: extensionSet)

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -202,21 +202,10 @@ class MessageGenerator {
     }
   }
 
-  func generateMessageSwiftExtensionForProtobufExtensions(printer p: inout CodePrinter) {
-    for e in extensions {
-      e.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
-    }
+  func registerExtensions(set: ExtensionGenerator.Set) {
+    set.register(extensions: extensions)
     for m in messages {
-      m.generateMessageSwiftExtensionForProtobufExtensions(printer: &p)
-    }
-  }
-
-  func registerExtensions(registry: inout [String]) {
-    for e in extensions {
-      e.register(&registry)
-    }
-    for m in messages {
-      m.registerExtensions(registry: &registry)
+      m.registerExtensions(set: set)
     }
   }
 

--- a/Sources/protoc-gen-swift/MessageGenerator.swift
+++ b/Sources/protoc-gen-swift/MessageGenerator.swift
@@ -202,7 +202,7 @@ class MessageGenerator {
     }
   }
 
-  func registerExtensions(set: ExtensionGenerator.Set) {
+  func registerExtensions(set: ExtensionGenerator.ExtensionSet) {
     set.register(extensions: extensions)
     for m in messages {
       m.registerExtensions(set: set)

--- a/Tests/SwiftProtobufTests/unittest.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest.pb.swift
@@ -6600,6 +6600,7 @@ struct ProtobufUnittest_TestHugeFieldNumbers: SwiftProtobuf.Message, SwiftProtob
 // MARK: - Extension support defined in unittest.proto.
 
 extension ProtobufUnittest_TestAllExtensions {
+
   /// Singular
   var ProtobufUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension) ?? 0}
@@ -6615,9 +6616,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalInt64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension, value: newValue)}
@@ -6632,9 +6631,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension, value: newValue)}
@@ -6649,9 +6646,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalUint64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension, value: newValue)}
@@ -6666,9 +6661,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSint32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension, value: newValue)}
@@ -6683,9 +6676,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSint64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension, value: newValue)}
@@ -6700,9 +6691,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFixed32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension, value: newValue)}
@@ -6717,9 +6706,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFixed64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension, value: newValue)}
@@ -6734,9 +6721,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSfixed32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension, value: newValue)}
@@ -6751,9 +6736,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalSfixed64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension, value: newValue)}
@@ -6768,9 +6751,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalFloatExtension: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension, value: newValue)}
@@ -6785,9 +6766,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalDoubleExtension: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension, value: newValue)}
@@ -6802,9 +6781,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalBoolExtension: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension, value: newValue)}
@@ -6819,9 +6796,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension, value: newValue)}
@@ -6836,9 +6811,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension, value: newValue)}
@@ -6853,9 +6826,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalGroupExtension: ProtobufUnittest_OptionalGroup_extension {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension) ?? ProtobufUnittest_OptionalGroup_extension()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension, value: newValue)}
@@ -6870,9 +6841,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalGroupExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension, value: newValue)}
@@ -6887,9 +6856,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalForeignMessageExtension: ProtobufUnittest_ForeignMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension) ?? ProtobufUnittest_ForeignMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension, value: newValue)}
@@ -6904,9 +6871,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalForeignMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalImportMessageExtension: ProtobufUnittestImport_ImportMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension) ?? ProtobufUnittestImport_ImportMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension, value: newValue)}
@@ -6921,9 +6886,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension) ?? .foo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension, value: newValue)}
@@ -6938,9 +6901,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalForeignEnumExtension: ProtobufUnittest_ForeignEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension) ?? .foreignFoo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension, value: newValue)}
@@ -6955,9 +6916,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalImportEnumExtension: ProtobufUnittestImport_ImportEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension) ?? .importFoo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension, value: newValue)}
@@ -6972,9 +6931,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalStringPieceExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension, value: newValue)}
@@ -6989,9 +6946,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalCordExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension, value: newValue)}
@@ -7006,9 +6961,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalPublicImportMessageExtension: ProtobufUnittestImport_PublicImportMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension) ?? ProtobufUnittestImport_PublicImportMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension, value: newValue)}
@@ -7023,9 +6976,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalPublicImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_optionalLazyMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension, value: newValue)}
@@ -7040,9 +6991,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_optionalLazyMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   /// Repeated
   var ProtobufUnittest_repeatedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension) ?? []}
@@ -7058,9 +7007,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedInt64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension, value: newValue)}
@@ -7075,9 +7022,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedUint32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension, value: newValue)}
@@ -7092,9 +7037,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedUint64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension, value: newValue)}
@@ -7109,9 +7052,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSint32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension, value: newValue)}
@@ -7126,9 +7067,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSint64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension, value: newValue)}
@@ -7143,9 +7082,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFixed32Extension: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension, value: newValue)}
@@ -7160,9 +7097,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFixed64Extension: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension, value: newValue)}
@@ -7177,9 +7112,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSfixed32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension, value: newValue)}
@@ -7194,9 +7127,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedSfixed64Extension: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension, value: newValue)}
@@ -7211,9 +7142,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedFloatExtension: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension, value: newValue)}
@@ -7228,9 +7157,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedDoubleExtension: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension, value: newValue)}
@@ -7245,9 +7172,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedBoolExtension: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension, value: newValue)}
@@ -7262,9 +7187,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedStringExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension, value: newValue)}
@@ -7279,9 +7202,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedBytesExtension: [Data] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension, value: newValue)}
@@ -7296,9 +7217,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedGroupExtension: [ProtobufUnittest_RepeatedGroup_extension] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension, value: newValue)}
@@ -7313,9 +7232,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedGroupExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedNestedMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension, value: newValue)}
@@ -7330,9 +7247,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedForeignMessageExtension: [ProtobufUnittest_ForeignMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension, value: newValue)}
@@ -7347,9 +7262,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedForeignMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedImportMessageExtension: [ProtobufUnittestImport_ImportMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension, value: newValue)}
@@ -7364,9 +7277,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedImportMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedNestedEnumExtension: [ProtobufUnittest_TestAllTypes.NestedEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension, value: newValue)}
@@ -7381,9 +7292,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedForeignEnumExtension: [ProtobufUnittest_ForeignEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension, value: newValue)}
@@ -7398,9 +7307,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedImportEnumExtension: [ProtobufUnittestImport_ImportEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension, value: newValue)}
@@ -7415,9 +7322,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedStringPieceExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension, value: newValue)}
@@ -7432,9 +7337,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedCordExtension: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension, value: newValue)}
@@ -7449,9 +7352,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_repeatedLazyMessageExtension: [ProtobufUnittest_TestAllTypes.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension, value: newValue)}
@@ -7466,9 +7367,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_repeatedLazyMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   /// Singular with defaults
   var ProtobufUnittest_defaultInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension) ?? 41}
@@ -7484,9 +7383,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultInt32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultInt64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension) ?? 42}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension, value: newValue)}
@@ -7501,9 +7398,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultInt64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension) ?? 43}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension, value: newValue)}
@@ -7518,9 +7413,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultUint64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension) ?? 44}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension, value: newValue)}
@@ -7535,9 +7428,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultUint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSint32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension) ?? -45}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension, value: newValue)}
@@ -7552,9 +7443,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultSint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSint64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension) ?? 46}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension, value: newValue)}
@@ -7569,9 +7458,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultSint64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFixed32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension) ?? 47}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension, value: newValue)}
@@ -7586,9 +7473,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultFixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFixed64Extension: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension) ?? 48}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension, value: newValue)}
@@ -7603,9 +7488,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultFixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSfixed32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension) ?? 49}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension, value: newValue)}
@@ -7620,9 +7503,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultSfixed32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultSfixed64Extension: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension) ?? -50}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension, value: newValue)}
@@ -7637,9 +7518,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultSfixed64Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultFloatExtension: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension) ?? 51.5}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension, value: newValue)}
@@ -7654,9 +7533,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultFloatExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultDoubleExtension: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension) ?? 52000}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension, value: newValue)}
@@ -7671,9 +7548,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultDoubleExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultBoolExtension: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension) ?? true}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension, value: newValue)}
@@ -7688,9 +7563,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultBoolExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension) ?? "hello"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension, value: newValue)}
@@ -7705,9 +7578,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension) ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension, value: newValue)}
@@ -7722,9 +7593,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultNestedEnumExtension: ProtobufUnittest_TestAllTypes.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension) ?? .bar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension, value: newValue)}
@@ -7739,9 +7608,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultNestedEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultForeignEnumExtension: ProtobufUnittest_ForeignEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension) ?? .foreignBar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension, value: newValue)}
@@ -7756,9 +7623,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultForeignEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultImportEnumExtension: ProtobufUnittestImport_ImportEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension) ?? .importBar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension, value: newValue)}
@@ -7773,9 +7638,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultImportEnumExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultStringPieceExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension) ?? "abc"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension, value: newValue)}
@@ -7790,9 +7653,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultStringPieceExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_defaultCordExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension) ?? "123"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension, value: newValue)}
@@ -7807,9 +7668,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_defaultCordExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   /// For oneof test
   var ProtobufUnittest_oneofUint32Extension: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension) ?? 0}
@@ -7825,9 +7684,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_oneofUint32Extension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofNestedMessageExtension: ProtobufUnittest_TestAllTypes.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension) ?? ProtobufUnittest_TestAllTypes.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension, value: newValue)}
@@ -7842,9 +7699,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_oneofNestedMessageExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofStringExtension: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension, value: newValue)}
@@ -7859,9 +7714,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_oneofStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_oneofBytesExtension: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension, value: newValue)}
@@ -7876,536 +7729,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_oneofBytesExtension() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension)
   }
-}
 
-extension ProtobufUnittest_TestFieldOrderings {
-  var ProtobufUnittest_myExtensionString: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string) ?? String()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_my_extension_string`
-  /// has been explicitly set.
-  var hasProtobufUnittest_myExtensionString: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_my_extension_string`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_myExtensionString() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
-  }
-}
-
-extension ProtobufUnittest_TestFieldOrderings {
-  var ProtobufUnittest_myExtensionInt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_my_extension_int`
-  /// has been explicitly set.
-  var hasProtobufUnittest_myExtensionInt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_my_extension_int`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_myExtensionInt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedInt64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedUint32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedUint64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedSint32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedSint64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedFixed32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedFixed64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedSfixed32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedSfixed64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedFloatExtension: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_float_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_float_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedDoubleExtension: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_double_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_double_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedBoolExtension: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_bool_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_bool_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensions {
-  var ProtobufUnittest_packedEnumExtension: [ProtobufUnittest_ForeignEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_enum_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_enum_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedInt32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_int32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedInt32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_int32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedInt32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedInt64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_int64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedInt64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_int64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedInt64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedUint32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_uint32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedUint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_uint32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedUint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedUint64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_uint64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedUint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_uint64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedUint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedSint32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sint32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedSint32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sint32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedSint32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedSint64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sint64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedSint64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sint64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedSint64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedFixed32Extension: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_fixed32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedFixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_fixed32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedFixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedFixed64Extension: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_fixed64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedFixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_fixed64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedFixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedSfixed32Extension: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sfixed32_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedSfixed32Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sfixed32_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedSfixed32Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedSfixed64Extension: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sfixed64_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedSfixed64Extension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sfixed64_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedSfixed64Extension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedFloatExtension: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_float_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedFloatExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_float_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedFloatExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedDoubleExtension: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_double_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedDoubleExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_double_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedDoubleExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedBoolExtension: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_bool_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedBoolExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_bool_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedBoolExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
-  }
-}
-
-extension ProtobufUnittest_TestUnpackedExtensions {
-  var ProtobufUnittest_unpackedEnumExtension: [ProtobufUnittest_ForeignEnum] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_enum_extension`
-  /// has been explicitly set.
-  var hasProtobufUnittest_unpackedEnumExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_enum_extension`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_unpackedEnumExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
-  }
-}
-
-extension ProtobufUnittest_TestHugeFieldNumbers {
-  var ProtobufUnittest_testAllTypes: ProtobufUnittest_TestAllTypes {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types) ?? ProtobufUnittest_TestAllTypes()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_test_all_types`
-  /// has been explicitly set.
-  var hasProtobufUnittest_testAllTypes: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_test_all_types`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_testAllTypes() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensions {
   /// Check for bug where string extensions declared in tested scope did not
   /// compile.
   var ProtobufUnittest_TestNestedExtension_test: String {
@@ -8422,9 +7746,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_TestNestedExtension_test() {
     clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.test)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   /// Used to test if generated extension name is correct when there are
   /// underscores.
   var ProtobufUnittest_TestNestedExtension_nestedStringExtension: String {
@@ -8441,9 +7763,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_TestNestedExtension_nestedStringExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestNestedExtension.Extensions.nested_string_extension)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_TestRequired_single: ProtobufUnittest_TestRequired {
     get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single) ?? ProtobufUnittest_TestRequired()}
     set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single, value: newValue)}
@@ -8458,9 +7778,7 @@ extension ProtobufUnittest_TestAllExtensions {
   mutating func clearProtobufUnittest_TestRequired_single() {
     clearExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.single)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensions {
   var ProtobufUnittest_TestRequired_multi: [ProtobufUnittest_TestRequired] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_TestRequired.Extensions.multi, value: newValue)}
@@ -8477,7 +7795,272 @@ extension ProtobufUnittest_TestAllExtensions {
   }
 }
 
+extension ProtobufUnittest_TestFieldOrderings {
+
+  var ProtobufUnittest_myExtensionString: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string) ?? String()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_my_extension_string`
+  /// has been explicitly set.
+  var hasProtobufUnittest_myExtensionString: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_my_extension_string`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_myExtensionString() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_string)
+  }
+
+  var ProtobufUnittest_myExtensionInt: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_my_extension_int`
+  /// has been explicitly set.
+  var hasProtobufUnittest_myExtensionInt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_my_extension_int`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_myExtensionInt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_my_extension_int)
+  }
+}
+
+extension ProtobufUnittest_TestHugeFieldNumbers {
+
+  var ProtobufUnittest_testAllTypes: ProtobufUnittest_TestAllTypes {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types) ?? ProtobufUnittest_TestAllTypes()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_test_all_types`
+  /// has been explicitly set.
+  var hasProtobufUnittest_testAllTypes: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_test_all_types`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_testAllTypes() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types)
+  }
+}
+
+extension ProtobufUnittest_TestPackedExtensions {
+
+  var ProtobufUnittest_packedInt32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedInt32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedInt32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension)
+  }
+
+  var ProtobufUnittest_packedInt64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedInt64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedInt64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension)
+  }
+
+  var ProtobufUnittest_packedUint32Extension: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedUint32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedUint32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension)
+  }
+
+  var ProtobufUnittest_packedUint64Extension: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedUint64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedUint64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension)
+  }
+
+  var ProtobufUnittest_packedSint32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSint32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSint32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension)
+  }
+
+  var ProtobufUnittest_packedSint64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSint64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSint64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension)
+  }
+
+  var ProtobufUnittest_packedFixed32Extension: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFixed32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFixed32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension)
+  }
+
+  var ProtobufUnittest_packedFixed64Extension: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFixed64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFixed64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension)
+  }
+
+  var ProtobufUnittest_packedSfixed32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSfixed32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSfixed32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension)
+  }
+
+  var ProtobufUnittest_packedSfixed64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSfixed64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSfixed64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension)
+  }
+
+  var ProtobufUnittest_packedFloatExtension: [Float] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_float_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFloatExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_float_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFloatExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension)
+  }
+
+  var ProtobufUnittest_packedDoubleExtension: [Double] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_double_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedDoubleExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_double_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedDoubleExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension)
+  }
+
+  var ProtobufUnittest_packedBoolExtension: [Bool] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_bool_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedBoolExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_bool_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedBoolExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension)
+  }
+
+  var ProtobufUnittest_packedEnumExtension: [ProtobufUnittest_ForeignEnum] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_enum_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedEnumExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_enum_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedEnumExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension)
+  }
+}
+
 extension ProtobufUnittest_TestParsingMerge {
+
   var ProtobufUnittest_TestParsingMerge_optionalExt: ProtobufUnittest_TestAllTypes {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypes()}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext, value: newValue)}
@@ -8492,9 +8075,7 @@ extension ProtobufUnittest_TestParsingMerge {
   mutating func clearProtobufUnittest_TestParsingMerge_optionalExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.optional_ext)
   }
-}
 
-extension ProtobufUnittest_TestParsingMerge {
   var ProtobufUnittest_TestParsingMerge_repeatedExt: [ProtobufUnittest_TestAllTypes] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext, value: newValue)}
@@ -8509,6 +8090,220 @@ extension ProtobufUnittest_TestParsingMerge {
   mutating func clearProtobufUnittest_TestParsingMerge_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMerge.Extensions.repeated_ext)
   }
+}
+
+extension ProtobufUnittest_TestUnpackedExtensions {
+
+  var ProtobufUnittest_unpackedInt32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_int32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedInt32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_int32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedInt32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int32_extension)
+  }
+
+  var ProtobufUnittest_unpackedInt64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_int64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedInt64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_int64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedInt64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_int64_extension)
+  }
+
+  var ProtobufUnittest_unpackedUint32Extension: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_uint32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedUint32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_uint32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedUint32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint32_extension)
+  }
+
+  var ProtobufUnittest_unpackedUint64Extension: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_uint64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedUint64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_uint64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedUint64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_uint64_extension)
+  }
+
+  var ProtobufUnittest_unpackedSint32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sint32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedSint32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sint32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedSint32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint32_extension)
+  }
+
+  var ProtobufUnittest_unpackedSint64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sint64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedSint64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sint64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedSint64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sint64_extension)
+  }
+
+  var ProtobufUnittest_unpackedFixed32Extension: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_fixed32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedFixed32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_fixed32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedFixed32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed32_extension)
+  }
+
+  var ProtobufUnittest_unpackedFixed64Extension: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_fixed64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedFixed64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_fixed64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedFixed64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_fixed64_extension)
+  }
+
+  var ProtobufUnittest_unpackedSfixed32Extension: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sfixed32_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedSfixed32Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sfixed32_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedSfixed32Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed32_extension)
+  }
+
+  var ProtobufUnittest_unpackedSfixed64Extension: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_sfixed64_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedSfixed64Extension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_sfixed64_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedSfixed64Extension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_sfixed64_extension)
+  }
+
+  var ProtobufUnittest_unpackedFloatExtension: [Float] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_float_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedFloatExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_float_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedFloatExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_float_extension)
+  }
+
+  var ProtobufUnittest_unpackedDoubleExtension: [Double] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_double_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedDoubleExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_double_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedDoubleExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_double_extension)
+  }
+
+  var ProtobufUnittest_unpackedBoolExtension: [Bool] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_bool_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedBoolExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_bool_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedBoolExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_bool_extension)
+  }
+
+  var ProtobufUnittest_unpackedEnumExtension: [ProtobufUnittest_ForeignEnum] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_unpacked_enum_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_unpackedEnumExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_unpacked_enum_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_unpackedEnumExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_unpacked_enum_extension)
+  }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_custom_options.pb.swift
@@ -1406,94 +1406,8 @@ struct ProtobufUnittest_TestMessageWithRequiredEnumOption: SwiftProtobuf.Message
 
 // MARK: - Extension support defined in unittest_custom_options.proto.
 
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_fileOpt1: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_file_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fileOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_file_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fileOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_messageOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_message_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_messageOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_message_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_messageOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
-  }
-}
-
-extension Google_Protobuf_FieldOptions {
-  var ProtobufUnittest_fieldOpt1: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_field_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fieldOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_field_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fieldOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
-  }
-}
-
-extension Google_Protobuf_FieldOptions {
-  /// This is useful for testing that we correctly register default values for
-  /// extension options.
-  var ProtobufUnittest_fieldOpt2: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2) ?? 42}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_field_opt2`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fieldOpt2: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_field_opt2`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fieldOpt2() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
-  }
-}
-
-extension Google_Protobuf_OneofOptions {
-  var ProtobufUnittest_oneofOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_oneof_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_oneofOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_oneof_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_oneofOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
-  }
-}
-
 extension Google_Protobuf_EnumOptions {
+
   var ProtobufUnittest_enumOpt1: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1, value: newValue)}
@@ -1508,536 +1422,7 @@ extension Google_Protobuf_EnumOptions {
   mutating func clearProtobufUnittest_enumOpt1() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt1)
   }
-}
 
-extension Google_Protobuf_EnumValueOptions {
-  var ProtobufUnittest_enumValueOpt1: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_enum_value_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_enumValueOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_enum_value_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_enumValueOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
-  }
-}
-
-extension Google_Protobuf_ServiceOptions {
-  var ProtobufUnittest_serviceOpt1: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_service_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_serviceOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_service_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_serviceOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
-  }
-}
-
-extension Google_Protobuf_MethodOptions {
-  var ProtobufUnittest_methodOpt1: ProtobufUnittest_MethodOpt1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1) ?? .val1}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_method_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_methodOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_method_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_methodOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_boolOpt: Bool {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt) ?? false}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_bool_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_boolOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_bool_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_boolOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_int32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_int32_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_int32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_int32_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_int32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_int64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_int64_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_int64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_int64_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_int64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_uint32Opt: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_uint32_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_uint32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_uint32_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_uint32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_uint64Opt: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_uint64_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_uint64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_uint64_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_uint64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_sint32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_sint32_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_sint32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_sint32_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_sint32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_sint64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_sint64_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_sint64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_sint64_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_sint64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_fixed32Opt: UInt32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_fixed32_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fixed32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_fixed32_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fixed32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_fixed64Opt: UInt64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_fixed64_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fixed64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_fixed64_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fixed64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_sfixed32Opt: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_sfixed32_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_sfixed32Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_sfixed32_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_sfixed32Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_sfixed64Opt: Int64 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_sfixed64_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_sfixed64Opt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_sfixed64_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_sfixed64Opt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_floatOpt: Float {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_float_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_float_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_float_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_floatOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_float_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_floatOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_doubleOpt: Double {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_double_opt) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_double_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_double_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_doubleOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_double_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_doubleOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_stringOpt: String {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_string_opt) ?? String()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_string_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_string_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_stringOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_string_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_stringOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_bytesOpt: Data {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt) ?? SwiftProtobuf.Internal.emptyData}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_bytes_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_bytesOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_bytes_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_bytesOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_enumOpt: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt) ?? .testOptionEnumType1}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_enum_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_enumOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_enum_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_enumOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_messageTypeOpt: ProtobufUnittest_DummyMessageInvalidAsOptionType {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt) ?? ProtobufUnittest_DummyMessageInvalidAsOptionType()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_message_type_opt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_messageTypeOpt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_message_type_opt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_messageTypeOpt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
-  }
-}
-
-extension ProtobufUnittest_ComplexOptionType1 {
-  var ProtobufUnittest_quux: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_quux) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_quux, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_quux`
-  /// has been explicitly set.
-  var hasProtobufUnittest_quux: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_quux)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_quux`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_quux() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_quux)
-  }
-}
-
-extension ProtobufUnittest_ComplexOptionType1 {
-  var ProtobufUnittest_corge: ProtobufUnittest_ComplexOptionType3 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_corge) ?? ProtobufUnittest_ComplexOptionType3()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_corge, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_corge`
-  /// has been explicitly set.
-  var hasProtobufUnittest_corge: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_corge)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_corge`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_corge() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_corge)
-  }
-}
-
-extension ProtobufUnittest_ComplexOptionType2 {
-  var ProtobufUnittest_grault: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_grault) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_grault, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_grault`
-  /// has been explicitly set.
-  var hasProtobufUnittest_grault: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_grault)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_grault`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_grault() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_grault)
-  }
-}
-
-extension ProtobufUnittest_ComplexOptionType2 {
-  var ProtobufUnittest_garply: ProtobufUnittest_ComplexOptionType1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_garply) ?? ProtobufUnittest_ComplexOptionType1()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_garply, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_garply`
-  /// has been explicitly set.
-  var hasProtobufUnittest_garply: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_garply)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_garply`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_garply() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_garply)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_complexOpt1: ProtobufUnittest_ComplexOptionType1 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1) ?? ProtobufUnittest_ComplexOptionType1()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt1`
-  /// has been explicitly set.
-  var hasProtobufUnittest_complexOpt1: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt1`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_complexOpt1() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_complexOpt2: ProtobufUnittest_ComplexOptionType2 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2) ?? ProtobufUnittest_ComplexOptionType2()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt2`
-  /// has been explicitly set.
-  var hasProtobufUnittest_complexOpt2: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt2`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_complexOpt2() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_complexOpt3: ProtobufUnittest_ComplexOptionType3 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3) ?? ProtobufUnittest_ComplexOptionType3()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt3`
-  /// has been explicitly set.
-  var hasProtobufUnittest_complexOpt3: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt3`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_complexOpt3() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_complexOpt6: ProtobufUnittest_ComplexOpt6 {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6) ?? ProtobufUnittest_ComplexOpt6()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_ComplexOpt6`
-  /// has been explicitly set.
-  var hasProtobufUnittest_complexOpt6: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_ComplexOpt6`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_complexOpt6() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
-  }
-}
-
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_fileopt: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fileopt) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fileopt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_fileopt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fileopt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fileopt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_fileopt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fileopt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fileopt)
-  }
-}
-
-extension Google_Protobuf_MessageOptions {
-  var ProtobufUnittest_msgopt: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_msgopt) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_msgopt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_msgopt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_msgopt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_msgopt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_msgopt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_msgopt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_msgopt)
-  }
-}
-
-extension Google_Protobuf_FieldOptions {
-  var ProtobufUnittest_fieldopt: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_fieldopt`
-  /// has been explicitly set.
-  var hasProtobufUnittest_fieldopt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_fieldopt`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_fieldopt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt)
-  }
-}
-
-extension Google_Protobuf_EnumOptions {
   var ProtobufUnittest_enumopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enumopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_enumopt, value: newValue)}
@@ -2055,6 +1440,22 @@ extension Google_Protobuf_EnumOptions {
 }
 
 extension Google_Protobuf_EnumValueOptions {
+
+  var ProtobufUnittest_enumValueOpt1: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_enum_value_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_enumValueOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_enum_value_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_enumValueOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_value_opt1)
+  }
+
   var ProtobufUnittest_enumvalopt: ProtobufUnittest_Aggregate {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enumvalopt) ?? ProtobufUnittest_Aggregate()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_enumvalopt, value: newValue)}
@@ -2071,41 +1472,466 @@ extension Google_Protobuf_EnumValueOptions {
   }
 }
 
-extension Google_Protobuf_ServiceOptions {
-  var ProtobufUnittest_serviceopt: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt, value: newValue)}
+extension Google_Protobuf_FieldOptions {
+
+  var ProtobufUnittest_fieldOpt1: UInt64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1, value: newValue)}
   }
-  /// Returns true if extension `ProtobufUnittest_Extensions_serviceopt`
+  /// Returns true if extension `ProtobufUnittest_Extensions_field_opt1`
   /// has been explicitly set.
-  var hasProtobufUnittest_serviceopt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt)
+  var hasProtobufUnittest_fieldOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
   }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_serviceopt`.
+  /// Clears the value of extension `ProtobufUnittest_Extensions_field_opt1`.
   /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_serviceopt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt)
+  mutating func clearProtobufUnittest_fieldOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt1)
+  }
+
+  /// This is useful for testing that we correctly register default values for
+  /// extension options.
+  var ProtobufUnittest_fieldOpt2: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2) ?? 42}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_field_opt2`
+  /// has been explicitly set.
+  var hasProtobufUnittest_fieldOpt2: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_field_opt2`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_fieldOpt2() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_field_opt2)
+  }
+
+  var ProtobufUnittest_fieldopt: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_fieldopt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_fieldopt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_fieldopt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_fieldopt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fieldopt)
   }
 }
 
-extension Google_Protobuf_MethodOptions {
-  var ProtobufUnittest_methodopt: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_methodopt) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_methodopt, value: newValue)}
+extension Google_Protobuf_FileOptions {
+
+  var ProtobufUnittest_fileOpt1: UInt64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1, value: newValue)}
   }
-  /// Returns true if extension `ProtobufUnittest_Extensions_methodopt`
+  /// Returns true if extension `ProtobufUnittest_Extensions_file_opt1`
   /// has been explicitly set.
-  var hasProtobufUnittest_methodopt: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_methodopt)
+  var hasProtobufUnittest_fileOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
   }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_methodopt`.
+  /// Clears the value of extension `ProtobufUnittest_Extensions_file_opt1`.
   /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_methodopt() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_methodopt)
+  mutating func clearProtobufUnittest_fileOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_file_opt1)
+  }
+
+  var ProtobufUnittest_fileopt: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fileopt) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fileopt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_fileopt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_fileopt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fileopt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_fileopt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_fileopt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fileopt)
+  }
+
+  var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Aggregate.Extensions.nested`
+  /// has been explicitly set.
+  var hasProtobufUnittest_Aggregate_nested: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Aggregate.Extensions.nested`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_Aggregate_nested() {
+    clearExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  }
+
+  var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_NestedOptionType.Extensions.nested_extension`
+  /// has been explicitly set.
+  var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
+  }
+  /// Clears the value of extension `ProtobufUnittest_NestedOptionType.Extensions.nested_extension`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
+    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
   }
 }
 
 extension Google_Protobuf_MessageOptions {
+
+  var ProtobufUnittest_messageOpt1: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_message_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_messageOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_message_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_messageOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_opt1)
+  }
+
+  var ProtobufUnittest_boolOpt: Bool {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt) ?? false}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_bool_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_boolOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_bool_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_boolOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_bool_opt)
+  }
+
+  var ProtobufUnittest_int32Opt: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_int32_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_int32Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_int32_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_int32Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_int32_opt)
+  }
+
+  var ProtobufUnittest_int64Opt: Int64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_int64_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_int64Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_int64_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_int64Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_int64_opt)
+  }
+
+  var ProtobufUnittest_uint32Opt: UInt32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_uint32_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_uint32Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_uint32_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_uint32Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint32_opt)
+  }
+
+  var ProtobufUnittest_uint64Opt: UInt64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_uint64_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_uint64Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_uint64_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_uint64Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_uint64_opt)
+  }
+
+  var ProtobufUnittest_sint32Opt: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_sint32_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_sint32Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_sint32_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_sint32Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint32_opt)
+  }
+
+  var ProtobufUnittest_sint64Opt: Int64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_sint64_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_sint64Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_sint64_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_sint64Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sint64_opt)
+  }
+
+  var ProtobufUnittest_fixed32Opt: UInt32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_fixed32_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_fixed32Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_fixed32_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_fixed32Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed32_opt)
+  }
+
+  var ProtobufUnittest_fixed64Opt: UInt64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_fixed64_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_fixed64Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_fixed64_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_fixed64Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_fixed64_opt)
+  }
+
+  var ProtobufUnittest_sfixed32Opt: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_sfixed32_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_sfixed32Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_sfixed32_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_sfixed32Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed32_opt)
+  }
+
+  var ProtobufUnittest_sfixed64Opt: Int64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_sfixed64_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_sfixed64Opt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_sfixed64_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_sfixed64Opt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_sfixed64_opt)
+  }
+
+  var ProtobufUnittest_floatOpt: Float {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_float_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_float_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_float_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_floatOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_float_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_floatOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_float_opt)
+  }
+
+  var ProtobufUnittest_doubleOpt: Double {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_double_opt) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_double_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_double_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_doubleOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_double_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_doubleOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_double_opt)
+  }
+
+  var ProtobufUnittest_stringOpt: String {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_string_opt) ?? String()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_string_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_string_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_stringOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_string_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_stringOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_string_opt)
+  }
+
+  var ProtobufUnittest_bytesOpt: Data {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt) ?? SwiftProtobuf.Internal.emptyData}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_bytes_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_bytesOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_bytes_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_bytesOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_bytes_opt)
+  }
+
+  var ProtobufUnittest_enumOpt: ProtobufUnittest_DummyMessageContainingEnum.TestEnumType {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt) ?? .testOptionEnumType1}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_enum_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_enumOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_enum_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_enumOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_enum_opt)
+  }
+
+  var ProtobufUnittest_messageTypeOpt: ProtobufUnittest_DummyMessageInvalidAsOptionType {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt) ?? ProtobufUnittest_DummyMessageInvalidAsOptionType()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_message_type_opt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_messageTypeOpt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_message_type_opt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_messageTypeOpt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_message_type_opt)
+  }
+
+  var ProtobufUnittest_complexOpt1: ProtobufUnittest_ComplexOptionType1 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1) ?? ProtobufUnittest_ComplexOptionType1()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_complexOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_complexOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt1)
+  }
+
+  var ProtobufUnittest_complexOpt2: ProtobufUnittest_ComplexOptionType2 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2) ?? ProtobufUnittest_ComplexOptionType2()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt2`
+  /// has been explicitly set.
+  var hasProtobufUnittest_complexOpt2: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt2`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_complexOpt2() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt2)
+  }
+
+  var ProtobufUnittest_complexOpt3: ProtobufUnittest_ComplexOptionType3 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3) ?? ProtobufUnittest_ComplexOptionType3()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_complex_opt3`
+  /// has been explicitly set.
+  var hasProtobufUnittest_complexOpt3: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_complex_opt3`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_complexOpt3() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_complex_opt3)
+  }
+
+  var ProtobufUnittest_complexOpt6: ProtobufUnittest_ComplexOpt6 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6) ?? ProtobufUnittest_ComplexOpt6()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_ComplexOpt6`
+  /// has been explicitly set.
+  var hasProtobufUnittest_complexOpt6: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_ComplexOpt6`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_complexOpt6() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_ComplexOpt6)
+  }
+
+  var ProtobufUnittest_msgopt: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_msgopt) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_msgopt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_msgopt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_msgopt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_msgopt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_msgopt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_msgopt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_msgopt)
+  }
+
   var ProtobufUnittest_requiredEnumOpt: ProtobufUnittest_OldOptionType {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt) ?? ProtobufUnittest_OldOptionType()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt, value: newValue)}
@@ -2120,9 +1946,7 @@ extension Google_Protobuf_MessageOptions {
   mutating func clearProtobufUnittest_requiredEnumOpt() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_required_enum_opt)
   }
-}
 
-extension Google_Protobuf_MessageOptions {
   var ProtobufUnittest_ComplexOptionType2_ComplexOptionType4_complexOpt4: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4 {
     get {return getExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4) ?? ProtobufUnittest_ComplexOptionType2.ComplexOptionType4()}
     set {setExtensionValue(ext: ProtobufUnittest_ComplexOptionType2.ComplexOptionType4.Extensions.complex_opt4, value: newValue)}
@@ -2139,7 +1963,92 @@ extension Google_Protobuf_MessageOptions {
   }
 }
 
+extension Google_Protobuf_MethodOptions {
+
+  var ProtobufUnittest_methodOpt1: ProtobufUnittest_MethodOpt1 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1) ?? .val1}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_method_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_methodOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_method_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_methodOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_method_opt1)
+  }
+
+  var ProtobufUnittest_methodopt: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_methodopt) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_methodopt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_methodopt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_methodopt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_methodopt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_methodopt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_methodopt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_methodopt)
+  }
+}
+
+extension Google_Protobuf_OneofOptions {
+
+  var ProtobufUnittest_oneofOpt1: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_oneof_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_oneofOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_oneof_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_oneofOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_opt1)
+  }
+}
+
+extension Google_Protobuf_ServiceOptions {
+
+  var ProtobufUnittest_serviceOpt1: Int64 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_service_opt1`
+  /// has been explicitly set.
+  var hasProtobufUnittest_serviceOpt1: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_service_opt1`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_serviceOpt1() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_service_opt1)
+  }
+
+  var ProtobufUnittest_serviceopt: ProtobufUnittest_Aggregate {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt) ?? ProtobufUnittest_Aggregate()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_serviceopt`
+  /// has been explicitly set.
+  var hasProtobufUnittest_serviceopt: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_serviceopt`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_serviceopt() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_serviceopt)
+  }
+}
+
 extension ProtobufUnittest_AggregateMessageSet {
+
   var ProtobufUnittest_AggregateMessageSetElement_messageSetExtension: ProtobufUnittest_AggregateMessageSetElement {
     get {return getExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension) ?? ProtobufUnittest_AggregateMessageSetElement()}
     set {setExtensionValue(ext: ProtobufUnittest_AggregateMessageSetElement.Extensions.message_set_extension, value: newValue)}
@@ -2156,38 +2065,71 @@ extension ProtobufUnittest_AggregateMessageSet {
   }
 }
 
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_Aggregate_nested: ProtobufUnittest_Aggregate {
-    get {return getExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested) ?? ProtobufUnittest_Aggregate()}
-    set {setExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested, value: newValue)}
+extension ProtobufUnittest_ComplexOptionType1 {
+
+  var ProtobufUnittest_quux: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_quux) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_quux, value: newValue)}
   }
-  /// Returns true if extension `ProtobufUnittest_Aggregate.Extensions.nested`
+  /// Returns true if extension `ProtobufUnittest_Extensions_quux`
   /// has been explicitly set.
-  var hasProtobufUnittest_Aggregate_nested: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  var hasProtobufUnittest_quux: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_quux)
   }
-  /// Clears the value of extension `ProtobufUnittest_Aggregate.Extensions.nested`.
+  /// Clears the value of extension `ProtobufUnittest_Extensions_quux`.
   /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_Aggregate_nested() {
-    clearExtensionValue(ext: ProtobufUnittest_Aggregate.Extensions.nested)
+  mutating func clearProtobufUnittest_quux() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_quux)
+  }
+
+  var ProtobufUnittest_corge: ProtobufUnittest_ComplexOptionType3 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_corge) ?? ProtobufUnittest_ComplexOptionType3()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_corge, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_corge`
+  /// has been explicitly set.
+  var hasProtobufUnittest_corge: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_corge)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_corge`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_corge() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_corge)
   }
 }
 
-extension Google_Protobuf_FileOptions {
-  var ProtobufUnittest_NestedOptionType_nestedExtension: Int32 {
-    get {return getExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension) ?? 0}
-    set {setExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension, value: newValue)}
+extension ProtobufUnittest_ComplexOptionType2 {
+
+  var ProtobufUnittest_grault: Int32 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_grault) ?? 0}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_grault, value: newValue)}
   }
-  /// Returns true if extension `ProtobufUnittest_NestedOptionType.Extensions.nested_extension`
+  /// Returns true if extension `ProtobufUnittest_Extensions_grault`
   /// has been explicitly set.
-  var hasProtobufUnittest_NestedOptionType_nestedExtension: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
+  var hasProtobufUnittest_grault: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_grault)
   }
-  /// Clears the value of extension `ProtobufUnittest_NestedOptionType.Extensions.nested_extension`.
+  /// Clears the value of extension `ProtobufUnittest_Extensions_grault`.
   /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_NestedOptionType_nestedExtension() {
-    clearExtensionValue(ext: ProtobufUnittest_NestedOptionType.Extensions.nested_extension)
+  mutating func clearProtobufUnittest_grault() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_grault)
   }
+
+  var ProtobufUnittest_garply: ProtobufUnittest_ComplexOptionType1 {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_garply) ?? ProtobufUnittest_ComplexOptionType1()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_garply, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_garply`
+  /// has been explicitly set.
+  var hasProtobufUnittest_garply: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_garply)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_garply`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_garply() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_garply)
+  }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_lite.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_lite.pb.swift
@@ -2524,6 +2524,7 @@ struct ProtobufUnittest_TestHugeFieldNumbersLite: SwiftProtobuf.Message, SwiftPr
 // MARK: - Extension support defined in unittest_lite.proto.
 
 extension ProtobufUnittest_TestAllExtensionsLite {
+
   /// Singular
   var ProtobufUnittest_optionalInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite) ?? 0}
@@ -2539,9 +2540,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalInt64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite, value: newValue)}
@@ -2556,9 +2555,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_int64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite, value: newValue)}
@@ -2573,9 +2570,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalUint64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite, value: newValue)}
@@ -2590,9 +2585,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_uint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSint32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite, value: newValue)}
@@ -2607,9 +2600,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSint64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite, value: newValue)}
@@ -2624,9 +2615,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFixed32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite, value: newValue)}
@@ -2641,9 +2630,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFixed64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite, value: newValue)}
@@ -2658,9 +2645,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_fixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSfixed32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite, value: newValue)}
@@ -2675,9 +2660,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalSfixed64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite, value: newValue)}
@@ -2692,9 +2675,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_sfixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalFloatExtensionLite: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite, value: newValue)}
@@ -2709,9 +2690,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_float_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalDoubleExtensionLite: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite, value: newValue)}
@@ -2726,9 +2705,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_double_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalBoolExtensionLite: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite, value: newValue)}
@@ -2743,9 +2720,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bool_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite, value: newValue)}
@@ -2760,9 +2735,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite, value: newValue)}
@@ -2777,9 +2750,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_bytes_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalGroupExtensionLite: ProtobufUnittest_OptionalGroup_extension_lite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite) ?? ProtobufUnittest_OptionalGroup_extension_lite()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite, value: newValue)}
@@ -2794,9 +2765,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalGroupExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_OptionalGroup_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite, value: newValue)}
@@ -2811,9 +2780,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalForeignMessageExtensionLite: ProtobufUnittest_ForeignMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite) ?? ProtobufUnittest_ForeignMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite, value: newValue)}
@@ -2828,9 +2795,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalForeignMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalImportMessageExtensionLite: ProtobufUnittestImport_ImportMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite) ?? ProtobufUnittestImport_ImportMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite, value: newValue)}
@@ -2845,9 +2810,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite) ?? .foo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite, value: newValue)}
@@ -2862,9 +2825,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_nested_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite) ?? .foreignLiteFoo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite, value: newValue)}
@@ -2879,9 +2840,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_foreign_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite) ?? .importLiteFoo}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite, value: newValue)}
@@ -2896,9 +2855,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_import_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalStringPieceExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite, value: newValue)}
@@ -2913,9 +2870,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_string_piece_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalCordExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite, value: newValue)}
@@ -2930,9 +2885,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_cord_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalPublicImportMessageExtensionLite: ProtobufUnittestImport_PublicImportMessageLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite) ?? ProtobufUnittestImport_PublicImportMessageLite()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite, value: newValue)}
@@ -2947,9 +2900,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalPublicImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_public_import_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_optionalLazyMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite, value: newValue)}
@@ -2964,9 +2915,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_optionalLazyMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_optional_lazy_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   /// Repeated
   var ProtobufUnittest_repeatedInt32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite) ?? []}
@@ -2982,9 +2931,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedInt64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite, value: newValue)}
@@ -2999,9 +2946,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_int64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedUint32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite, value: newValue)}
@@ -3016,9 +2961,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedUint64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite, value: newValue)}
@@ -3033,9 +2976,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_uint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSint32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite, value: newValue)}
@@ -3050,9 +2991,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSint64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite, value: newValue)}
@@ -3067,9 +3006,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFixed32ExtensionLite: [UInt32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite, value: newValue)}
@@ -3084,9 +3021,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFixed64ExtensionLite: [UInt64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite, value: newValue)}
@@ -3101,9 +3036,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_fixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSfixed32ExtensionLite: [Int32] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite, value: newValue)}
@@ -3118,9 +3051,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedSfixed64ExtensionLite: [Int64] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite, value: newValue)}
@@ -3135,9 +3066,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_sfixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedFloatExtensionLite: [Float] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite, value: newValue)}
@@ -3152,9 +3081,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_float_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedDoubleExtensionLite: [Double] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite, value: newValue)}
@@ -3169,9 +3096,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_double_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedBoolExtensionLite: [Bool] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite, value: newValue)}
@@ -3186,9 +3111,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bool_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedStringExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite, value: newValue)}
@@ -3203,9 +3126,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedBytesExtensionLite: [Data] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite, value: newValue)}
@@ -3220,9 +3141,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_bytes_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedGroupExtensionLite: [ProtobufUnittest_RepeatedGroup_extension_lite] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite, value: newValue)}
@@ -3237,9 +3156,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedGroupExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_RepeatedGroup_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedNestedMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite, value: newValue)}
@@ -3254,9 +3171,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedForeignMessageExtensionLite: [ProtobufUnittest_ForeignMessageLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite, value: newValue)}
@@ -3271,9 +3186,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedForeignMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedImportMessageExtensionLite: [ProtobufUnittestImport_ImportMessageLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite, value: newValue)}
@@ -3288,9 +3201,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedImportMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedNestedEnumExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedEnum] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite, value: newValue)}
@@ -3305,9 +3216,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_nested_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedForeignEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite, value: newValue)}
@@ -3322,9 +3231,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_foreign_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedImportEnumExtensionLite: [ProtobufUnittestImport_ImportEnumLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite, value: newValue)}
@@ -3339,9 +3246,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_import_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedStringPieceExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite, value: newValue)}
@@ -3356,9 +3261,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_string_piece_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedCordExtensionLite: [String] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite, value: newValue)}
@@ -3373,9 +3276,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_cord_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_repeatedLazyMessageExtensionLite: [ProtobufUnittest_TestAllTypesLite.NestedMessage] {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite, value: newValue)}
@@ -3390,9 +3291,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_repeatedLazyMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_repeated_lazy_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   /// Singular with defaults
   var ProtobufUnittest_defaultInt32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite) ?? 41}
@@ -3408,9 +3307,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultInt32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultInt64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite) ?? 42}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite, value: newValue)}
@@ -3425,9 +3322,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultInt64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_int64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite) ?? 43}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite, value: newValue)}
@@ -3442,9 +3337,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultUint64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite) ?? 44}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite, value: newValue)}
@@ -3459,9 +3352,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultUint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_uint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSint32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite) ?? -45}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite, value: newValue)}
@@ -3476,9 +3367,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultSint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSint64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite) ?? 46}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite, value: newValue)}
@@ -3493,9 +3382,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultSint64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sint64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFixed32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite) ?? 47}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite, value: newValue)}
@@ -3510,9 +3397,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultFixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFixed64ExtensionLite: UInt64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite) ?? 48}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite, value: newValue)}
@@ -3527,9 +3412,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultFixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_fixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSfixed32ExtensionLite: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite) ?? 49}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite, value: newValue)}
@@ -3544,9 +3427,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultSfixed32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultSfixed64ExtensionLite: Int64 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite) ?? -50}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite, value: newValue)}
@@ -3561,9 +3442,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultSfixed64ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_sfixed64_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultFloatExtensionLite: Float {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite) ?? 51.5}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite, value: newValue)}
@@ -3578,9 +3457,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultFloatExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_float_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultDoubleExtensionLite: Double {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite) ?? 52000}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite, value: newValue)}
@@ -3595,9 +3472,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultDoubleExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_double_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultBoolExtensionLite: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite) ?? true}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite, value: newValue)}
@@ -3612,9 +3487,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultBoolExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bool_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite) ?? "hello"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite, value: newValue)}
@@ -3629,9 +3502,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite) ?? Data(bytes: [119, 111, 114, 108, 100])}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite, value: newValue)}
@@ -3646,9 +3517,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_bytes_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultNestedEnumExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedEnum {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite) ?? .bar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite, value: newValue)}
@@ -3663,9 +3532,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultNestedEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_nested_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultForeignEnumExtensionLite: ProtobufUnittest_ForeignEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite) ?? .foreignLiteBar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite, value: newValue)}
@@ -3680,9 +3547,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultForeignEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_foreign_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultImportEnumExtensionLite: ProtobufUnittestImport_ImportEnumLite {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite) ?? .importLiteBar}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite, value: newValue)}
@@ -3697,9 +3562,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultImportEnumExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_import_enum_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultStringPieceExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite) ?? "abc"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite, value: newValue)}
@@ -3714,9 +3577,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultStringPieceExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_string_piece_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_defaultCordExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite) ?? "123"}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite, value: newValue)}
@@ -3731,9 +3592,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_defaultCordExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_default_cord_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   /// For oneof test
   var ProtobufUnittest_oneofUint32ExtensionLite: UInt32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite) ?? 0}
@@ -3749,9 +3608,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_oneofUint32ExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_uint32_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofNestedMessageExtensionLite: ProtobufUnittest_TestAllTypesLite.NestedMessage {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite) ?? ProtobufUnittest_TestAllTypesLite.NestedMessage()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite, value: newValue)}
@@ -3766,9 +3623,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_oneofNestedMessageExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_nested_message_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofStringExtensionLite: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite, value: newValue)}
@@ -3783,9 +3638,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_oneofStringExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_string_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_oneofBytesExtensionLite: Data {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite) ?? SwiftProtobuf.Internal.emptyData}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite, value: newValue)}
@@ -3800,264 +3653,7 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   mutating func clearProtobufUnittest_oneofBytesExtensionLite() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_oneof_bytes_extension_lite)
   }
-}
 
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedInt32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int32_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedInt32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int32_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedInt32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedInt64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int64_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedInt64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int64_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedInt64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedUint32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint32_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedUint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint32_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedUint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedUint64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint64_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedUint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint64_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedUint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedSint32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint32_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSint32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint32_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSint32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedSint64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint64_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSint64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint64_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSint64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedFixed32ExtensionLite: [UInt32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed32_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed32_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedFixed64ExtensionLite: [UInt64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed64_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed64_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedSfixed32ExtensionLite: [Int32] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed32_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSfixed32ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed32_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSfixed32ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedSfixed64ExtensionLite: [Int64] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed64_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedSfixed64ExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed64_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedSfixed64ExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedFloatExtensionLite: [Float] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_float_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedFloatExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_float_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedFloatExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedDoubleExtensionLite: [Double] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_double_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedDoubleExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_double_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedDoubleExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedBoolExtensionLite: [Bool] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_bool_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedBoolExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_bool_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedBoolExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestPackedExtensionsLite {
-  var ProtobufUnittest_packedEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite) ?? []}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_packed_enum_extension_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_packedEnumExtensionLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_enum_extension_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_packedEnumExtensionLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
-  }
-}
-
-extension ProtobufUnittest_TestHugeFieldNumbersLite {
-  var ProtobufUnittest_testAllTypesLite: ProtobufUnittest_TestAllTypesLite {
-    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite) ?? ProtobufUnittest_TestAllTypesLite()}
-    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite, value: newValue)}
-  }
-  /// Returns true if extension `ProtobufUnittest_Extensions_test_all_types_lite`
-  /// has been explicitly set.
-  var hasProtobufUnittest_testAllTypesLite: Bool {
-    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
-  }
-  /// Clears the value of extension `ProtobufUnittest_Extensions_test_all_types_lite`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearProtobufUnittest_testAllTypesLite() {
-    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
-  }
-}
-
-extension ProtobufUnittest_TestAllExtensionsLite {
   var ProtobufUnittest_TestNestedExtensionLite_nestedExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestNestedExtensionLite.Extensions.nested_extension, value: newValue)}
@@ -4074,7 +3670,239 @@ extension ProtobufUnittest_TestAllExtensionsLite {
   }
 }
 
+extension ProtobufUnittest_TestHugeFieldNumbersLite {
+
+  var ProtobufUnittest_testAllTypesLite: ProtobufUnittest_TestAllTypesLite {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite) ?? ProtobufUnittest_TestAllTypesLite()}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_test_all_types_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_testAllTypesLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_test_all_types_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_testAllTypesLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_test_all_types_lite)
+  }
+}
+
+extension ProtobufUnittest_TestPackedExtensionsLite {
+
+  var ProtobufUnittest_packedInt32ExtensionLite: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int32_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedInt32ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int32_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedInt32ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int32_extension_lite)
+  }
+
+  var ProtobufUnittest_packedInt64ExtensionLite: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_int64_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedInt64ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_int64_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedInt64ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_int64_extension_lite)
+  }
+
+  var ProtobufUnittest_packedUint32ExtensionLite: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint32_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedUint32ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint32_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedUint32ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint32_extension_lite)
+  }
+
+  var ProtobufUnittest_packedUint64ExtensionLite: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_uint64_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedUint64ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_uint64_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedUint64ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_uint64_extension_lite)
+  }
+
+  var ProtobufUnittest_packedSint32ExtensionLite: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint32_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSint32ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint32_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSint32ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint32_extension_lite)
+  }
+
+  var ProtobufUnittest_packedSint64ExtensionLite: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sint64_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSint64ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sint64_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSint64ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sint64_extension_lite)
+  }
+
+  var ProtobufUnittest_packedFixed32ExtensionLite: [UInt32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed32_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFixed32ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed32_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFixed32ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed32_extension_lite)
+  }
+
+  var ProtobufUnittest_packedFixed64ExtensionLite: [UInt64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_fixed64_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFixed64ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_fixed64_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFixed64ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_fixed64_extension_lite)
+  }
+
+  var ProtobufUnittest_packedSfixed32ExtensionLite: [Int32] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed32_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSfixed32ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed32_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSfixed32ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed32_extension_lite)
+  }
+
+  var ProtobufUnittest_packedSfixed64ExtensionLite: [Int64] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_sfixed64_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedSfixed64ExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_sfixed64_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedSfixed64ExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_sfixed64_extension_lite)
+  }
+
+  var ProtobufUnittest_packedFloatExtensionLite: [Float] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_float_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedFloatExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_float_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedFloatExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_float_extension_lite)
+  }
+
+  var ProtobufUnittest_packedDoubleExtensionLite: [Double] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_double_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedDoubleExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_double_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedDoubleExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_double_extension_lite)
+  }
+
+  var ProtobufUnittest_packedBoolExtensionLite: [Bool] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_bool_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedBoolExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_bool_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedBoolExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_bool_extension_lite)
+  }
+
+  var ProtobufUnittest_packedEnumExtensionLite: [ProtobufUnittest_ForeignEnumLite] {
+    get {return getExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite) ?? []}
+    set {setExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite, value: newValue)}
+  }
+  /// Returns true if extension `ProtobufUnittest_Extensions_packed_enum_extension_lite`
+  /// has been explicitly set.
+  var hasProtobufUnittest_packedEnumExtensionLite: Bool {
+    return hasExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
+  }
+  /// Clears the value of extension `ProtobufUnittest_Extensions_packed_enum_extension_lite`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearProtobufUnittest_packedEnumExtensionLite() {
+    clearExtensionValue(ext: ProtobufUnittest_Extensions_packed_enum_extension_lite)
+  }
+}
+
 extension ProtobufUnittest_TestParsingMergeLite {
+
   var ProtobufUnittest_TestParsingMergeLite_optionalExt: ProtobufUnittest_TestAllTypesLite {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext) ?? ProtobufUnittest_TestAllTypesLite()}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext, value: newValue)}
@@ -4089,9 +3917,7 @@ extension ProtobufUnittest_TestParsingMergeLite {
   mutating func clearProtobufUnittest_TestParsingMergeLite_optionalExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.optional_ext)
   }
-}
 
-extension ProtobufUnittest_TestParsingMergeLite {
   var ProtobufUnittest_TestParsingMergeLite_repeatedExt: [ProtobufUnittest_TestAllTypesLite] {
     get {return getExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext) ?? []}
     set {setExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext, value: newValue)}
@@ -4106,6 +3932,7 @@ extension ProtobufUnittest_TestParsingMergeLite {
   mutating func clearProtobufUnittest_TestParsingMergeLite_repeatedExt() {
     clearExtensionValue(ext: ProtobufUnittest_TestParsingMergeLite.Extensions.repeated_ext)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_mset.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_mset.pb.swift
@@ -303,6 +303,7 @@ struct ProtobufUnittest_RawMessageSet: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_mset.proto.
 
 extension Proto2WireformatUnittest_TestMessageSet {
+
   var ProtobufUnittest_TestMessageSetExtension1_messageSetExtension: ProtobufUnittest_TestMessageSetExtension1 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension) ?? ProtobufUnittest_TestMessageSetExtension1()}
     set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension, value: newValue)}
@@ -317,9 +318,7 @@ extension Proto2WireformatUnittest_TestMessageSet {
   mutating func clearProtobufUnittest_TestMessageSetExtension1_messageSetExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension1.Extensions.message_set_extension)
   }
-}
 
-extension Proto2WireformatUnittest_TestMessageSet {
   var ProtobufUnittest_TestMessageSetExtension2_messageSetExtension: ProtobufUnittest_TestMessageSetExtension2 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension) ?? ProtobufUnittest_TestMessageSetExtension2()}
     set {setExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension, value: newValue)}
@@ -334,6 +333,7 @@ extension Proto2WireformatUnittest_TestMessageSet {
   mutating func clearProtobufUnittest_TestMessageSetExtension2_messageSetExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestMessageSetExtension2.Extensions.message_set_extension)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_no_generic_services.pb.swift
@@ -129,6 +129,7 @@ struct Google_Protobuf_NoGenericServicesTest_TestMessage: SwiftProtobuf.Message,
 // MARK: - Extension support defined in unittest_no_generic_services.proto.
 
 extension Google_Protobuf_NoGenericServicesTest_TestMessage {
+
   var Google_Protobuf_NoGenericServicesTest_testExtension: Int32 {
     get {return getExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension) ?? 0}
     set {setExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension, value: newValue)}
@@ -143,6 +144,7 @@ extension Google_Protobuf_NoGenericServicesTest_TestMessage {
   mutating func clearGoogle_Protobuf_NoGenericServicesTest_testExtension() {
     clearExtensionValue(ext: Google_Protobuf_NoGenericServicesTest_Extensions_test_extension)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_optimize_for.pb.swift
@@ -282,6 +282,7 @@ struct ProtobufUnittest_TestOptionalOptimizedForSize: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_optimize_for.proto.
 
 extension ProtobufUnittest_TestOptimizedForSize {
+
   var ProtobufUnittest_TestOptimizedForSize_testExtension: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension, value: newValue)}
@@ -296,9 +297,7 @@ extension ProtobufUnittest_TestOptimizedForSize {
   mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension() {
     clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension)
   }
-}
 
-extension ProtobufUnittest_TestOptimizedForSize {
   var ProtobufUnittest_TestOptimizedForSize_testExtension2: ProtobufUnittest_TestRequiredOptimizedForSize {
     get {return getExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2) ?? ProtobufUnittest_TestRequiredOptimizedForSize()}
     set {setExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2, value: newValue)}
@@ -313,6 +312,7 @@ extension ProtobufUnittest_TestOptimizedForSize {
   mutating func clearProtobufUnittest_TestOptimizedForSize_testExtension2() {
     clearExtensionValue(ext: ProtobufUnittest_TestOptimizedForSize.Extensions.test_extension2)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension.pb.swift
@@ -382,6 +382,7 @@ struct ProtobufUnittest_Extend_MsgUsesStorage: SwiftProtobuf.Message, SwiftProto
 // MARK: - Extension support defined in unittest_swift_extension.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+
   var ProtobufUnittest_Extend_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b, value: newValue)}
@@ -396,9 +397,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend_b() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend_c: ProtobufUnittest_Extend_C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C) ?? ProtobufUnittest_Extend_C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_C, value: newValue)}
@@ -416,6 +415,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
 }
 
 extension ProtobufUnittest_Extend_Msg1 {
+
   var ProtobufUnittest_Extend_aB: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_a_b, value: newValue)}
@@ -433,6 +433,7 @@ extension ProtobufUnittest_Extend_Msg1 {
 }
 
 extension ProtobufUnittest_Extend_Msg2 {
+
   var ProtobufUnittest_Extend_aB: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_aB, value: newValue)}
@@ -450,6 +451,7 @@ extension ProtobufUnittest_Extend_Msg2 {
 }
 
 extension ProtobufUnittest_Extend_MsgNoStorage {
+
   var ProtobufUnittest_Extend_extA: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_a) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_a, value: newValue)}
@@ -464,9 +466,7 @@ extension ProtobufUnittest_Extend_MsgNoStorage {
   mutating func clearProtobufUnittest_Extend_extA() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_a)
   }
-}
 
-extension ProtobufUnittest_Extend_MsgNoStorage {
   var ProtobufUnittest_Extend_extB: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_b) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_b, value: newValue)}
@@ -484,6 +484,7 @@ extension ProtobufUnittest_Extend_MsgNoStorage {
 }
 
 extension ProtobufUnittest_Extend_MsgUsesStorage {
+
   var ProtobufUnittest_Extend_extC: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_c) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_c, value: newValue)}
@@ -498,9 +499,7 @@ extension ProtobufUnittest_Extend_MsgUsesStorage {
   mutating func clearProtobufUnittest_Extend_extC() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_c)
   }
-}
 
-extension ProtobufUnittest_Extend_MsgUsesStorage {
   var ProtobufUnittest_Extend_extD: Int32 {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_d) ?? 0}
     set {setExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_d, value: newValue)}
@@ -515,6 +514,7 @@ extension ProtobufUnittest_Extend_MsgUsesStorage {
   mutating func clearProtobufUnittest_Extend_extD() {
     clearExtensionValue(ext: ProtobufUnittest_Extend_Extensions_ext_d)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension2.pb.swift
@@ -151,6 +151,7 @@ struct ProtobufUnittest_Extend2_C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension2.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+
   var ProtobufUnittest_Extend2_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b, value: newValue)}
@@ -165,9 +166,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend2_b() {
     clearExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_c: ProtobufUnittest_Extend2_C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C) ?? ProtobufUnittest_Extend2_C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C, value: newValue)}
@@ -182,9 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend2_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend2_Extensions_C)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_MyMessage_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b, value: newValue)}
@@ -199,9 +196,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend2_MyMessage_b() {
     clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend2_MyMessage_c: ProtobufUnittest_Extend2_MyMessage.C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend2_MyMessage.C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C, value: newValue)}
@@ -216,6 +211,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend2_MyMessage_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend2_MyMessage.Extensions.C)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension3.pb.swift
@@ -151,6 +151,7 @@ struct ProtobufUnittest_Extend3_C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension3.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+
   var ProtobufUnittest_Extend3_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b, value: newValue)}
@@ -165,9 +166,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend3_b() {
     clearExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_c: ProtobufUnittest_Extend3_C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C) ?? ProtobufUnittest_Extend3_C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C, value: newValue)}
@@ -182,9 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend3_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend3_Extensions_C)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_MyMessage_b: String {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b, value: newValue)}
@@ -199,9 +196,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend3_MyMessage_b() {
     clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var ProtobufUnittest_Extend3_MyMessage_c: ProtobufUnittest_Extend3_MyMessage.C {
     get {return getExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C) ?? ProtobufUnittest_Extend3_MyMessage.C()}
     set {setExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C, value: newValue)}
@@ -216,6 +211,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearProtobufUnittest_Extend3_MyMessage_c() {
     clearExtensionValue(ext: ProtobufUnittest_Extend3_MyMessage.Extensions.C)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_extension4.pb.swift
@@ -151,6 +151,7 @@ struct Ext4C: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_extension4.proto.
 
 extension ProtobufUnittest_Extend_Foo.Bar.Baz {
+
   var Ext4b: String {
     get {return getExtensionValue(ext: Ext4Extensions_b) ?? String()}
     set {setExtensionValue(ext: Ext4Extensions_b, value: newValue)}
@@ -165,9 +166,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearExt4b() {
     clearExtensionValue(ext: Ext4Extensions_b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4c: Ext4C {
     get {return getExtensionValue(ext: Ext4Extensions_C) ?? Ext4C()}
     set {setExtensionValue(ext: Ext4Extensions_C, value: newValue)}
@@ -182,9 +181,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearExt4c() {
     clearExtensionValue(ext: Ext4Extensions_C)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4MyMessage_b: String {
     get {return getExtensionValue(ext: Ext4MyMessage.Extensions.b) ?? String()}
     set {setExtensionValue(ext: Ext4MyMessage.Extensions.b, value: newValue)}
@@ -199,9 +196,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearExt4MyMessage_b() {
     clearExtensionValue(ext: Ext4MyMessage.Extensions.b)
   }
-}
 
-extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   var Ext4MyMessage_c: Ext4MyMessage.C {
     get {return getExtensionValue(ext: Ext4MyMessage.Extensions.C) ?? Ext4MyMessage.C()}
     set {setExtensionValue(ext: Ext4MyMessage.Extensions.C, value: newValue)}
@@ -216,6 +211,7 @@ extension ProtobufUnittest_Extend_Foo.Bar.Baz {
   mutating func clearExt4MyMessage_c() {
     clearExtensionValue(ext: Ext4MyMessage.Extensions.C)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_fieldorder.pb.swift
@@ -533,6 +533,7 @@ struct Swift_Protobuf_OneofTraversalGeneration: SwiftProtobuf.Message, SwiftProt
 // MARK: - Extension support defined in unittest_swift_fieldorder.proto.
 
 extension Swift_Protobuf_TestFieldOrderings {
+
   var Swift_Protobuf_myExtensionString: String {
     get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string) ?? String()}
     set {setExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string, value: newValue)}
@@ -547,9 +548,7 @@ extension Swift_Protobuf_TestFieldOrderings {
   mutating func clearSwift_Protobuf_myExtensionString() {
     clearExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_string)
   }
-}
 
-extension Swift_Protobuf_TestFieldOrderings {
   var Swift_Protobuf_myExtensionInt: Int32 {
     get {return getExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int) ?? 0}
     set {setExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int, value: newValue)}
@@ -564,6 +563,7 @@ extension Swift_Protobuf_TestFieldOrderings {
   mutating func clearSwift_Protobuf_myExtensionInt() {
     clearExtensionValue(ext: Swift_Protobuf_Extensions_my_extension_int)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_groups.pb.swift
@@ -500,6 +500,7 @@ struct SwiftTestNestingGroupsMessage: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_groups.proto.
 
 extension SwiftTestGroupExtensions {
+
   var extensionGroup: ExtensionGroup {
     get {return getExtensionValue(ext: Extensions_ExtensionGroup) ?? ExtensionGroup()}
     set {setExtensionValue(ext: Extensions_ExtensionGroup, value: newValue)}
@@ -514,9 +515,7 @@ extension SwiftTestGroupExtensions {
   mutating func clearExtensionGroup() {
     clearExtensionValue(ext: Extensions_ExtensionGroup)
   }
-}
 
-extension SwiftTestGroupExtensions {
   var repeatedExtensionGroup: [RepeatedExtensionGroup] {
     get {return getExtensionValue(ext: Extensions_RepeatedExtensionGroup) ?? []}
     set {setExtensionValue(ext: Extensions_RepeatedExtensionGroup, value: newValue)}
@@ -531,6 +530,7 @@ extension SwiftTestGroupExtensions {
   mutating func clearRepeatedExtensionGroup() {
     clearExtensionValue(ext: Extensions_RepeatedExtensionGroup)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming.pb.swift
@@ -18787,7 +18787,746 @@ struct SwiftUnittest_Names_ExtensionNamingInitialsWordCase: SwiftProtobuf.Messag
 
 // MARK: - Extension support defined in unittest_swift_naming.proto.
 
+extension SwiftUnittest_Names_ExtensionNamingInitials {
+
+  var SwiftUnittest_Names_Lowers_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.http`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.http`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
+  }
+
+  var SwiftUnittest_Names_Lowers_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.http_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.http_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
+  }
+
+  var SwiftUnittest_Names_Lowers_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_http_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_http_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
+  }
+
+  var SwiftUnittest_Names_Lowers_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_http`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_http`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
+  }
+
+  var SwiftUnittest_Names_Lowers_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.https`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.https`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
+  }
+
+  var SwiftUnittest_Names_Lowers_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.https_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.https_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
+  }
+
+  var SwiftUnittest_Names_Lowers_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_https_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_https_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
+  }
+
+  var SwiftUnittest_Names_Lowers_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_https`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_https`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
+  }
+
+  var SwiftUnittest_Names_Lowers_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.url`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.url`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
+  }
+
+  var SwiftUnittest_Names_Lowers_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.url_value`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.url_value`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
+  }
+
+  var SwiftUnittest_Names_Lowers_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_url_value`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_url_value`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
+  }
+
+  var SwiftUnittest_Names_Lowers_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_url`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_url`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
+  }
+
+  var SwiftUnittest_Names_Lowers_aBC: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.a_b_c`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_aBC: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.a_b_c`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_aBC() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
+  }
+
+  var SwiftUnittest_Names_Lowers_id: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.id`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_id: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.id`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_id() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id)
+  }
+
+  var SwiftUnittest_Names_Lowers_idNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.id_number`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_idNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.id_number`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_idNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number)
+  }
+
+  var SwiftUnittest_Names_Lowers_theIDNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_id_number`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_theIDNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_id_number`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_theIDNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number)
+  }
+
+  var SwiftUnittest_Names_Lowers_requestID: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.request_id`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Lowers_requestID: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.request_id`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Lowers_requestID() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id)
+  }
+
+  var SwiftUnittest_Names_Uppers_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTP`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTP`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
+  }
+
+  var SwiftUnittest_Names_Uppers_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTP_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTP_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
+  }
+
+  var SwiftUnittest_Names_Uppers_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
+  }
+
+  var SwiftUnittest_Names_Uppers_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
+  }
+
+  var SwiftUnittest_Names_Uppers_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
+  }
+
+  var SwiftUnittest_Names_Uppers_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
+  }
+
+  var SwiftUnittest_Names_Uppers_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
+  }
+
+  var SwiftUnittest_Names_Uppers_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
+  }
+
+  var SwiftUnittest_Names_Uppers_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.URL`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.URL`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
+  }
+
+  var SwiftUnittest_Names_Uppers_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.URL_value`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.URL_value`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
+  }
+
+  var SwiftUnittest_Names_Uppers_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_URL_value`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_URL_value`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
+  }
+
+  var SwiftUnittest_Names_Uppers_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_URL`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_URL`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
+  }
+
+  var SwiftUnittest_Names_Uppers_id: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.ID`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_id: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.ID`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_id() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID)
+  }
+
+  var SwiftUnittest_Names_Uppers_idNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.ID_number`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_idNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.ID_number`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_idNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number)
+  }
+
+  var SwiftUnittest_Names_Uppers_theIDNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_ID_number`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_theIDNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_ID_number`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_theIDNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number)
+  }
+
+  var SwiftUnittest_Names_Uppers_requestID: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.request_ID`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_Uppers_requestID: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.request_ID`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_Uppers_requestID() {
+    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID)
+  }
+
+  var SwiftUnittest_Names_WordCase_http: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Http`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_http: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Http`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_http() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
+  }
+
+  var SwiftUnittest_Names_WordCase_httpRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.HttpRequest`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_httpRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.HttpRequest`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_httpRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
+  }
+
+  var SwiftUnittest_Names_WordCase_theHTTPRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theHTTPRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
+  }
+
+  var SwiftUnittest_Names_WordCase_theHTTP: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttp`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theHTTP: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttp`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTP() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
+  }
+
+  var SwiftUnittest_Names_WordCase_https: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Https`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_https: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Https`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_https() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
+  }
+
+  var SwiftUnittest_Names_WordCase_httpsRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.HttpsRequest`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_httpsRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.HttpsRequest`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_httpsRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
+  }
+
+  var SwiftUnittest_Names_WordCase_theHTTPSRequest: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theHTTPSRequest: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPSRequest() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
+  }
+
+  var SwiftUnittest_Names_WordCase_theHTTPS: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttps`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theHTTPS: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttps`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theHTTPS() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
+  }
+
+  var SwiftUnittest_Names_WordCase_url: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Url`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_url: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Url`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_url() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
+  }
+
+  var SwiftUnittest_Names_WordCase_urlValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.UrlValue`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_urlValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.UrlValue`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_urlValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
+  }
+
+  var SwiftUnittest_Names_WordCase_theURLValue: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheUrlValue`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theURLValue: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheUrlValue`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theURLValue() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
+  }
+
+  var SwiftUnittest_Names_WordCase_theURL: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheUrl`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theURL: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheUrl`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theURL() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
+  }
+
+  var SwiftUnittest_Names_WordCase_id: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Id`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_id: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Id`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_id() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id)
+  }
+
+  var SwiftUnittest_Names_WordCase_idNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.IdNumber`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_idNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.IdNumber`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_idNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber)
+  }
+
+  var SwiftUnittest_Names_WordCase_theIDNumber: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheIdNumber`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_theIDNumber: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheIdNumber`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_theIDNumber() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber)
+  }
+
+  var SwiftUnittest_Names_WordCase_requestID: Int32 {
+    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId) ?? 0}
+    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId, value: newValue)}
+  }
+  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.RequestId`
+  /// has been explicitly set.
+  var hasSwiftUnittest_Names_WordCase_requestID: Bool {
+    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId)
+  }
+  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.RequestId`.
+  /// Subsequent reads from it will return its default value.
+  mutating func clearSwiftUnittest_Names_WordCase_requestID() {
+    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId)
+  }
+}
+
 extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
+
   var SwiftUnittest_Names_http: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_http) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_http, value: newValue)}
@@ -18802,9 +19541,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_http() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_httpRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_http_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_http_request, value: newValue)}
@@ -18819,9 +19556,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_httpRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_http_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http_request, value: newValue)}
@@ -18836,9 +19571,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theHTTPRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theHTTP: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http, value: newValue)}
@@ -18853,9 +19586,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theHTTP() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_https: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_https) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_https, value: newValue)}
@@ -18870,9 +19601,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_https() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_httpsRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_https_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_https_request, value: newValue)}
@@ -18887,9 +19616,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_httpsRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_https_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https_request, value: newValue)}
@@ -18904,9 +19631,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theHTTPSRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theHTTPS: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https, value: newValue)}
@@ -18921,9 +19646,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theHTTPS() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_url: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_url) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_url, value: newValue)}
@@ -18938,9 +19661,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_url() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_urlValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_url_value) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_url_value, value: newValue)}
@@ -18955,9 +19676,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_urlValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_url_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theURLValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url_value) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url_value, value: newValue)}
@@ -18972,9 +19691,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theURLValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theURL: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url, value: newValue)}
@@ -18989,9 +19706,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theURL() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_aBC: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_a_b_c) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_a_b_c, value: newValue)}
@@ -19006,9 +19721,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_aBC() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_a_b_c)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_id: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_id) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_id, value: newValue)}
@@ -19023,9 +19736,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_id() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_id)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_idNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_id_number) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_id_number, value: newValue)}
@@ -19040,9 +19751,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_idNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_id_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_theIDNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_id_number) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_id_number, value: newValue)}
@@ -19057,9 +19766,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearSwiftUnittest_Names_theIDNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_id_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var SwiftUnittest_Names_requestID: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_request_id) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_request_id, value: newValue)}
@@ -19077,6 +19784,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
+
   var SwiftUnittest_Names_http: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP, value: newValue)}
@@ -19091,9 +19799,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_http() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_httpRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP_request, value: newValue)}
@@ -19108,9 +19814,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_httpRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTP_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP_request, value: newValue)}
@@ -19125,9 +19829,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theHTTPRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theHTTP: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP, value: newValue)}
@@ -19142,9 +19844,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theHTTP() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTP)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_https: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS, value: newValue)}
@@ -19159,9 +19859,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_https() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_httpsRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS_request, value: newValue)}
@@ -19176,9 +19874,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_httpsRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HTTPS_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS_request) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS_request, value: newValue)}
@@ -19193,9 +19889,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theHTTPSRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theHTTPS: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS, value: newValue)}
@@ -19210,9 +19904,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theHTTPS() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_HTTPS)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_url: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_URL) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_URL, value: newValue)}
@@ -19227,9 +19919,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_url() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_URL)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_urlValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_URL_value) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_URL_value, value: newValue)}
@@ -19244,9 +19934,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_urlValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_URL_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theURLValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL_value) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL_value, value: newValue)}
@@ -19261,9 +19949,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theURLValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theURL: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL, value: newValue)}
@@ -19278,9 +19964,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theURL() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_URL)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_id: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_ID) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_ID, value: newValue)}
@@ -19295,9 +19979,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_id() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_ID)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_idNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_ID_number) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_ID_number, value: newValue)}
@@ -19312,9 +19994,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_idNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_ID_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_theIDNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_the_ID_number) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_the_ID_number, value: newValue)}
@@ -19329,9 +20009,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearSwiftUnittest_Names_theIDNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_the_ID_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var SwiftUnittest_Names_requestID: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_request_ID) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_request_ID, value: newValue)}
@@ -19349,6 +20027,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
+
   var SwiftUnittest_Names_http: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_Http) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_Http, value: newValue)}
@@ -19363,9 +20042,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_http() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_Http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_httpRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpRequest) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpRequest, value: newValue)}
@@ -19380,9 +20057,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_httpRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpRequest) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpRequest, value: newValue)}
@@ -19397,9 +20072,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theHTTPRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theHTTP: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttp) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttp, value: newValue)}
@@ -19414,9 +20087,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theHTTP() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttp)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_https: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_Https) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_Https, value: newValue)}
@@ -19431,9 +20102,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_https() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_Https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_httpsRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpsRequest) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpsRequest, value: newValue)}
@@ -19448,9 +20117,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_httpsRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_HttpsRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpsRequest) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpsRequest, value: newValue)}
@@ -19465,9 +20132,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theHTTPSRequest() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttpsRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theHTTPS: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttps) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttps, value: newValue)}
@@ -19482,9 +20147,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theHTTPS() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheHttps)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_url: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_Url) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_Url, value: newValue)}
@@ -19499,9 +20162,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_url() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_Url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_urlValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_UrlValue) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_UrlValue, value: newValue)}
@@ -19516,9 +20177,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_urlValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_UrlValue)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theURLValue: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrlValue) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrlValue, value: newValue)}
@@ -19533,9 +20192,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theURLValue() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrlValue)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theURL: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrl) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrl, value: newValue)}
@@ -19550,9 +20207,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theURL() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheUrl)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_id: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_Id) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_Id, value: newValue)}
@@ -19567,9 +20222,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_id() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_Id)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_idNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_IdNumber) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_IdNumber, value: newValue)}
@@ -19584,9 +20237,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_idNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_IdNumber)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_theIDNumber: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_TheIdNumber) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_TheIdNumber, value: newValue)}
@@ -19601,9 +20252,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearSwiftUnittest_Names_theIDNumber() {
     clearExtensionValue(ext: SwiftUnittest_Names_Extensions_TheIdNumber)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var SwiftUnittest_Names_requestID: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_Extensions_RequestId) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_Extensions_RequestId, value: newValue)}
@@ -19621,6 +20270,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
 }
 
 extension SwiftUnittest_Names_Foo {
+
   var SwiftUnittest_Names_FieldNames_foo1: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_FieldNames.Extensions.foo1) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_FieldNames.Extensions.foo1, value: newValue)}
@@ -19635,9 +20285,7 @@ extension SwiftUnittest_Names_Foo {
   mutating func clearSwiftUnittest_Names_FieldNames_foo1() {
     clearExtensionValue(ext: SwiftUnittest_Names_FieldNames.Extensions.foo1)
   }
-}
 
-extension SwiftUnittest_Names_Foo {
   var SwiftUnittest_Names_MessageNames_foo2: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo2) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo2, value: newValue)}
@@ -19652,9 +20300,7 @@ extension SwiftUnittest_Names_Foo {
   mutating func clearSwiftUnittest_Names_MessageNames_foo2() {
     clearExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo2)
   }
-}
 
-extension SwiftUnittest_Names_Foo {
   var SwiftUnittest_Names_MessageNames_foo4: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo4) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo4, value: newValue)}
@@ -19669,9 +20315,7 @@ extension SwiftUnittest_Names_Foo {
   mutating func clearSwiftUnittest_Names_MessageNames_foo4() {
     clearExtensionValue(ext: SwiftUnittest_Names_MessageNames.Extensions.foo4)
   }
-}
 
-extension SwiftUnittest_Names_Foo {
   var SwiftUnittest_Names_MessageNames_StringMessage_foo3: Int32 {
     get {return getExtensionValue(ext: SwiftUnittest_Names_MessageNames.StringMessage.Extensions.foo3) ?? 0}
     set {setExtensionValue(ext: SwiftUnittest_Names_MessageNames.StringMessage.Extensions.foo3, value: newValue)}
@@ -19686,839 +20330,7 @@ extension SwiftUnittest_Names_Foo {
   mutating func clearSwiftUnittest_Names_MessageNames_StringMessage_foo3() {
     clearExtensionValue(ext: SwiftUnittest_Names_MessageNames.StringMessage.Extensions.foo3)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.http`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.http`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.http_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.http_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.http_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_http_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_http_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_http`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_http`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.https`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.https`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.https_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.https_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.https_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_https_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_https_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_https`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_https`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.url`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.url`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.url_value`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.url_value`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.url_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_url_value`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_url_value`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_url`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_url`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_aBC: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.a_b_c`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_aBC: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.a_b_c`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_aBC() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.a_b_c)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_id: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.id`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_id: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.id`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_id() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_idNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.id_number`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_idNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.id_number`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_idNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.id_number)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_theIDNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.the_id_number`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_theIDNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.the_id_number`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_theIDNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.the_id_number)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Lowers_requestID: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Lowers.Extensions.request_id`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Lowers_requestID: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Lowers.Extensions.request_id`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Lowers_requestID() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Lowers.Extensions.request_id)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTP`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTP`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTP_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTP_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTP_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTP`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTP)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.HTTPS_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.HTTPS_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS_request)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_HTTPS`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_HTTPS)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.URL`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.URL`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.URL_value`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.URL_value`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.URL_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_URL_value`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_URL_value`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL_value)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_URL`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_URL`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_URL)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_id: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.ID`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_id: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.ID`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_id() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_idNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.ID_number`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_idNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.ID_number`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_idNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.ID_number)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_theIDNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.the_ID_number`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_theIDNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.the_ID_number`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_theIDNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.the_ID_number)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_Uppers_requestID: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_Uppers.Extensions.request_ID`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_Uppers_requestID: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_Uppers.Extensions.request_ID`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_Uppers_requestID() {
-    clearExtensionValue(ext: SwiftUnittest_Names_Uppers.Extensions.request_ID)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_http: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Http`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_http: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Http`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_http() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Http)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_httpRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.HttpRequest`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_httpRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.HttpRequest`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_httpRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theHTTPRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTP: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttp`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theHTTP: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttp`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTP() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttp)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_https: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Https`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_https: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Https`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_https() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Https)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_httpsRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.HttpsRequest`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_httpsRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.HttpsRequest`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_httpsRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.HttpsRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPSRequest: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theHTTPSRequest: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPSRequest() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttpsRequest)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theHTTPS: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheHttps`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theHTTPS: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheHttps`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theHTTPS() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheHttps)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_url: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Url`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_url: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Url`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_url() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Url)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_urlValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.UrlValue`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_urlValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.UrlValue`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_urlValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.UrlValue)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theURLValue: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheUrlValue`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theURLValue: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheUrlValue`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theURLValue() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrlValue)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theURL: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheUrl`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theURL: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheUrl`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theURL() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheUrl)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_id: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.Id`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_id: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.Id`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_id() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.Id)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_idNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.IdNumber`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_idNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.IdNumber`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_idNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.IdNumber)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_theIDNumber: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.TheIdNumber`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_theIDNumber: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.TheIdNumber`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_theIDNumber() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.TheIdNumber)
-  }
-}
-
-extension SwiftUnittest_Names_ExtensionNamingInitials {
-  var SwiftUnittest_Names_WordCase_requestID: Int32 {
-    get {return getExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId) ?? 0}
-    set {setExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId, value: newValue)}
-  }
-  /// Returns true if extension `SwiftUnittest_Names_WordCase.Extensions.RequestId`
-  /// has been explicitly set.
-  var hasSwiftUnittest_Names_WordCase_requestID: Bool {
-    return hasExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId)
-  }
-  /// Clears the value of extension `SwiftUnittest_Names_WordCase.Extensions.RequestId`.
-  /// Subsequent reads from it will return its default value.
-  mutating func clearSwiftUnittest_Names_WordCase_requestID() {
-    clearExtensionValue(ext: SwiftUnittest_Names_WordCase.Extensions.RequestId)
-  }
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_naming_no_prefix.pb.swift
@@ -38,6 +38,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 // MARK: - Extension support defined in unittest_swift_naming_no_prefix.proto.
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
+
   var http: Int32 {
     get {return getExtensionValue(ext: Extensions_http) ?? 0}
     set {setExtensionValue(ext: Extensions_http, value: newValue)}
@@ -52,9 +53,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearHTTP() {
     clearExtensionValue(ext: Extensions_http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var httpRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_http_request) ?? 0}
     set {setExtensionValue(ext: Extensions_http_request, value: newValue)}
@@ -69,9 +68,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearHTTPRequest() {
     clearExtensionValue(ext: Extensions_http_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_the_http_request) ?? 0}
     set {setExtensionValue(ext: Extensions_the_http_request, value: newValue)}
@@ -86,9 +83,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheHTTPRequest() {
     clearExtensionValue(ext: Extensions_the_http_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theHTTP: Int32 {
     get {return getExtensionValue(ext: Extensions_the_http) ?? 0}
     set {setExtensionValue(ext: Extensions_the_http, value: newValue)}
@@ -103,9 +98,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheHTTP() {
     clearExtensionValue(ext: Extensions_the_http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var https: Int32 {
     get {return getExtensionValue(ext: Extensions_https) ?? 0}
     set {setExtensionValue(ext: Extensions_https, value: newValue)}
@@ -120,9 +113,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearHTTPS() {
     clearExtensionValue(ext: Extensions_https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var httpsRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_https_request) ?? 0}
     set {setExtensionValue(ext: Extensions_https_request, value: newValue)}
@@ -137,9 +128,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearHTTPSRequest() {
     clearExtensionValue(ext: Extensions_https_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_the_https_request) ?? 0}
     set {setExtensionValue(ext: Extensions_the_https_request, value: newValue)}
@@ -154,9 +143,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheHTTPSRequest() {
     clearExtensionValue(ext: Extensions_the_https_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theHTTPS: Int32 {
     get {return getExtensionValue(ext: Extensions_the_https) ?? 0}
     set {setExtensionValue(ext: Extensions_the_https, value: newValue)}
@@ -171,9 +158,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheHTTPS() {
     clearExtensionValue(ext: Extensions_the_https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var url: Int32 {
     get {return getExtensionValue(ext: Extensions_url) ?? 0}
     set {setExtensionValue(ext: Extensions_url, value: newValue)}
@@ -188,9 +173,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearURL() {
     clearExtensionValue(ext: Extensions_url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var urlValue: Int32 {
     get {return getExtensionValue(ext: Extensions_url_value) ?? 0}
     set {setExtensionValue(ext: Extensions_url_value, value: newValue)}
@@ -205,9 +188,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearURLValue() {
     clearExtensionValue(ext: Extensions_url_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theURLValue: Int32 {
     get {return getExtensionValue(ext: Extensions_the_url_value) ?? 0}
     set {setExtensionValue(ext: Extensions_the_url_value, value: newValue)}
@@ -222,9 +203,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheURLValue() {
     clearExtensionValue(ext: Extensions_the_url_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theURL: Int32 {
     get {return getExtensionValue(ext: Extensions_the_url) ?? 0}
     set {setExtensionValue(ext: Extensions_the_url, value: newValue)}
@@ -239,9 +218,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheURL() {
     clearExtensionValue(ext: Extensions_the_url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var aBC: Int32 {
     get {return getExtensionValue(ext: Extensions_a_b_c) ?? 0}
     set {setExtensionValue(ext: Extensions_a_b_c, value: newValue)}
@@ -256,9 +233,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearABC() {
     clearExtensionValue(ext: Extensions_a_b_c)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var id: Int32 {
     get {return getExtensionValue(ext: Extensions_id) ?? 0}
     set {setExtensionValue(ext: Extensions_id, value: newValue)}
@@ -273,9 +248,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearID() {
     clearExtensionValue(ext: Extensions_id)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var idNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_id_number) ?? 0}
     set {setExtensionValue(ext: Extensions_id_number, value: newValue)}
@@ -290,9 +263,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearIDNumber() {
     clearExtensionValue(ext: Extensions_id_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var theIDNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_the_id_number) ?? 0}
     set {setExtensionValue(ext: Extensions_the_id_number, value: newValue)}
@@ -307,9 +278,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   mutating func clearTheIDNumber() {
     clearExtensionValue(ext: Extensions_the_id_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
   var requestID: Int32 {
     get {return getExtensionValue(ext: Extensions_request_id) ?? 0}
     set {setExtensionValue(ext: Extensions_request_id, value: newValue)}
@@ -327,6 +296,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsLowers {
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
+
   var http: Int32 {
     get {return getExtensionValue(ext: Extensions_HTTP) ?? 0}
     set {setExtensionValue(ext: Extensions_HTTP, value: newValue)}
@@ -341,9 +311,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearHTTP() {
     clearExtensionValue(ext: Extensions_HTTP)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var httpRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_HTTP_request) ?? 0}
     set {setExtensionValue(ext: Extensions_HTTP_request, value: newValue)}
@@ -358,9 +326,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearHTTPRequest() {
     clearExtensionValue(ext: Extensions_HTTP_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_the_HTTP_request) ?? 0}
     set {setExtensionValue(ext: Extensions_the_HTTP_request, value: newValue)}
@@ -375,9 +341,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheHTTPRequest() {
     clearExtensionValue(ext: Extensions_the_HTTP_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theHTTP: Int32 {
     get {return getExtensionValue(ext: Extensions_the_HTTP) ?? 0}
     set {setExtensionValue(ext: Extensions_the_HTTP, value: newValue)}
@@ -392,9 +356,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheHTTP() {
     clearExtensionValue(ext: Extensions_the_HTTP)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var https: Int32 {
     get {return getExtensionValue(ext: Extensions_HTTPS) ?? 0}
     set {setExtensionValue(ext: Extensions_HTTPS, value: newValue)}
@@ -409,9 +371,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearHTTPS() {
     clearExtensionValue(ext: Extensions_HTTPS)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var httpsRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_HTTPS_request) ?? 0}
     set {setExtensionValue(ext: Extensions_HTTPS_request, value: newValue)}
@@ -426,9 +386,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearHTTPSRequest() {
     clearExtensionValue(ext: Extensions_HTTPS_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_the_HTTPS_request) ?? 0}
     set {setExtensionValue(ext: Extensions_the_HTTPS_request, value: newValue)}
@@ -443,9 +401,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheHTTPSRequest() {
     clearExtensionValue(ext: Extensions_the_HTTPS_request)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theHTTPS: Int32 {
     get {return getExtensionValue(ext: Extensions_the_HTTPS) ?? 0}
     set {setExtensionValue(ext: Extensions_the_HTTPS, value: newValue)}
@@ -460,9 +416,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheHTTPS() {
     clearExtensionValue(ext: Extensions_the_HTTPS)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var url: Int32 {
     get {return getExtensionValue(ext: Extensions_URL) ?? 0}
     set {setExtensionValue(ext: Extensions_URL, value: newValue)}
@@ -477,9 +431,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearURL() {
     clearExtensionValue(ext: Extensions_URL)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var urlValue: Int32 {
     get {return getExtensionValue(ext: Extensions_URL_value) ?? 0}
     set {setExtensionValue(ext: Extensions_URL_value, value: newValue)}
@@ -494,9 +446,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearURLValue() {
     clearExtensionValue(ext: Extensions_URL_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theURLValue: Int32 {
     get {return getExtensionValue(ext: Extensions_the_URL_value) ?? 0}
     set {setExtensionValue(ext: Extensions_the_URL_value, value: newValue)}
@@ -511,9 +461,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheURLValue() {
     clearExtensionValue(ext: Extensions_the_URL_value)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theURL: Int32 {
     get {return getExtensionValue(ext: Extensions_the_URL) ?? 0}
     set {setExtensionValue(ext: Extensions_the_URL, value: newValue)}
@@ -528,9 +476,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheURL() {
     clearExtensionValue(ext: Extensions_the_URL)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var id: Int32 {
     get {return getExtensionValue(ext: Extensions_ID) ?? 0}
     set {setExtensionValue(ext: Extensions_ID, value: newValue)}
@@ -545,9 +491,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearID() {
     clearExtensionValue(ext: Extensions_ID)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var idNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_ID_number) ?? 0}
     set {setExtensionValue(ext: Extensions_ID_number, value: newValue)}
@@ -562,9 +506,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearIDNumber() {
     clearExtensionValue(ext: Extensions_ID_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var theIDNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_the_ID_number) ?? 0}
     set {setExtensionValue(ext: Extensions_the_ID_number, value: newValue)}
@@ -579,9 +521,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   mutating func clearTheIDNumber() {
     clearExtensionValue(ext: Extensions_the_ID_number)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
   var requestID: Int32 {
     get {return getExtensionValue(ext: Extensions_request_ID) ?? 0}
     set {setExtensionValue(ext: Extensions_request_ID, value: newValue)}
@@ -599,6 +539,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsUppers {
 }
 
 extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
+
   var http: Int32 {
     get {return getExtensionValue(ext: Extensions_Http) ?? 0}
     set {setExtensionValue(ext: Extensions_Http, value: newValue)}
@@ -613,9 +554,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearHTTP() {
     clearExtensionValue(ext: Extensions_Http)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var httpRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_HttpRequest) ?? 0}
     set {setExtensionValue(ext: Extensions_HttpRequest, value: newValue)}
@@ -630,9 +569,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearHTTPRequest() {
     clearExtensionValue(ext: Extensions_HttpRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theHTTPRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_TheHttpRequest) ?? 0}
     set {setExtensionValue(ext: Extensions_TheHttpRequest, value: newValue)}
@@ -647,9 +584,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheHTTPRequest() {
     clearExtensionValue(ext: Extensions_TheHttpRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theHTTP: Int32 {
     get {return getExtensionValue(ext: Extensions_TheHttp) ?? 0}
     set {setExtensionValue(ext: Extensions_TheHttp, value: newValue)}
@@ -664,9 +599,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheHTTP() {
     clearExtensionValue(ext: Extensions_TheHttp)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var https: Int32 {
     get {return getExtensionValue(ext: Extensions_Https) ?? 0}
     set {setExtensionValue(ext: Extensions_Https, value: newValue)}
@@ -681,9 +614,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearHTTPS() {
     clearExtensionValue(ext: Extensions_Https)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var httpsRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_HttpsRequest) ?? 0}
     set {setExtensionValue(ext: Extensions_HttpsRequest, value: newValue)}
@@ -698,9 +629,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearHTTPSRequest() {
     clearExtensionValue(ext: Extensions_HttpsRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theHTTPSRequest: Int32 {
     get {return getExtensionValue(ext: Extensions_TheHttpsRequest) ?? 0}
     set {setExtensionValue(ext: Extensions_TheHttpsRequest, value: newValue)}
@@ -715,9 +644,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheHTTPSRequest() {
     clearExtensionValue(ext: Extensions_TheHttpsRequest)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theHTTPS: Int32 {
     get {return getExtensionValue(ext: Extensions_TheHttps) ?? 0}
     set {setExtensionValue(ext: Extensions_TheHttps, value: newValue)}
@@ -732,9 +659,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheHTTPS() {
     clearExtensionValue(ext: Extensions_TheHttps)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var url: Int32 {
     get {return getExtensionValue(ext: Extensions_Url) ?? 0}
     set {setExtensionValue(ext: Extensions_Url, value: newValue)}
@@ -749,9 +674,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearURL() {
     clearExtensionValue(ext: Extensions_Url)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var urlValue: Int32 {
     get {return getExtensionValue(ext: Extensions_UrlValue) ?? 0}
     set {setExtensionValue(ext: Extensions_UrlValue, value: newValue)}
@@ -766,9 +689,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearURLValue() {
     clearExtensionValue(ext: Extensions_UrlValue)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theURLValue: Int32 {
     get {return getExtensionValue(ext: Extensions_TheUrlValue) ?? 0}
     set {setExtensionValue(ext: Extensions_TheUrlValue, value: newValue)}
@@ -783,9 +704,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheURLValue() {
     clearExtensionValue(ext: Extensions_TheUrlValue)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theURL: Int32 {
     get {return getExtensionValue(ext: Extensions_TheUrl) ?? 0}
     set {setExtensionValue(ext: Extensions_TheUrl, value: newValue)}
@@ -800,9 +719,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheURL() {
     clearExtensionValue(ext: Extensions_TheUrl)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var id: Int32 {
     get {return getExtensionValue(ext: Extensions_Id) ?? 0}
     set {setExtensionValue(ext: Extensions_Id, value: newValue)}
@@ -817,9 +734,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearID() {
     clearExtensionValue(ext: Extensions_Id)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var idNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_IdNumber) ?? 0}
     set {setExtensionValue(ext: Extensions_IdNumber, value: newValue)}
@@ -834,9 +749,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearIDNumber() {
     clearExtensionValue(ext: Extensions_IdNumber)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var theIDNumber: Int32 {
     get {return getExtensionValue(ext: Extensions_TheIdNumber) ?? 0}
     set {setExtensionValue(ext: Extensions_TheIdNumber, value: newValue)}
@@ -851,9 +764,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearTheIDNumber() {
     clearExtensionValue(ext: Extensions_TheIdNumber)
   }
-}
 
-extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   var requestID: Int32 {
     get {return getExtensionValue(ext: Extensions_RequestId) ?? 0}
     set {setExtensionValue(ext: Extensions_RequestId, value: newValue)}
@@ -868,6 +779,7 @@ extension SwiftUnittest_Names_ExtensionNamingInitialsWordCase {
   mutating func clearRequestID() {
     clearExtensionValue(ext: Extensions_RequestId)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved.pb.swift
@@ -370,6 +370,7 @@ struct ProtobufUnittest_SwiftReservedTestExt: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_reserved.proto.
 
 extension ProtobufUnittest_SwiftReservedTest.classMessage {
+
   /// Won't get _p added because it is fully qualified.
   var ProtobufUnittest_debugDescription: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_debug_description) ?? false}
@@ -385,9 +386,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_debugDescription() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_debug_description)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   /// These are scoped to the file, so the package prefix (or a Swift prefix)
   /// will get added to them to they aren't going to get renamed.
   var ProtobufUnittest_as: Bool {
@@ -404,9 +403,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_as() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_as)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_var: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_var) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_var, value: newValue)}
@@ -421,9 +418,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_var() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_var)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_try: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_try) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_try, value: newValue)}
@@ -438,9 +433,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_try() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_try)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_do: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_do) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_do, value: newValue)}
@@ -455,9 +448,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_do() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_do)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_nil: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_Extensions_nil) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_Extensions_nil, value: newValue)}
@@ -472,9 +463,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_nil() {
     clearExtensionValue(ext: ProtobufUnittest_Extensions_nil)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   /// This will end up in the "enum Extensions" to scope it, but there
   /// the raw form is used ("hash_value", not the Swift one "hashValue"),
   /// so there is no conflict, and no renaming happens.
@@ -492,9 +481,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_hashValue() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.hash_value)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   /// Reserved words, since these end up in the "struct Extensions", they
   /// can't just be get their names, and sanitation kicks.
   var ProtobufUnittest_SwiftReservedTestExt_as: Bool {
@@ -511,9 +498,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_as() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.as)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_SwiftReservedTestExt_var: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.var) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.var, value: newValue)}
@@ -528,9 +513,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_var() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.var)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_SwiftReservedTestExt_try: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.try) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.try, value: newValue)}
@@ -545,9 +528,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_try() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.try)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_SwiftReservedTestExt_do: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.do) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.do, value: newValue)}
@@ -562,9 +543,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_do() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.do)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.classMessage {
   var ProtobufUnittest_SwiftReservedTestExt_nil: Bool {
     get {return getExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.nil) ?? false}
     set {setExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.nil, value: newValue)}
@@ -579,6 +558,7 @@ extension ProtobufUnittest_SwiftReservedTest.classMessage {
   mutating func clearProtobufUnittest_SwiftReservedTestExt_nil() {
     clearExtensionValue(ext: ProtobufUnittest_SwiftReservedTestExt.Extensions.nil)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_reserved_ext.pb.swift
@@ -63,6 +63,7 @@ struct SwiftReservedTestExt2: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_reserved_ext.proto.
 
 extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
+
   /// Will get _p added because it has no package/swift prefix to scope and
   /// would otherwise be a problem when added to the message.
   var debugDescription_p: Bool {
@@ -79,9 +80,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearDebugDescription_p() {
     clearExtensionValue(ext: Extensions_debugDescription)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   /// These will get _p added for the same reasoning.
   var `as`: Bool {
     get {return getExtensionValue(ext: Extensions_as) ?? false}
@@ -97,9 +96,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearAs() {
     clearExtensionValue(ext: Extensions_as)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var `var`: Bool {
     get {return getExtensionValue(ext: Extensions_var) ?? false}
     set {setExtensionValue(ext: Extensions_var, value: newValue)}
@@ -114,9 +111,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearVar() {
     clearExtensionValue(ext: Extensions_var)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var `try`: Bool {
     get {return getExtensionValue(ext: Extensions_try) ?? false}
     set {setExtensionValue(ext: Extensions_try, value: newValue)}
@@ -131,9 +126,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearTry() {
     clearExtensionValue(ext: Extensions_try)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var `do`: Bool {
     get {return getExtensionValue(ext: Extensions_do) ?? false}
     set {setExtensionValue(ext: Extensions_do, value: newValue)}
@@ -148,9 +141,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearDo() {
     clearExtensionValue(ext: Extensions_do)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var `nil`: Bool {
     get {return getExtensionValue(ext: Extensions_nil) ?? false}
     set {setExtensionValue(ext: Extensions_nil, value: newValue)}
@@ -165,9 +156,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearNil() {
     clearExtensionValue(ext: Extensions_nil)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_hashValue: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue_) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue_, value: newValue)}
@@ -182,9 +171,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_hashValue() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.hashValue_)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   /// Reserved words, since these end up in the "enum Extensions", they
   /// can't just be get their names, and sanitation kicks.
   var SwiftReservedTestExt2_as: Bool {
@@ -201,9 +188,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_as() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.as)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_var: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.var) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.var, value: newValue)}
@@ -218,9 +203,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_var() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.var)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_try: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.try) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.try, value: newValue)}
@@ -235,9 +218,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_try() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.try)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_do: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.do) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.do, value: newValue)}
@@ -252,9 +233,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_do() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.do)
   }
-}
 
-extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   var SwiftReservedTestExt2_nil: Bool {
     get {return getExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil) ?? false}
     set {setExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil, value: newValue)}
@@ -269,6 +248,7 @@ extension ProtobufUnittest_SwiftReservedTest.TypeMessage {
   mutating func clearSwiftReservedTestExt2_nil() {
     clearExtensionValue(ext: SwiftReservedTestExt2.Extensions.nil)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by

--- a/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
+++ b/Tests/SwiftProtobufTests/unittest_swift_startup.pb.swift
@@ -113,6 +113,7 @@ struct ProtobufObjcUnittest_TestObjCStartupNested: SwiftProtobuf.Message {
 // MARK: - Extension support defined in unittest_swift_startup.proto.
 
 extension ProtobufObjcUnittest_TestObjCStartupMessage {
+
   /// Singular
   var ProtobufObjcUnittest_optionalInt32Extension: Int32 {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension) ?? 0}
@@ -128,9 +129,7 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   mutating func clearProtobufObjcUnittest_optionalInt32Extension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_optional_int32_extension)
   }
-}
 
-extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_repeatedInt32Extension: [Int32] {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension) ?? []}
     set {setExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension, value: newValue)}
@@ -145,9 +144,7 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   mutating func clearProtobufObjcUnittest_repeatedInt32Extension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_Extensions_repeated_int32_extension)
   }
-}
 
-extension ProtobufObjcUnittest_TestObjCStartupMessage {
   var ProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension: String {
     get {return getExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension) ?? String()}
     set {setExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension, value: newValue)}
@@ -162,6 +159,7 @@ extension ProtobufObjcUnittest_TestObjCStartupMessage {
   mutating func clearProtobufObjcUnittest_TestObjCStartupNested_nestedStringExtension() {
     clearExtensionValue(ext: ProtobufObjcUnittest_TestObjCStartupNested.Extensions.nested_string_extension)
   }
+
 }
 
 /// A `SwiftProtobuf.SimpleExtensionMap` that includes all of the extensions defined by


### PR DESCRIPTION
_tl;dr;_ -

```protobuf
extend MyMessage {
  optional int32 a = 100;
  optional string b = 101;
}
```

used to generate:

```swift
extension MyMessage {
  var a: Int32 { ... }
  var hasA: Bool { ... }
  func clearA() { ... }
}

extension MyMessage {
  var b: String { ... }
  var hasB: Bool { ... }
  func clearB() { ... }
}
```  

but now it generates:

```swift
extension MyMessage {
  var a: Int32 { ... }
  var hasA: Bool { ... }
  func clearA() { ... }

  var b: String { ... }
  var hasB: Bool { ... }
  func clearB() { ... }
}
```  

Fixes #492 
