### PR TITLE
Make union() not return a new instance.

### DIFF
--- a/Sources/SwiftProtobuf/SimpleExtensionMap.swift
+++ b/Sources/SwiftProtobuf/SimpleExtensionMap.swift
@@ -73,13 +73,17 @@ public struct SimpleExtensionMap: ExtensionMap, ExpressibleByArrayLiteral, Custo
         }
     }
 
-    public mutating func union(_ other: SimpleExtensionMap) -> SimpleExtensionMap {
-        var out = self
+    public mutating func formUnion(_ other: SimpleExtensionMap) {
         for (_, list) in other.fields {
             for (_, e) in list {
-                out.insert(e)
+                insert(e)
             }
         }
+    }
+
+    public func union(_ other: SimpleExtensionMap) -> SimpleExtensionMap {
+        var out = self
+        out.formUnion(other)
         return out
     }
 

--- a/Tests/SwiftProtobufTests/Test_Extensions.swift
+++ b/Tests/SwiftProtobufTests/Test_Extensions.swift
@@ -74,7 +74,7 @@ class Test_Extensions: XCTestCase, PBTestHelpers {
         // Start with all the extensions from the unittest.proto file:
         extensions = ProtobufUnittest_Unittest_Extensions
         // Append another file's worth:
-        extensions = extensions.union(ProtobufUnittest_UnittestCustomOptions_Extensions)
+        extensions.formUnion(ProtobufUnittest_UnittestCustomOptions_Extensions)
         // Append an array of extensions
         extensions.insert(contentsOf:
             [


### PR DESCRIPTION
The two insert() methods are mutating and modify the instance.  union() was tagged as
mutating, but it didn't return a new instance, so change it to actually be mutating
since that seems more consistent.