### PR TITLE
Fix Float round-trip accuracy in JSON & Text format

### DIFF
--- a/Sources/SwiftProtobuf/DoubleFormatter.swift
+++ b/Sources/SwiftProtobuf/DoubleFormatter.swift
@@ -14,13 +14,6 @@
 
 import Foundation
 
-#if os(Linux)
-// Linux doesn't seem to define these by default.
-// https://bugs.swift.org/browse/SR-4198
-internal let FLT_DIG: Int32 = 6
-internal let DBL_DIG: Int32 = 15
-#endif
-
 // TODO: Experiment with other approaches for formatting float/double.
 // Profiling shows that the `CVarArg` and `withVaList` glue consumes
 // about 50% of the total run time just marshalling the arguments.
@@ -82,11 +75,15 @@ internal class DoubleFormatter {
     }
 
     func floatToUtf8(_ f: Float) -> UnsafeBufferPointer<UInt8> {
-        return _doubleToUtf8(Double(f), digits: FLT_DIG + 2)
+        // This many digits suffices for any IEEE754 single-precision number.
+        let floatDigitsToPrint: Int32 = 9
+        return _doubleToUtf8(Double(f), digits: floatDigitsToPrint)
     }
 
     func doubleToUtf8(_ d: Double) -> UnsafeBufferPointer<UInt8> {
-        return _doubleToUtf8(d, digits: DBL_DIG + 2)
+        // This many digits suffices for any IEEE754 double-precision number.
+        let doubleDigitsToPrint: Int32 = 17
+        return _doubleToUtf8(d, digits: doubleDigitsToPrint)
     }
 
     private func _doubleToUtf8(_ d: Double, digits: Int32) -> UnsafeBufferPointer<UInt8> {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -577,6 +577,8 @@ extension Test_JSON {
             ("testSingleFloat", {try run_test(test:($0 as! Test_JSON).testSingleFloat)}),
             ("testSingleDouble_NaN", {try run_test(test:($0 as! Test_JSON).testSingleDouble_NaN)}),
             ("testSingleFloat_NaN", {try run_test(test:($0 as! Test_JSON).testSingleFloat_NaN)}),
+            ("testSingleDouble_roundtrip", {try run_test(test:($0 as! Test_JSON).testSingleDouble_roundtrip)}),
+            ("testSingleFloat_roundtrip", {try run_test(test:($0 as! Test_JSON).testSingleFloat_roundtrip)}),
             ("testSingleBool", {try run_test(test:($0 as! Test_JSON).testSingleBool)}),
             ("testSingleString", {try run_test(test:($0 as! Test_JSON).testSingleString)}),
             ("testSingleString_controlCharacters", {try run_test(test:($0 as! Test_JSON).testSingleString_controlCharacters)}),

--- a/Tests/SwiftProtobufTests/Test_JSON.swift
+++ b/Tests/SwiftProtobufTests/Test_JSON.swift
@@ -439,6 +439,7 @@ class Test_JSON: XCTestCase, PBTestHelpers {
         assertRoundTripJSON {$0.singleFloat = 0.0001}
         assertRoundTripJSON {$0.singleFloat = 0.00001}
         assertRoundTripJSON {$0.singleFloat = 0.000001}
+        assertRoundTripJSON {$0.singleFloat = 1.00000075e-36}
         assertRoundTripJSON {$0.singleFloat = 1e-10}
         assertRoundTripJSON {$0.singleFloat = 1e-20}
         assertRoundTripJSON {$0.singleFloat = 1e-30}
@@ -478,6 +479,20 @@ class Test_JSON: XCTestCase, PBTestHelpers {
             XCTAssert(o2.singleFloat.isNaN == .some(true))
         } catch let e {
             XCTFail("Couldn't decode: \(e) -- \(encoded)")
+        }
+    }
+
+    func testSingleDouble_roundtrip() throws {
+        for _ in 0..<10000 {
+            let d = drand48()
+            assertRoundTripJSON {$0.singleDouble = d}
+        }
+    }
+
+    func testSingleFloat_roundtrip() throws {
+        for _ in 0..<10000 {
+            let f = Float(drand48())
+            assertRoundTripJSON {$0.singleFloat = f}
         }
     }
 


### PR DESCRIPTION
We originally copied Google's C++ implementation and used 8 digits for
float.  Unfortunately, about 1.5% of all floats require 9 digits.

This adds a test for one specific value that requires 9 digits, and adds tests that verify round-trip
correctness for 10,000 random floats and doubles.

Also, stop referring to FLT_DIG and DBL_DIG in the code.  Those
constants refer to concepts that aren't particularly helpful here.