### PR TITLE
Directly use the extension's fieldName.

### DIFF
--- a/Sources/SwiftProtobuf/SimpleExtensionMap.swift
+++ b/Sources/SwiftProtobuf/SimpleExtensionMap.swift
@@ -43,8 +43,7 @@ public struct SimpleExtensionMap: ExtensionMap, ExpressibleByArrayLiteral, Custo
         // TODO: Make this faster...
         for (_, list) in fields {
             for (t, e) in list {
-                let extensionName = e.fieldName.description
-                if extensionName == protoFieldName && t == messageType {
+                if e.fieldName == protoFieldName && t == messageType {
                     return e.fieldNumber
                 }
             }
@@ -88,8 +87,7 @@ public struct SimpleExtensionMap: ExtensionMap, ExpressibleByArrayLiteral, Custo
         var names = [String]()
         for (_, list) in fields {
             for (_, e) in list {
-                let extensionName = e.fieldName
-                names.append("\(extensionName)(\(e.fieldNumber))")
+                names.append("\(e.fieldName)(\(e.fieldNumber))")
             }
         }
         let d = names.joined(separator: ",")


### PR DESCRIPTION
- Skip the local, wasn't needed.
- Skip the .description, want to compare the name.