### PR TITLE
Don't visit unknowns unless there is data.

### DIFF
--- a/Sources/SwiftProtobuf/HashVisitor.swift
+++ b/Sources/SwiftProtobuf/HashVisitor.swift
@@ -47,9 +47,7 @@ internal struct HashVisitor: Visitor {
   init() {}
 
   mutating func visitUnknown(bytes: Data) throws {
-    if bytes.count > 0 { // Workaround for Linux Foundation bug
-      mix(bytes.hashValue)
-    }
+    mix(bytes.hashValue)
   }
 
   mutating func visitSingularDoubleField(value: Double, fieldNumber: Int) throws {

--- a/Sources/SwiftProtobuf/UnknownStorage.swift
+++ b/Sources/SwiftProtobuf/UnknownStorage.swift
@@ -37,6 +37,8 @@ public struct UnknownStorage: Equatable {
   }
 
   public func traverse<V: Visitor>(visitor: inout V) throws {
-    try visitor.visitUnknown(bytes: data)
+    if !data.isEmpty {
+      try visitor.visitUnknown(bytes: data)
+    }
   }
 }

--- a/Sources/SwiftProtobuf/Visitor.swift
+++ b/Sources/SwiftProtobuf/Visitor.swift
@@ -435,7 +435,7 @@ public protocol Visitor {
   /// Called for each extension range.
   mutating func visitExtensionFields(fields: ExtensionFieldValueSet, start: Int, end: Int) throws
 
-  /// Called with the raw bytes that represent any proto2 unknown fields.
+  /// Called with the raw bytes that represent any unknown fields.
   mutating func visitUnknown(bytes: Data) throws
 }
 


### PR DESCRIPTION
A few of the Visitors to some level of work around the zero length (trying to append it, etc.), this way we generally avoid they having to be defensive against zero length.

