### PR TITLE
Provide a default for Visitor.visitExtensionFields.

### DIFF
--- a/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingSizeVisitor.swift
@@ -332,9 +332,4 @@ internal struct BinaryEncodingSizeVisitor: Visitor {
     }
     serializedSize += value.count * tagSize
   }
-
-  /// Called for each extension range.
-  mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
-    try fields.traverse(visitor: &self, start: start, end: end)
-  }
 }

--- a/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/BinaryEncodingVisitor.swift
@@ -309,9 +309,4 @@ internal struct BinaryEncodingVisitor: Visitor {
       try visitSingularMessageField(value: v, fieldNumber: 2)
     }
   }
-
-  /// Called for each extension range.
-  mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
-    try fields.traverse(visitor: &self, start: start, end: end)
-  }
 }

--- a/Sources/SwiftProtobuf/HashVisitor.swift
+++ b/Sources/SwiftProtobuf/HashVisitor.swift
@@ -131,9 +131,4 @@ internal struct HashVisitor: Visitor {
     mix(fieldNumber)
     mixMap(map: value)
   }
-
-  /// Called for each extension range.
-  mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
-    try fields.traverse(visitor: &self, start: start, end: end)
-  }
 }

--- a/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
+++ b/Sources/SwiftProtobuf/TextFormatEncodingVisitor.swift
@@ -522,9 +522,4 @@ internal struct TextFormatEncodingVisitor: Visitor {
           try visitor.visitSingularMessageField(value: value, fieldNumber: 2)
       }
   }
-
-  /// Called for each extension range.
-  mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
-    try fields.traverse(visitor: &self, start: start, end: end)
-  }
 }

--- a/Sources/SwiftProtobuf/Visitor.swift
+++ b/Sources/SwiftProtobuf/Visitor.swift
@@ -664,4 +664,13 @@ extension Visitor {
                                                   fieldNumber: Int) throws {
     try visitSingularMessageField(value: value, fieldNumber: fieldNumber)
   }
+
+  // Default handling for Extensions is to forward the traverse to
+  // the ExtensionFieldValueSet. Formats that don't care about extensions
+  // can override to avoid it.
+
+  /// Called for each extension range.
+  public mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws {
+    try fields.traverse(visitor: &self, start: start, end: end)
+  }
 }


### PR DESCRIPTION
The common case is to just forward it on to the fields, so provide a default
and only hook it in the few places that don't want extensions.